### PR TITLE
DejaVu Sans: fix, U+06BD Nya has three dots below in init and medi forms, make U+06BA dotless

### DIFF
--- a/src/DejaVuSans-Bold.sfd
+++ b/src/DejaVuSans-Bold.sfd
@@ -190103,21 +190103,19 @@ Encoding: 1114139 -1 1114139
 Width: 769
 Flags: W
 AnchorPoint: "rtl-below" 418 -100 basechar 0
-AnchorPoint: "rtl-above" 418 1090 basechar 0
+AnchorPoint: "rtl-above" 418 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 343 835 2
 Refer: 64488 64488 N 1 0 0 1 0 0 2
 EndChar
 StartChar: uni06BA.medi
 Encoding: 1114140 -1 1114140
 Width: 836
 Flags: W
-AnchorPoint: "rtl-above" 418 1090 basechar 0
+AnchorPoint: "rtl-above" 418 1000 basechar 0
 AnchorPoint: "rtl-below" 418 -100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 343 835 2
 Refer: 64489 64489 N 1 0 0 1 0 0 2
 EndChar
 StartChar: arabic_ring

--- a/src/DejaVuSans-Bold.sfd
+++ b/src/DejaVuSans-Bold.sfd
@@ -195197,22 +195197,22 @@ StartChar: uni06BD.init
 Encoding: 1114412 -1 1114412
 Width: 769
 Flags: W
-AnchorPoint: "rtl-above" 418 1350 basechar 0
-AnchorPoint: "rtl-below" 418 -100 basechar 0
+AnchorPoint: "rtl-above" 418 1000 basechar 0
+AnchorPoint: "rtl-below" 418 -550 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 218 850 2
+Refer: 1114127 -1 N 1 0 0 1 218 -250 2
 Refer: 1114131 -1 N 1 0 0 1 0 0 2
 EndChar
 StartChar: uni06BD.medi
 Encoding: 1114413 -1 1114413
 Width: 836
 Flags: W
-AnchorPoint: "rtl-above" 418 1350 basechar 0
-AnchorPoint: "rtl-below" 418 -100 basechar 0
+AnchorPoint: "rtl-above" 418 1000 basechar 0
+AnchorPoint: "rtl-below" 418 -550 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 218 850 2
+Refer: 1114127 -1 N 1 0 0 1 218 -250 2
 Refer: 1114132 -1 N 1 0 0 1 0 0 2
 EndChar
 StartChar: exclamdown.case


### PR DESCRIPTION
U+06BD ڽ Jawi nya has three dots above in isolated and final forms but below in initial and medial forms.
See http://www.unicode.org/versions/Unicode8.0.0/ch09.pdf#page=22 and http://www.unicode.org/L2/L2009/09146-moving-dots.pdf

/cc @eimai 