### PR TITLE
fontconfig: remove generic name assignment and aliasing

### DIFF
--- a/fontconfig/57-dejavu-sans-mono.conf
+++ b/fontconfig/57-dejavu-sans-mono.conf
@@ -45,18 +45,4 @@
       <family>DejaVu Sans Mono</family>
     </accept>
   </alias>
-  <!-- Generic name assignment -->
-  <alias>
-    <family>DejaVu Sans Mono</family>
-    <default>
-      <family>monospace</family>
-    </default>
-  </alias>
-  <!-- Generic name aliasing -->
-  <alias>
-    <family>monospace</family>
-    <prefer>
-      <family>DejaVu Sans Mono</family>
-    </prefer>
-  </alias>
 </fontconfig>

--- a/fontconfig/57-dejavu-sans.conf
+++ b/fontconfig/57-dejavu-sans.conf
@@ -70,18 +70,4 @@
       <family>DejaVu Sans</family>
     </accept>
   </alias>
-  <!-- Generic name assignment -->
-  <alias>
-    <family>DejaVu Sans</family>
-    <default>
-      <family>sans-serif</family>
-    </default>
-  </alias>
-  <!-- Generic name aliasing -->
-  <alias>
-    <family>sans-serif</family>
-    <prefer>
-      <family>DejaVu Sans</family>
-    </prefer>
-  </alias>
 </fontconfig>

--- a/fontconfig/57-dejavu-serif.conf
+++ b/fontconfig/57-dejavu-serif.conf
@@ -52,18 +52,4 @@
       <family>DejaVu Serif</family>
     </accept>
   </alias>
-  <!-- Generic name assignment -->
-  <alias>
-    <family>DejaVu Serif</family>
-    <default>
-      <family>serif</family>
-    </default>
-  </alias>
-  <!-- Generic name aliasing -->
-  <alias>
-    <family>serif</family>
-    <prefer>
-      <family>DejaVu Serif</family>
-    </prefer>
-  </alias>
 </fontconfig>


### PR DESCRIPTION
This removes the generic name assignment and the generic name aliasing
rules for the three standard DejaVu Sans, Sans-Mono and Serif fonts.

These rules are redundant as they are already in the fontconfig
upstream config files 45-latin.conf and 60-latin.conf, respectively,
for at least 10 years now, c.f.:

https://cgit.freedesktop.org/fontconfig/commit/conf.d/45-latin.conf?id=4b51f173c99152586db26b03752873a4b4020672
https://cgit.freedesktop.org/fontconfig/commit/conf.d/60-latin.conf?id=6c5619a08575943f75d2341e1a4931ec5faf716b

We have a bug report in Debian from a user who complains that he
changed the preference for the default sans-serif font in the expected
rule, i.e. 60-latin.conf, and was confused when his change was
overridden by fonts-dejavu's own rule in 57-dejavu-sans.conf:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=753401

The reporter confirms that removing the offending lines from the
config files in the fonts-dejavu package causes the intended changes
applied to the 60-latin.conf file to take effect.

Thanks for considering!