### PR TITLE
made DejaVuSansMono brackets monospaced

### DIFF
--- a/src/DejaVuSansMono.sfd
+++ b/src/DejaVuSansMono.sfd
@@ -10,13 +10,16 @@ UnderlinePosition: -85
 UnderlineWidth: 90
 Ascent: 1556
 Descent: 492
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 1 "Back"  1
-Layer: 1 1 "Fore"  0
+Layer: 0 1 "Back" 1
+Layer: 1 1 "Fore" 0
 FSType: 0
 OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
+CreationTime: 1527855879
+ModificationTime: 1527860974
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -37,29 +40,29 @@ HheadAOffset: 0
 HheadDescent: -483
 HheadDOffset: 0
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0"  {"'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
-Lookup: 6 0 0 "'ccmp' Glyph Composition/Decomposition lookup 0"  {"'ccmp' Glyph Composition/Decomposition lookup 0"  } ['ccmp' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 1"  {"'locl' Localized Forms in Cyrillic lookup 1"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 3"  {"'fina' Terminal Forms in Arabic lookup 3"  } ['fina' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 4"  {"'medi' Medial Forms in Arabic lookup 4"  } ['medi' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 5"  {"'init' Initial Forms in Arabic lookup 5"  } ['init' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 6"  {"'rlig' Required Ligatures in Arabic lookup 6"  } ['rlig' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 7"  {"'liga' Standard Ligatures in Arabic lookup 7"  } ['liga' ('arab' <'dflt' > ) ]
-Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 10"  {"'dlig' Discretionary Ligatures in Latin lookup 10"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution - Dotless Form"  {"Single Substitution - Dotless Form"  } []
-Lookup: 1 0 0 "'case' Case-Sensitive Forms"  {"'case' Case-Sensitive Forms" ("case" ) } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0"  {"'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1"  {"'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2"  {"'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3"  {"'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4"  {"'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5"  {"'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark to Base in Basic"  {"'mark' cedilla"  "'mark' above, below"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 257 0 0 "'mark' Zero-Width Marks in Basic"  {"'mark' Zero-Width Marks lookup"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark positioning in Lao"  {"'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
-Lookup: 257 8 0 "'rtbd' Mark width in Lao"  {"'rtbd' Mark width in Lao-2"  } ['rtbd' ('lao ' <'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0" { "'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
+Lookup: 6 0 0 "'ccmp' Glyph Composition/Decomposition lookup 0" { "'ccmp' Glyph Composition/Decomposition lookup 0"  } ['ccmp' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 1" { "'locl' Localized Forms in Cyrillic lookup 1"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 3" { "'fina' Terminal Forms in Arabic lookup 3"  } ['fina' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 4" { "'medi' Medial Forms in Arabic lookup 4"  } ['medi' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 5" { "'init' Initial Forms in Arabic lookup 5"  } ['init' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 6" { "'rlig' Required Ligatures in Arabic lookup 6"  } ['rlig' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 7" { "'liga' Standard Ligatures in Arabic lookup 7"  } ['liga' ('arab' <'dflt' > ) ]
+Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 10" { "'dlig' Discretionary Ligatures in Latin lookup 10"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution - Dotless Form" { "Single Substitution - Dotless Form"  } []
+Lookup: 1 0 0 "'case' Case-Sensitive Forms" { "'case' Case-Sensitive Forms" ("case") } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0" { "'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1" { "'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2" { "'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3" { "'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4" { "'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5" { "'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark to Base in Basic" { "'mark' cedilla"  "'mark' above, below"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 257 0 0 "'mark' Zero-Width Marks in Basic" { "'mark' Zero-Width Marks lookup"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark positioning in Lao" { "'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
+Lookup: 257 8 0 "'rtbd' Mark width in Lao" { "'rtbd' Mark width in Lao-2"  } ['rtbd' ('lao ' <'dflt' > ) ]
 DEI: 91125
-ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0"  4 1 4 3
+ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0" 4 1 4 3
   Class: 3 i j
   Class: 227 gravecomb acutecomb uni0302 tildecomb uni0304 uni0305 uni0306 uni0307 uni0308 hookabovecomb uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314 uni0315 uni033D uni033E uni033F uni0343 uni0374
   Class: 244 uni0316 uni0317 uni0318 uni0319 uni031C uni031D uni031E uni031F uni0320 dotbelowcomb uni0324 uni0325 uni0326 uni0327 uni0328 uni0329 uni032A uni032B uni032C uni032D uni032E uni032F uni0330 uni0331 uni0332 uni0333 uni0339 uni033A uni033B uni033C
@@ -71,22 +74,22 @@ ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0"  4 1 4 3
   BClsList:
   FClsList: 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
+  SeqLookup: 0 "Single Substitution - Dotless Form"
  1 0 2
   ClsList: 1
   BClsList:
   FClsList: 3 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
+  SeqLookup: 0 "Single Substitution - Dotless Form"
  1 0 3
   ClsList: 1
   BClsList:
   FClsList: 3 3 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
-  ClassNames: "0"  "1"  "2"  "3"  
-  BClassNames: "0"  
-  FClassNames: "0"  "1"  "2"  "3"  
+  SeqLookup: 0 "Single Substitution - Dotless Form"
+  ClassNames: "0" "1" "2" "3"
+  BClassNames: "0"
+  FClassNames: "0" "1" "2" "3"
 EndFPST
 TtTable: prep
 PUSHW_2
@@ -2298,12 +2301,14 @@ ShortTable: maxp 16
   3
   1
 EndShort
-LangName: 1033 "" "" "" "DejaVu Sans Mono" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License" 
+LangName: 1033 "" "" "" "DejaVu Sans Mono" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License"
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
+WinInfo: 5744 16 11
 GridOrder2: 1
 Grid
 1 740 m 25,0,-1
@@ -2313,50 +2318,50 @@ Grid
  1 894 l 25,1,-1
  -139 1034 l 25,0,0
 1 1510 m 9,0,-1
- -139 1650 l 17,0,0
+ -139 1650 l 1041,0,0
 1 1202 m 9,1,-1
- -139 1342 l 17,0,0
+ -139 1342 l 1041,0,0
 1 1818 m 9,1,-1
- -139 1958 l 17,0,0
+ -139 1958 l 1041,0,0
 1 1048 m 9,1,-1
- -139 1188 l 17,0,0
+ -139 1188 l 1041,0,0
 1 1664 m 9,1,-1
- -139 1804 l 17,0,0
+ -139 1804 l 1041,0,0
 1 1356 m 9,1,-1
- -139 1496 l 17,0,0
+ -139 1496 l 1041,0,0
 -139 -352 m 9,0,0
  1 -492 l 25,1,-1
- 141 -632 l 17
+ 141 -632 l 1041
 -139 -198 m 25,0,0
  1 -338 l 25,1,-1
  -139 -198 l 25,0,0
 1 278 m 9,0,-1
- -139 418 l 17,0,0
+ -139 418 l 1041,0,0
 1 -30 m 9,1,-1
- -139 110 l 17,0,0
+ -139 110 l 1041,0,0
 1 586 m 9,1,-1
- -139 726 l 17,0,0
+ -139 726 l 1041,0,0
 1 -184 m 9,1,-1
- -139 -44 l 17,0,0
+ -139 -44 l 1041,0,0
 1 432 m 9,1,-1
- -139 572 l 17,0,0
+ -139 572 l 1041,0,0
 1 124 m 9,1,-1
- -139 264 l 17,0,0
+ -139 264 l 1041,0,0
 1232 -409 m 25,0,0
  1372 -549 l 25,1,-1
  1232 -409 l 25,0,0
 1372 67 m 9,0,-1
- 1232 207 l 17,0,0
+ 1232 207 l 1041,0,0
 1372 -241 m 9,1,-1
- 1232 -101 l 17,0,0
+ 1232 -101 l 1041,0,0
 1372 375 m 9,1,-1
- 1232 515 l 17,0,0
+ 1232 515 l 1041,0,0
 1372 -395 m 9,1,-1
- 1232 -255 l 17,0,0
+ 1232 -255 l 1041,0,0
 1372 221 m 9,1,-1
- 1232 361 l 17,0,0
+ 1232 361 l 1041,0,0
 1372 -87 m 9,1,-1
- 1232 53 l 17,0,0
+ 1232 53 l 1041,0,0
 1232 669 m 25,0,0
  1372 529 l 25,1,-1
  1232 669 l 25,0,0
@@ -2364,56 +2369,56 @@ Grid
  1372 683 l 25,1,-1
  1232 823 l 25,0,0
 1372 1299 m 9,0,-1
- 1232 1439 l 17,0,0
+ 1232 1439 l 1041,0,0
 1372 991 m 9,1,-1
- 1232 1131 l 17,0,0
+ 1232 1131 l 1041,0,0
 1372 1607 m 9,1,-1
- 1232 1747 l 17,0,0
+ 1232 1747 l 1041,0,0
 1372 837 m 9,1,-1
- 1232 977 l 17,0,0
+ 1232 977 l 1041,0,0
 1372 1453 m 9,1,-1
- 1232 1593 l 17,0,0
+ 1232 1593 l 1041,0,0
 1372 1145 m 9,1,-1
- 1232 1285 l 17,0,0
+ 1232 1285 l 1041,0,0
 1372 1761 m 9,1,-1
  1232 1901 l 25,0,0
- 1092 2041 l 17,0,0
+ 1092 2041 l 1041,0,0
 1373 -632 m 9,1,-1
- 1233 -492 l 17,0,0
+ 1233 -492 l 1041,0,0
 1079 -492 m 25,0,0
  1219 -632 l 25,1,-1
  1079 -492 l 25,0,0
 603 -632 m 9,0,-1
- 463 -492 l 17,0,0
+ 463 -492 l 1041,0,0
 911 -632 m 9,1,-1
- 771 -492 l 17,0,0
+ 771 -492 l 1041,0,0
 295 -632 m 9,1,-1
- 155 -492 l 17,0,0
+ 155 -492 l 1041,0,0
 1065 -632 m 9,1,-1
- 925 -492 l 17,0,0
+ 925 -492 l 1041,0,0
 449 -632 m 9,1,-1
- 309 -492 l 17,0,0
+ 309 -492 l 1041,0,0
 757 -632 m 9,1,-1
- 617 -492 l 17,0,0
+ 617 -492 l 1041,0,0
 1386 1901 m 9,1,-1
- 1246 2041 l 17,0,0
+ 1246 2041 l 1041,0,0
 938 2041 m 25,0,0
  1078 1901 l 25,1,-1
  938 2041 l 25,0,0
 462 1901 m 9,0,-1
- 322 2041 l 17,0,0
+ 322 2041 l 1041,0,0
 770 1901 m 9,1,-1
- 630 2041 l 17,0,0
+ 630 2041 l 1041,0,0
 154 1901 m 9,1,-1
- 14 2041 l 17,0,0
+ 14 2041 l 1041,0,0
 924 1901 m 9,1,-1
- 784 2041 l 17,0,0
+ 784 2041 l 1041,0,0
 308 1901 m 9,1,-1
- 168 2041 l 17,0,0
+ 168 2041 l 1041,0,0
 616 1901 m 9,1,-1
- 476 2041 l 17,0,0
+ 476 2041 l 1041,0,0
 0 1901 m 9,1,-1
- -140 2041 l 17,0,0
+ -140 2041 l 1041,0,0
 -140 2041 m 1,1,-1
  1373 2041 l 1,2,-1
  1373 -632 l 1,3,-1
@@ -2425,8 +2430,9 @@ Grid
  0 -492 l 1,8,-1
  0 1901 l 1,5,-1
 EndSplineSet
-AnchorClass2: "cedilla"  "'mark' cedilla" "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" "above"  "'mark' above, below" "below"  "'mark' above, below" "rtl-above"  "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above"  "'mark' Mark Positioning in Arabic lookup 4" "rtl-below"  "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below"  "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark"  "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark"  "'mkmk' Mark to Mark in Arabic lookup 0" 
-BeginChars: 1114165 0
+AnchorClass2: "cedilla" "'mark' cedilla" "lao-below" "'mark' Mark positioning in Lao" "lao-above" "'mark' Mark positioning in Lao" "above" "'mark' above, below" "below" "'mark' above, below" "rtl-above" "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above" "'mark' Mark Positioning in Arabic lookup 4" "rtl-below" "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below" "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark" "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark" "'mkmk' Mark to Mark in Arabic lookup 0"
+BeginChars: 1114165 3802
+
 StartChar: .notdef
 Encoding: 0 -1 0
 Width: 1233
@@ -2474,14 +2480,16 @@ SplineSet
  219 -248 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: space
-Encoding: 32 32 32
+Encoding: 32 32 1
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclam
-Encoding: 33 33 33
+Encoding: 33 33 2
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2534,8 +2542,9 @@ SplineSet
  516 254 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedbl
-Encoding: 34 34 34
+Encoding: 34 34 3
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2584,8 +2593,9 @@ SplineSet
  512 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: numbersign
-Encoding: 35 35 35
+Encoding: 35 35 4
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2703,8 +2713,9 @@ SplineSet
  788 901 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: dollar
-Encoding: 36 36 36
+Encoding: 36 36 5
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2847,14 +2858,15 @@ SplineSet
  772 1177 772 1177 692 1181 c 1,40,-1
  692 750 l 1,41,42
  898 719 898 719 1006 622 c 128,-1,43
- 1114 525 1114 525 1114 371 c 0,44,45
+ 1114 525 1114 525 1114 371 c 256,44,45
  1114 217 1114 217 997.5 114 c 128,-1,46
  881 11 881 11 693 2 c 1,47,-1
  692 -301 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: percent
-Encoding: 37 37 37
+Encoding: 37 37 6
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2952,7 +2964,7 @@ SplineSet
  696 241 696 241 748.5 188 c 128,-1,2
  801 135 801 135 879 135 c 0,3,4
  956 135 956 135 1009.5 188.5 c 128,-1,5
- 1063 242 1063 242 1063 319 c 0,6,7
+ 1063 242 1063 242 1063 319 c 256,6,7
  1063 396 1063 396 1009 450 c 128,-1,8
  955 504 955 504 879 504 c 0,9,10
  801 504 801 504 748.5 451 c 128,-1,11
@@ -2977,26 +2989,27 @@ SplineSet
  168 1033 168 1033 220.5 980.5 c 128,-1,33
  273 928 273 928 352 928 c 0,34,35
  429 928 429 928 483 981.5 c 128,-1,36
- 537 1035 537 1035 537 1112 c 0,37,38
+ 537 1035 537 1035 537 1112 c 256,37,38
  537 1189 537 1189 483 1242.5 c 128,-1,39
- 429 1296 429 1296 352 1296 c 0,40,41
+ 429 1296 429 1296 352 1296 c 256,40,41
  275 1296 275 1296 221.5 1243 c 128,-1,42
  168 1190 168 1190 168 1112 c 0,31,32
-33 1112 m 0,43,44
+33 1112 m 256,43,44
  33 1247 33 1247 125 1339.5 c 128,-1,45
  217 1432 217 1432 352 1432 c 0,46,47
  416 1432 416 1432 474.5 1408 c 128,-1,48
- 533 1384 533 1384 578 1339 c 0,49,50
+ 533 1384 533 1384 578 1339 c 256,49,50
  623 1294 623 1294 647.5 1235.5 c 128,-1,51
  672 1177 672 1177 672 1112 c 0,52,53
  672 978 672 978 579 885.5 c 128,-1,54
  486 793 486 793 352 793 c 0,55,56
  217 793 217 793 125 885 c 128,-1,57
- 33 977 33 977 33 1112 c 0,43,44
+ 33 977 33 977 33 1112 c 256,43,44
 EndSplineSet
 EndChar
+
 StartChar: ampersand
-Encoding: 38 38 38
+Encoding: 38 38 7
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3227,8 +3240,9 @@ SplineSet
  416 803 l 1,43,44
 EndSplineSet
 EndChar
+
 StartChar: quotesingle
-Encoding: 39 39 39
+Encoding: 39 39 8
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3261,8 +3275,9 @@ SplineSet
  702 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: parenleft
-Encoding: 40 40 40
+Encoding: 40 40 9
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3314,8 +3329,9 @@ SplineSet
  885 1554 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: parenright
-Encoding: 41 41 41
+Encoding: 41 41 10
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3367,8 +3383,9 @@ SplineSet
  481 1325 481 1325 348 1554 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asterisk
-Encoding: 42 42 42
+Encoding: 42 42 11
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3475,8 +3492,9 @@ SplineSet
  1067 1247 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: plus
-Encoding: 43 43 43
+Encoding: 43 43 12
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3538,8 +3556,9 @@ SplineSet
  700 1171 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: comma
-Encoding: 44 44 44
+Encoding: 44 44 13
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3580,8 +3599,9 @@ SplineSet
  502 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: hyphen
-Encoding: 45 45 45
+Encoding: 45 45 14
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3613,8 +3633,9 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: period
-Encoding: 46 46 46
+Encoding: 46 46 15
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3645,8 +3666,9 @@ SplineSet
  489 305 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: slash
-Encoding: 47 47 47
+Encoding: 47 47 16
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3685,8 +3707,9 @@ SplineSet
  889 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zero
-Encoding: 48 48 48
+Encoding: 48 48 17
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3978,19 +4001,20 @@ SplineSet
  897 435 897 435 897 745 c 0,21,22
  897 1056 897 1056 827.5 1208 c 128,-1,23
  758 1360 758 1360 616 1360 c 0,12,13
-616 1520 m 0,24,25
+616 1520 m 256,24,25
  855 1520 855 1520 977.5 1324 c 128,-1,26
  1100 1128 1100 1128 1100 745 c 0,27,28
  1100 363 1100 363 977.5 167 c 128,-1,29
- 855 -29 855 -29 616 -29 c 0,30,31
+ 855 -29 855 -29 616 -29 c 256,30,31
  377 -29 377 -29 255 167 c 128,-1,32
  133 363 133 363 133 745 c 0,33,34
  133 1128 133 1128 255 1324 c 128,-1,35
- 377 1520 377 1520 616 1520 c 0,24,25
+ 377 1520 377 1520 616 1520 c 256,24,25
 EndSplineSet
 EndChar
+
 StartChar: one
-Encoding: 49 49 49
+Encoding: 49 49 18
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4050,8 +4074,9 @@ SplineSet
  270 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: two
-Encoding: 50 50 50
+Encoding: 50 50 19
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4164,8 +4189,9 @@ SplineSet
  591 399 591 399 373 170 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: three
-Encoding: 51 51 51
+Encoding: 51 51 20
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4276,8 +4302,9 @@ SplineSet
  907 833 907 833 776 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: four
-Encoding: 52 52 52
+Encoding: 52 52 21
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4369,8 +4396,9 @@ SplineSet
  702 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: five
-Encoding: 53 53 53
+Encoding: 53 53 22
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4464,8 +4492,9 @@ SplineSet
  207 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: six
-Encoding: 54 54 54
+Encoding: 54 54 23
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4554,7 +4583,7 @@ SplineSet
  922 1489 922 1489 991 1460 c 1,0,-1
 631 829 m 0,25,26
  502 829 502 829 428 736 c 128,-1,27
- 354 643 354 643 354 479 c 0,28,29
+ 354 643 354 643 354 479 c 256,28,29
  354 315 354 315 428 222 c 128,-1,30
  502 129 502 129 631 129 c 0,31,32
  765 129 765 129 833 217.5 c 128,-1,33
@@ -4563,8 +4592,9 @@ SplineSet
  765 829 765 829 631 829 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: seven
-Encoding: 55 55 55
+Encoding: 55 55 24
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4635,8 +4665,9 @@ SplineSet
  139 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: eight
-Encoding: 56 56 56
+Encoding: 56 56 25
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4713,7 +4744,7 @@ Fore
 SplineSet
 616 709 m 0,0,1
  481 709 481 709 407.5 633.5 c 128,-1,2
- 334 558 334 558 334 420 c 0,3,4
+ 334 558 334 558 334 420 c 256,3,4
  334 282 334 282 408.5 205.5 c 128,-1,5
  483 129 483 129 616 129 c 0,6,7
  752 129 752 129 825.5 204.5 c 128,-1,8
@@ -4732,7 +4763,7 @@ SplineSet
  943 760 943 760 1022.5 660 c 128,-1,26
  1102 560 1102 560 1102 401 c 0,27,28
  1102 199 1102 199 973 85 c 128,-1,29
- 844 -29 844 -29 616 -29 c 0,30,31
+ 844 -29 844 -29 616 -29 c 256,30,31
  388 -29 388 -29 259.5 84.5 c 128,-1,32
  131 198 131 198 131 399 c 0,33,34
  131 559 131 559 210.5 659.5 c 128,-1,35
@@ -4748,8 +4779,9 @@ SplineSet
  367 1235 367 1235 367 1114 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: nine
-Encoding: 57 57 57
+Encoding: 57 57 26
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4818,7 +4850,7 @@ Fore
 SplineSet
 596 662 m 0,0,1
  725 662 725 662 798.5 755 c 128,-1,2
- 872 848 872 848 872 1012 c 0,3,4
+ 872 848 872 848 872 1012 c 256,3,4
  872 1176 872 1176 798.5 1269 c 128,-1,5
  725 1362 725 1362 596 1362 c 0,6,7
  462 1362 462 1362 394 1273.5 c 128,-1,8
@@ -4845,8 +4877,9 @@ SplineSet
  305 2 305 2 236 31 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: colon
-Encoding: 58 58 58
+Encoding: 58 58 27
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4893,8 +4926,9 @@ SplineSet
  489 305 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: semicolon
-Encoding: 59 59 59
+Encoding: 59 59 28
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4953,8 +4987,9 @@ SplineSet
  489 1063 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: less
-Encoding: 60 60 60
+Encoding: 60 60 29
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5005,8 +5040,9 @@ SplineSet
  1145 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equal
-Encoding: 61 61 61
+Encoding: 61 61 30
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5053,8 +5089,9 @@ SplineSet
  88 930 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: greater
-Encoding: 62 62 62
+Encoding: 62 62 31
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5105,8 +5142,9 @@ SplineSet
  88 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: question
-Encoding: 63 63 63
+Encoding: 63 63 32
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5268,8 +5306,9 @@ SplineSet
  487 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: at
-Encoding: 64 64 64
+Encoding: 64 64 33
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5391,11 +5430,11 @@ Fore
 SplineSet
 1038 545 m 0,0,1
  1038 674 1038 674 974 751.5 c 128,-1,2
- 910 829 910 829 803 829 c 0,3,4
+ 910 829 910 829 803 829 c 256,3,4
  696 829 696 829 631.5 751.5 c 128,-1,5
  567 674 567 674 567 545 c 0,6,7
  567 415 567 415 631.5 337.5 c 128,-1,8
- 696 260 696 260 803 260 c 0,9,10
+ 696 260 696 260 803 260 c 256,9,10
  910 260 910 260 974 337.5 c 128,-1,11
  1038 415 1038 415 1038 545 c 0,0,1
 1178 135 m 1,12,-1
@@ -5404,7 +5443,7 @@ SplineSet
  997 183 997 183 931.5 149 c 128,-1,16
  866 115 866 115 784 115 c 0,17,18
  623 115 623 115 517.5 236 c 128,-1,19
- 412 357 412 357 412 545 c 0,20,21
+ 412 357 412 357 412 545 c 256,20,21
  412 733 412 733 517.5 854 c 128,-1,22
  623 975 623 975 784 975 c 0,23,24
  864 975 864 975 931 940 c 128,-1,25
@@ -5430,8 +5469,9 @@ SplineSet
  1178 135 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: A
-Encoding: 65 65 65
+Encoding: 65 65 34
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5609,8 +5649,9 @@ SplineSet
  494 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: B
-Encoding: 66 66 66
+Encoding: 66 66 35
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5712,8 +5753,9 @@ SplineSet
  166 1493 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: C
-Encoding: 67 67 67
+Encoding: 67 67 36
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5791,8 +5833,9 @@ SplineSet
  1073 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: D
-Encoding: 68 68 68
+Encoding: 68 68 37
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5861,8 +5904,9 @@ SplineSet
  440 1493 l 2,9,10
 EndSplineSet
 EndChar
+
 StartChar: E
-Encoding: 69 69 69
+Encoding: 69 69 38
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5929,8 +5973,9 @@ SplineSet
  197 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: F
-Encoding: 70 70 70
+Encoding: 70 70 39
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5990,8 +6035,9 @@ SplineSet
  233 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: G
-Encoding: 71 71 71
+Encoding: 71 71 40
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6087,8 +6133,9 @@ SplineSet
  1104 123 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: H
-Encoding: 72 72 72
+Encoding: 72 72 41
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6152,8 +6199,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: I
-Encoding: 73 73 73
+Encoding: 73 73 42
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6216,8 +6264,9 @@ SplineSet
  201 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: J
-Encoding: 74 74 74
+Encoding: 74 74 43
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6289,8 +6338,9 @@ SplineSet
  212 15 212 15 109 61 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: K
-Encoding: 75 75 75
+Encoding: 75 75 44
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6467,8 +6517,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: L
-Encoding: 76 76 76
+Encoding: 76 76 45
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6512,8 +6563,9 @@ SplineSet
  215 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: M
-Encoding: 77 77 77
+Encoding: 77 77 46
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6673,8 +6725,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: N
-Encoding: 78 78 78
+Encoding: 78 78 47
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6807,8 +6860,9 @@ SplineSet
  139 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: O
-Encoding: 79 79 79
+Encoding: 79 79 48
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6854,7 +6908,7 @@ AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-905 745 m 0,0,1
+905 745 m 256,0,1
  905 1074 905 1074 837.5 1215 c 128,-1,2
  770 1356 770 1356 616 1356 c 0,3,4
  463 1356 463 1356 395.5 1215 c 128,-1,5
@@ -6862,10 +6916,10 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,8
  463 135 463 135 616 135 c 0,9,10
  770 135 770 135 837.5 275.5 c 128,-1,11
- 905 416 905 416 905 745 c 0,0,1
+ 905 416 905 416 905 745 c 256,0,1
 1116 745 m 0,12,13
  1116 355 1116 355 992.5 163 c 128,-1,14
- 869 -29 869 -29 616 -29 c 0,15,16
+ 869 -29 869 -29 616 -29 c 256,15,16
  363 -29 363 -29 240 162 c 128,-1,17
  117 353 117 353 117 745 c 0,18,19
  117 1136 117 1136 240.5 1328 c 128,-1,20
@@ -6874,8 +6928,9 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: P
-Encoding: 80 80 80
+Encoding: 80 80 49
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6933,7 +6988,7 @@ SplineSet
  399 766 l 1,1,-1
  633 766 l 2,2,3
  773 766 773 766 851.5 840 c 128,-1,4
- 930 914 930 914 930 1047 c 0,5,6
+ 930 914 930 914 930 1047 c 256,5,6
  930 1180 930 1180 852 1253.5 c 128,-1,7
  774 1327 774 1327 633 1327 c 2,8,-1
  399 1327 l 1,0,-1
@@ -6949,8 +7004,9 @@ SplineSet
  197 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Q
-Encoding: 81 81 81
+Encoding: 81 81 50
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7036,7 +7092,7 @@ SplineSet
  1040 -170 l 1,16,-1
  889 -270 l 1,17,-1
  655 -27 l 1,0,1
-905 745 m 0,18,19
+905 745 m 256,18,19
  905 1074 905 1074 837.5 1215 c 128,-1,20
  770 1356 770 1356 616 1356 c 0,21,22
  463 1356 463 1356 395.5 1215 c 128,-1,23
@@ -7044,11 +7100,12 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,26
  463 135 463 135 616 135 c 0,27,28
  770 135 770 135 837.5 275.5 c 128,-1,29
- 905 416 905 416 905 745 c 0,18,19
+ 905 416 905 416 905 745 c 256,18,19
 EndSplineSet
 EndChar
+
 StartChar: R
-Encoding: 82 82 82
+Encoding: 82 82 51
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7192,8 +7249,9 @@ SplineSet
  346 1327 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: S
-Encoding: 83 83 83
+Encoding: 83 83 52
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7367,8 +7425,9 @@ SplineSet
  907 1481 907 1481 1012 1442 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: T
-Encoding: 84 84 84
+Encoding: 84 84 53
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7418,8 +7477,9 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: U
-Encoding: 85 85 85
+Encoding: 85 85 54
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7496,8 +7556,9 @@ SplineSet
  147 347 147 347 147 573 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: V
-Encoding: 86 86 86
+Encoding: 86 86 55
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7594,8 +7655,9 @@ SplineSet
  616 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: W
-Encoding: 87 87 87
+Encoding: 87 87 56
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7847,8 +7909,9 @@ SplineSet
  0 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: X
-Encoding: 88 88 88
+Encoding: 88 88 57
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8072,8 +8135,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Y
-Encoding: 89 89 89
+Encoding: 89 89 58
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8185,8 +8249,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Z
-Encoding: 90 90 90
+Encoding: 90 90 59
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8279,8 +8344,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketleft
-Encoding: 91 91 91
+Encoding: 91 91 60
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8329,8 +8395,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: backslash
-Encoding: 92 92 92
+Encoding: 92 92 61
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8369,8 +8436,9 @@ SplineSet
  293 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketright
-Encoding: 93 93 93
+Encoding: 93 93 62
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8419,8 +8487,9 @@ SplineSet
  770 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciicircum
-Encoding: 94 94 94
+Encoding: 94 94 63
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8462,8 +8531,9 @@ SplineSet
  705 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underscore
-Encoding: 95 95 95
+Encoding: 95 95 64
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8493,8 +8563,9 @@ SplineSet
  1233 -403 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: grave
-Encoding: 96 96 96
+Encoding: 96 96 65
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8544,8 +8615,9 @@ SplineSet
  477 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: a
-Encoding: 97 97 97
+Encoding: 97 97 66
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8701,8 +8773,9 @@ SplineSet
  1059 786 1059 786 1059 639 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: b
-Encoding: 98 98 98
+Encoding: 98 98 67
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8761,7 +8834,7 @@ AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-918 559 m 0,0,1
+918 559 m 256,0,1
  918 773 918 773 850 882 c 128,-1,2
  782 991 782 991 649 991 c 0,3,4
  515 991 515 991 446 881.5 c 128,-1,5
@@ -8769,7 +8842,7 @@ SplineSet
  377 347 377 347 446 237 c 128,-1,8
  515 127 515 127 649 127 c 0,9,10
  782 127 782 127 850 236 c 128,-1,11
- 918 345 918 345 918 559 c 0,0,1
+ 918 345 918 345 918 559 c 256,0,1
 377 977 m 1,12,13
  421 1059 421 1059 498.5 1103 c 128,-1,14
  576 1147 576 1147 678 1147 c 0,15,16
@@ -8786,8 +8859,9 @@ SplineSet
  377 977 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: c
-Encoding: 99 99 99
+Encoding: 99 99 68
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8849,7 +8923,7 @@ SplineSet
  987 14 987 14 908.5 -7.5 c 128,-1,2
  830 -29 830 -29 748 -29 c 0,3,4
  488 -29 488 -29 341.5 127 c 128,-1,5
- 195 283 195 283 195 559 c 0,6,7
+ 195 283 195 283 195 559 c 256,6,7
  195 835 195 835 341.5 991 c 128,-1,8
  488 1147 488 1147 748 1147 c 0,9,10
  829 1147 829 1147 906 1126 c 128,-1,11
@@ -8866,8 +8940,9 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: d
-Encoding: 100 100 100
+Encoding: 100 100 69
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8940,19 +9015,20 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,14,15
  660 1147 660 1147 737 1103.5 c 128,-1,16
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,17,18
+317 559 m 256,17,18
  317 345 317 345 385 236 c 128,-1,19
- 453 127 453 127 586 127 c 0,20,21
+ 453 127 453 127 586 127 c 256,20,21
  719 127 719 127 788.5 237 c 128,-1,22
  858 347 858 347 858 559 c 0,23,24
  858 772 858 772 788.5 881.5 c 128,-1,25
- 719 991 719 991 586 991 c 0,26,27
+ 719 991 719 991 586 991 c 256,26,27
  453 991 453 991 385 882 c 128,-1,28
- 317 773 317 773 317 559 c 0,17,18
+ 317 773 317 773 317 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: e
-Encoding: 101 101 101
+Encoding: 101 101 70
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9057,8 +9133,9 @@ SplineSet
  928 660 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: f
-Encoding: 102 102 102
+Encoding: 102 102 71
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9142,8 +9219,9 @@ SplineSet
  1063 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: g
-Encoding: 103 103 103
+Encoding: 103 103 72
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9230,7 +9308,7 @@ SplineSet
  858 776 858 776 790.5 883.5 c 128,-1,2
  723 991 723 991 594 991 c 0,3,4
  459 991 459 991 388 883.5 c 128,-1,5
- 317 776 317 776 317 569 c 0,6,7
+ 317 776 317 776 317 569 c 256,6,7
  317 362 317 362 388.5 253.5 c 128,-1,8
  460 145 460 145 596 145 c 0,9,10
  723 145 723 145 790.5 254 c 128,-1,11
@@ -9260,8 +9338,9 @@ SplineSet
  1042 72 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: h
-Encoding: 104 104 104
+Encoding: 104 104 73
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9335,8 +9414,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: i
-Encoding: 105 105 105
+Encoding: 105 105 74
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9411,8 +9491,9 @@ SplineSet
 EndSplineSet
 Substitution2: "Single Substitution - Dotless Form" dotlessi
 EndChar
+
 StartChar: j
-Encoding: 106 106 106
+Encoding: 106 106 75
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9499,8 +9580,9 @@ SplineSet
 EndSplineSet
 Substitution2: "Single Substitution - Dotless Form" dotlessj
 EndChar
+
 StartChar: k
-Encoding: 107 107 107
+Encoding: 107 107 76
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9723,8 +9805,9 @@ SplineSet
  236 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: l
-Encoding: 108 108 108
+Encoding: 108 108 77
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9788,8 +9871,9 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: m
-Encoding: 109 109 109
+Encoding: 109 109 78
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9991,8 +10075,9 @@ SplineSet
  648 1077 648 1077 676 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: n
-Encoding: 110 110 110
+Encoding: 110 110 79
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10066,8 +10151,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: o
-Encoding: 111 111 111
+Encoding: 111 111 80
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10122,7 +10208,7 @@ SplineSet
  901 346 901 346 901 559 c 0,9,10
  901 773 901 773 829 882 c 128,-1,11
  757 991 757 991 616 991 c 0,0,1
-616 1147 m 0,12,13
+616 1147 m 256,12,13
  849 1147 849 1147 972.5 996 c 128,-1,14
  1096 845 1096 845 1096 559 c 0,15,16
  1096 272 1096 272 973 121.5 c 128,-1,17
@@ -10130,11 +10216,12 @@ SplineSet
  383 -29 383 -29 260 121.5 c 128,-1,20
  137 272 137 272 137 559 c 0,21,22
  137 845 137 845 260 996 c 128,-1,23
- 383 1147 383 1147 616 1147 c 0,12,13
+ 383 1147 383 1147 616 1147 c 256,12,13
 EndSplineSet
 EndChar
+
 StartChar: p
-Encoding: 112 112 112
+Encoding: 112 112 81
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10210,7 +10297,7 @@ SplineSet
  876 -29 876 -29 674 -29 c 0,14,15
  572 -29 572 -29 495.5 14.5 c 128,-1,16
  419 58 419 58 375 141 c 1,0,-1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -10218,11 +10305,12 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: q
-Encoding: 113 113 113
+Encoding: 113 113 82
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10284,15 +10372,15 @@ AnchorPoint: "below" 616 -426 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-332 555 m 0,0,1
+332 555 m 256,0,1
  332 341 332 341 399.5 232 c 128,-1,2
- 467 123 467 123 600 123 c 0,3,4
+ 467 123 467 123 600 123 c 256,3,4
  733 123 733 123 801.5 232.5 c 128,-1,5
- 870 342 870 342 870 555 c 0,6,7
+ 870 342 870 342 870 555 c 256,6,7
  870 768 870 768 801.5 877.5 c 128,-1,8
- 733 987 733 987 600 987 c 0,9,10
+ 733 987 733 987 600 987 c 256,9,10
  467 987 467 987 399.5 878 c 128,-1,11
- 332 769 332 769 332 555 c 0,0,1
+ 332 769 332 769 332 555 c 256,0,1
 870 139 m 1,12,13
  825 56 825 56 748.5 11.5 c 128,-1,14
  672 -33 672 -33 571 -33 c 0,15,16
@@ -10309,8 +10397,9 @@ SplineSet
  870 139 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: r
-Encoding: 114 114 114
+Encoding: 114 114 83
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10417,8 +10506,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: s
-Encoding: 115 115 115
+Encoding: 115 115 84
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10577,8 +10667,9 @@ SplineSet
  893 1114 893 1114 973 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: t
-Encoding: 116 116 116
+Encoding: 116 116 85
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10659,8 +10750,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: u
-Encoding: 117 117 117
+Encoding: 117 117 86
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10734,8 +10826,9 @@ SplineSet
  195 196 195 196 195 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: v
-Encoding: 118 118 118
+Encoding: 118 118 87
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10857,8 +10950,9 @@ SplineSet
  100 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: w
-Encoding: 119 119 119
+Encoding: 119 119 88
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11158,8 +11252,9 @@ SplineSet
  0 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: x
-Encoding: 120 120 120
+Encoding: 120 120 89
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11354,8 +11449,9 @@ SplineSet
  1118 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: y
-Encoding: 121 121 121
+Encoding: 121 121 90
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11544,8 +11640,9 @@ SplineSet
  858 360 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: z
-Encoding: 122 122 122
+Encoding: 122 122 91
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11657,8 +11754,9 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceleft
-Encoding: 123 123 123
+Encoding: 123 123 92
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11800,8 +11898,9 @@ SplineSet
  1012 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bar
-Encoding: 124 124 124
+Encoding: 124 124 93
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11834,8 +11933,9 @@ SplineSet
  702 1565 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceright
-Encoding: 125 125 125
+Encoding: 125 125 94
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11981,8 +12081,9 @@ SplineSet
  221 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciitilde
-Encoding: 126 126 126
+Encoding: 126 126 95
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12049,14 +12150,16 @@ SplineSet
  1071 718 1071 718 1145 780 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: nonbreakingspace
-Encoding: 160 160 160
+Encoding: 160 160 96
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclamdown
-Encoding: 161 161 161
+Encoding: 161 161 97
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12112,8 +12215,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" exclamdown.case
 EndChar
+
 StartChar: cent
-Encoding: 162 162 162
+Encoding: 162 162 98
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12224,13 +12328,14 @@ SplineSet
 698 127 m 1,27,-1
  698 991 l 1,28,29
  566 979 566 979 486 861 c 128,-1,30
- 406 743 406 743 406 559 c 0,31,32
+ 406 743 406 743 406 559 c 256,31,32
  406 375 406 375 486 257.5 c 128,-1,33
  566 140 566 140 698 127 c 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: sterling
-Encoding: 163 163 163
+Encoding: 163 163 99
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12327,8 +12432,9 @@ SplineSet
  1019 1491 1019 1491 1092 1462 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: currency
-Encoding: 164 164 164
+Encoding: 164 164 100
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12504,8 +12610,9 @@ SplineSet
  793 954 793 954 844 924 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: yen
-Encoding: 165 165 165
+Encoding: 165 165 101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12668,8 +12775,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: brokenbar
-Encoding: 166 166 166
+Encoding: 166 166 102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12717,8 +12825,9 @@ SplineSet
  702 408 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: section
-Encoding: 167 167 167
+Encoding: 167 167 103
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12878,8 +12987,9 @@ SplineSet
  729 804 729 804 485 936 c 1,51,52
 EndSplineSet
 EndChar
+
 StartChar: dieresis
-Encoding: 168 168 168
+Encoding: 168 168 104
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12927,10 +13037,11 @@ SplineSet
  711 1350 l 1,7,-1
  711 1552 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: copyright
-Encoding: 169 169 169
+Encoding: 169 169 105
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13027,7 +13138,7 @@ SplineSet
  812 1094 812 1094 864 1071 c 1,0,-1
 616 1255 m 0,26,27
  510 1255 510 1255 419.5 1218 c 128,-1,28
- 329 1181 329 1181 254 1106 c 0,29,30
+ 329 1181 329 1181 254 1106 c 256,29,30
  179 1031 179 1031 140.5 939 c 128,-1,31
  102 847 102 847 102 741 c 0,32,33
  102 637 102 637 140.5 545.5 c 128,-1,34
@@ -13035,11 +13146,11 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,37
  511 227 511 227 616 227 c 0,38,39
  722 227 722 227 812.5 265 c 128,-1,40
- 903 303 903 303 979 379 c 0,41,42
+ 903 303 903 303 979 379 c 256,41,42
  1055 455 1055 455 1092.5 545.5 c 128,-1,43
  1130 636 1130 636 1130 741 c 0,44,45
  1130 847 1130 847 1092 939 c 128,-1,46
- 1054 1031 1054 1031 979 1106 c 0,47,48
+ 1054 1031 1054 1031 979 1106 c 256,47,48
  904 1181 904 1181 813.5 1218 c 128,-1,49
  723 1255 723 1255 616 1255 c 0,26,27
 616 1358 m 0,50,51
@@ -13048,11 +13159,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,55
  1233 867 1233 867 1233 741 c 0,56,57
  1233 616 1233 616 1187.5 507 c 128,-1,58
- 1142 398 1142 398 1051 307 c 0,59,60
+ 1142 398 1142 398 1051 307 c 256,59,60
  960 216 960 216 851 170.5 c 128,-1,61
  742 125 742 125 616 125 c 0,62,63
  491 125 491 125 382 170.5 c 128,-1,64
- 273 216 273 216 182 307 c 0,65,66
+ 273 216 273 216 182 307 c 256,65,66
  91 398 91 398 45.5 507 c 128,-1,67
  0 616 0 616 0 741 c 0,68,69
  0 867 0 867 46 977 c 128,-1,70
@@ -13061,8 +13172,9 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,50,51
 EndSplineSet
 EndChar
+
 StartChar: ordfeminine
-Encoding: 170 170 170
+Encoding: 170 170 106
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13207,8 +13319,9 @@ SplineSet
  293 592 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotleft
-Encoding: 171 171 171
+Encoding: 171 171 107
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13281,8 +13394,9 @@ SplineSet
  1042 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalnot
-Encoding: 172 172 172
+Encoding: 172 172 108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13323,8 +13437,9 @@ SplineSet
  88 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: sfthyphen
-Encoding: 173 173 173
+Encoding: 173 173 109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13356,8 +13471,9 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: registered
-Encoding: 174 174 174
+Encoding: 174 174 110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13529,11 +13645,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,34
  1233 867 1233 867 1233 741 c 0,35,36
  1233 616 1233 616 1187.5 507 c 128,-1,37
- 1142 398 1142 398 1051 307 c 0,38,39
+ 1142 398 1142 398 1051 307 c 256,38,39
  960 216 960 216 851 170.5 c 128,-1,40
  742 125 742 125 616 125 c 0,41,42
  491 125 491 125 382 170.5 c 128,-1,43
- 273 216 273 216 182 307 c 0,44,45
+ 273 216 273 216 182 307 c 256,44,45
  91 398 91 398 45.5 507 c 128,-1,46
  0 616 0 616 0 741 c 0,47,48
  0 867 0 867 46 977 c 128,-1,49
@@ -13542,7 +13658,7 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,29,30
 616 1255 m 0,53,54
  510 1255 510 1255 419.5 1218 c 128,-1,55
- 329 1181 329 1181 254 1106 c 0,56,57
+ 329 1181 329 1181 254 1106 c 256,56,57
  179 1031 179 1031 140.5 939 c 128,-1,58
  102 847 102 847 102 741 c 0,59,60
  102 637 102 637 140.5 545.5 c 128,-1,61
@@ -13550,17 +13666,18 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,64
  511 227 511 227 616 227 c 0,65,66
  722 227 722 227 812.5 265 c 128,-1,67
- 903 303 903 303 979 379 c 0,68,69
+ 903 303 903 303 979 379 c 256,68,69
  1055 455 1055 455 1092.5 545.5 c 128,-1,70
  1130 636 1130 636 1130 741 c 0,71,72
  1130 847 1130 847 1092 939 c 128,-1,73
- 1054 1031 1054 1031 979 1106 c 0,74,75
+ 1054 1031 1054 1031 979 1106 c 256,74,75
  904 1181 904 1181 813.5 1218 c 128,-1,76
  723 1255 723 1255 616 1255 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: macron
-Encoding: 175 175 175
+Encoding: 175 175 111
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13591,10 +13708,11 @@ SplineSet
  317 1378 l 1,3,-1
  317 1526 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: degree
-Encoding: 176 176 176
+Encoding: 176 176 112
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13645,19 +13763,20 @@ SplineSet
  299 1065 299 1065 299 1200 c 0,12,13
  299 1334 299 1334 391 1427 c 128,-1,14
  483 1520 483 1520 616 1520 c 0,0,1
-616 1391 m 0,15,16
+616 1391 m 256,15,16
  537 1391 537 1391 481.5 1335.5 c 128,-1,17
- 426 1280 426 1280 426 1200 c 0,18,19
+ 426 1280 426 1280 426 1200 c 256,18,19
  426 1120 426 1120 480.5 1066 c 128,-1,20
  535 1012 535 1012 614 1012 c 0,21,22
  694 1012 694 1012 750.5 1067 c 128,-1,23
  807 1122 807 1122 807 1200 c 0,24,25
  807 1279 807 1279 751 1335 c 128,-1,26
- 695 1391 695 1391 616 1391 c 0,15,16
+ 695 1391 695 1391 616 1391 c 256,15,16
 EndSplineSet
 EndChar
+
 StartChar: plusminus
-Encoding: 177 177 177
+Encoding: 177 177 113
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13731,8 +13850,9 @@ SplineSet
  700 1171 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: twosuperior
-Encoding: 178 178 178
+Encoding: 178 178 114
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13850,8 +13970,9 @@ SplineSet
  483 782 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: threesuperior
-Encoding: 179 179 179
+Encoding: 179 179 115
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13963,8 +14084,9 @@ SplineSet
  815 1139 815 1139 731 1120 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: acute
-Encoding: 180 180 180
+Encoding: 180 180 116
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14013,10 +14135,11 @@ SplineSet
  475 1262 l 1,3,-1
  756 1638 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: mu
-Encoding: 181 181 181
+Encoding: 181 181 117
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14128,8 +14251,9 @@ SplineSet
  195 -428 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: paragraph
-Encoding: 182 182 182
+Encoding: 182 182 118
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14187,8 +14311,9 @@ SplineSet
  367 1493 367 1493 582 1493 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: periodcentered
-Encoding: 183 183 183
+Encoding: 183 183 119
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14222,17 +14347,19 @@ SplineSet
  489 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: cedilla
-Encoding: 184 184 184
+Encoding: 184 184 120
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: onesuperior
-Encoding: 185 185 185
+Encoding: 185 185 121
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14300,8 +14427,9 @@ SplineSet
  362 778 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ordmasculine
-Encoding: 186 186 186
+Encoding: 186 186 122
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14362,7 +14490,7 @@ Fore
 SplineSet
 616 1403 m 0,0,1
  514 1403 514 1403 456.5 1325 c 128,-1,2
- 399 1247 399 1247 399 1108 c 0,3,4
+ 399 1247 399 1247 399 1108 c 256,3,4
  399 969 399 969 456.5 892 c 128,-1,5
  514 815 514 815 616 815 c 0,6,7
  717 815 717 815 775.5 893.5 c 128,-1,8
@@ -14385,8 +14513,9 @@ SplineSet
  276 592 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotright
-Encoding: 187 187 187
+Encoding: 187 187 123
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14459,41 +14588,45 @@ SplineSet
  193 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: onequarter
-Encoding: 188 188 188
+Encoding: 188 188 124
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: onehalf
-Encoding: 189 189 189
+Encoding: 189 189 125
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 201 -938 2
-LCarets2: 2 0 0 
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 201 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: threequarters
-Encoding: 190 190 190
+Encoding: 190 190 126
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 179 179 N 1 0 0 1 -227 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 115 179 N 1 0 0 1 -227 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: questiondown
-Encoding: 191 191 191
+Encoding: 191 191 127
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14664,8 +14797,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" questiondown.case
 EndChar
+
 StartChar: Agrave
-Encoding: 192 192 192
+Encoding: 192 192 128
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14681,12 +14815,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aacute
-Encoding: 193 193 193
+Encoding: 193 193 129
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14702,12 +14837,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Acircumflex
-Encoding: 194 194 194
+Encoding: 194 194 130
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14736,12 +14872,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Atilde
-Encoding: 195 195 195
+Encoding: 195 195 131
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14766,12 +14903,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Adieresis
-Encoding: 196 196 196
+Encoding: 196 196 132
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14808,12 +14946,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aring
-Encoding: 197 197 197
+Encoding: 197 197 133
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15016,15 +15155,15 @@ AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-768 1626 m 0,0,1
+768 1626 m 256,0,1
  768 1689 768 1689 723.5 1733.5 c 128,-1,2
  679 1778 679 1778 616 1778 c 0,3,4
  552 1778 552 1778 508.5 1734.5 c 128,-1,5
  465 1691 465 1691 465 1626 c 0,6,7
  465 1563 465 1563 509 1519 c 128,-1,8
- 553 1475 553 1475 616 1475 c 0,9,10
+ 553 1475 553 1475 616 1475 c 256,9,10
  679 1475 679 1475 723.5 1519 c 128,-1,11
- 768 1563 768 1563 768 1626 c 0,0,1
+ 768 1563 768 1563 768 1626 c 256,0,1
 616 1311 m 1,12,-1
  403 551 l 1,13,-1
  829 551 l 1,14,-1
@@ -15033,7 +15172,7 @@ SplineSet
  407 1432 407 1432 374.5 1492.5 c 128,-1,17
  342 1553 342 1553 342 1626 c 0,18,19
  342 1740 342 1740 422 1820.5 c 128,-1,20
- 502 1901 502 1901 616 1901 c 0,21,22
+ 502 1901 502 1901 616 1901 c 256,21,22
  730 1901 730 1901 810.5 1820.5 c 128,-1,23
  891 1740 891 1740 891 1626 c 0,24,25
  891 1553 891 1553 859 1494 c 128,-1,26
@@ -15046,10 +15185,11 @@ SplineSet
  37 0 l 1,33,-1
  465 1399 l 1,15,16
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: AE
-Encoding: 198 198 198
+Encoding: 198 198 134
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15186,91 +15326,99 @@ SplineSet
  530 1323 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: Ccedilla
-Encoding: 199 199 199
+Encoding: 199 199 135
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Egrave
-Encoding: 200 200 200
+Encoding: 200 200 136
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eacute
-Encoding: 201 201 201
+Encoding: 201 201 137
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ecircumflex
-Encoding: 202 202 202
+Encoding: 202 202 138
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Edieresis
-Encoding: 203 203 203
+Encoding: 203 203 139
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Igrave
-Encoding: 204 204 204
+Encoding: 204 204 140
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Iacute
-Encoding: 205 205 205
+Encoding: 205 205 141
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Icircumflex
-Encoding: 206 206 206
+Encoding: 206 206 142
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15290,12 +15438,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Idieresis
-Encoding: 207 207 207
+Encoding: 207 207 143
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15312,12 +15461,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eth
-Encoding: 208 208 208
+Encoding: 208 208 144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15413,8 +15563,9 @@ SplineSet
  436 166 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: Ntilde
-Encoding: 209 209 209
+Encoding: 209 209 145
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15439,12 +15590,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 377 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 377 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ograve
-Encoding: 210 210 210
+Encoding: 210 210 146
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15460,12 +15612,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Oacute
-Encoding: 211 211 211
+Encoding: 211 211 147
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15481,12 +15634,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ocircumflex
-Encoding: 212 212 212
+Encoding: 212 212 148
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15515,12 +15669,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Otilde
-Encoding: 213 213 213
+Encoding: 213 213 149
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15545,12 +15700,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Odieresis
-Encoding: 214 214 214
+Encoding: 214 214 150
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15587,12 +15743,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: multiply
-Encoding: 215 215 215
+Encoding: 215 215 151
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15661,8 +15818,9 @@ SplineSet
  150 293 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Oslash
-Encoding: 216 216 216
+Encoding: 216 216 152
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15817,8 +15975,9 @@ SplineSet
  1032 1247 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: Ugrave
-Encoding: 217 217 217
+Encoding: 217 217 153
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15834,12 +15993,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uacute
-Encoding: 218 218 218
+Encoding: 218 218 154
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15855,12 +16015,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ucircumflex
-Encoding: 219 219 219
+Encoding: 219 219 155
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15889,12 +16050,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Udieresis
-Encoding: 220 220 220
+Encoding: 220 220 156
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15931,12 +16093,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Yacute
-Encoding: 221 221 221
+Encoding: 221 221 157
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15952,12 +16115,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Thorn
-Encoding: 222 222 222
+Encoding: 222 222 158
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16023,7 +16187,7 @@ SplineSet
  403 532 l 1,1,-1
  637 532 l 2,2,3
  795 532 795 532 873.5 598 c 128,-1,4
- 952 664 952 664 952 795 c 0,5,6
+ 952 664 952 664 952 795 c 256,5,6
  952 926 952 926 873.5 991.5 c 128,-1,7
  795 1057 795 1057 637 1057 c 2,8,-1
  403 1057 l 1,0,-1
@@ -16041,8 +16205,9 @@ SplineSet
  201 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: germandbls
-Encoding: 223 223 223
+Encoding: 223 223 159
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16176,80 +16341,87 @@ SplineSet
  188 1137 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: agrave
-Encoding: 224 224 224
+Encoding: 224 224 160
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aacute
-Encoding: 225 225 225
+Encoding: 225 225 161
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: acircumflex
-Encoding: 226 226 226
+Encoding: 226 226 162
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: atilde
-Encoding: 227 227 227
+Encoding: 227 227 163
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: adieresis
-Encoding: 228 228 228
+Encoding: 228 228 164
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aring
-Encoding: 229 229 229
+Encoding: 229 229 165
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ae
-Encoding: 230 230 230
+Encoding: 230 230 166
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16414,7 +16586,7 @@ SplineSet
 1036 657 m 1,11,-1
  1036 709 l 2,12,13
  1036 860 1036 860 997.5 926.5 c 128,-1,14
- 959 993 959 993 872 993 c 0,15,16
+ 959 993 959 993 872 993 c 256,15,16
  785 993 785 993 747 925 c 128,-1,17
  709 857 709 857 709 700 c 2,18,-1
  709 657 l 1,19,-1
@@ -16456,55 +16628,60 @@ SplineSet
  1200 514 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: ccedilla
-Encoding: 231 231 231
+Encoding: 231 231 167
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: egrave
-Encoding: 232 232 232
+Encoding: 232 232 168
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eacute
-Encoding: 233 233 233
+Encoding: 233 233 169
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecircumflex
-Encoding: 234 234 234
+Encoding: 234 234 170
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: edieresis
-Encoding: 235 235 235
+Encoding: 235 235 171
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16520,36 +16697,39 @@ AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: igrave
-Encoding: 236 236 236
+Encoding: 236 236 172
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: iacute
-Encoding: 237 237 237
+Encoding: 237 237 173
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: icircumflex
-Encoding: 238 238 238
+Encoding: 238 238 174
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16567,12 +16747,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: idieresis
-Encoding: 239 239 239
+Encoding: 239 239 175
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16589,12 +16770,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 24 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 24 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eth
-Encoding: 240 240 240
+Encoding: 240 240 176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16778,44 +16960,48 @@ SplineSet
  843 848 843 848 793 918 c 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: ntilde
-Encoding: 241 241 241
+Encoding: 241 241 177
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ograve
-Encoding: 242 242 242
+Encoding: 242 242 178
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: oacute
-Encoding: 243 243 243
+Encoding: 243 243 179
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ocircumflex
-Encoding: 244 244 244
+Encoding: 244 244 180
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16840,12 +17026,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: otilde
-Encoding: 245 245 245
+Encoding: 245 245 181
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16878,12 +17065,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: odieresis
-Encoding: 246 246 246
+Encoding: 246 246 182
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16916,12 +17104,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: divide
-Encoding: 247 247 247
+Encoding: 247 247 183
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16985,8 +17174,9 @@ SplineSet
  88 727 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: oslash
-Encoding: 248 248 248
+Encoding: 248 248 184
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17149,32 +17339,35 @@ SplineSet
  217 180 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: ugrave
-Encoding: 249 249 249
+Encoding: 249 249 185
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uacute
-Encoding: 250 250 250
+Encoding: 250 250 186
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ucircumflex
-Encoding: 251 251 251
+Encoding: 251 251 187
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17199,12 +17392,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: udieresis
-Encoding: 252 252 252
+Encoding: 252 252 188
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17237,24 +17431,26 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: yacute
-Encoding: 253 253 253
+Encoding: 253 253 189
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: thorn
-Encoding: 254 254 254
+Encoding: 254 254 190
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17330,7 +17526,7 @@ SplineSet
  876 -29 876 -29 674 -29 c 0,14,15
  572 -29 572 -29 495.5 14.5 c 128,-1,16
  419 58 419 58 375 141 c 1,0,-1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -17338,23 +17534,25 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: ydieresis
-Encoding: 255 255 255
+Encoding: 255 255 191
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Amacron
-Encoding: 256 256 256
+Encoding: 256 256 192
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17382,19 +17580,21 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: amacron
-Encoding: 257 257 257
+Encoding: 257 257 193
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Abreve
-Encoding: 258 258 258
+Encoding: 258 258 194
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17427,142 +17627,155 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: abreve
-Encoding: 259 259 259
+Encoding: 259 259 195
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Aogonek
-Encoding: 260 260 260
+Encoding: 260 260 196
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 455 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 455 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aogonek
-Encoding: 261 261 261
+Encoding: 261 261 197
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 345 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 345 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cacute
-Encoding: 262 262 262
+Encoding: 262 262 198
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: cacute
-Encoding: 263 263 263
+Encoding: 263 263 199
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ccircumflex
-Encoding: 264 264 264
+Encoding: 264 264 200
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 126.5 380 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 126.5 380 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ccircumflex
-Encoding: 265 265 265
+Encoding: 265 265 201
 Width: 1233
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 90 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 90 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cdotaccent
-Encoding: 266 266 266
+Encoding: 266 266 202
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 75 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 75 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: cdotaccent
-Encoding: 267 267 267
+Encoding: 267 267 203
 Width: 1233
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 75 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 75 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ccaron
-Encoding: 268 268 268
+Encoding: 268 268 204
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 90 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 90 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ccaron
-Encoding: 269 269 269
+Encoding: 269 269 205
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcaron
-Encoding: 270 270 270
+Encoding: 270 270 206
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -78 367 2
-LCarets2: 1 0 
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 -78 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dcaron
-Encoding: 271 271 271
+Encoding: 271 271 207
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17582,12 +17795,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 570 -81 2
-Refer: 100 100 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 570 -81 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcroat
-Encoding: 272 272 272
+Encoding: 272 272 208
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -17595,10 +17809,11 @@ AnchorPoint: "above" 566 1493 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dcroat
-Encoding: 273 273 273
+Encoding: 273 273 209
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17702,208 +17917,227 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,22,23
  660 1147 660 1147 737 1103.5 c 128,-1,24
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,25,26
+317 559 m 256,25,26
  317 345 317 345 385 236 c 128,-1,27
- 453 127 453 127 586 127 c 0,28,29
+ 453 127 453 127 586 127 c 256,28,29
  719 127 719 127 788.5 237 c 128,-1,30
  858 347 858 347 858 559 c 0,31,32
  858 772 858 772 788.5 881.5 c 128,-1,33
- 719 991 719 991 586 991 c 0,34,35
+ 719 991 719 991 586 991 c 256,34,35
  453 991 453 991 385 882 c 128,-1,36
- 317 773 317 773 317 559 c 0,25,26
+ 317 773 317 773 317 559 c 256,25,26
 EndSplineSet
 EndChar
+
 StartChar: Emacron
-Encoding: 274 274 274
+Encoding: 274 274 210
 Width: 1233
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: emacron
-Encoding: 275 275 275
+Encoding: 275 275 211
 Width: 1233
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 35 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 35 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ebreve
-Encoding: 276 276 276
+Encoding: 276 276 212
 Width: 1233
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ebreve
-Encoding: 277 277 277
+Encoding: 277 277 213
 Width: 1233
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Edotaccent
-Encoding: 278 278 278
+Encoding: 278 278 214
 Width: 1233
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: edotaccent
-Encoding: 279 279 279
+Encoding: 279 279 215
 Width: 1233
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eogonek
-Encoding: 280 280 280
+Encoding: 280 280 216
 Width: 1233
 Flags: W
 AnchorPoint: "above" 634 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 305 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 305 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eogonek
-Encoding: 281 281 281
+Encoding: 281 281 217
 Width: 1233
 Flags: W
 AnchorPoint: "above" 630 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 246 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 246 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ecaron
-Encoding: 282 282 282
+Encoding: 282 282 218
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 36 367 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 36 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecaron
-Encoding: 283 283 283
+Encoding: 283 283 219
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 35 -5 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 35 -5 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gcircumflex
-Encoding: 284 284 284
+Encoding: 284 284 220
 Width: 1233
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcircumflex
-Encoding: 285 285 285
+Encoding: 285 285 221
 Width: 1233
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gbreve
-Encoding: 286 286 286
+Encoding: 286 286 222
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3735 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: gbreve
-Encoding: 287 287 287
+Encoding: 287 287 223
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gdotaccent
-Encoding: 288 288 288
+Encoding: 288 288 224
 Width: 1233
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gdotaccent
-Encoding: 289 289 289
+Encoding: 289 289 225
 Width: 1233
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcommaaccent
-Encoding: 290 290 290
+Encoding: 290 290 226
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 127.5 -31 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 127.5 -31 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcommaaccent
-Encoding: 291 291 291
+Encoding: 291 291 227
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 786 786 N 1 0 0 1 17 302 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 673 786 N 1 0 0 1 17 302 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hcircumflex
-Encoding: 292 292 292
+Encoding: 292 292 228
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17931,11 +18165,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 994 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hcircumflex
-Encoding: 293 293 293
+Encoding: 293 293 229
 Width: 1233
 TtInstrs:
 SVTCA[y-axis]
@@ -17965,11 +18200,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hbar
-Encoding: 294 294 294
+Encoding: 294 294 230
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18071,8 +18307,9 @@ SplineSet
  339 1105 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: hbar
-Encoding: 295 295 295
+Encoding: 295 295 231
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18173,8 +18410,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Itilde
-Encoding: 296 296 296
+Encoding: 296 296 232
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18206,21 +18444,23 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: itilde
-Encoding: 297 297 297
+Encoding: 297 297 233
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Imacron
-Encoding: 298 298 298
+Encoding: 298 298 234
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18244,21 +18484,23 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: imacron
-Encoding: 299 299 299
+Encoding: 299 299 235
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ibreve
-Encoding: 300 300 300
+Encoding: 300 300 236
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18282,52 +18524,57 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ibreve
-Encoding: 301 301 301
+Encoding: 301 301 237
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iogonek
-Encoding: 302 302 302
+Encoding: 302 302 238
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 70 -0.000325203 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 70 -0.000325203 2
 EndChar
+
 StartChar: iogonek
-Encoding: 303 303 303
+Encoding: 303 303 239
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 80.0029 0.0016284 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 80.0029 0.0016284 2
 EndChar
+
 StartChar: Idotaccent
-Encoding: 304 304 304
+Encoding: 304 304 240
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotlessi
-Encoding: 305 305 305
+Encoding: 305 305 241
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18385,8 +18632,9 @@ SplineSet
  256 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: IJ
-Encoding: 306 306 306
+Encoding: 306 306 242
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18459,16 +18707,16 @@ SplineSet
  651.6 300 l 1,1,2
  713.48 219 713.48 219 779.44 178.5 c 128,-1,3
  845.4 138 845.4 138 916.12 138 c 0,4,5
- 1013.36 138 1013.36 138 1051.78 212.5 c 0,6,7
+ 1013.36 138 1013.36 138 1051.78 212.5 c 256,6,7
  1090.2 287 1090.2 287 1090.2 490 c 2,8,-1
  1090.2 1326 l 1,9,-1
  831.12 1326 l 1,10,-1
  831.12 1496 l 1,11,-1
  1227.56 1496 l 1,12,-1
  1227.56 490 l 2,13,14
- 1227.56 208 1227.56 208 1155.82 91 c 0,15,16
+ 1227.56 208 1227.56 208 1155.82 91 c 256,15,16
  1084.08 -26 1084.08 -26 916.12 -26 c 0,17,18
- 850.84 -26 850.84 -26 786.24 -4 c 0,19,20
+ 850.84 -26 850.84 -26 786.24 -4 c 256,19,20
  721.64 18 721.64 18 651.6 64 c 1,0,-1
 -1 1493 m 1,21,-1
  604.17 1493 l 1,22,-1
@@ -18484,10 +18732,11 @@ SplineSet
  -1 1323 l 1,32,-1
  -1 1493 l 1,21,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ij
-Encoding: 307 307 307
+Encoding: 307 307 243
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18603,51 +18852,56 @@ SplineSet
  294.42 1323 l 1,31,-1
  294.42 1556 l 1,28,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: Jcircumflex
-Encoding: 308 308 308
+Encoding: 308 308 244
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 48 373 2
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 48 373 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: jcircumflex
-Encoding: 309 309 309
+Encoding: 309 309 245
 Width: 1233
 AnchorPoint: "cedilla" 441 -423 basechar 0
 AnchorPoint: "below" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 493 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kcommaaccent
-Encoding: 310 310 310
+Encoding: 310 310 246
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 106.5 -2 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 106.5 -2 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kcommaaccent
-Encoding: 311 311 311
+Encoding: 311 311 247
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 144.5 -2 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 144.5 -2 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kgreenlandic
-Encoding: 312 312 312
+Encoding: 312 312 248
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18869,8 +19123,9 @@ SplineSet
  236 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Lacute
-Encoding: 313 313 313
+Encoding: 313 313 249
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18886,12 +19141,13 @@ AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -275 374 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -275 374 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lacute
-Encoding: 314 314 314
+Encoding: 314 314 250
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18922,68 +19178,74 @@ AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -95 374 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -95 374 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lcommaaccent
-Encoding: 315 315 315
+Encoding: 315 315 251
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 102.5 -2 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 102.5 -2 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lcommaaccent
-Encoding: 316 316 316
+Encoding: 316 316 252
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -5 -2 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 -5 -2 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lcaron
-Encoding: 317 317 317
+Encoding: 317 317 253
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 174 -147 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 174 -147 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lcaron
-Encoding: 318 318 318
+Encoding: 318 318 254
 Width: 1233
 Flags: W
 AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 416 -71 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 416 -71 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ldot
-Encoding: 319 319 319
+Encoding: 319 319 255
 Width: 1233
 AnchorPoint: "above" 666 1493 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 352 133.5 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 352 133.5 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ldot
-Encoding: 320 320 320
+Encoding: 320 320 256
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
@@ -18991,12 +19253,13 @@ AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 471 144 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 471 144 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lslash
-Encoding: 321 321 321
+Encoding: 321 321 257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19079,8 +19342,9 @@ SplineSet
  215 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lslash
-Encoding: 322 322 322
+Encoding: 322 322 258
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19176,86 +19440,94 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: Nacute
-Encoding: 323 323 323
+Encoding: 323 323 259
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 33 373 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 33 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nacute
-Encoding: 324 324 324
+Encoding: 324 324 260
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 20.5 7 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 20.5 7 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncommaaccent
-Encoding: 325 325 325
+Encoding: 325 325 261
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 42 -2 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 42 -2 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ncommaaccent
-Encoding: 326 326 326
+Encoding: 326 326 262
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 48.5 -2 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 48.5 -2 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncaron
-Encoding: 327 327 327
+Encoding: 327 327 263
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 42 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 42 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ncaron
-Encoding: 328 328 328
+Encoding: 328 328 264
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 -12 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 -12 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: napostrophe
-Encoding: 329 329 329
+Encoding: 329 329 265
 Width: 1233
 Flags: W
 AnchorPoint: "below" 739 0 basechar 0
 AnchorPoint: "cedilla" 1081 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 123 0 2
-Refer: 700 700 N 1 0 0 1 -439 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 123 0 2
+Refer: 616 700 N 1 0 0 1 -439 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eng
-Encoding: 330 330 330
+Encoding: 330 330 266
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19342,8 +19614,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Latin lookup 0-1" Eng.alt
 EndChar
+
 StartChar: eng
-Encoding: 331 331 331
+Encoding: 331 331 267
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19429,8 +19702,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omacron
-Encoding: 332 332 332
+Encoding: 332 332 268
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19458,11 +19732,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omacron
-Encoding: 333 333 333
+Encoding: 333 333 269
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19478,11 +19753,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Obreve
-Encoding: 334 334 334
+Encoding: 334 334 270
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19506,11 +19782,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: obreve
-Encoding: 335 335 335
+Encoding: 335 335 271
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19534,31 +19811,34 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ohungarumlaut
-Encoding: 336 336 336
+Encoding: 336 336 272
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ohungarumlaut
-Encoding: 337 337 337
+Encoding: 337 337 273
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: OE
-Encoding: 338 338 338
+Encoding: 338 338 274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19653,8 +19933,9 @@ SplineSet
  590 1323 l 2,17,18
 EndSplineSet
 EndChar
+
 StartChar: oe
-Encoding: 339 339 339
+Encoding: 339 339 275
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19784,7 +20065,7 @@ SplineSet
  557 821 557 821 517 908 c 128,-1,16
  477 995 477 995 373 995 c 0,17,18
  270 995 270 995 230 911.5 c 128,-1,19
- 190 828 190 828 190 559 c 0,20,21
+ 190 828 190 828 190 559 c 256,20,21
  190 290 190 290 230 206.5 c 128,-1,22
  270 123 270 123 373 123 c 0,11,12
 1210 514 m 1,23,-1
@@ -19802,7 +20083,7 @@ SplineSet
  585 36 585 36 521 3.5 c 128,-1,40
  457 -29 457 -29 373 -29 c 0,41,42
  184 -29 184 -29 99 109 c 128,-1,43
- 14 247 14 247 14 559 c 0,44,45
+ 14 247 14 247 14 559 c 256,44,45
  14 871 14 871 99 1009 c 128,-1,46
  184 1147 184 1147 373 1147 c 0,47,48
  462 1147 462 1147 526 1116 c 128,-1,49
@@ -19814,63 +20095,69 @@ SplineSet
  1210 514 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: Racute
-Encoding: 340 340 340
+Encoding: 340 340 276
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -75 373 2
-Refer: 82 82 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -75 373 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: racute
-Encoding: 341 341 341
+Encoding: 341 341 277
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 454 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 206 7 2
-Refer: 114 114 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 116 180 N 1 0 0 1 206 7 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Rcommaaccent
-Encoding: 342 342 342
+Encoding: 342 342 278
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 113.5 -2 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 113.5 -2 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: rcommaaccent
-Encoding: 343 343 343
+Encoding: 343 343 279
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -120 -2 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 -120 -2 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rcaron
-Encoding: 344 344 344
+Encoding: 344 344 280
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -60 367 2
-LCarets2: 1 0 
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 -60 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: rcaron
-Encoding: 345 345 345
+Encoding: 345 345 281
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -19878,120 +20165,131 @@ AnchorPoint: "above" 616 1120 basechar 0
 AnchorPoint: "cedilla" 454 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Sacute
-Encoding: 346 346 346
+Encoding: 346 346 282
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 25 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 25 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: sacute
-Encoding: 347 347 347
+Encoding: 347 347 283
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 26.5 7 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 26.5 7 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scircumflex
-Encoding: 348 348 348
+Encoding: 348 348 284
 Width: 1233
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scircumflex
-Encoding: 349 349 349
+Encoding: 349 349 285
 Width: 1233
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scedilla
-Encoding: 350 350 350
+Encoding: 350 350 286
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scedilla
-Encoding: 351 351 351
+Encoding: 351 351 287
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Scaron
-Encoding: 352 352 352
+Encoding: 352 352 288
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scaron
-Encoding: 353 353 353
+Encoding: 353 353 289
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tcommaaccent
-Encoding: 354 354 354
+Encoding: 354 354 290
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tcommaaccent
-Encoding: 355 355 355
+Encoding: 355 355 291
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 121 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 121 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Tcaron
-Encoding: 356 356 356
+Encoding: 356 356 292
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20008,24 +20306,26 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 6 373 2
-LCarets2: 1 0 
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 6 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: tcaron
-Encoding: 357 357 357
+Encoding: 357 357 293
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114113 -1 N 1 0 0 1 276 24 2
-LCarets2: 1 0 
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3726 -1 N 1 0 0 1 276 24 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tbar
-Encoding: 358 358 358
+Encoding: 358 358 294
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20100,8 +20400,9 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tbar
-Encoding: 359 359 359
+Encoding: 359 359 295
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20207,8 +20508,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Utilde
-Encoding: 360 360 360
+Encoding: 360 360 296
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20233,11 +20535,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: utilde
-Encoding: 361 361 361
+Encoding: 361 361 297
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20261,11 +20564,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Umacron
-Encoding: 362 362 362
+Encoding: 362 362 298
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20294,11 +20598,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: umacron
-Encoding: 363 363 363
+Encoding: 363 363 299
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20315,11 +20620,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ubreve
-Encoding: 364 364 364
+Encoding: 364 364 300
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20343,11 +20649,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ubreve
-Encoding: 365 365 365
+Encoding: 365 365 301
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20371,75 +20678,82 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uring
-Encoding: 366 366 366
+Encoding: 366 366 302
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 10 103 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 10 103 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uring
-Encoding: 367 367 367
+Encoding: 367 367 303
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 15 -45 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 15 -45 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uhungarumlaut
-Encoding: 368 368 368
+Encoding: 368 368 304
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uhungarumlaut
-Encoding: 369 369 369
+Encoding: 369 369 305
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uogonek
-Encoding: 370 370 370
+Encoding: 370 370 306
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
 EndChar
+
 StartChar: uogonek
-Encoding: 371 371 371
+Encoding: 371 371 307
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 407 0.166702 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 407 0.166702 2
 EndChar
+
 StartChar: Wcircumflex
-Encoding: 372 372 372
+Encoding: 372 372 308
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20456,11 +20770,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 915 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wcircumflex
-Encoding: 373 373 373
+Encoding: 373 373 309
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20477,11 +20792,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 883 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ycircumflex
-Encoding: 374 374 374
+Encoding: 374 374 310
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20498,22 +20814,24 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ycircumflex
-Encoding: 375 375 375
+Encoding: 375 375 311
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 12 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 12 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ydieresis
-Encoding: 376 376 376
+Encoding: 376 376 312
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20530,80 +20848,87 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Zacute
-Encoding: 377 377 377
+Encoding: 377 377 313
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 27 373 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 27 373 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zacute
-Encoding: 378 378 378
+Encoding: 378 378 314
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 86 7 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 86 7 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zdotaccent
-Encoding: 379 379 379
+Encoding: 379 379 315
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 666 0 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zdotaccent
-Encoding: 380 380 380
+Encoding: 380 380 316
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zcaron
-Encoding: 381 381 381
+Encoding: 381 381 317
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 666 0 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: zcaron
-Encoding: 382 382 382
+Encoding: 382 382 318
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: longs
-Encoding: 383 383 383
+Encoding: 383 383 319
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20675,8 +21000,9 @@ SplineSet
  678 1322 678 1322 678.005 1219 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0180
-Encoding: 384 384 384
+Encoding: 384 384 320
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20720,8 +21046,9 @@ SplineSet
  918 345 918 345 918 559 c 128,-1,28
 EndSplineSet
 EndChar
+
 StartChar: uni0181
-Encoding: 385 385 385
+Encoding: 385 385 321
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20832,8 +21159,9 @@ SplineSet
  189 1493 189 1493 338 1493 c 2,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0182
-Encoding: 386 386 386
+Encoding: 386 386 322
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20841,10 +21169,11 @@ AnchorPoint: "above" 616 1493 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1041 1041 N 1 0 0 1 0 0 2
+Refer: 855 1041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0183
-Encoding: 387 387 387
+Encoding: 387 387 323
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20880,8 +21209,9 @@ SplineSet
  918 345 918 345 918 559 c 128,-1,20
 EndSplineSet
 EndChar
+
 StartChar: uni0184
-Encoding: 388 388 388
+Encoding: 388 388 324
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -20911,8 +21241,9 @@ SplineSet
  417 877 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0185
-Encoding: 389 389 389
+Encoding: 389 389 325
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -20947,8 +21278,9 @@ SplineSet
  438 977 l 1,13,14
 EndSplineSet
 EndChar
+
 StartChar: uni0186
-Encoding: 390 390 390
+Encoding: 390 390 326
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21027,8 +21359,9 @@ SplineSet
  139 1438 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0187
-Encoding: 391 391 391
+Encoding: 391 391 327
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -21063,8 +21396,9 @@ SplineSet
  994 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0188
-Encoding: 392 392 392
+Encoding: 392 392 328
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -21099,8 +21433,9 @@ SplineSet
  960 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0189
-Encoding: 393 393 393
+Encoding: 393 393 329
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -21108,10 +21443,11 @@ AnchorPoint: "above" 566 1493 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni018A
-Encoding: 394 394 394
+Encoding: 394 394 330
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -21145,8 +21481,9 @@ SplineSet
  555 166 l 2,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni018B
-Encoding: 395 395 395
+Encoding: 395 395 331
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21177,8 +21514,9 @@ SplineSet
  200 1327 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018C
-Encoding: 396 396 396
+Encoding: 396 396 332
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -21214,8 +21552,9 @@ SplineSet
  324 1372 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018D
-Encoding: 397 397 397
+Encoding: 397 397 333
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -21261,8 +21600,9 @@ SplineSet
  941 84 941 84 898 51.4697 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni018E
-Encoding: 398 398 398
+Encoding: 398 398 334
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21331,8 +21671,9 @@ SplineSet
  1102 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018F
-Encoding: 399 399 399
+Encoding: 399 399 335
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21418,19 +21759,20 @@ SplineSet
  869 1520 869 1520 992.5 1328 c 128,-1,15
  1116 1136 1116 1136 1116 745 c 0,16,17
  1116 355 1116 355 992.5 163 c 128,-1,18
- 869 -29 869 -29 616 -29 c 0,19,20
+ 869 -29 869 -29 616 -29 c 256,19,20
  363 -29 363 -29 240 162 c 128,-1,21
  117 353 117 353 117 745 c 2,0,-1
 332 644 m 1,22,23
  332 395.594 332 395.594 402 265.257 c 128,-1,24
- 471.915 135 471.915 135 619.958 135 c 0,25,26
+ 471.915 135 471.915 135 619.958 135 c 256,25,26
  768 135 768 135 831 262.5 c 128,-1,27
  894 390 894 390 903 644 c 1,28,-1
  332 644 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0190
-Encoding: 400 400 400
+Encoding: 400 400 336
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21535,8 +21877,9 @@ SplineSet
  293 760 293 760 440 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0191
-Encoding: 401 401 401
+Encoding: 401 401 337
 Width: 1233
 Flags: W
 AnchorPoint: "below" 770 -426 basechar 0
@@ -21564,8 +21907,9 @@ SplineSet
  380 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: florin
-Encoding: 402 402 402
+Encoding: 402 402 338
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -21605,8 +21949,9 @@ SplineSet
  1063 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0193
-Encoding: 403 403 403
+Encoding: 403 403 339
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
@@ -21646,8 +21991,9 @@ SplineSet
  1053.5 123 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0194
-Encoding: 404 404 404
+Encoding: 404 404 340
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -21674,8 +22020,9 @@ SplineSet
  822 194.575 822 194.575 600.5 495 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0195
-Encoding: 405 405 405
+Encoding: 405 405 341
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21714,8 +22061,9 @@ SplineSet
  754.875 922.002 754.875 922.002 754.875 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0196
-Encoding: 406 406 406
+Encoding: 406 406 342
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21741,8 +22089,9 @@ SplineSet
  514 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0197
-Encoding: 407 407 407
+Encoding: 407 407 343
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21776,8 +22125,9 @@ SplineSet
  201 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0198
-Encoding: 408 408 408
+Encoding: 408 408 344
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21809,8 +22159,9 @@ SplineSet
  646.556 1180 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0199
-Encoding: 409 409 409
+Encoding: 409 409 345
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1556 basechar 0
@@ -21842,8 +22193,9 @@ SplineSet
  236 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019A
-Encoding: 410 410 410
+Encoding: 410 410 346
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
@@ -21877,8 +22229,9 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019B
-Encoding: 411 411 411
+Encoding: 411 411 347
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 1032 0 basechar 0
@@ -21906,8 +22259,9 @@ SplineSet
  578.858 1213.1 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019C
-Encoding: 412 412 412
+Encoding: 412 412 348
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21946,8 +22300,9 @@ SplineSet
  596 43 596 43 568 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019D
-Encoding: 413 413 413
+Encoding: 413 413 349
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21974,8 +22329,9 @@ SplineSet
  190 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019E
-Encoding: 414 414 414
+Encoding: 414 414 350
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -22003,8 +22359,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019F
-Encoding: 415 415 415
+Encoding: 415 415 351
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22036,8 +22393,9 @@ SplineSet
  329.758 644 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: Ohorn
-Encoding: 416 416 416
+Encoding: 416 416 352
 Width: 1233
 Flags: W
 AnchorPoint: "above" 505 1493 basechar 0
@@ -22045,11 +22403,12 @@ AnchorPoint: "below" 505 0 basechar 0
 AnchorPoint: "cedilla" 505 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 377 420 2
-Refer: 79 79 N 1 0 0 1 -111 0 2
+Refer: 682 795 N 1 0 0 1 377 420 2
+Refer: 48 79 N 1 0 0 1 -111 0 2
 EndChar
+
 StartChar: ohorn
-Encoding: 417 417 417
+Encoding: 417 417 353
 Width: 1233
 Flags: W
 AnchorPoint: "below" 511 0 basechar 0
@@ -22057,11 +22416,12 @@ AnchorPoint: "above" 511 1120 basechar 0
 AnchorPoint: "cedilla" 511 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 387.5 0 2
-Refer: 111 111 N 1 0 0 1 -105 0 2
+Refer: 682 795 N 1 0 0 1 387.5 0 2
+Refer: 80 111 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni01A2
-Encoding: 418 418 418
+Encoding: 418 418 354
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22094,8 +22454,9 @@ SplineSet
  693.225 1215 l 1,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni01A3
-Encoding: 419 419 419
+Encoding: 419 419 355
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -22129,8 +22490,9 @@ SplineSet
  261.588 639.325 261.588 639.325 261.588 559 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni01A4
-Encoding: 420 420 420
+Encoding: 420 420 356
 Width: 1233
 Flags: W
 AnchorPoint: "above" 748 1493 basechar 0
@@ -22166,8 +22528,9 @@ SplineSet
  669.25 766 l 2,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni01A5
-Encoding: 421 421 421
+Encoding: 421 421 357
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -22207,8 +22570,9 @@ SplineSet
  375 977 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni01A6
-Encoding: 422 422 422
+Encoding: 422 422 358
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 1130 -264 basechar 0
@@ -22246,8 +22610,9 @@ SplineSet
  346 1063 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A7
-Encoding: 423 423 423
+Encoding: 423 423 359
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22287,8 +22652,9 @@ SplineSet
  225 1442 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A8
-Encoding: 424 424 424
+Encoding: 424 424 360
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -22328,8 +22694,9 @@ SplineSet
  270 1081 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A9
-Encoding: 425 425 425
+Encoding: 425 425 361
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22337,10 +22704,11 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 931 931 N 1 0 0 1 0 0 2
+Refer: 760 931 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01AA
-Encoding: 426 426 426
+Encoding: 426 426 362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22372,8 +22740,9 @@ SplineSet
  765 1130 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AB
-Encoding: 427 427 427
+Encoding: 427 427 363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22409,8 +22778,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AC
-Encoding: 428 428 428
+Encoding: 428 428 364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22433,8 +22803,9 @@ SplineSet
  453 1327 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AD
-Encoding: 429 429 429
+Encoding: 429 429 365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22467,8 +22838,9 @@ SplineSet
  614 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AE
-Encoding: 430 430 430
+Encoding: 430 430 366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22491,26 +22863,29 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Uhorn
-Encoding: 431 431 431
+Encoding: 431 431 367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 410 424 2
-Refer: 85 85 N 1 0 0 1 -138 0 2
+Refer: 682 795 N 1 0 0 1 410 424 2
+Refer: 54 85 N 1 0 0 1 -138 0 2
 EndChar
+
 StartChar: uhorn
-Encoding: 432 432 432
+Encoding: 432 432 368
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 380 0 2
-Refer: 117 117 N 1 0 0 1 -156 0 2
+Refer: 682 795 N 1 0 0 1 380 0 2
+Refer: 86 117 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni01B1
-Encoding: 433 433 433
+Encoding: 433 433 369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22543,8 +22918,9 @@ SplineSet
  1159 1460 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B2
-Encoding: 434 434 434
+Encoding: 434 434 370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22569,8 +22945,9 @@ SplineSet
  775.09 0 775.09 0 505.5 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B3
-Encoding: 435 435 435
+Encoding: 435 435 371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22596,8 +22973,9 @@ SplineSet
  951 1285 951 1285 875 1140 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B4
-Encoding: 436 436 436
+Encoding: 436 436 372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22627,8 +23005,9 @@ SplineSet
  622 -104 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B5
-Encoding: 437 437 437
+Encoding: 437 437 373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22656,8 +23035,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B6
-Encoding: 438 438 438
+Encoding: 438 438 374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22685,8 +23065,9 @@ SplineSet
  222 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B7
-Encoding: 439 439 439
+Encoding: 439 439 375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22717,8 +23098,9 @@ SplineSet
  227.5 435 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B8
-Encoding: 440 440 440
+Encoding: 440 440 376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22749,8 +23131,9 @@ SplineSet
  1005.5 292.378 1005.5 292.378 1005.5 435 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B9
-Encoding: 441 441 441
+Encoding: 441 441 377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22781,8 +23164,9 @@ SplineSet
  518 476 518 476 624 476 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni01BA
-Encoding: 442 442 442
+Encoding: 442 442 378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22811,8 +23195,9 @@ SplineSet
  370 -274 370 -274 699 -274 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BB
-Encoding: 443 443 443
+Encoding: 443 443 379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22845,8 +23230,9 @@ SplineSet
  164 1421 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BC
-Encoding: 444 444 444
+Encoding: 444 444 380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22876,8 +23262,9 @@ SplineSet
  476.552 142 476.552 142 616 142 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BD
-Encoding: 445 445 445
+Encoding: 445 445 381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22905,8 +23292,9 @@ SplineSet
  294.714 -266 294.714 -266 518 -266 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BE
-Encoding: 446 446 446
+Encoding: 446 446 382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22938,8 +23326,9 @@ SplineSet
  844.003 306.321 844.003 306.321 845 439 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BF
-Encoding: 447 447 447
+Encoding: 447 447 383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22964,8 +23353,9 @@ SplineSet
  310 60 l 17,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni01C0
-Encoding: 448 448 448
+Encoding: 448 448 384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22978,17 +23368,19 @@ SplineSet
  515.5 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C1
-Encoding: 449 449 449
+Encoding: 449 449 385
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 448 448 N 1 0 0 1 -202 0 2
-Refer: 448 448 N 1 0 0 1 202 0 2
+Refer: 384 448 N 1 0 0 1 -202 0 2
+Refer: 384 448 N 1 0 0 1 202 0 2
 EndChar
+
 StartChar: uni01C2
-Encoding: 450 450 450
+Encoding: 450 450 386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23017,131 +23409,148 @@ SplineSet
  515.5 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C3
-Encoding: 451 451 451
+Encoding: 451 451 387
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -1 0 2
+Refer: 2 33 N 1 0 0 1 -1 0 2
 EndChar
+
 StartChar: uni01C4
-Encoding: 452 452 452
+Encoding: 452 452 388
 Width: 2048
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 Colour: ffff00
 EndChar
+
 StartChar: uni01C5
-Encoding: 453 453 453
+Encoding: 453 453 389
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C6
-Encoding: 454 454 454
+Encoding: 454 454 390
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C7
-Encoding: 455 455 455
+Encoding: 455 455 391
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C8
-Encoding: 456 456 456
+Encoding: 456 456 392
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C9
-Encoding: 457 457 457
+Encoding: 457 457 393
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CA
-Encoding: 458 458 458
+Encoding: 458 458 394
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CB
-Encoding: 459 459 459
+Encoding: 459 459 395
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CC
-Encoding: 460 460 460
+Encoding: 460 460 396
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CD
-Encoding: 461 461 461
+Encoding: 461 461 397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CE
-Encoding: 462 462 462
+Encoding: 462 462 398
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CF
-Encoding: 463 463 463
+Encoding: 463 463 399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D0
-Encoding: 464 464 464
+Encoding: 464 464 400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D1
-Encoding: 465 465 465
+Encoding: 465 465 401
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D2
-Encoding: 466 466 466
+Encoding: 466 466 402
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D3
-Encoding: 467 467 467
+Encoding: 467 467 403
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23168,263 +23577,293 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D4
-Encoding: 468 468 468
+Encoding: 468 468 404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D5
-Encoding: 469 469 469
+Encoding: 469 469 405
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 713 713 N 1 0 0 1 0 426 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
 EndChar
+
 StartChar: uni01D6
-Encoding: 470 470 470
+Encoding: 470 470 406
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01D7
-Encoding: 471 471 471
+Encoding: 471 471 407
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01D8
-Encoding: 472 472 472
+Encoding: 472 472 408
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01D9
-Encoding: 473 473 473
+Encoding: 473 473 409
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01DA
-Encoding: 474 474 474
+Encoding: 474 474 410
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 780 780 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 667 780 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01DB
-Encoding: 475 475 475
+Encoding: 475 475 411
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01DC
-Encoding: 476 476 476
+Encoding: 476 476 412
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 0 316 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 655 768 N 1 0 0 1 0 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DD
-Encoding: 477 477 477
+Encoding: 477 477 413
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01DE
-Encoding: 478 478 478
+Encoding: 478 478 414
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DF
-Encoding: 479 479 479
+Encoding: 479 479 415
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 228 228 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 164 228 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E0
-Encoding: 480 480 480
+Encoding: 480 480 416
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 1114123 -1 N 1 0 0 1 0 -124 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 3736 -1 N 1 0 0 1 0 -124 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E1
-Encoding: 481 481 481
+Encoding: 481 481 417
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 551 551 N 1 0 0 1 0 0 3
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 477 551 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01E2
-Encoding: 482 482 482
+Encoding: 482 482 418
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 170 0 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 170 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E3
-Encoding: 483 483 483
+Encoding: 483 483 419
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcaron
-Encoding: 486 486 486
+Encoding: 486 486 420
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcaron
-Encoding: 487 487 487
+Encoding: 487 487 421
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E8
-Encoding: 488 488 488
+Encoding: 488 488 422
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E9
-Encoding: 489 489 489
+Encoding: 489 489 423
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EA
-Encoding: 490 490 490
+Encoding: 490 490 424
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EB
-Encoding: 491 491 491
+Encoding: 491 491 425
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EC
-Encoding: 492 492 492
+Encoding: 492 492 426
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 490 490 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 424 490 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01ED
-Encoding: 493 493 493
+Encoding: 493 493 427
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 491 491 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 425 491 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EE
-Encoding: 494 494 494
+Encoding: 494 494 428
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EF
-Encoding: 495 495 495
+Encoding: 495 495 429
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F0
-Encoding: 496 496 496
+Encoding: 496 496 430
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 35 -5 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 35 -5 2
+Refer: 493 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F4
-Encoding: 500 500 500
+Encoding: 500 500 431
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F5
-Encoding: 501 501 501
+Encoding: 501 501 432
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F6
-Encoding: 502 502 502
+Encoding: 502 502 433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23455,310 +23894,345 @@ SplineSet
  830.749 135 830.749 135 877.05 135 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01F8
-Encoding: 504 504 504
+Encoding: 504 504 434
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F9
-Encoding: 505 505 505
+Encoding: 505 505 435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: AEacute
-Encoding: 508 508 508
+Encoding: 508 508 436
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 240 373 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 240 373 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aeacute
-Encoding: 509 509 509
+Encoding: 509 509 437
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Oslashacute
-Encoding: 510 510 510
+Encoding: 510 510 438
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 216 216 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 152 216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: oslashacute
-Encoding: 511 511 511
+Encoding: 511 511 439
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 248 248 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 184 248 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0200
-Encoding: 512 512 512
+Encoding: 512 512 440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0201
-Encoding: 513 513 513
+Encoding: 513 513 441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0202
-Encoding: 514 514 514
+Encoding: 514 514 442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0203
-Encoding: 515 515 515
+Encoding: 515 515 443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0204
-Encoding: 516 516 516
+Encoding: 516 516 444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0205
-Encoding: 517 517 517
+Encoding: 517 517 445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0206
-Encoding: 518 518 518
+Encoding: 518 518 446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0207
-Encoding: 519 519 519
+Encoding: 519 519 447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0208
-Encoding: 520 520 520
+Encoding: 520 520 448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0209
-Encoding: 521 521 521
+Encoding: 521 521 449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020A
-Encoding: 522 522 522
+Encoding: 522 522 450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020B
-Encoding: 523 523 523
+Encoding: 523 523 451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020C
-Encoding: 524 524 524
+Encoding: 524 524 452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020D
-Encoding: 525 525 525
+Encoding: 525 525 453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020E
-Encoding: 526 526 526
+Encoding: 526 526 454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020F
-Encoding: 527 527 527
+Encoding: 527 527 455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0210
-Encoding: 528 528 528
+Encoding: 528 528 456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0211
-Encoding: 529 529 529
+Encoding: 529 529 457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 150 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0212
-Encoding: 530 530 530
+Encoding: 530 530 458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0213
-Encoding: 531 531 531
+Encoding: 531 531 459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 150 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0214
-Encoding: 532 532 532
+Encoding: 532 532 460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0215
-Encoding: 533 533 533
+Encoding: 533 533 461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0216
-Encoding: 534 534 534
+Encoding: 534 534 462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0217
-Encoding: 535 535 535
+Encoding: 535 535 463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scommaaccent
-Encoding: 536 536 536
+Encoding: 536 536 464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scommaaccent
-Encoding: 537 537 537
+Encoding: 537 537 465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021A
-Encoding: 538 538 538
+Encoding: 538 538 466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021B
-Encoding: 539 539 539
+Encoding: 539 539 467
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 89 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 89 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021C
-Encoding: 540 540 540
+Encoding: 540 540 468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23803,8 +24277,9 @@ SplineSet
  882 733 882 733 800 674 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021D
-Encoding: 541 541 541
+Encoding: 541 541 469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23855,24 +24330,27 @@ SplineSet
  924 570 924 570 782 461 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021E
-Encoding: 542 542 542
+Encoding: 542 542 470
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021F
-Encoding: 543 543 543
+Encoding: 543 543 471
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0220
-Encoding: 544 544 544
+Encoding: 544 544 472
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -23899,8 +24377,9 @@ SplineSet
  1085 1260.95 1085 1260.95 1085 998.75 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0221
-Encoding: 545 545 545
+Encoding: 545 545 473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23944,8 +24423,9 @@ SplineSet
  172.715 773 172.715 773 172.715 559 c 128,-1,42
 EndSplineSet
 EndChar
+
 StartChar: uni0224
-Encoding: 548 548 548
+Encoding: 548 548 474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23974,8 +24454,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0225
-Encoding: 549 549 549
+Encoding: 549 549 475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24004,129 +24485,144 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0226
-Encoding: 550 550 550
+Encoding: 550 550 476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0227
-Encoding: 551 551 551
+Encoding: 551 551 477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0228
-Encoding: 552 552 552
+Encoding: 552 552 478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0229
-Encoding: 553 553 553
+Encoding: 553 553 479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022A
-Encoding: 554 554 554
+Encoding: 554 554 480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022B
-Encoding: 555 555 555
+Encoding: 555 555 481
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 246 246 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 182 246 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022C
-Encoding: 556 556 556
+Encoding: 556 556 482
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 245 2
-Refer: 713 713 N 1 0 0 1 0 426 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 245 2
+Refer: 625 713 N 1 0 0 1 0 426 2
 EndChar
+
 StartChar: uni022D
-Encoding: 557 557 557
+Encoding: 557 557 483
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 3.5 316 2
-Refer: 245 245 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 3.5 316 2
+Refer: 181 245 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022E
-Encoding: 558 558 558
+Encoding: 558 558 484
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022F
-Encoding: 559 559 559
+Encoding: 559 559 485
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0230
-Encoding: 560 560 560
+Encoding: 560 560 486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 1114123 -1 N 1 0 0 1 0 -124 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 3736 -1 N 1 0 0 1 0 -124 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0231
-Encoding: 561 561 561
+Encoding: 561 561 487
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 559 559 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 485 559 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0232
-Encoding: 562 562 562
+Encoding: 562 562 488
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0233
-Encoding: 563 563 563
+Encoding: 563 563 489
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0234
-Encoding: 564 564 564
+Encoding: 564 564 490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24155,8 +24651,9 @@ SplineSet
  713.5 -29 713.5 -29 664.5 -12 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0235
-Encoding: 565 565 565
+Encoding: 565 565 491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24196,8 +24693,9 @@ SplineSet
  714.999 406 l 2,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0236
-Encoding: 566 566 566
+Encoding: 566 566 492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24232,8 +24730,9 @@ SplineSet
  614 406 l 2,5,6
 EndSplineSet
 EndChar
+
 StartChar: dotlessj
-Encoding: 567 567 567
+Encoding: 567 567 493
 Width: 1233
 Flags: W
 TtInstrs:
@@ -24302,8 +24801,9 @@ SplineSet
  600 -145 600 -145 600 -20 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0238
-Encoding: 568 568 568
+Encoding: 568 568 494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24352,8 +24852,9 @@ SplineSet
  671.7 977 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0239
-Encoding: 569 569 569
+Encoding: 569 569 495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24402,8 +24903,9 @@ SplineSet
  561.3 141 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni023A
-Encoding: 570 570 570
+Encoding: 570 570 496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24436,8 +24938,9 @@ SplineSet
  705.138 995.274 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023B
-Encoding: 571 571 571
+Encoding: 571 571 497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24476,8 +24979,9 @@ SplineSet
  1073 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023C
-Encoding: 572 572 572
+Encoding: 572 572 498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24515,8 +25019,9 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023D
-Encoding: 573 573 573
+Encoding: 573 573 499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24539,8 +25044,9 @@ SplineSet
  288 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023E
-Encoding: 574 574 574
+Encoding: 574 574 500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24569,8 +25075,9 @@ SplineSet
  514 686.702 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023F
-Encoding: 575 575 575
+Encoding: 575 575 501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24615,8 +25122,9 @@ SplineSet
  893 1114 893 1114 973 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0240
-Encoding: 576 576 576
+Encoding: 576 576 502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24644,8 +25152,9 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0241
-Encoding: 577 577 577
+Encoding: 577 577 503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24675,8 +25184,9 @@ SplineSet
  373.75 1327 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0243
-Encoding: 579 579 579
+Encoding: 579 579 504
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -24723,8 +25233,9 @@ SplineSet
  369 366 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0244
-Encoding: 580 580 580
+Encoding: 580 580 505
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -24771,8 +25282,9 @@ SplineSet
  883 577 l 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0245
-Encoding: 581 581 581
+Encoding: 581 581 506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24788,8 +25300,9 @@ SplineSet
  617 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024C
-Encoding: 588 588 588
+Encoding: 588 588 507
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
@@ -24829,8 +25342,9 @@ SplineSet
  430 1327 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024D
-Encoding: 589 589 589
+Encoding: 589 589 508
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -24863,8 +25377,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0250
-Encoding: 592 592 592
+Encoding: 592 592 509
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -24907,8 +25422,9 @@ SplineSet
  154 332 154 332 154 479 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0251
-Encoding: 593 593 593
+Encoding: 593 593 510
 Width: 1233
 Flags: W
 TtInstrs:
@@ -24980,19 +25496,20 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,14,15
  660 1147 660 1147 737 1103.5 c 128,-1,16
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,17,18
+317 559 m 256,17,18
  317 345 317 345 385 236 c 128,-1,19
- 453 127 453 127 586 127 c 0,20,21
+ 453 127 453 127 586 127 c 256,20,21
  719 127 719 127 788.5 237 c 128,-1,22
  858 347 858 347 858 559 c 0,23,24
  858 772 858 772 788.5 881.5 c 128,-1,25
- 719 991 719 991 586 991 c 0,26,27
+ 719 991 719 991 586 991 c 256,26,27
  453 991 453 991 385 882 c 128,-1,28
- 317 773 317 773 317 559 c 0,17,18
+ 317 773 317 773 317 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0252
-Encoding: 594 594 594
+Encoding: 594 594 511
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25050,15 +25567,15 @@ AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-917 557 m 0,0,1
+917 557 m 256,0,1
  917 771 917 771 849 880 c 128,-1,2
- 781 989 781 989 648 989 c 0,3,4
+ 781 989 781 989 648 989 c 256,3,4
  515 989 515 989 445.5 879 c 128,-1,5
  376 769 376 769 376 557 c 0,6,7
  376 344 376 344 445.5 234.5 c 128,-1,8
- 515 125 515 125 648 125 c 0,9,10
+ 515 125 515 125 648 125 c 256,9,10
  781 125 781 125 849 234 c 128,-1,11
- 917 343 917 343 917 557 c 0,0,1
+ 917 343 917 343 917 557 c 256,0,1
 376 975 m 1,12,13
  422 1058 422 1058 498.5 1101.5 c 128,-1,14
  575 1145 575 1145 675 1145 c 0,15,16
@@ -25075,8 +25592,9 @@ SplineSet
  376 975 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0253
-Encoding: 595 595 595
+Encoding: 595 595 512
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25143,7 +25661,7 @@ AnchorPoint: "above" 652 1556 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-918 559 m 0,0,1
+918 559 m 256,0,1
  918 773 918 773 850 882 c 128,-1,2
  782 991 782 991 649 991 c 0,3,4
  515 991 515 991 446 881.5 c 128,-1,5
@@ -25151,7 +25669,7 @@ SplineSet
  377 347 377 347 446 237 c 128,-1,8
  515 127 515 127 649 127 c 0,9,10
  782 127 782 127 850 236 c 128,-1,11
- 918 345 918 345 918 559 c 0,0,1
+ 918 345 918 345 918 559 c 256,0,1
 377 977 m 1,12,13
  421 1059 421 1059 498.5 1103 c 128,-1,14
  576 1147 576 1147 678 1147 c 24,15,16
@@ -25174,8 +25692,9 @@ SplineSet
  377 977 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0254
-Encoding: 596 596 596
+Encoding: 596 596 513
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25237,7 +25756,7 @@ SplineSet
  258 1104 258 1104 336 1125.5 c 128,-1,2
  414 1147 414 1147 496 1147 c 0,3,4
  756 1147 756 1147 903 991 c 128,-1,5
- 1050 835 1050 835 1050 559 c 0,6,7
+ 1050 835 1050 835 1050 559 c 256,6,7
  1050 283 1050 283 903 127 c 128,-1,8
  756 -29 756 -29 496 -29 c 0,9,10
  416 -29 416 -29 339 -8 c 128,-1,11
@@ -25254,8 +25773,9 @@ SplineSet
  184 1061 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0255
-Encoding: 597 597 597
+Encoding: 597 597 514
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -25291,8 +25811,9 @@ SplineSet
  679 259 679 259 632 146 c 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni0256
-Encoding: 598 598 598
+Encoding: 598 598 515
 Width: 1233
 Flags: W
 AnchorPoint: "above" 601 1556 basechar 0
@@ -25331,8 +25852,9 @@ SplineSet
  714 1060 714 1060 750 977 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0257
-Encoding: 599 599 599
+Encoding: 599 599 516
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -25372,8 +25894,9 @@ SplineSet
  748 1002 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0258
-Encoding: 600 600 600
+Encoding: 600 600 517
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
@@ -25406,8 +25929,9 @@ SplineSet
  306 821 306 821 306 659 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0259
-Encoding: 601 601 601
+Encoding: 601 601 518
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25505,8 +26029,9 @@ SplineSet
  306 459 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni025A
-Encoding: 602 602 602
+Encoding: 602 602 519
 Width: 1233
 Flags: W
 AnchorPoint: "below" 410 0 basechar 0
@@ -25547,8 +26072,9 @@ SplineSet
  207.571 1147 207.571 1147 368 1147 c 0,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni025B
-Encoding: 603 603 603
+Encoding: 603 603 520
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25647,8 +26173,9 @@ SplineSet
  317 584 317 584 449 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025C
-Encoding: 604 604 604
+Encoding: 604 604 521
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25750,8 +26277,9 @@ SplineSet
  902 632 902 632 783 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025D
-Encoding: 605 605 605
+Encoding: 605 605 522
 Width: 1233
 Flags: W
 AnchorPoint: "below" 370 0 basechar 0
@@ -25803,8 +26331,9 @@ SplineSet
  606.375 631.999 606.375 631.999 517.125 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025E
-Encoding: 606 606 606
+Encoding: 606 606 523
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
@@ -25841,8 +26370,9 @@ SplineSet
  176 950.176 176 950.176 451 1099 c 0,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni025F
-Encoding: 607 607 607
+Encoding: 607 607 524
 Width: 1233
 Flags: W
 AnchorPoint: "below" 689 -426 basechar 0
@@ -25873,8 +26403,9 @@ SplineSet
  1137 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0260
-Encoding: 608 608 608
+Encoding: 608 608 525
 Width: 1233
 Flags: W
 AnchorPoint: "below" 574 -426 basechar 0
@@ -25921,8 +26452,9 @@ SplineSet
  752 363 752 363 752 569 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0261
-Encoding: 609 609 609
+Encoding: 609 609 526
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -25961,8 +26493,9 @@ SplineSet
  1076 72 l 2,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni0262
-Encoding: 610 610 610
+Encoding: 610 610 527
 Width: 1233
 Flags: W
 AnchorPoint: "below" 661 0 basechar 0
@@ -25994,8 +26527,9 @@ SplineSet
  866 156 866 156 946 178 c 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0263
-Encoding: 611 611 611
+Encoding: 611 611 528
 Width: 1233
 Flags: W
 AnchorPoint: "below" 622 -426 basechar 0
@@ -26029,8 +26563,9 @@ SplineSet
  497.246 -267.998 497.246 -267.998 610.469 -267.998 c 24,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0264
-Encoding: 612 612 612
+Encoding: 612 612 529
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26056,8 +26591,9 @@ SplineSet
  727 286 727 286 608 440 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0265
-Encoding: 613 613 613
+Encoding: 613 613 530
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26084,8 +26620,9 @@ SplineSet
  188.5 196 188.5 196 188.5 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0266
-Encoding: 614 614 614
+Encoding: 614 614 531
 Width: 1233
 Flags: W
 AnchorPoint: "above" 623 1556 basechar 0
@@ -26120,8 +26657,9 @@ SplineSet
  381 962 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0267
-Encoding: 615 615 615
+Encoding: 615 615 532
 Width: 1233
 Flags: W
 AnchorPoint: "above" 623 1556 basechar 0
@@ -26162,8 +26700,9 @@ SplineSet
  381 962 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0268
-Encoding: 616 616 616
+Encoding: 616 616 533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26195,8 +26734,9 @@ SplineSet
  238 1118 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0269
-Encoding: 617 617 617
+Encoding: 617 617 534
 Width: 1233
 Flags: W
 AnchorPoint: "above" 580 1120 basechar 0
@@ -26219,8 +26759,9 @@ SplineSet
  1034 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026A
-Encoding: 618 618 618
+Encoding: 618 618 535
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26243,8 +26784,9 @@ SplineSet
  160 1118 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026B
-Encoding: 619 619 619
+Encoding: 619 619 536
 Width: 1233
 Flags: W
 AnchorPoint: "above" 568 1556 basechar 0
@@ -26283,8 +26825,9 @@ SplineSet
  658.5 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026C
-Encoding: 620 620 620
+Encoding: 620 620 537
 Width: 1233
 Flags: W
 AnchorPoint: "above" 592 1556 basechar 0
@@ -26321,8 +26864,9 @@ SplineSet
  498 786 l 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni026D
-Encoding: 621 621 621
+Encoding: 621 621 538
 Width: 1233
 Flags: W
 AnchorPoint: "above" 574 1556 basechar 0
@@ -26345,8 +26889,9 @@ SplineSet
  639 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026E
-Encoding: 622 622 622
+Encoding: 622 622 539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26389,8 +26934,9 @@ SplineSet
  424 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026F
-Encoding: 623 623 623
+Encoding: 623 623 540
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26428,8 +26974,9 @@ SplineSet
  590 41 590 41 562 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0270
-Encoding: 624 624 624
+Encoding: 624 624 541
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26467,8 +27014,9 @@ SplineSet
  590 41 590 41 562 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0271
-Encoding: 625 625 625
+Encoding: 625 625 542
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26512,8 +27060,9 @@ SplineSet
  645.122 1069.08 645.122 1069.08 670 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0272
-Encoding: 626 626 626
+Encoding: 626 626 543
 Width: 1233
 Flags: W
 AnchorPoint: "below" 694 -426 basechar 0
@@ -26546,8 +27095,9 @@ SplineSet
  490 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0273
-Encoding: 627 627 627
+Encoding: 627 627 544
 Width: 1233
 Flags: W
 AnchorPoint: "below" 550 -426 basechar 0
@@ -26580,8 +27130,9 @@ SplineSet
  744 -234 744 -234 744 -20 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0274
-Encoding: 628 628 628
+Encoding: 628 628 545
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26602,8 +27153,9 @@ SplineSet
  144 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0275
-Encoding: 629 629 629
+Encoding: 629 629 546
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26634,8 +27186,9 @@ SplineSet
  880.677 315.092 880.677 315.092 895.263 447 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0276
-Encoding: 630 630 630
+Encoding: 630 630 547
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26669,8 +27222,9 @@ SplineSet
  596 973 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0277
-Encoding: 631 631 631
+Encoding: 631 631 548
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26707,8 +27261,9 @@ SplineSet
  1062 733.594 1062 733.594 1062 435 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0278
-Encoding: 632 632 632
+Encoding: 632 632 549
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -26753,8 +27308,9 @@ SplineSet
  452.544 162.672 452.544 162.672 532 138.621 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0279
-Encoding: 633 633 633
+Encoding: 633 633 550
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26779,8 +27335,9 @@ SplineSet
  152 231 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027A
-Encoding: 634 634 634
+Encoding: 634 634 551
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26805,8 +27362,9 @@ SplineSet
  152 231 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027B
-Encoding: 635 635 635
+Encoding: 635 635 552
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 -426 basechar 0
@@ -26837,8 +27395,9 @@ SplineSet
  895 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027C
-Encoding: 636 636 636
+Encoding: 636 636 553
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26863,8 +27422,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027D
-Encoding: 637 637 637
+Encoding: 637 637 554
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26895,8 +27455,9 @@ SplineSet
  547 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027E
-Encoding: 638 638 638
+Encoding: 638 638 555
 Width: 1233
 Flags: W
 AnchorPoint: "below" 611.5 0 basechar 0
@@ -26921,8 +27482,9 @@ SplineSet
  520 741 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027F
-Encoding: 639 639 639
+Encoding: 639 639 556
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26947,8 +27509,9 @@ SplineSet
  712 953 712 953 712 741 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0280
-Encoding: 640 640 640
+Encoding: 640 640 557
 Width: 1233
 Flags: W
 AnchorPoint: "below" 512.5 0 basechar 0
@@ -26983,8 +27546,9 @@ SplineSet
  307 965 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0281
-Encoding: 641 641 641
+Encoding: 641 641 558
 Width: 1233
 Flags: W
 AnchorPoint: "above" 512.5 1120 basechar 0
@@ -27019,8 +27583,9 @@ SplineSet
  307 155 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0282
-Encoding: 642 642 642
+Encoding: 642 642 559
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27065,8 +27630,9 @@ SplineSet
  909 1117 909 1117 984 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0283
-Encoding: 643 643 643
+Encoding: 643 643 560
 Width: 1233
 Flags: W
 AnchorPoint: "below" 627 -426 basechar 0
@@ -27093,8 +27659,9 @@ SplineSet
  723 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0284
-Encoding: 644 644 644
+Encoding: 644 644 561
 Width: 1233
 Flags: W
 AnchorPoint: "above" 627 1556 basechar 0
@@ -27133,8 +27700,9 @@ SplineSet
  1076.5 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0285
-Encoding: 645 645 645
+Encoding: 645 645 562
 Width: 1233
 Flags: W
 AnchorPoint: "below" 632.5 -426 basechar 0
@@ -27161,8 +27729,9 @@ SplineSet
  723 906.938 723 906.938 723 712 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0286
-Encoding: 646 646 646
+Encoding: 646 646 563
 Width: 1233
 Flags: W
 AnchorPoint: "above" 627 1556 basechar 0
@@ -27196,8 +27765,9 @@ SplineSet
  763 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0287
-Encoding: 647 647 647
+Encoding: 647 647 564
 Width: 1233
 Flags: W
 AnchorPoint: "below" 676 -426 basechar 0
@@ -27226,8 +27796,9 @@ SplineSet
  584 -318 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0288
-Encoding: 648 648 648
+Encoding: 648 648 565
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -27256,8 +27827,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0289
-Encoding: 649 649 649
+Encoding: 649 649 566
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27296,8 +27868,9 @@ SplineSet
  886.656 311.231 886.656 311.231 894.591 452 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028A
-Encoding: 650 650 650
+Encoding: 650 650 567
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27332,8 +27905,9 @@ SplineSet
  95 956 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028B
-Encoding: 651 651 651
+Encoding: 651 651 568
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27365,8 +27939,9 @@ SplineSet
  643 974 643 974 597 986 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028C
-Encoding: 652 652 652
+Encoding: 652 652 569
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27384,8 +27959,9 @@ SplineSet
  1162 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028D
-Encoding: 653 653 653
+Encoding: 653 653 570
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27409,8 +27985,9 @@ SplineSet
  1218 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028E
-Encoding: 654 654 654
+Encoding: 654 654 571
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27435,8 +28012,9 @@ SplineSet
  564 1224 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028F
-Encoding: 655 655 655
+Encoding: 655 655 572
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27456,8 +28034,9 @@ SplineSet
  102 1149 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0290
-Encoding: 656 656 656
+Encoding: 656 656 573
 Width: 1233
 Flags: W
 AnchorPoint: "above" 540 1120 basechar 0
@@ -27486,8 +28065,9 @@ SplineSet
  213 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0291
-Encoding: 657 657 657
+Encoding: 657 657 574
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -114 basechar 0
@@ -27519,8 +28099,9 @@ SplineSet
  739 290 739 290 703 147 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0292
-Encoding: 658 658 658
+Encoding: 658 658 575
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27553,8 +28134,9 @@ SplineSet
  609 476 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0293
-Encoding: 659 659 659
+Encoding: 659 659 576
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -27594,8 +28176,9 @@ SplineSet
  773 -186 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0294
-Encoding: 660 660 660
+Encoding: 660 660 577
 Width: 1233
 Flags: W
 AnchorPoint: "below" 548 0 basechar 0
@@ -27623,8 +28206,9 @@ SplineSet
  446 798 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0295
-Encoding: 661 661 661
+Encoding: 661 661 578
 Width: 1233
 Flags: W
 AnchorPoint: "below" 682 0 basechar 0
@@ -27652,8 +28236,9 @@ SplineSet
  786 798 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0296
-Encoding: 662 662 662
+Encoding: 662 662 579
 Width: 1233
 Flags: W
 AnchorPoint: "above" 548 1556 basechar 0
@@ -27681,8 +28266,9 @@ SplineSet
  446 756 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0297
-Encoding: 663 663 663
+Encoding: 663 663 580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27711,8 +28297,9 @@ SplineSet
  194 1086 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0298
-Encoding: 664 664 664
+Encoding: 664 664 581
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -27749,8 +28336,9 @@ SplineSet
  503 520 503 520 503 567 c 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni0299
-Encoding: 665 665 665
+Encoding: 665 665 582
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27835,8 +28423,9 @@ SplineSet
  209 1149 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029A
-Encoding: 666 666 666
+Encoding: 666 666 583
 Width: 1233
 Flags: W
 AnchorPoint: "above" 574 1120 basechar 0
@@ -27873,8 +28462,9 @@ SplineSet
  699 1145 699 1145 782 1099 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni029B
-Encoding: 667 667 667
+Encoding: 667 667 584
 Width: 1233
 Flags: W
 AnchorPoint: "above" 538 1556 basechar 0
@@ -27916,8 +28506,9 @@ SplineSet
  659 156 659 156 718 178 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029C
-Encoding: 668 668 668
+Encoding: 668 668 585
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27940,8 +28531,9 @@ SplineSet
  144 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029D
-Encoding: 669 669 669
+Encoding: 669 669 586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27974,8 +28566,9 @@ SplineSet
  645.067 -199.079 645.067 -199.079 654.513 -154.325 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029E
-Encoding: 670 670 670
+Encoding: 670 670 587
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27997,8 +28590,9 @@ SplineSet
  1113.5 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029F
-Encoding: 671 671 671
+Encoding: 671 671 588
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -28015,8 +28609,9 @@ SplineSet
  245 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A0
-Encoding: 672 672 672
+Encoding: 672 672 589
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -28055,8 +28650,9 @@ SplineSet
  228.375 762 228.375 762 228.375 559 c 128,-1,31
 EndSplineSet
 EndChar
+
 StartChar: uni02A1
-Encoding: 673 673 673
+Encoding: 673 673 590
 Width: 1233
 Flags: W
 AnchorPoint: "above" 548 1556 basechar 0
@@ -28092,8 +28688,9 @@ SplineSet
  446 798 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A2
-Encoding: 674 674 674
+Encoding: 674 674 591
 Width: 1233
 Flags: W
 AnchorPoint: "above" 682 1556 basechar 0
@@ -28129,8 +28726,9 @@ SplineSet
  584 440 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A3
-Encoding: 675 675 675
+Encoding: 675 675 592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28172,8 +28770,9 @@ SplineSet
  654.301 973 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A4
-Encoding: 676 676 676
+Encoding: 676 676 593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28227,8 +28826,9 @@ SplineSet
  627 973 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A5
-Encoding: 677 677 677
+Encoding: 677 677 594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28281,8 +28881,9 @@ SplineSet
  980.001 290.209 980.001 290.209 958.633 147 c 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A6
-Encoding: 678 678 678
+Encoding: 678 678 595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28337,8 +28938,9 @@ SplineSet
  998.399 1117 998.399 1117 1044 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A7
-Encoding: 679 679 679
+Encoding: 679 679 596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28382,8 +28984,9 @@ SplineSet
  675 154 l 1,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni02A8
-Encoding: 680 680 680
+Encoding: 680 680 597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28436,8 +29039,9 @@ SplineSet
  587.061 154 l 1,57,58
 EndSplineSet
 EndChar
+
 StartChar: uni02A9
-Encoding: 681 681 681
+Encoding: 681 681 598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28486,8 +29090,9 @@ SplineSet
  1095.1 908.004 1095.1 908.004 1095.1 676 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AA
-Encoding: 682 682 682
+Encoding: 682 682 599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28530,8 +29135,9 @@ SplineSet
  374.106 676.569 374.106 676.569 368 788 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AB
-Encoding: 683 683 683
+Encoding: 683 683 600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28555,8 +29161,9 @@ SplineSet
  357.375 973 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AC
-Encoding: 684 684 684
+Encoding: 684 684 601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28592,8 +29199,9 @@ SplineSet
  143.055 1311.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AD
-Encoding: 685 685 685
+Encoding: 685 685 602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28619,8 +29227,9 @@ SplineSet
  143 1311 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AE
-Encoding: 686 686 686
+Encoding: 686 686 603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28648,8 +29257,9 @@ SplineSet
  817.242 -29 817.242 -29 644.25 -29 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni02AF
-Encoding: 687 687 687
+Encoding: 687 687 604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28683,8 +29293,9 @@ SplineSet
  445.5 448 l 2,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni02B0
-Encoding: 688 688 688
+Encoding: 688 688 605
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28743,8 +29354,9 @@ SplineSet
  911.97 1176.48 911.97 1176.48 911.97 1046.56 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B1
-Encoding: 689 689 689
+Encoding: 689 689 606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28777,8 +29389,9 @@ SplineSet
  436.95 1196.38 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B2
-Encoding: 690 690 690
+Encoding: 690 690 607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28802,8 +29415,9 @@ SplineSet
  630.99 1539.36 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B3
-Encoding: 691 691 691
+Encoding: 691 691 608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28826,8 +29440,9 @@ SplineSet
  823.14 1198.88 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B4
-Encoding: 692 692 692
+Encoding: 692 692 609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28850,8 +29465,9 @@ SplineSet
  409.86 764.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B5
-Encoding: 693 693 693
+Encoding: 693 693 610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28884,8 +29500,9 @@ SplineSet
  337.41 764.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B6
-Encoding: 694 694 694
+Encoding: 694 694 611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28918,8 +29535,9 @@ SplineSet
  421.515 754.8 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B7
-Encoding: 695 695 695
+Encoding: 695 695 612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28941,8 +29559,9 @@ SplineSet
  143.055 1295.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B8
-Encoding: 696 696 696
+Encoding: 696 696 613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28965,39 +29584,44 @@ SplineSet
  649.891 609.76 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B9
-Encoding: 697 697 697
+Encoding: 697 697 614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 884 884 N 1 0 0 1 0 0 2
+Refer: 722 884 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BB
-Encoding: 699 699 699
+Encoding: 699 699 615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8216 8216 N 1 0 0 1 0 0 2
+Refer: 1970 8216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BC
-Encoding: 700 700 700
+Encoding: 700 700 616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8217 8217 N 1 0 0 1 0 0 2
+Refer: 1971 8217 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BD
-Encoding: 701 701 701
+Encoding: 701 701 617
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 788 788 N 1 0 0 1 0 0 2
+Refer: 675 788 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BE
-Encoding: 702 702 702
+Encoding: 702 702 618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29016,8 +29640,9 @@ SplineSet
  594.5 1007 594.5 1007 479.5 1007 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02BF
-Encoding: 703 703 703
+Encoding: 703 703 619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29036,8 +29661,9 @@ SplineSet
  753.5 1068 753.5 1068 753.5 1007 c 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02C0
-Encoding: 704 704 704
+Encoding: 704 704 620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29063,8 +29689,9 @@ SplineSet
  509.085 1356.88 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C1
-Encoding: 705 705 705
+Encoding: 705 705 621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29090,8 +29717,9 @@ SplineSet
  723.285 1356.88 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circumflex
-Encoding: 710 710 710
+Encoding: 710 710 622
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29158,8 +29786,9 @@ SplineSet
  543 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: caron
-Encoding: 711 711 711
+Encoding: 711 711 623
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29226,8 +29855,9 @@ SplineSet
  543 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C8
-Encoding: 712 712 712
+Encoding: 712 712 624
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29261,16 +29891,18 @@ SplineSet
  684.5 1554 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C9
-Encoding: 713 713 713
+Encoding: 713 713 625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CC
-Encoding: 716 716 716
+Encoding: 716 716 626
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29304,32 +29936,36 @@ SplineSet
  684.5 252 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02CD
-Encoding: 717 717 717
+Encoding: 717 717 627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CE
-Encoding: 718 718 718
+Encoding: 718 718 628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni02CF
-Encoding: 719 719 719
+Encoding: 719 719 629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni02D0
-Encoding: 720 720 720
+Encoding: 720 720 630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29345,8 +29981,9 @@ SplineSet
  616.5 330.199 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D1
-Encoding: 721 721 721
+Encoding: 721 721 631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29358,24 +29995,27 @@ SplineSet
  616.5 728.801 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D2
-Encoding: 722 722 722
+Encoding: 722 722 632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 702 702 N 1 0 0 1 0 -497 2
+Refer: 618 702 N 1 0 0 1 0 -497 2
 EndChar
+
 StartChar: uni02D3
-Encoding: 723 723 723
+Encoding: 723 723 633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 -497 2
+Refer: 619 703 N 1 0 0 1 0 -497 2
 EndChar
+
 StartChar: uni02D6
-Encoding: 726 726 726
+Encoding: 726 726 634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29396,8 +30036,9 @@ SplineSet
  542 629 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D7
-Encoding: 727 727 727
+Encoding: 727 727 635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29410,26 +30051,29 @@ SplineSet
  842 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: breve
-Encoding: 728 728 728
+Encoding: 728 728 636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 661 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotaccent
-Encoding: 729 729 729
+Encoding: 729 729 637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 662 775 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ring
-Encoding: 730 730 730
+Encoding: 730 730 638
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29511,29 +30155,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-891 1524 m 0,0,1
+891 1524 m 256,0,1
  891 1409 891 1409 811.5 1329 c 128,-1,2
  732 1249 732 1249 616 1249 c 0,3,4
  501 1249 501 1249 421.5 1329 c 128,-1,5
- 342 1409 342 1409 342 1524 c 0,6,7
+ 342 1409 342 1409 342 1524 c 256,6,7
  342 1639 342 1639 421.5 1718.5 c 128,-1,8
  501 1798 501 1798 616 1798 c 0,9,10
  732 1798 732 1798 811.5 1718.5 c 128,-1,11
- 891 1639 891 1639 891 1524 c 0,0,1
+ 891 1639 891 1639 891 1524 c 256,0,1
 768 1524 m 0,12,13
  768 1587 768 1587 724 1631 c 128,-1,14
- 680 1675 680 1675 616 1675 c 0,15,16
+ 680 1675 680 1675 616 1675 c 256,15,16
  552 1675 552 1675 508.5 1631.5 c 128,-1,17
  465 1588 465 1588 465 1524 c 0,18,19
  465 1459 465 1459 508.5 1415.5 c 128,-1,20
- 552 1372 552 1372 616 1372 c 0,21,22
+ 552 1372 552 1372 616 1372 c 256,21,22
  680 1372 680 1372 724 1416 c 128,-1,23
  768 1460 768 1460 768 1524 c 0,12,13
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ogonek
-Encoding: 731 731 731
+Encoding: 731 731 639
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29591,8 +30236,9 @@ SplineSet
  473 -62 473 -62 528 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tilde
-Encoding: 732 732 732
+Encoding: 732 732 640
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29797,19 +30443,21 @@ SplineSet
  713 1309 713 1309 681 1323 c 128,-1,27
  649 1337 649 1337 612 1370 c 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: hungarumlaut
-Encoding: 733 733 733
+Encoding: 733 733 641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 666 779 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni02DE
-Encoding: 734 734 734
+Encoding: 734 734 642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29830,8 +30478,9 @@ SplineSet
  -351 868 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E0
-Encoding: 736 736 736
+Encoding: 736 736 643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29855,8 +30504,9 @@ SplineSet
  745 735 745 735 616 921 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni02E1
-Encoding: 737 737 737
+Encoding: 737 737 644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29877,8 +30527,9 @@ SplineSet
  644 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02E2
-Encoding: 738 738 738
+Encoding: 738 738 645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29915,8 +30566,9 @@ SplineSet
  800 1310 800 1310 848 1293 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E3
-Encoding: 739 739 739
+Encoding: 739 739 646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29937,8 +30589,9 @@ SplineSet
  945 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E4
-Encoding: 740 740 740
+Encoding: 740 740 647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29964,8 +30617,9 @@ SplineSet
  723 1115 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E5
-Encoding: 741 741 741
+Encoding: 741 741 648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29980,8 +30634,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E6
-Encoding: 742 742 742
+Encoding: 742 742 649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29998,8 +30653,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E7
-Encoding: 743 743 743
+Encoding: 743 743 650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30016,8 +30672,9 @@ SplineSet
  797 752 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E8
-Encoding: 744 744 744
+Encoding: 744 744 651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30034,8 +30691,9 @@ SplineSet
  797 444 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E9
-Encoding: 745 745 745
+Encoding: 745 745 652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30050,64 +30708,71 @@ SplineSet
  797 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02EE
-Encoding: 750 750 750
+Encoding: 750 750 653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8221 8221 N 1 0 0 1 0 0 3
+Refer: 1975 8221 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni02F3
-Encoding: 755 755 755
+Encoding: 755 755 654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gravecomb
-Encoding: 768 768 768
+Encoding: 768 768 655
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: acutecomb
-Encoding: 769 769 769
+Encoding: 769 769 656
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0302
-Encoding: 770 770 770
+Encoding: 770 770 657
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: tildecomb
-Encoding: 771 771 771
+Encoding: 771 771 658
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0304
-Encoding: 772 772 772
+Encoding: 772 772 659
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30141,18 +30806,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0305
-Encoding: 773 773 773
+Encoding: 773 773 660
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0306
-Encoding: 774 774 774
+Encoding: 774 774 661
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30205,8 +30872,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0307
-Encoding: 775 775 775
+Encoding: 775 775 662
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30243,18 +30911,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0308
-Encoding: 776 776 776
+Encoding: 776 776 663
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: hookabovecomb
-Encoding: 777 777 777
+Encoding: 777 777 664
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30278,18 +30948,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030A
-Encoding: 778 778 778
+Encoding: 778 778 665
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030B
-Encoding: 779 779 779
+Encoding: 779 779 666
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30348,18 +31020,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030C
-Encoding: 780 780 780
+Encoding: 780 780 667
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030D
-Encoding: 781 781 781
+Encoding: 781 781 668
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30374,19 +31048,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030E
-Encoding: 782 782 782
+Encoding: 782 782 669
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 781 781 N 1 0 0 1 204 0 2
-Refer: 781 781 N 1 0 0 1 -204 0 2
+Refer: 668 781 N 1 0 0 1 204 0 2
+Refer: 668 781 N 1 0 0 1 -204 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030F
-Encoding: 783 783 783
+Encoding: 783 783 670
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30406,19 +31082,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0310
-Encoding: 784 784 784
+Encoding: 784 784 671
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 0 204 2
-Refer: 728 728 N 1 0 0 1 0 0 2
+Refer: 637 729 N 1 0 0 1 0 204 2
+Refer: 636 728 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0311
-Encoding: 785 785 785
+Encoding: 785 785 672
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30439,8 +31117,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0312
-Encoding: 786 786 786
+Encoding: 786 786 673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30453,8 +31132,9 @@ SplineSet
  708 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0313
-Encoding: 787 787 787
+Encoding: 787 787 674
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30472,8 +31152,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0314
-Encoding: 788 788 788
+Encoding: 788 788 675
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30491,8 +31172,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0315
-Encoding: 789 789 789
+Encoding: 789 789 676
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30507,28 +31189,31 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0316
-Encoding: 790 790 790
+Encoding: 790 790 677
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0317
-Encoding: 791 791 791
+Encoding: 791 791 678
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0318
-Encoding: 792 792 792
+Encoding: 792 792 679
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30547,8 +31232,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0319
-Encoding: 793 793 793
+Encoding: 793 793 680
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30567,8 +31253,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031A
-Encoding: 794 794 794
+Encoding: 794 794 681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30583,8 +31270,9 @@ SplineSet
  725.5 1768 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031B
-Encoding: 795 795 795
+Encoding: 795 795 682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30607,8 +31295,9 @@ SplineSet
  481 817 481 817 419 872 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031C
-Encoding: 796 796 796
+Encoding: 796 796 683
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30629,8 +31318,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031D
-Encoding: 797 797 797
+Encoding: 797 797 684
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30649,8 +31339,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031E
-Encoding: 798 798 798
+Encoding: 798 798 685
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30669,8 +31360,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031F
-Encoding: 799 799 799
+Encoding: 799 799 686
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30693,8 +31385,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0320
-Encoding: 800 800 800
+Encoding: 800 800 687
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30709,8 +31402,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0321
-Encoding: 801 801 801
+Encoding: 801 801 688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30729,8 +31423,9 @@ SplineSet
  1051 128 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0322
-Encoding: 802 802 802
+Encoding: 802 802 689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30749,8 +31444,9 @@ SplineSet
  182 128 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dotbelowcomb
-Encoding: 803 803 803
+Encoding: 803 803 690
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30786,8 +31482,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0324
-Encoding: 804 804 804
+Encoding: 804 804 691
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30837,8 +31534,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0325
-Encoding: 805 805 805
+Encoding: 805 805 692
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30876,29 +31574,30 @@ AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
 SplineSet
-836 -282 m 0,0,1
+836 -282 m 256,0,1
  836 -374 836 -374 772.5 -438 c 128,-1,2
  709 -502 709 -502 616 -502 c 0,3,4
  524 -502 524 -502 460.5 -438 c 128,-1,5
- 397 -374 397 -374 397 -282 c 0,6,7
+ 397 -374 397 -374 397 -282 c 256,6,7
  397 -190 397 -190 460.5 -126.5 c 128,-1,8
  524 -63 524 -63 616 -63 c 0,9,10
  709 -63 709 -63 772.5 -126.5 c 128,-1,11
- 836 -190 836 -190 836 -282 c 0,0,1
+ 836 -190 836 -190 836 -282 c 256,0,1
 738 -282 m 0,12,13
  738 -232 738 -232 702.5 -196.5 c 128,-1,14
- 667 -161 667 -161 616 -161 c 0,15,16
+ 667 -161 667 -161 616 -161 c 256,15,16
  565 -161 565 -161 530 -196 c 128,-1,17
  495 -231 495 -231 495 -282 c 0,18,19
  495 -334 495 -334 530 -369 c 128,-1,20
- 565 -404 565 -404 616 -404 c 0,21,22
+ 565 -404 565 -404 616 -404 c 256,21,22
  667 -404 667 -404 702.5 -368.5 c 128,-1,23
  738 -333 738 -333 738 -282 c 0,12,13
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0326
-Encoding: 806 806 806
+Encoding: 806 806 693
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30932,8 +31631,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0327
-Encoding: 807 807 807
+Encoding: 807 807 694
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31013,17 +31713,19 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0328
-Encoding: 808 808 808
+Encoding: 808 808 695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 10 0 2
+Refer: 639 731 N 1 0 0 1 10 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0329
-Encoding: 809 809 809
+Encoding: 809 809 696
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31038,8 +31740,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032A
-Encoding: 810 810 810
+Encoding: 810 810 697
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31058,8 +31761,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032B
-Encoding: 811 811 811
+Encoding: 811 811 698
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31082,8 +31786,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032C
-Encoding: 812 812 812
+Encoding: 812 812 699
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31128,8 +31833,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032D
-Encoding: 813 813 813
+Encoding: 813 813 700
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31174,8 +31880,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032E
-Encoding: 814 814 814
+Encoding: 814 814 701
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31228,8 +31935,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032F
-Encoding: 815 815 815
+Encoding: 815 815 702
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31250,8 +31958,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0330
-Encoding: 816 816 816
+Encoding: 816 816 703
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31418,8 +32127,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0331
-Encoding: 817 817 817
+Encoding: 817 817 704
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31453,32 +32163,36 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0332
-Encoding: 818 818 818
+Encoding: 818 818 705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0333
-Encoding: 819 819 819
+Encoding: 819 819 706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8215 8215 N 1 0 0 1 0 0 2
+Refer: 1969 8215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0334
-Encoding: 820 820 820
+Encoding: 820 820 707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0335
-Encoding: 821 821 821
+Encoding: 821 821 708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31491,8 +32205,9 @@ SplineSet
  1062 616 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0336
-Encoding: 822 822 822
+Encoding: 822 822 709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31505,8 +32220,9 @@ SplineSet
  0 452 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0337
-Encoding: 823 823 823
+Encoding: 823 823 710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31519,8 +32235,9 @@ SplineSet
  139 -96 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0338
-Encoding: 824 824 824
+Encoding: 824 824 711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31533,8 +32250,9 @@ SplineSet
  111 -70 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0339
-Encoding: 825 825 825
+Encoding: 825 825 712
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31555,8 +32273,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033A
-Encoding: 826 826 826
+Encoding: 826 826 713
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31575,8 +32294,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033B
-Encoding: 827 827 827
+Encoding: 827 827 714
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31596,8 +32316,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033C
-Encoding: 828 828 828
+Encoding: 828 828 715
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31620,8 +32341,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033D
-Encoding: 829 829 829
+Encoding: 829 829 716
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -31644,8 +32366,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033E
-Encoding: 830 830 830
+Encoding: 830 830 717
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -31676,35 +32399,39 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033F
-Encoding: 831 831 831
+Encoding: 831 831 718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
-Refer: 8254 8254 N 1 0 0 1 0 -240 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 -240 2
 EndChar
+
 StartChar: uni0343
-Encoding: 835 835 835
+Encoding: 835 835 719
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 787 787 N 1 0 0 1 0 0 2
+Refer: 674 787 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0358
-Encoding: 856 856 856
+Encoding: 856 856 720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 513 0 2
+Refer: 637 729 N 1 0 0 1 513 0 2
 EndChar
+
 StartChar: uni0361
-Encoding: 865 865 865
+Encoding: 865 865 721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31723,8 +32450,9 @@ SplineSet
  671.5 1710 671.5 1710 616.5 1710 c 24,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0374
-Encoding: 884 884 884
+Encoding: 884 884 722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31737,8 +32465,9 @@ SplineSet
  492 1140 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0375
-Encoding: 885 885 885
+Encoding: 885 885 723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31751,24 +32480,27 @@ SplineSet
  741 72 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0376
-Encoding: 886 886 886
+Encoding: 886 886 724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 3
+Refer: 862 1048 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0377
-Encoding: 887 887 887
+Encoding: 887 887 725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 3
+Refer: 894 1080 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037A
-Encoding: 890 890 890
+Encoding: 890 890 726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31785,42 +32517,47 @@ SplineSet
  762 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni037B
-Encoding: 891 891 891
+Encoding: 891 891 727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 513 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037C
-Encoding: 892 892 892
+Encoding: 892 892 728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 135 -124 2
+Refer: 68 99 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 135 -124 2
 EndChar
+
 StartChar: uni037D
-Encoding: 893 893 893
+Encoding: 893 893 729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 -118 -124 2
+Refer: 513 596 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 -118 -124 2
 EndChar
+
 StartChar: uni037E
-Encoding: 894 894 894
+Encoding: 894 894 730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 59 59 N 1 0 0 1 0 0 2
+Refer: 28 59 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni037F
-Encoding: 895 895 895
+Encoding: 895 895 731
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
@@ -31828,131 +32565,146 @@ AnchorPoint: "above" 666 1493 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 3
+Refer: 43 74 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: tonos
-Encoding: 900 900 900
+Encoding: 900 900 732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dieresistonos
-Encoding: 901 901 901
+Encoding: 901 901 733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 370 2
 EndChar
+
 StartChar: Alphatonos
-Encoding: 902 902 902
+Encoding: 902 902 734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -450 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -450 0 2
 EndChar
+
 StartChar: anoteleia
-Encoding: 903 903 903
+Encoding: 903 903 735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Epsilontonos
-Encoding: 904 904 904
+Encoding: 904 904 736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -700 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: Etatonos
-Encoding: 905 905 905
+Encoding: 905 905 737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -750 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -750 0 2
 EndChar
+
 StartChar: Iotatonos
-Encoding: 906 906 906
+Encoding: 906 906 738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -700 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: Omicrontonos
-Encoding: 908 908 908
+Encoding: 908 908 739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -550 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: Upsilontonos
-Encoding: 910 910 910
+Encoding: 910 910 740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -875 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: Omegatonos
-Encoding: 911 911 911
+Encoding: 911 911 741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -525 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: iotadieresistonos
-Encoding: 912 912 912
+Encoding: 912 912 742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alpha
-Encoding: 913 913 913
+Encoding: 913 913 743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Beta
-Encoding: 914 914 914
+Encoding: 914 914 744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gamma
-Encoding: 915 915 915
+Encoding: 915 915 745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0394
-Encoding: 916 916 916
+Encoding: 916 916 746
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32020,32 +32772,36 @@ SplineSet
  1196 0 l 9,3,-1
 EndSplineSet
 EndChar
+
 StartChar: Epsilon
-Encoding: 917 917 917
+Encoding: 917 917 747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zeta
-Encoding: 918 918 918
+Encoding: 918 918 748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eta
-Encoding: 919 919 919
+Encoding: 919 919 749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Theta
-Encoding: 920 920 920
+Encoding: 920 920 750
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32112,7 +32868,7 @@ SplineSet
  417.42 881 l 1,2,-1
  815.58 881 l 9,3,-1
  815.58 711 l 17,0,-1
-905 745 m 0,4,5
+905 745 m 256,4,5
  905 1074 905 1074 837.5 1215 c 128,-1,6
  770 1356 770 1356 616 1356 c 0,7,8
  463 1356 463 1356 395.5 1215 c 128,-1,9
@@ -32120,10 +32876,10 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,12
  463 135 463 135 616 135 c 0,13,14
  770 135 770 135 837.5 275.5 c 128,-1,15
- 905 416 905 416 905 745 c 0,4,5
+ 905 416 905 416 905 745 c 256,4,5
 1116 745 m 0,16,17
  1116 355 1116 355 992.5 163 c 128,-1,18
- 869 -29 869 -29 616 -29 c 0,19,20
+ 869 -29 869 -29 616 -29 c 256,19,20
  363 -29 363 -29 240 162 c 128,-1,21
  117 353 117 353 117 745 c 0,22,23
  117 1136 117 1136 240.5 1328 c 128,-1,24
@@ -32132,24 +32888,27 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: Iota
-Encoding: 921 921 921
+Encoding: 921 921 751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kappa
-Encoding: 922 922 922
+Encoding: 922 922 752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lambda
-Encoding: 923 923 923
+Encoding: 923 923 753
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32215,24 +32974,27 @@ SplineSet
  246 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Mu
-Encoding: 924 924 924
+Encoding: 924 924 754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Nu
-Encoding: 925 925 925
+Encoding: 925 925 755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Xi
-Encoding: 926 926 926
+Encoding: 926 926 756
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32297,32 +33059,36 @@ SplineSet
  1096 170 l 25,8,-1
 EndSplineSet
 EndChar
+
 StartChar: Omicron
-Encoding: 927 927 927
+Encoding: 927 927 757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Pi
-Encoding: 928 928 928
+Encoding: 928 928 758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1055 1055 N 1 0 0 1 0 0 2
+Refer: 869 1055 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rho
-Encoding: 929 929 929
+Encoding: 929 929 759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Sigma
-Encoding: 931 931 931
+Encoding: 931 931 760
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32405,24 +33171,27 @@ SplineSet
  786 747 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tau
-Encoding: 932 932 932
+Encoding: 932 932 761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilon
-Encoding: 933 933 933
+Encoding: 933 933 762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Phi
-Encoding: 934 934 934
+Encoding: 934 934 763
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32544,16 +33313,18 @@ SplineSet
  437.89 477.637 437.89 477.637 514 461.826 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: Chi
-Encoding: 935 935 935
+Encoding: 935 935 764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Psi
-Encoding: 936 936 936
+Encoding: 936 936 765
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32645,8 +33416,9 @@ SplineSet
  717 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omega
-Encoding: 937 937 937
+Encoding: 937 937 766
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32736,7 +33508,7 @@ SplineSet
  816 248 816 248 883 412.5 c 128,-1,20
  950 577 950 577 950 799 c 0,21,22
  950 1029 950 1029 860 1161.5 c 128,-1,23
- 770 1294 770 1294 616 1294 c 0,24,25
+ 770 1294 770 1294 616 1294 c 256,24,25
  462 1294 462 1294 372.5 1161.5 c 128,-1,26
  283 1029 283 1029 283 799 c 0,27,28
  283 577 283 577 350 412.5 c 128,-1,29
@@ -32745,71 +33517,79 @@ SplineSet
  74 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Iotadieresis
-Encoding: 938 938 938
+Encoding: 938 938 767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilondieresis
-Encoding: 939 939 939
+Encoding: 939 939 768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alphatonos
-Encoding: 940 940 940
+Encoding: 940 940 769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: epsilontonos
-Encoding: 941 941 941
+Encoding: 941 941 770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: etatonos
-Encoding: 942 942 942
+Encoding: 942 942 771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotatonos
-Encoding: 943 943 943
+Encoding: 943 943 772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresistonos
-Encoding: 944 944 944
+Encoding: 944 944 773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alpha
-Encoding: 945 945 945
+Encoding: 945 945 774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32845,8 +33625,9 @@ SplineSet
  809.801 1150.23 809.801 1150.23 869.15 826.833 c 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: beta
-Encoding: 946 946 946
+Encoding: 946 946 775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32873,8 +33654,9 @@ SplineSet
  336.7 342 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: gamma
-Encoding: 947 947 947
+Encoding: 947 947 776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32896,8 +33678,9 @@ SplineSet
  220.5 836 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: delta
-Encoding: 948 948 948
+Encoding: 948 948 777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32939,16 +33722,18 @@ SplineSet
  291 1034 291 1034 334 1066.53 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: epsilon
-Encoding: 949 949 949
+Encoding: 949 949 778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 603 603 N 1 0 0 1 0 0 2
+Refer: 520 603 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zeta
-Encoding: 950 950 950
+Encoding: 950 950 779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32974,8 +33759,9 @@ SplineSet
  382 127 382 127 760 127 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: eta
-Encoding: 951 951 951
+Encoding: 951 951 780
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33048,8 +33834,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: theta
-Encoding: 952 952 952
+Encoding: 952 952 781
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33126,7 +33913,7 @@ SplineSet
  476 129.072 476 129.072 616 129.072 c 0,14,15
  757 129.072 757 129.072 829 282.81 c 24,16,17
  893.082 419.641 893.082 419.641 899 644 c 9,9,-1
-616 1500 m 0,18,19
+616 1500 m 256,18,19
  849 1500 849 1500 972.5 1303.7 c 128,-1,20
  1096 1107.4 1096 1107.4 1096 735.6 c 0,21,22
  1096 362.5 1096 362.5 973 166.85 c 128,-1,23
@@ -33134,11 +33921,12 @@ SplineSet
  383 -28.7998 383 -28.7998 260 166.85 c 128,-1,26
  137 362.5 137 362.5 137 735.6 c 0,27,28
  137 1107.4 137 1107.4 260 1303.7 c 128,-1,29
- 383 1500 383 1500 616 1500 c 0,18,19
+ 383 1500 383 1500 616 1500 c 256,18,19
 EndSplineSet
 EndChar
+
 StartChar: iota
-Encoding: 953 953 953
+Encoding: 953 953 782
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33190,16 +33978,18 @@ SplineSet
  708.5 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: kappa
-Encoding: 954 954 954
+Encoding: 954 954 783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 3
+Refer: 248 312 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: lambda
-Encoding: 955 955 955
+Encoding: 955 955 784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33220,16 +34010,18 @@ SplineSet
  579.251 1547.44 579.251 1547.44 641.5 1381 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03BC
-Encoding: 956 956 956
+Encoding: 956 956 785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 181 181 N 1 0 0 1 0 0 2
+Refer: 117 181 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nu
-Encoding: 957 957 957
+Encoding: 957 957 786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33251,8 +34043,9 @@ SplineSet
  458 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: xi
-Encoding: 958 958 958
+Encoding: 958 958 787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33283,16 +34076,18 @@ SplineSet
  348.957 131.096 348.957 131.096 785 127 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: omicron
-Encoding: 959 959 959
+Encoding: 959 959 788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: pi
-Encoding: 960 960 960
+Encoding: 960 960 789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33321,8 +34116,9 @@ SplineSet
  80 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rho
-Encoding: 961 961 961
+Encoding: 961 961 790
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33388,7 +34184,7 @@ SplineSet
  190 540 l 2,13,14
  190 856 190 856 300 990 c 24,15,16
  431.259 1146.98 431.259 1146.98 644 1147 c 0,0,1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -33396,11 +34192,12 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: sigma1
-Encoding: 962 962 962
+Encoding: 962 962 791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33431,8 +34228,9 @@ SplineSet
  576.192 128.789 576.192 128.789 748 127 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: sigma
-Encoding: 963 963 963
+Encoding: 963 963 792
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33512,8 +34310,9 @@ SplineSet
  890 936 l 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: tau
-Encoding: 964 964 964
+Encoding: 964 964 793
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33571,8 +34370,9 @@ SplineSet
  708.5 249.652 708.5 249.652 742.5 204 c 16,0,1
 EndSplineSet
 EndChar
+
 StartChar: upsilon
-Encoding: 965 965 965
+Encoding: 965 965 794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33599,8 +34399,9 @@ SplineSet
  520 156 520 156 628 156 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: phi
-Encoding: 966 966 966
+Encoding: 966 966 795
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33715,8 +34516,9 @@ SplineSet
  525 1128 525 1128 773 1128 c 8,11,12
 EndSplineSet
 EndChar
+
 StartChar: chi
-Encoding: 967 967 967
+Encoding: 967 967 796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33745,8 +34547,9 @@ SplineSet
  816.646 -426 816.646 -426 750.5 -250.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: psi
-Encoding: 968 968 968
+Encoding: 968 968 797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33775,8 +34578,9 @@ SplineSet
  708 140 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: omega
-Encoding: 969 969 969
+Encoding: 969 969 798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33808,53 +34612,59 @@ SplineSet
  1033 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: iotadieresis
-Encoding: 970 970 970
+Encoding: 970 970 799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresis
-Encoding: 971 971 971
+Encoding: 971 971 800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omicrontonos
-Encoding: 972 972 972
+Encoding: 972 972 801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilontonos
-Encoding: 973 973 973
+Encoding: 973 973 802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omegatonos
-Encoding: 974 974 974
+Encoding: 974 974 803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D0
-Encoding: 976 976 976
+Encoding: 976 976 804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33883,8 +34693,9 @@ SplineSet
  969.09 590 969.09 590 653 730 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: theta1
-Encoding: 977 977 977
+Encoding: 977 977 805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33913,8 +34724,9 @@ SplineSet
  904.93 471.523 904.93 471.523 909.758 710 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: Upsilon1
-Encoding: 978 978 978
+Encoding: 978 978 806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33939,26 +34751,29 @@ SplineSet
  954.966 1181.53 954.966 1181.53 941.079 1296.95 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D3
-Encoding: 979 979 979
+Encoding: 979 979 807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -875 0 2
+Refer: 806 978 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni03D4
-Encoding: 980 980 980
+Encoding: 980 980 808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 806 978 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: phi1
-Encoding: 981 981 981
+Encoding: 981 981 809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33993,8 +34808,9 @@ SplineSet
  425.166 168.092 425.166 168.092 524 141.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: omega1
-Encoding: 982 982 982
+Encoding: 982 982 810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34023,8 +34839,9 @@ SplineSet
  1110.5 936 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D7
-Encoding: 983 983 983
+Encoding: 983 983 811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34059,8 +34876,9 @@ SplineSet
  888 -372 888 -372 957 -10 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D8
-Encoding: 984 984 984
+Encoding: 984 984 812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34089,8 +34907,9 @@ SplineSet
  514 -426 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D9
-Encoding: 985 985 985
+Encoding: 985 985 813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34119,8 +34938,9 @@ SplineSet
  877.709 3.50293 877.709 3.50293 708 -23 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DA
-Encoding: 986 986 986
+Encoding: 986 986 814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34149,8 +34969,9 @@ SplineSet
  743 1323 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DB
-Encoding: 987 987 987
+Encoding: 987 987 815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34179,16 +35000,18 @@ SplineSet
  1065 964 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DC
-Encoding: 988 988 988
+Encoding: 988 988 816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 3
+Refer: 39 70 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03DD
-Encoding: 989 989 989
+Encoding: 989 989 817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34221,8 +35044,9 @@ SplineSet
  430 -113.331 430 -113.331 430 0 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DE
-Encoding: 990 990 990
+Encoding: 990 990 818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34247,8 +35071,9 @@ SplineSet
  502.216 1340.82 502.216 1340.82 483 1159 c 26,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DF
-Encoding: 991 991 991
+Encoding: 991 991 819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34265,8 +35090,9 @@ SplineSet
  1101 880 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E0
-Encoding: 992 992 992
+Encoding: 992 992 820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34296,8 +35122,9 @@ SplineSet
  460 1355 460 1355 385 1355 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E1
-Encoding: 993 993 993
+Encoding: 993 993 821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34322,8 +35149,9 @@ SplineSet
  848 308 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03F0
-Encoding: 1008 1008 1008
+Encoding: 1008 1008 822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34360,8 +35188,9 @@ SplineSet
  492 409 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03F1
-Encoding: 1009 1009 1009
+Encoding: 1009 1009 823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34393,24 +35222,27 @@ SplineSet
  915 345 915 345 915 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03F2
-Encoding: 1010 1010 1010
+Encoding: 1010 1010 824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F3
-Encoding: 1011 1011 1011
+Encoding: 1011 1011 825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 3
+Refer: 75 106 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F4
-Encoding: 1012 1012 1012
+Encoding: 1012 1012 826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34439,8 +35271,9 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni03F5
-Encoding: 1013 1013 1013
+Encoding: 1013 1013 827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34470,8 +35303,9 @@ SplineSet
  1033 942 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F6
-Encoding: 1014 1014 1014
+Encoding: 1014 1014 828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34501,32 +35335,36 @@ SplineSet
  198.992 954.997 198.992 954.997 162 942 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F7
-Encoding: 1015 1015 1015
+Encoding: 1015 1015 829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 222 222 N 1 0 0 1 0 0 3
+Refer: 158 222 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F8
-Encoding: 1016 1016 1016
+Encoding: 1016 1016 830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 254 254 N 1 0 0 1 0 0 3
+Refer: 190 254 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F9
-Encoding: 1017 1017 1017
+Encoding: 1017 1017 831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 3
+Refer: 36 67 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FA
-Encoding: 1018 1018 1018
+Encoding: 1018 1018 832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34548,8 +35386,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FB
-Encoding: 1019 1019 1019
+Encoding: 1019 1019 833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34571,8 +35410,9 @@ SplineSet
  127 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FC
-Encoding: 1020 1020 1020
+Encoding: 1020 1020 834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34609,8 +35449,9 @@ SplineSet
  915 345 915 345 915 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03FD
-Encoding: 1021 1021 1021
+Encoding: 1021 1021 835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34637,44 +35478,49 @@ SplineSet
  216 12 216 12 139 53 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FE
-Encoding: 1022 1022 1022
+Encoding: 1022 1022 836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1017 1017 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 139 0 2
+Refer: 831 1017 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 139 0 2
 EndChar
+
 StartChar: uni03FF
-Encoding: 1023 1023 1023
+Encoding: 1023 1023 837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -157 0 2
-Refer: 1021 1021 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 -157 0 2
+Refer: 835 1021 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0400
-Encoding: 1024 1024 1024
+Encoding: 1024 1024 838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0401
-Encoding: 1025 1025 1025
+Encoding: 1025 1025 839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 56 373 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 56 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0402
-Encoding: 1026 1026 1026
+Encoding: 1026 1026 840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34714,17 +35560,19 @@ SplineSet
  576 -466 576 -466 573 -287 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0403
-Encoding: 1027 1027 1027
+Encoding: 1027 1027 841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 72 373 2
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 72 373 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0404
-Encoding: 1028 1028 1028
+Encoding: 1028 1028 842
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34810,17 +35658,17 @@ Fore
 SplineSet
 350 661 m 1,0,1
  354 433 354 433 450 284 c 128,-1,2
- 546 135 546 135 734.705 135 c 0,3,4
+ 546 135 546 135 734.705 135 c 256,3,4
  923.41 135 923.41 135 1073 260 c 1,5,-1
  1073 53 l 1,6,7
  919 -29 919 -29 743 -29 c 0,8,9
  456 -29 456 -29 297.5 174 c 128,-1,10
- 139 377 139 377 139 744 c 0,11,12
+ 139 377 139 377 139 744 c 256,11,12
  139 1111 139 1111 298.5 1315.5 c 128,-1,13
  458 1520 458 1520 743 1520 c 0,14,15
  919 1520 919 1520 1073 1438 c 1,16,-1
  1073 1231 l 1,17,18
- 921.361 1356 921.361 1356 731.18 1356 c 0,19,20
+ 921.361 1356 921.361 1356 731.18 1356 c 256,19,20
  541 1356 541 1356 459.5 1222 c 128,-1,21
  378 1088 378 1088 355 831 c 1,22,-1
  982 831 l 1,23,-1
@@ -34828,24 +35676,27 @@ SplineSet
  350 661 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0405
-Encoding: 1029 1029 1029
+Encoding: 1029 1029 843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0406
-Encoding: 1030 1030 1030
+Encoding: 1030 1030 844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0407
-Encoding: 1031 1031 1031
+Encoding: 1031 1031 845
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34860,19 +35711,21 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1030 1030 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 844 1030 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni0408
-Encoding: 1032 1032 1032
+Encoding: 1032 1032 846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0409
-Encoding: 1033 1033 1033
+Encoding: 1033 1033 847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34908,8 +35761,9 @@ SplineSet
  801 1493 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040A
-Encoding: 1034 1034 1034
+Encoding: 1034 1034 848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34943,8 +35797,9 @@ SplineSet
  615 0 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040B
-Encoding: 1035 1035 1035
+Encoding: 1035 1035 849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34977,35 +35832,39 @@ SplineSet
  383 1325 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040C
-Encoding: 1036 1036 1036
+Encoding: 1036 1036 850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 27 373 2
-Refer: 1050 1050 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 27 373 2
+Refer: 864 1050 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040D
-Encoding: 1037 1037 1037
+Encoding: 1037 1037 851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040E
-Encoding: 1038 1038 1038
+Encoding: 1038 1038 852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040F
-Encoding: 1039 1039 1039
+Encoding: 1039 1039 853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35026,16 +35885,18 @@ SplineSet
  137 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0410
-Encoding: 1040 1040 1040
+Encoding: 1040 1040 854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0411
-Encoding: 1041 1041 1041
+Encoding: 1041 1041 855
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35107,7 +35968,7 @@ SplineSet
  604 877 l 1,12,13
  982.571 862.441 982.571 862.441 1084 671 c 0,14,15
  1137 570.76 1137 570.76 1137 410 c 0,16,17
- 1137 206.996 1137 206.996 1004 103.5 c 0,18,19
+ 1137 206.996 1137 206.996 1004 103.5 c 256,18,19
  871 0 871 0 608 0 c 2,20,-1
  166 0 l 1,21,-1
  166 1493 l 1,22,-1
@@ -35115,16 +35976,18 @@ SplineSet
  1068 1327 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0412
-Encoding: 1042 1042 1042
+Encoding: 1042 1042 856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0413
-Encoding: 1043 1043 1043
+Encoding: 1043 1043 857
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35165,8 +36028,9 @@ SplineSet
  215 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0414
-Encoding: 1044 1044 1044
+Encoding: 1044 1044 858
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35248,16 +36112,18 @@ SplineSet
  876 1323 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0415
-Encoding: 1045 1045 1045
+Encoding: 1045 1045 859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0416
-Encoding: 1046 1046 1046
+Encoding: 1046 1046 860
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35408,16 +36274,18 @@ SplineSet
  523 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0417
-Encoding: 1047 1047 1047
+Encoding: 1047 1047 861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0418
-Encoding: 1048 1048 1048
+Encoding: 1048 1048 862
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35498,25 +36366,28 @@ SplineSet
  139 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0419
-Encoding: 1049 1049 1049
+Encoding: 1049 1049 863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041A
-Encoding: 1050 1050 1050
+Encoding: 1050 1050 864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041B
-Encoding: 1051 1051 1051
+Encoding: 1051 1051 865
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35577,32 +36448,36 @@ SplineSet
  483 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni041C
-Encoding: 1052 1052 1052
+Encoding: 1052 1052 866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041D
-Encoding: 1053 1053 1053
+Encoding: 1053 1053 867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041E
-Encoding: 1054 1054 1054
+Encoding: 1054 1054 868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041F
-Encoding: 1055 1055 1055
+Encoding: 1055 1055 869
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35651,32 +36526,36 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0420
-Encoding: 1056 1056 1056
+Encoding: 1056 1056 870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0421
-Encoding: 1057 1057 1057
+Encoding: 1057 1057 871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0422
-Encoding: 1058 1058 1058
+Encoding: 1058 1058 872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0423
-Encoding: 1059 1059 1059
+Encoding: 1059 1059 873
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35765,8 +36644,9 @@ SplineSet
  741 425 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0424
-Encoding: 1060 1060 1060
+Encoding: 1060 1060 874
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35898,16 +36778,18 @@ SplineSet
  718 316 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0425
-Encoding: 1061 1061 1061
+Encoding: 1061 1061 875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0426
-Encoding: 1062 1062 1062
+Encoding: 1062 1062 876
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35966,8 +36848,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0427
-Encoding: 1063 1063 1063
+Encoding: 1063 1063 877
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36026,8 +36909,9 @@ SplineSet
  137 773 137 773 137 980 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0428
-Encoding: 1064 1064 1064
+Encoding: 1064 1064 878
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36088,8 +36972,9 @@ SplineSet
  1120 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0429
-Encoding: 1065 1065 1065
+Encoding: 1065 1065 879
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36163,8 +37048,9 @@ SplineSet
  60 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042A
-Encoding: 1066 1066 1066
+Encoding: 1066 1066 880
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36217,7 +37103,7 @@ SplineSet
 495 166 m 1,0,-1
  633 166 l 2,1,2
  774 166 774 166 852 239.5 c 128,-1,3
- 930 313 930 313 930 446 c 0,4,5
+ 930 313 930 313 930 446 c 256,4,5
  930 579 930 579 851.5 653 c 128,-1,6
  773 727 773 727 633 727 c 2,7,-1
  495 727 l 1,8,-1
@@ -36236,8 +37122,9 @@ SplineSet
  293 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042B
-Encoding: 1067 1067 1067
+Encoding: 1067 1067 881
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36314,8 +37201,9 @@ SplineSet
  65 0 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042C
-Encoding: 1068 1068 1068
+Encoding: 1068 1068 882
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36369,7 +37257,7 @@ SplineSet
 399 166 m 1,0,-1
  633 166 l 2,1,2
  774 166 774 166 852 239.5 c 128,-1,3
- 930 313 930 313 930 446 c 0,4,5
+ 930 313 930 313 930 446 c 256,4,5
  930 579 930 579 851.5 653 c 128,-1,6
  773 727 773 727 633 727 c 2,7,-1
  399 727 l 1,8,-1
@@ -36379,15 +37267,16 @@ SplineSet
  399 1493 l 1,11,-1
  399 893 l 1,12,-1
  633 893 l 2,13,14
- 884 893 884 893 1012.5 780 c 0,15,16
+ 884 893 884 893 1012.5 780 c 256,15,16
  1141 667.005 1141 667.005 1141 446 c 0,17,18
- 1141 227.005 1141 227.005 1012 113.5 c 0,19,20
+ 1141 227.005 1141 227.005 1012 113.5 c 256,19,20
  883.005 0 883.005 0 633 0 c 2,21,-1
  197 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042D
-Encoding: 1069 1069 1069
+Encoding: 1069 1069 883
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36492,8 +37381,9 @@ SplineSet
  756 -29 756 -29 469 -29 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni042E
-Encoding: 1070 1070 1070
+Encoding: 1070 1070 884
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36573,19 +37463,19 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-975 745 m 0,0,1
+975 745 m 256,0,1
  975 1074 975 1074 927.5 1215 c 128,-1,2
- 880 1356 880 1356 773 1356 c 0,3,4
+ 880 1356 880 1356 773 1356 c 256,3,4
  666 1356 666 1356 618.5 1215 c 128,-1,5
  571 1074 571 1074 571 745 c 0,6,7
  571 417 571 417 618.5 276 c 128,-1,8
- 666 135 666 135 773 135 c 0,9,10
+ 666 135 666 135 773 135 c 256,9,10
  880 135 880 135 927.5 275.5 c 128,-1,11
- 975 416 975 416 975 745 c 0,0,1
+ 975 416 975 416 975 745 c 256,0,1
 263 836 m 9,12,-1
  374 836 l 17,13,14
  383.936 1159 383.936 1159 477.468 1339.5 c 128,-1,15
- 571 1520 571 1520 773 1520 c 0,16,17
+ 571 1520 571 1520 773 1520 c 256,16,17
  975 1520 975 1520 1074 1328 c 128,-1,18
  1173 1136 1173 1136 1173 745 c 0,19,20
  1173 355 1173 355 1074 163 c 128,-1,21
@@ -36600,8 +37490,9 @@ SplineSet
  263 836 l 9,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042F
-Encoding: 1071 1071 1071
+Encoding: 1071 1071 885
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36699,17 +37590,19 @@ SplineSet
  76 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0430
-Encoding: 1072 1072 1072
+Encoding: 1072 1072 886
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0431
-Encoding: 1073 1073 1073
+Encoding: 1073 1073 887
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36772,18 +37665,18 @@ AnchorPoint: "above" 616 1556 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-901 559 m 0,0,1
- 901 991 901 991 616.5 991 c 0,2,3
+901 559 m 256,0,1
+ 901 991 901 991 616.5 991 c 256,2,3
  332 991 332 991 332 559 c 0,4,5
  332 346 332 346 404 236.5 c 128,-1,6
  476 127 476 127 616 127 c 0,7,8
- 901 127 901 127 901 559 c 0,0,1
+ 901 127 901 127 901 559 c 256,0,1
 285 1024 m 1,9,10
- 405 1147 405 1147 627 1147 c 0,11,12
+ 405 1147 405 1147 627 1147 c 256,11,12
  849 1147 849 1147 972.5 996 c 128,-1,13
- 1096 845 1096 845 1096 558.5 c 0,14,15
+ 1096 845 1096 845 1096 558.5 c 256,14,15
  1096 272 1096 272 973 121.5 c 128,-1,16
- 850 -29 850 -29 616.5 -29 c 0,17,18
+ 850 -29 850 -29 616.5 -29 c 256,17,18
  383 -29 383 -29 257.73 124.277 c 128,-1,19
  132.461 277.555 132.461 277.555 137 559 c 0,20,21
  137.722 603.772 137.722 603.772 137 621 c 2,22,-1
@@ -36803,8 +37696,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 1" uniF6C5
 EndChar
+
 StartChar: uni0432
-Encoding: 1074 1074 1074
+Encoding: 1074 1074 888
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36862,7 +37756,7 @@ SplineSet
  393 150 l 1,1,-1
  632 150 l 2,2,3
  727 150 727 150 777.5 206 c 128,-1,4
- 828 262 828 262 828 341.5 c 0,5,6
+ 828 262 828 262 828 341.5 c 256,5,6
  828 421 828 421 785.5 468 c 128,-1,7
  743 515 743 515 636 515 c 2,8,-1
  393 515 l 1,0,-1
@@ -36870,7 +37764,7 @@ SplineSet
  393 665 l 1,10,-1
  621 665 l 2,11,12
  706 665 706 665 748 707.5 c 128,-1,13
- 790 750 790 750 790 817 c 0,14,15
+ 790 750 790 750 790 817 c 256,14,15
  790 884 790 884 748 927 c 128,-1,16
  706 970 706 970 620 970 c 2,17,-1
  393 970 l 1,9,-1
@@ -36888,8 +37782,9 @@ SplineSet
  209 1120 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0433
-Encoding: 1075 1075 1075
+Encoding: 1075 1075 889
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36929,8 +37824,9 @@ SplineSet
  441 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0434
-Encoding: 1076 1076 1076
+Encoding: 1076 1076 890
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37013,17 +37909,19 @@ SplineSet
  822 150 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0435
-Encoding: 1077 1077 1077
+Encoding: 1077 1077 891
 Width: 1233
 Flags: W
 AnchorPoint: "above" 630 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0436
-Encoding: 1078 1078 1078
+Encoding: 1078 1078 892
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37175,17 +38073,19 @@ SplineSet
  533 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0437
-Encoding: 1079 1079 1079
+Encoding: 1079 1079 893
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 604 604 N 1 0 0 1 0 0 2
+Refer: 521 604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0438
-Encoding: 1080 1080 1080
+Encoding: 1080 1080 894
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37268,26 +38168,29 @@ SplineSet
  866 809 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0439
-Encoding: 1081 1081 1081
+Encoding: 1081 1081 895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043A
-Encoding: 1082 1082 1082
+Encoding: 1082 1082 896
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 3
+Refer: 248 312 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni043B
-Encoding: 1083 1083 1083
+Encoding: 1083 1083 897
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37349,8 +38252,9 @@ SplineSet
  265 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043C
-Encoding: 1084 1084 1084
+Encoding: 1084 1084 898
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37453,8 +38357,9 @@ SplineSet
  61 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043D
-Encoding: 1085 1085 1085
+Encoding: 1085 1085 899
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37514,17 +38419,19 @@ SplineSet
  866 515 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043E
-Encoding: 1086 1086 1086
+Encoding: 1086 1086 900
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043F
-Encoding: 1087 1087 1087
+Encoding: 1087 1087 901
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37572,26 +38479,29 @@ SplineSet
  866 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0440
-Encoding: 1088 1088 1088
+Encoding: 1088 1088 902
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0441
-Encoding: 1089 1089 1089
+Encoding: 1089 1089 903
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0442
-Encoding: 1090 1090 1090
+Encoding: 1090 1090 904
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37639,17 +38549,19 @@ SplineSet
  720 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0443
-Encoding: 1091 1091 1091
+Encoding: 1091 1091 905
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0444
-Encoding: 1092 1092 1092
+Encoding: 1092 1092 906
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37751,20 +38663,20 @@ Fore
 SplineSet
 520 982 m 1,0,1
  400 957 400 957 347 880.5 c 128,-1,2
- 294 804 294 804 294 559 c 0,3,4
+ 294 804 294 804 294 559 c 256,3,4
  294 314 294 314 347 233 c 128,-1,5
  400 152 400 152 520 127 c 1,6,-1
  520 982 l 1,0,1
 520 -29 m 17,7,8
  300 -7 300 -7 199.5 126.5 c 128,-1,9
- 99 260 99 260 99 559 c 0,10,11
+ 99 260 99 260 99 559 c 256,10,11
  99 858 99 858 198.5 991.5 c 128,-1,12
  298 1125 298 1125 520 1147 c 1,13,-1
  520 1556 l 1,14,-1
  704 1556 l 1,15,-1
  704 1147 l 1,16,17
  926 1125 926 1125 1025.5 991.5 c 128,-1,18
- 1125 858 1125 858 1125 559 c 0,19,20
+ 1125 858 1125 858 1125 559 c 256,19,20
  1125 260 1125 260 1024.5 126.5 c 128,-1,21
  924 -7 924 -7 704 -29 c 1,22,-1
  704 -426 l 1,23,-1
@@ -37773,22 +38685,24 @@ SplineSet
 704 982 m 1,25,-1
  704 127 l 1,26,27
  824 152 824 152 877 233 c 128,-1,28
- 930 314 930 314 930 559 c 0,29,30
+ 930 314 930 314 930 559 c 256,29,30
  930 804 930 804 877 880.5 c 128,-1,31
  824 957 824 957 704 982 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0445
-Encoding: 1093 1093 1093
+Encoding: 1093 1093 907
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0446
-Encoding: 1094 1094 1094
+Encoding: 1094 1094 908
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37848,8 +38762,9 @@ SplineSet
  1118 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0447
-Encoding: 1095 1095 1095
+Encoding: 1095 1095 909
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37910,8 +38825,9 @@ SplineSet
  195 565 195 565 195 755 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0448
-Encoding: 1096 1096 1096
+Encoding: 1096 1096 910
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37971,8 +38887,9 @@ SplineSet
  1109 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0449
-Encoding: 1097 1097 1097
+Encoding: 1097 1097 911
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38045,8 +38962,9 @@ SplineSet
  1058 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044A
-Encoding: 1098 1098 1098
+Encoding: 1098 1098 912
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38099,7 +39017,7 @@ SplineSet
 462 156 m 1,0,-1
  710 156 l 2,1,2
  834 156 834 156 901 200 c 128,-1,3
- 968 244 968 244 968 334 c 0,4,5
+ 968 244 968 244 968 334 c 256,4,5
  968 424 968 424 899.5 469 c 128,-1,6
  831 514 831 514 710 514 c 2,7,-1
  462 514 l 1,8,-1
@@ -38112,14 +39030,15 @@ SplineSet
  462 667 l 1,14,-1
  718 667 l 2,15,16
  927 667 927 667 1045.5 583.5 c 128,-1,17
- 1164 500 1164 500 1164 332 c 0,18,19
+ 1164 500 1164 500 1164 332 c 256,18,19
  1164 164 1164 164 1048 82 c 128,-1,20
  932 0 932 0 718 0 c 2,21,-1
  278 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044B
-Encoding: 1099 1099 1099
+Encoding: 1099 1099 913
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38179,7 +39098,7 @@ SplineSet
 286 154 m 1,4,-1
  369 154 l 2,5,6
  493 154 493 154 560 198.5 c 128,-1,7
- 627 243 627 243 627 334 c 0,8,9
+ 627 243 627 243 627 334 c 256,8,9
  627 425 627 425 558.5 470.5 c 128,-1,10
  490 516 490 516 369 516 c 2,11,-1
  286 516 l 1,12,-1
@@ -38190,14 +39109,15 @@ SplineSet
  286 667 l 1,16,-1
  377 667 l 2,17,18
  586 667 586 667 704.5 583.5 c 128,-1,19
- 823 500 823 500 823 332 c 0,20,21
+ 823 500 823 500 823 332 c 256,20,21
  823 164 823 164 707 82 c 128,-1,22
  591 0 591 0 377 0 c 2,23,-1
  104 0 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044C
-Encoding: 1100 1100 1100
+Encoding: 1100 1100 914
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38262,14 +39182,15 @@ SplineSet
  379 667 l 1,12,-1
  635 667 l 2,13,14
  843.321 667 843.321 667 961.66 583.498 c 128,-1,15
- 1080 499.996 1080 499.996 1080 332 c 0,16,17
+ 1080 499.996 1080 499.996 1080 332 c 256,16,17
  1080 164.004 1080 164.004 964.5 82.002 c 128,-1,18
  849 0 849 0 635 0 c 2,19,-1
  195 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044D
-Encoding: 1101 1101 1101
+Encoding: 1101 1101 915
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38370,15 +39291,16 @@ SplineSet
  273 1105 273 1105 350 1126 c 128,-1,21
  427 1147 427 1147 508 1147 c 0,22,23
  768 1147 768 1147 914.5 991 c 128,-1,24
- 1061 835 1061 835 1061 559 c 0,25,26
+ 1061 835 1061 835 1061 559 c 256,25,26
  1061 283 1061 283 914 127 c 0,27,28
  768 -29 768 -29 508 -29 c 0,29,30
  426 -29 426 -29 347.5 -7.5 c 128,-1,31
  269 14 269 14 195 57 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044E
-Encoding: 1102 1102 1102
+Encoding: 1102 1102 916
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38462,11 +39384,11 @@ SplineSet
 262 634 m 1,12,-1
  404 634 l 1,13,14
  421 890 421 890 526 1018.5 c 128,-1,15
- 631 1147 631 1147 788 1147 c 0,16,17
+ 631 1147 631 1147 788 1147 c 256,16,17
  945 1147 945 1147 1056.5 1001 c 128,-1,18
- 1168 855 1168 855 1168 553.5 c 0,19,20
+ 1168 855 1168 855 1168 553.5 c 256,19,20
  1168 252 1168 252 1053 111.5 c 128,-1,21
- 938 -29 938 -29 784.5 -29 c 0,22,23
+ 938 -29 938 -29 784.5 -29 c 256,22,23
  631 -29 631 -29 525.5 109 c 128,-1,24
  420 247 420 247 404 484 c 1,25,-1
  262 484 l 1,26,-1
@@ -38477,8 +39399,9 @@ SplineSet
  262 634 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044F
-Encoding: 1103 1103 1103
+Encoding: 1103 1103 917
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38553,14 +39476,14 @@ AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-403 787 m 0,0,1
+403 787 m 256,0,1
  403 690 403 690 460 647.5 c 128,-1,2
  517 605 517 605 572 605 c 2,3,-1
  800 605 l 1,4,-1
  800 970 l 1,5,-1
  573 970 l 2,6,7
  517 970 517 970 460 927 c 128,-1,8
- 403 884 403 884 403 787 c 0,0,1
+ 403 884 403 884 403 787 c 256,0,1
 168 0 m 1,9,-1
  440 479 l 1,10,11
  387 501 387 501 302 566 c 128,-1,12
@@ -38576,26 +39499,29 @@ SplineSet
  168 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0450
-Encoding: 1104 1104 1104
+Encoding: 1104 1104 918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 -30 7 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -30 7 2
 EndChar
+
 StartChar: uni0451
-Encoding: 1105 1105 1105
+Encoding: 1105 1105 919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 35 -81 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 35 -81 2
 EndChar
+
 StartChar: uni0452
-Encoding: 1106 1106 1106
+Encoding: 1106 1106 920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38630,17 +39556,19 @@ SplineSet
  35 977 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0453
-Encoding: 1107 1107 1107
+Encoding: 1107 1107 921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1075 1075 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 81 7 2
+Refer: 889 1075 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 81 7 2
 EndChar
+
 StartChar: uni0454
-Encoding: 1108 1108 1108
+Encoding: 1108 1108 922
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38749,25 +39677,28 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0455
-Encoding: 1109 1109 1109
+Encoding: 1109 1109 923
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0456
-Encoding: 1110 1110 1110
+Encoding: 1110 1110 924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0457
-Encoding: 1111 1111 1111
+Encoding: 1111 1111 925
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38782,19 +39713,21 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 24 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 24 0 2
 EndChar
+
 StartChar: uni0458
-Encoding: 1112 1112 1112
+Encoding: 1112 1112 926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0459
-Encoding: 1113 1113 1113
+Encoding: 1113 1113 927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38830,8 +39763,9 @@ SplineSet
  995 0 995 0 831 0 c 2,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni045A
-Encoding: 1114 1114 1114
+Encoding: 1114 1114 928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38863,8 +39797,9 @@ SplineSet
  765 667 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045B
-Encoding: 1115 1115 1115
+Encoding: 1115 1115 929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38897,35 +39832,39 @@ SplineSet
  35 977 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045C
-Encoding: 1116 1116 1116
+Encoding: 1116 1116 930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 48.5 7 2
+Refer: 896 1082 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 48.5 7 2
 EndChar
+
 StartChar: uni045D
-Encoding: 1117 1117 1117
+Encoding: 1117 1117 931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 64.5 7 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 64.5 7 2
 EndChar
+
 StartChar: uni045E
-Encoding: 1118 1118 1118
+Encoding: 1118 1118 932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045F
-Encoding: 1119 1119 1119
+Encoding: 1119 1119 933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38946,8 +39885,9 @@ SplineSet
  195 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0462
-Encoding: 1122 1122 1122
+Encoding: 1122 1122 934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38981,8 +39921,9 @@ SplineSet
  495 1105 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0463
-Encoding: 1123 1123 1123
+Encoding: 1123 1123 935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39016,76 +39957,87 @@ SplineSet
  462 156 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni046A
-Encoding: 1130 1130 1130
+Encoding: 1130 1130 936
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni046B
-Encoding: 1131 1131 1131
+Encoding: 1131 1131 937
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0472
-Encoding: 1138 1138 1138
+Encoding: 1138 1138 938
 Width: 1233
 Flags: W
 AnchorPoint: "above" 807 1520 basechar 0
 AnchorPoint: "below" 807 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 415 415 N 1 0 0 1 0 0 3
+Refer: 351 415 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0473
-Encoding: 1139 1139 1139
+Encoding: 1139 1139 939
 Width: 1233
 Flags: W
 AnchorPoint: "below" 637 0 basechar 0
 AnchorPoint: "above" 637 1147 basechar 0
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 3
+Refer: 546 629 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni048A
-Encoding: 1162 1162 1162
+Encoding: 1162 1162 940
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048B
-Encoding: 1163 1163 1163
+Encoding: 1163 1163 941
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048C
-Encoding: 1164 1164 1164
+Encoding: 1164 1164 942
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048D
-Encoding: 1165 1165 1165
+Encoding: 1165 1165 943
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048E
-Encoding: 1166 1166 1166
+Encoding: 1166 1166 944
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048F
-Encoding: 1167 1167 1167
+Encoding: 1167 1167 945
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0490
-Encoding: 1168 1168 1168
+Encoding: 1168 1168 946
 Width: 1233
 Flags: W
 TtInstrs:
@@ -39132,8 +40084,9 @@ SplineSet
  215 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0491
-Encoding: 1169 1169 1169
+Encoding: 1169 1169 947
 Width: 1233
 Flags: W
 TtInstrs:
@@ -39178,8 +40131,9 @@ SplineSet
  441 936 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0492
-Encoding: 1170 1170 1170
+Encoding: 1170 1170 948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39202,8 +40156,9 @@ SplineSet
  85 1000 l 9,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0493
-Encoding: 1171 1171 1171
+Encoding: 1171 1171 949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39226,8 +40181,9 @@ SplineSet
  257 0 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0494
-Encoding: 1172 1172 1172
+Encoding: 1172 1172 950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39258,8 +40214,9 @@ SplineSet
  418 711 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0495
-Encoding: 1173 1173 1173
+Encoding: 1173 1173 951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39290,8 +40247,9 @@ SplineSet
  441 487 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0496
-Encoding: 1174 1174 1174
+Encoding: 1174 1174 952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39324,8 +40282,9 @@ SplineSet
  15 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0497
-Encoding: 1175 1175 1175
+Encoding: 1175 1175 953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39358,26 +40317,29 @@ SplineSet
  59 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0498
-Encoding: 1176 1176 1176
+Encoding: 1176 1176 954
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -73 0 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -73 0 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0499
-Encoding: 1177 1177 1177
+Encoding: 1177 1177 955
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -67 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -67 0 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni049A
-Encoding: 1178 1178 1178
+Encoding: 1178 1178 956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39402,8 +40364,9 @@ SplineSet
  1110 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049B
-Encoding: 1179 1179 1179
+Encoding: 1179 1179 957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39428,44 +40391,51 @@ SplineSet
  1068 184 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049C
-Encoding: 1180 1180 1180
+Encoding: 1180 1180 958
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049D
-Encoding: 1181 1181 1181
+Encoding: 1181 1181 959
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049E
-Encoding: 1182 1182 1182
+Encoding: 1182 1182 960
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049F
-Encoding: 1183 1183 1183
+Encoding: 1183 1183 961
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A0
-Encoding: 1184 1184 1184
+Encoding: 1184 1184 962
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A1
-Encoding: 1185 1185 1185
+Encoding: 1185 1185 963
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A2
-Encoding: 1186 1186 1186
+Encoding: 1186 1186 964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39490,8 +40460,9 @@ SplineSet
  990 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04A3
-Encoding: 1187 1187 1187
+Encoding: 1187 1187 965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39516,8 +40487,9 @@ SplineSet
  953 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04A4
-Encoding: 1188 1188 1188
+Encoding: 1188 1188 966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39540,8 +40512,9 @@ SplineSet
  113 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A5
-Encoding: 1189 1189 1189
+Encoding: 1189 1189 967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39564,50 +40537,57 @@ SplineSet
  125 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A6
-Encoding: 1190 1190 1190
+Encoding: 1190 1190 968
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A7
-Encoding: 1191 1191 1191
+Encoding: 1191 1191 969
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A8
-Encoding: 1192 1192 1192
+Encoding: 1192 1192 970
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A9
-Encoding: 1193 1193 1193
+Encoding: 1193 1193 971
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04AA
-Encoding: 1194 1194 1194
+Encoding: 1194 1194 972
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 1057 1057 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 871 1057 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AB
-Encoding: 1195 1195 1195
+Encoding: 1195 1195 973
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 1089 1089 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 903 1089 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AC
-Encoding: 1196 1196 1196
+Encoding: 1196 1196 974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39628,8 +40608,9 @@ SplineSet
  719 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04AD
-Encoding: 1197 1197 1197
+Encoding: 1197 1197 975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39650,16 +40631,18 @@ SplineSet
  720 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04AE
-Encoding: 1198 1198 1198
+Encoding: 1198 1198 976
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AF
-Encoding: 1199 1199 1199
+Encoding: 1199 1199 977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39677,8 +40660,9 @@ SplineSet
  92 1120 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B0
-Encoding: 1200 1200 1200
+Encoding: 1200 1200 978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39704,8 +40688,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B1
-Encoding: 1201 1201 1201
+Encoding: 1201 1201 979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39731,8 +40716,9 @@ SplineSet
  92 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B2
-Encoding: 1202 1202 1202
+Encoding: 1202 1202 980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39757,8 +40743,9 @@ SplineSet
  1112 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B3
-Encoding: 1203 1203 1203
+Encoding: 1203 1203 981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39783,44 +40770,51 @@ SplineSet
  1018 184 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B4
-Encoding: 1204 1204 1204
+Encoding: 1204 1204 982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B5
-Encoding: 1205 1205 1205
+Encoding: 1205 1205 983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B6
-Encoding: 1206 1206 1206
+Encoding: 1206 1206 984
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B7
-Encoding: 1207 1207 1207
+Encoding: 1207 1207 985
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B8
-Encoding: 1208 1208 1208
+Encoding: 1208 1208 986
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B9
-Encoding: 1209 1209 1209
+Encoding: 1209 1209 987
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BA
-Encoding: 1210 1210 1210
+Encoding: 1210 1210 988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39849,66 +40843,75 @@ SplineSet
  1095 727.993 1095 727.993 1095 500 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04BB
-Encoding: 1211 1211 1211
+Encoding: 1211 1211 989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04BC
-Encoding: 1212 1212 1212
+Encoding: 1212 1212 990
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BD
-Encoding: 1213 1213 1213
+Encoding: 1213 1213 991
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BE
-Encoding: 1214 1214 1214
+Encoding: 1214 1214 992
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BF
-Encoding: 1215 1215 1215
+Encoding: 1215 1215 993
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C0
-Encoding: 1216 1216 1216
+Encoding: 1216 1216 994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C1
-Encoding: 1217 1217 1217
+Encoding: 1217 1217 995
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C2
-Encoding: 1218 1218 1218
+Encoding: 1218 1218 996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C3
-Encoding: 1219 1219 1219
+Encoding: 1219 1219 997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39941,8 +40944,9 @@ SplineSet
  627 881 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C4
-Encoding: 1220 1220 1220
+Encoding: 1220 1220 998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39975,20 +40979,23 @@ SplineSet
  617.765 631 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C5
-Encoding: 1221 1221 1221
+Encoding: 1221 1221 999
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C6
-Encoding: 1222 1222 1222
+Encoding: 1222 1222 1000
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C7
-Encoding: 1223 1223 1223
+Encoding: 1223 1223 1001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40015,8 +41022,9 @@ SplineSet
  1096 104 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C8
-Encoding: 1224 1224 1224
+Encoding: 1224 1224 1002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40043,20 +41051,23 @@ SplineSet
  1050 -20 l 18,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni04C9
-Encoding: 1225 1225 1225
+Encoding: 1225 1225 1003
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CA
-Encoding: 1226 1226 1226
+Encoding: 1226 1226 1004
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CB
-Encoding: 1227 1227 1227
+Encoding: 1227 1227 1005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40089,8 +41100,9 @@ SplineSet
  892 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CC
-Encoding: 1228 1228 1228
+Encoding: 1228 1228 1006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40120,20 +41132,23 @@ SplineSet
  867 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CD
-Encoding: 1229 1229 1229
+Encoding: 1229 1229 1007
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CE
-Encoding: 1230 1230 1230
+Encoding: 1230 1230 1008
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CF
-Encoding: 1231 1231 1231
+Encoding: 1231 1231 1009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40146,8 +41161,9 @@ SplineSet
  639 1567 l 17,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04D0
-Encoding: 1232 1232 1232
+Encoding: 1232 1232 1010
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40178,20 +41194,22 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1040 1040 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D1
-Encoding: 1233 1233 1233
+Encoding: 1233 1233 1011
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D2
-Encoding: 1234 1234 1234
+Encoding: 1234 1234 1012
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40226,176 +41244,196 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1040 1040 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04D3
-Encoding: 1235 1235 1235
+Encoding: 1235 1235 1013
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D4
-Encoding: 1236 1236 1236
+Encoding: 1236 1236 1014
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D5
-Encoding: 1237 1237 1237
+Encoding: 1237 1237 1015
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D6
-Encoding: 1238 1238 1238
+Encoding: 1238 1238 1016
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D7
-Encoding: 1239 1239 1239
+Encoding: 1239 1239 1017
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D8
-Encoding: 1240 1240 1240
+Encoding: 1240 1240 1018
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 399 399 N 1 0 0 1 0 0 3
+Refer: 335 399 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04D9
-Encoding: 1241 1241 1241
+Encoding: 1241 1241 1019
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04DA
-Encoding: 1242 1242 1242
+Encoding: 1242 1242 1020
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1240 1240 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 1018 1240 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DB
-Encoding: 1243 1243 1243
+Encoding: 1243 1243 1021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1241 1241 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1019 1241 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DC
-Encoding: 1244 1244 1244
+Encoding: 1244 1244 1022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DD
-Encoding: 1245 1245 1245
+Encoding: 1245 1245 1023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DE
-Encoding: 1246 1246 1246
+Encoding: 1246 1246 1024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -17 373 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 -17 373 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DF
-Encoding: 1247 1247 1247
+Encoding: 1247 1247 1025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -15 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -15 0 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E0
-Encoding: 1248 1248 1248
+Encoding: 1248 1248 1026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E1
-Encoding: 1249 1249 1249
+Encoding: 1249 1249 1027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E2
-Encoding: 1250 1250 1250
+Encoding: 1250 1250 1028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E3
-Encoding: 1251 1251 1251
+Encoding: 1251 1251 1029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E4
-Encoding: 1252 1252 1252
+Encoding: 1252 1252 1030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E5
-Encoding: 1253 1253 1253
+Encoding: 1253 1253 1031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E6
-Encoding: 1254 1254 1254
+Encoding: 1254 1254 1032
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40430,11 +41468,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1054 1054 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 868 1054 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04E7
-Encoding: 1255 1255 1255
+Encoding: 1255 1255 1033
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40461,135 +41500,150 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1086 1086 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 900 1086 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E8
-Encoding: 1256 1256 1256
+Encoding: 1256 1256 1034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1012 1012 N 1 0 0 1 0 0 2
+Refer: 826 1012 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E9
-Encoding: 1257 1257 1257
+Encoding: 1257 1257 1035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 2
+Refer: 546 629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EA
-Encoding: 1258 1258 1258
+Encoding: 1258 1258 1036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1256 1256 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 1034 1256 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EB
-Encoding: 1259 1259 1259
+Encoding: 1259 1259 1037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1257 1257 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1035 1257 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EC
-Encoding: 1260 1260 1260
+Encoding: 1260 1260 1038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -33 373 2
-Refer: 1069 1069 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 -33 373 2
+Refer: 883 1069 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04ED
-Encoding: 1261 1261 1261
+Encoding: 1261 1261 1039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -20 0 2
-Refer: 1101 1101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -20 0 2
+Refer: 915 1101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EE
-Encoding: 1262 1262 1262
+Encoding: 1262 1262 1040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EF
-Encoding: 1263 1263 1263
+Encoding: 1263 1263 1041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F0
-Encoding: 1264 1264 1264
+Encoding: 1264 1264 1042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F1
-Encoding: 1265 1265 1265
+Encoding: 1265 1265 1043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F2
-Encoding: 1266 1266 1266
+Encoding: 1266 1266 1044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F3
-Encoding: 1267 1267 1267
+Encoding: 1267 1267 1045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F4
-Encoding: 1268 1268 1268
+Encoding: 1268 1268 1046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1063 1063 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 877 1063 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F5
-Encoding: 1269 1269 1269
+Encoding: 1269 1269 1047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1095 1095 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 909 1095 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F6
-Encoding: 1270 1270 1270
+Encoding: 1270 1270 1048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40608,8 +41662,9 @@ SplineSet
  418 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04F7
-Encoding: 1271 1271 1271
+Encoding: 1271 1271 1049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40628,170 +41683,195 @@ SplineSet
  441 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04F8
-Encoding: 1272 1272 1272
+Encoding: 1272 1272 1050
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1067 1067 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 881 1067 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F9
-Encoding: 1273 1273 1273
+Encoding: 1273 1273 1051
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1099 1099 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 913 1099 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0500
-Encoding: 1280 1280 1280
+Encoding: 1280 1280 1052
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0501
-Encoding: 1281 1281 1281
+Encoding: 1281 1281 1053
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0502
-Encoding: 1282 1282 1282
+Encoding: 1282 1282 1054
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0503
-Encoding: 1283 1283 1283
+Encoding: 1283 1283 1055
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0504
-Encoding: 1284 1284 1284
+Encoding: 1284 1284 1056
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0505
-Encoding: 1285 1285 1285
+Encoding: 1285 1285 1057
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0506
-Encoding: 1286 1286 1286
+Encoding: 1286 1286 1058
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0507
-Encoding: 1287 1287 1287
+Encoding: 1287 1287 1059
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0508
-Encoding: 1288 1288 1288
+Encoding: 1288 1288 1060
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0509
-Encoding: 1289 1289 1289
+Encoding: 1289 1289 1061
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050A
-Encoding: 1290 1290 1290
+Encoding: 1290 1290 1062
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050B
-Encoding: 1291 1291 1291
+Encoding: 1291 1291 1063
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050C
-Encoding: 1292 1292 1292
+Encoding: 1292 1292 1064
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050D
-Encoding: 1293 1293 1293
+Encoding: 1293 1293 1065
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050E
-Encoding: 1294 1294 1294
+Encoding: 1294 1294 1066
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050F
-Encoding: 1295 1295 1295
+Encoding: 1295 1295 1067
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0510
-Encoding: 1296 1296 1296
+Encoding: 1296 1296 1068
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 400 400 N 1 0 0 1 0 0 3
+Refer: 336 400 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0511
-Encoding: 1297 1297 1297
+Encoding: 1297 1297 1069
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 3
+Refer: 778 949 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni051A
-Encoding: 1306 1306 1306
+Encoding: 1306 1306 1070
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051B
-Encoding: 1307 1307 1307
+Encoding: 1307 1307 1071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051C
-Encoding: 1308 1308 1308
+Encoding: 1308 1308 1072
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051D
-Encoding: 1309 1309 1309
+Encoding: 1309 1309 1073
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0531
-Encoding: 1329 1329 1329
+Encoding: 1329 1329 1074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40830,8 +41910,9 @@ SplineSet
  669 458 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0532
-Encoding: 1330 1330 1330
+Encoding: 1330 1330 1075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40866,8 +41947,9 @@ SplineSet
  1066 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0533
-Encoding: 1331 1331 1331
+Encoding: 1331 1331 1076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40911,8 +41993,9 @@ SplineSet
  821 1058 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0534
-Encoding: 1332 1332 1332
+Encoding: 1332 1332 1077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40947,8 +42030,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0535
-Encoding: 1333 1333 1333
+Encoding: 1333 1333 1078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40983,8 +42067,9 @@ SplineSet
  1066 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0536
-Encoding: 1334 1334 1334
+Encoding: 1334 1334 1079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41031,8 +42116,9 @@ SplineSet
  1137 1067 1137 1067 1137 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0537
-Encoding: 1335 1335 1335
+Encoding: 1335 1335 1080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41051,8 +42137,9 @@ SplineSet
  323 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0538
-Encoding: 1336 1336 1336
+Encoding: 1336 1336 1081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41085,8 +42172,9 @@ SplineSet
  1066 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0539
-Encoding: 1337 1337 1337
+Encoding: 1337 1337 1082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41148,8 +42236,9 @@ SplineSet
  589 499 589 499 589 415 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni053A
-Encoding: 1338 1338 1338
+Encoding: 1338 1338 1083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41193,8 +42282,9 @@ SplineSet
  552 950 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni053B
-Encoding: 1339 1339 1339
+Encoding: 1339 1339 1084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41225,8 +42315,9 @@ SplineSet
  1085 494 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053C
-Encoding: 1340 1340 1340
+Encoding: 1340 1340 1085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41241,8 +42332,9 @@ SplineSet
  154 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053D
-Encoding: 1341 1341 1341
+Encoding: 1341 1341 1086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41279,8 +42371,9 @@ SplineSet
  648 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053E
-Encoding: 1342 1342 1342
+Encoding: 1342 1342 1087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41345,8 +42438,9 @@ SplineSet
  307 749 307 749 307 621 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni053F
-Encoding: 1343 1343 1343
+Encoding: 1343 1343 1088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41377,8 +42471,9 @@ SplineSet
  1085 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0540
-Encoding: 1344 1344 1344
+Encoding: 1344 1344 1089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41409,8 +42504,9 @@ SplineSet
  1142 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0541
-Encoding: 1345 1345 1345
+Encoding: 1345 1345 1090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41467,8 +42563,9 @@ SplineSet
  508 408 508 408 434 408 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni0542
-Encoding: 1346 1346 1346
+Encoding: 1346 1346 1091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41501,8 +42598,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0543
-Encoding: 1347 1347 1347
+Encoding: 1347 1347 1092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41538,8 +42636,9 @@ SplineSet
  458 669 458 669 429 618 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0544
-Encoding: 1348 1348 1348
+Encoding: 1348 1348 1093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41572,8 +42671,9 @@ SplineSet
  790 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0545
-Encoding: 1349 1349 1349
+Encoding: 1349 1349 1094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41631,8 +42731,9 @@ SplineSet
  1169 506 1169 506 1169 444 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0546
-Encoding: 1350 1350 1350
+Encoding: 1350 1350 1095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41665,8 +42766,9 @@ SplineSet
  1179 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0547
-Encoding: 1351 1351 1351
+Encoding: 1351 1351 1096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41717,8 +42819,9 @@ SplineSet
  307 722 307 722 307 596 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0548
-Encoding: 1352 1352 1352
+Encoding: 1352 1352 1097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41749,8 +42852,9 @@ SplineSet
  1085 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0549
-Encoding: 1353 1353 1353
+Encoding: 1353 1353 1098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41795,8 +42899,9 @@ SplineSet
  926 769 926 769 926 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054A
-Encoding: 1354 1354 1354
+Encoding: 1354 1354 1099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41830,8 +42935,9 @@ SplineSet
  798 1342 798 1342 711 1351 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054B
-Encoding: 1355 1355 1355
+Encoding: 1355 1355 1100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41897,8 +43003,9 @@ SplineSet
  925 761 925 761 925 895 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni054C
-Encoding: 1356 1356 1356
+Encoding: 1356 1356 1101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41933,8 +43040,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054D
-Encoding: 1357 1357 1357
+Encoding: 1357 1357 1102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41965,8 +43073,9 @@ SplineSet
  147 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054E
-Encoding: 1358 1358 1358
+Encoding: 1358 1358 1103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41999,8 +43108,9 @@ SplineSet
  33 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054F
-Encoding: 1359 1359 1359
+Encoding: 1359 1359 1104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42061,8 +43171,9 @@ SplineSet
  105 340 105 340 105 447 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0550
-Encoding: 1360 1360 1360
+Encoding: 1360 1360 1105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42093,8 +43204,9 @@ SplineSet
  1085 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0551
-Encoding: 1361 1361 1361
+Encoding: 1361 1361 1106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42164,8 +43276,9 @@ SplineSet
  551 1520 551 1520 658 1520 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0552
-Encoding: 1362 1362 1362
+Encoding: 1362 1362 1107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42182,8 +43295,9 @@ SplineSet
  338 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0553
-Encoding: 1363 1363 1363
+Encoding: 1363 1363 1108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42234,8 +43348,9 @@ SplineSet
  518 158 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0554
-Encoding: 1364 1364 1364
+Encoding: 1364 1364 1109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42288,16 +43403,18 @@ SplineSet
  791 1356 791 1356 713 1356 c 0,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni0555
-Encoding: 1365 1365 1365
+Encoding: 1365 1365 1110
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 3
+Refer: 48 79 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0556
-Encoding: 1366 1366 1366
+Encoding: 1366 1366 1111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42360,16 +43477,18 @@ SplineSet
  964 438 964 438 964 537 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: uni0559
-Encoding: 1369 1369 1369
+Encoding: 1369 1369 1112
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 0 3
+Refer: 619 703 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni055A
-Encoding: 1370 1370 1370
+Encoding: 1370 1370 1113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42384,16 +43503,18 @@ SplineSet
  552 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055B
-Encoding: 1371 1371 1371
+Encoding: 1371 1371 1114
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -97 7 3
+Refer: 116 180 N 1 0 0 1 -97 7 3
 EndChar
+
 StartChar: uni055C
-Encoding: 1372 1372 1372
+Encoding: 1372 1372 1115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42420,16 +43541,18 @@ SplineSet
  377 1335 377 1335 377 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055D
-Encoding: 1373 1373 1373
+Encoding: 1373 1373 1116
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 0 3
+Refer: 65 96 N 1 0 0 1 98 0 3
 EndChar
+
 StartChar: uni055E
-Encoding: 1374 1374 1374
+Encoding: 1374 1374 1117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42471,8 +43594,9 @@ SplineSet
  336 1422 336 1422 336 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055F
-Encoding: 1375 1375 1375
+Encoding: 1375 1375 1118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42487,8 +43611,9 @@ SplineSet
  188 1265 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0561
-Encoding: 1377 1377 1377
+Encoding: 1377 1377 1119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42526,8 +43651,9 @@ SplineSet
  617 -27 617 -27 562 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0562
-Encoding: 1378 1378 1378
+Encoding: 1378 1378 1120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42556,8 +43682,9 @@ SplineSet
  1039 923 1039 923 1039 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0563
-Encoding: 1379 1379 1379
+Encoding: 1379 1379 1121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42596,8 +43723,9 @@ SplineSet
  268 770 268 770 268 555 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0564
-Encoding: 1380 1380 1380
+Encoding: 1380 1380 1122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42626,8 +43754,9 @@ SplineSet
  970 923 970 923 970 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0565
-Encoding: 1381 1381 1381
+Encoding: 1381 1381 1123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42656,8 +43785,9 @@ SplineSet
  164 195 164 195 164 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0566
-Encoding: 1382 1382 1382
+Encoding: 1382 1382 1124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42694,8 +43824,9 @@ SplineSet
  268 770 268 770 268 555 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0567
-Encoding: 1383 1383 1383
+Encoding: 1383 1383 1125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42714,8 +43845,9 @@ SplineSet
  940 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0568
-Encoding: 1384 1384 1384
+Encoding: 1384 1384 1126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42742,8 +43874,9 @@ SplineSet
  1039 923 1039 923 1039 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0569
-Encoding: 1385 1385 1385
+Encoding: 1385 1385 1127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42803,8 +43936,9 @@ SplineSet
  656 107 656 107 694 107 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni056A
-Encoding: 1386 1386 1386
+Encoding: 1386 1386 1128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42848,8 +43982,9 @@ SplineSet
  991 977 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056B
-Encoding: 1387 1387 1387
+Encoding: 1387 1387 1129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42874,8 +44009,9 @@ SplineSet
  1044 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056C
-Encoding: 1388 1388 1388
+Encoding: 1388 1388 1130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42890,8 +44026,9 @@ SplineSet
  511 -283 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056D
-Encoding: 1389 1389 1389
+Encoding: 1389 1389 1131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42932,8 +44069,9 @@ SplineSet
  700 479 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni056E
-Encoding: 1390 1390 1390
+Encoding: 1390 1390 1132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42984,8 +44122,9 @@ SplineSet
  330 620 330 620 330 535 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni056F
-Encoding: 1391 1391 1391
+Encoding: 1391 1391 1133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43010,16 +44149,18 @@ SplineSet
  188 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0570
-Encoding: 1392 1392 1392
+Encoding: 1392 1392 1134
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 -6 0 3
+Refer: 73 104 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0571
-Encoding: 1393 1393 1393
+Encoding: 1393 1393 1135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43083,8 +44224,9 @@ SplineSet
  362 532 362 532 362 453 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni0572
-Encoding: 1394 1394 1394
+Encoding: 1394 1394 1136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43111,8 +44253,9 @@ SplineSet
  970 923 970 923 970 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0573
-Encoding: 1395 1395 1395
+Encoding: 1395 1395 1137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43172,8 +44315,9 @@ SplineSet
  379 583 379 583 379 435 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni0574
-Encoding: 1396 1396 1396
+Encoding: 1396 1396 1138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43200,8 +44344,9 @@ SplineSet
  104 195 104 195 104 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0575
-Encoding: 1397 1397 1397
+Encoding: 1397 1397 1139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43219,8 +44364,9 @@ SplineSet
  731 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0576
-Encoding: 1398 1398 1398
+Encoding: 1398 1398 1140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43247,8 +44393,9 @@ SplineSet
  272 195 272 195 272 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0577
-Encoding: 1399 1399 1399
+Encoding: 1399 1399 1141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43299,16 +44446,18 @@ SplineSet
  385 -180 385 -180 385 -207 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0578
-Encoding: 1400 1400 1400
+Encoding: 1400 1400 1142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 -6 0 3
+Refer: 79 110 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0579
-Encoding: 1401 1401 1401
+Encoding: 1401 1401 1143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43356,8 +44505,9 @@ SplineSet
  506 -283 506 -283 527 -283 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057A
-Encoding: 1402 1402 1402
+Encoding: 1402 1402 1144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43395,8 +44545,9 @@ SplineSet
  617 -27 617 -27 562 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057B
-Encoding: 1403 1403 1403
+Encoding: 1403 1403 1145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43464,8 +44615,9 @@ SplineSet
  660 994 660 994 595 994 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni057C
-Encoding: 1404 1404 1404
+Encoding: 1404 1404 1146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43505,16 +44657,18 @@ SplineSet
  644 987 644 987 571 987 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057D
-Encoding: 1405 1405 1405
+Encoding: 1405 1405 1147
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 -6 0 3
+Refer: 86 117 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni057E
-Encoding: 1406 1406 1406
+Encoding: 1406 1406 1148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43541,8 +44695,9 @@ SplineSet
  102 195 102 195 102 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057F
-Encoding: 1407 1407 1407
+Encoding: 1407 1407 1149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43584,8 +44739,9 @@ SplineSet
  1129 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0580
-Encoding: 1408 1408 1408
+Encoding: 1408 1408 1150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43610,16 +44766,18 @@ SplineSet
  1044 923 1044 923 1044 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0581
-Encoding: 1409 1409 1409
+Encoding: 1409 1409 1151
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 34 0 3
+Refer: 72 103 N 1 0 0 1 34 0 3
 EndChar
+
 StartChar: uni0582
-Encoding: 1410 1410 1410
+Encoding: 1410 1410 1152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43634,8 +44792,9 @@ SplineSet
  433 143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0583
-Encoding: 1411 1411 1411
+Encoding: 1411 1411 1153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43677,8 +44836,9 @@ SplineSet
  1129 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0584
-Encoding: 1412 1412 1412
+Encoding: 1412 1412 1154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43721,16 +44881,18 @@ SplineSet
  932 344 932 344 932 559 c 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0585
-Encoding: 1413 1413 1413
+Encoding: 1413 1413 1155
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 3
+Refer: 80 111 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0586
-Encoding: 1414 1414 1414
+Encoding: 1414 1414 1156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43786,8 +44948,9 @@ SplineSet
  1011 482 1011 482 1011 576 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni0587
-Encoding: 1415 1415 1415
+Encoding: 1415 1415 1157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43814,8 +44977,9 @@ SplineSet
  72 195 72 195 72 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0589
-Encoding: 1417 1417 1417
+Encoding: 1417 1417 1158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43833,8 +44997,9 @@ SplineSet
  511 850 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni058A
-Encoding: 1418 1418 1418
+Encoding: 1418 1418 1159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43849,8 +45014,9 @@ SplineSet
  356 643 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0606
-Encoding: 1542 1542 1542
+Encoding: 1542 1542 1160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43892,8 +45058,9 @@ SplineSet
  1133 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0607
-Encoding: 1543 1543 1543
+Encoding: 1543 1543 1161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43937,8 +45104,9 @@ SplineSet
  1133 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0609
-Encoding: 1545 1545 1545
+Encoding: 1545 1545 1162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43966,8 +45134,9 @@ SplineSet
  764 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060A
-Encoding: 1546 1546 1546
+Encoding: 1546 1546 1163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44000,8 +45169,9 @@ SplineSet
  474 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060C
-Encoding: 1548 1548 1548
+Encoding: 1548 1548 1164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44016,8 +45186,9 @@ SplineSet
  681 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0615
-Encoding: 1557 1557 1557
+Encoding: 1557 1557 1165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44045,8 +45216,9 @@ SplineSet
  759 1277 759 1277 643 1277 c 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni061B
-Encoding: 1563 1563 1563
+Encoding: 1563 1563 1166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44066,8 +45238,9 @@ SplineSet
  470 254 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni061F
-Encoding: 1567 1567 1567
+Encoding: 1567 1567 1167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44105,8 +45278,9 @@ SplineSet
  574 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0621
-Encoding: 1569 1569 1569
+Encoding: 1569 1569 1168
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 0 basechar 0
@@ -44136,65 +45310,71 @@ SplineSet
  543 100 543 100 434 85 c 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0622
-Encoding: 1570 1570 1570
+Encoding: 1570 1570 1169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 0 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE82
 EndChar
+
 StartChar: uni0623
-Encoding: 1571 1571 1571
+Encoding: 1571 1571 1170
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 612 2164 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 0 390 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 390 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE84
 EndChar
+
 StartChar: uni0624
-Encoding: 1572 1572 1572
+Encoding: 1572 1572 1171
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 720 1312 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 99 -450 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 99 -450 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE86
 EndChar
+
 StartChar: uni0625
-Encoding: 1573 1573 1573
+Encoding: 1573 1573 1172
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -545 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 0 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE88
 EndChar
+
 StartChar: uni0626
-Encoding: 1574 1574 1574
+Encoding: 1574 1574 1173
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 636 basechar 0
 AnchorPoint: "rtl-above" 460 1208 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -142 -540 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -142 -540 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE8A
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE8C
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE8B
 EndChar
+
 StartChar: uni0627
-Encoding: 1575 1575 1575
+Encoding: 1575 1575 1174
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -78 basechar 0
@@ -44210,76 +45390,82 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE8E
 EndChar
+
 StartChar: uni0628
-Encoding: 1576 1576 1576
+Encoding: 1576 1576 1175
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -376 basechar 0
 AnchorPoint: "rtl-above" 612 764 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 556 -312 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 556 -312 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE92
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE91
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE90
 EndChar
+
 StartChar: uni0629
-Encoding: 1577 1577 1577
+Encoding: 1577 1577 1176
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -160 basechar 0
 AnchorPoint: "rtl-above" 568 1184 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 369 900 2
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 369 900 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE94
 EndChar
+
 StartChar: uni062A
-Encoding: 1578 1578 1578
+Encoding: 1578 1578 1177
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 AnchorPoint: "rtl-above" 636 980 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 440 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 440 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE96
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE98
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE97
 EndChar
+
 StartChar: uni062B
-Encoding: 1579 1579 1579
+Encoding: 1579 1579 1178
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 AnchorPoint: "rtl-above" 548 1184 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 420 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 420 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE9A
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE9C
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE9B
 EndChar
+
 StartChar: uni062C
-Encoding: 1580 1580 1580
+Encoding: 1580 1580 1179
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 508 -564 basechar 0
 AnchorPoint: "rtl-above" 500 1148 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 663 13 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 663 13 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE9E
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE9F
 EndChar
+
 StartChar: uni062D
-Encoding: 1581 1581 1581
+Encoding: 1581 1581 1180
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -560 basechar 0
@@ -44310,22 +45496,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEA2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEA3
 EndChar
+
 StartChar: uni062E
-Encoding: 1582 1582 1582
+Encoding: 1582 1582 1181
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -585 basechar 0
 AnchorPoint: "rtl-above" 516 1352 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 458 1050 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 458 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEA6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEA7
 EndChar
+
 StartChar: uni062F
-Encoding: 1583 1583 1583
+Encoding: 1583 1583 1182
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -132 basechar 0
@@ -44351,20 +45539,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAA
 EndChar
+
 StartChar: uni0630
-Encoding: 1584 1584 1584
+Encoding: 1584 1584 1183
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -116 basechar 0
 AnchorPoint: "rtl-above" 448 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 540 1074 2
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 540 1074 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAC
 EndChar
+
 StartChar: uni0631
-Encoding: 1585 1585 1585
+Encoding: 1585 1585 1184
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -544 basechar 0
@@ -44386,20 +45576,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAE
 EndChar
+
 StartChar: uni0632
-Encoding: 1586 1586 1586
+Encoding: 1586 1586 1185
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -532 basechar 0
 AnchorPoint: "rtl-above" 408 1056 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 853 800 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 853 800 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB0
 EndChar
+
 StartChar: uni0633
-Encoding: 1587 1587 1587
+Encoding: 1587 1587 1186
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -436 basechar 0
@@ -44449,22 +45641,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEB4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEB3
 EndChar
+
 StartChar: uni0634
-Encoding: 1588 1588 1588
+Encoding: 1588 1588 1187
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 672 -380 basechar 0
 AnchorPoint: "rtl-above" 476 1396 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 355 800 2
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 355 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEB8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEB7
 EndChar
+
 StartChar: uni0635
-Encoding: 1589 1589 1589
+Encoding: 1589 1589 1188
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 808 -292 basechar 0
@@ -44512,22 +45706,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEBA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEBC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEBB
 EndChar
+
 StartChar: uni0636
-Encoding: 1590 1590 1590
+Encoding: 1590 1590 1189
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 800 -320 basechar 0
 AnchorPoint: "rtl-above" 308 1096 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 335 695 2
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 335 695 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEBE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEBF
 EndChar
+
 StartChar: uni0637
-Encoding: 1591 1591 1591
+Encoding: 1591 1591 1190
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 340 -144 basechar 0
@@ -44562,22 +45758,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEC2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEC3
 EndChar
+
 StartChar: uni0638
-Encoding: 1592 1592 1592
+Encoding: 1592 1592 1191
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 364 -136 basechar 0
 AnchorPoint: "rtl-above" 236 1748 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 601 790 2
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 601 790 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEC6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEC7
 EndChar
+
 StartChar: uni0639
-Encoding: 1593 1593 1593
+Encoding: 1593 1593 1192
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 656 -564 basechar 0
@@ -44614,22 +45812,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFECA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFECC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFECB
 EndChar
+
 StartChar: uni063A
-Encoding: 1594 1594 1594
+Encoding: 1594 1594 1193
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 648 -560 basechar 0
 AnchorPoint: "rtl-above" 380 1524 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 381 1200 2
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 381 1200 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFECE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFECF
 EndChar
+
 StartChar: uni0640
-Encoding: 1600 1600 1600
+Encoding: 1600 1600 1194
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -136 basechar 0
@@ -44644,36 +45844,39 @@ SplineSet
  -20 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0641
-Encoding: 1601 1601 1601
+Encoding: 1601 1601 1195
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -188 basechar 0
 AnchorPoint: "rtl-above" 764 1412 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 764 1078 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 764 1078 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFED2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFED3
 EndChar
+
 StartChar: uni0642
-Encoding: 1602 1602 1602
+Encoding: 1602 1602 1196
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 552 -444 basechar 0
 AnchorPoint: "rtl-above" 668 1528 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 595 1150 2
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 595 1150 2
+Refer: 3762 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFED6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFED7
 EndChar
+
 StartChar: uni0643
-Encoding: 1603 1603 1603
+Encoding: 1603 1603 1197
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 508 -156 basechar 0
@@ -44722,8 +45925,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEDA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEDC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEDB
 EndChar
+
 StartChar: uni0644
-Encoding: 1604 1604 1604
+Encoding: 1604 1604 1198
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 532 -388 basechar 0
@@ -44753,8 +45957,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEDE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEDF
 EndChar
+
 StartChar: uni0645
-Encoding: 1605 1605 1605
+Encoding: 1605 1605 1199
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
@@ -44794,22 +45999,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEE2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEE3
 EndChar
+
 StartChar: uni0646
-Encoding: 1606 1606 1606
+Encoding: 1606 1606 1200
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -420 basechar 0
 AnchorPoint: "rtl-above" 504 1132 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 490 714 2
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 490 714 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEE6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEE7
 EndChar
+
 StartChar: uni0647
-Encoding: 1607 1607 1607
+Encoding: 1607 1607 1201
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -216 basechar 0
@@ -44840,8 +46047,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEEA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEEC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEEB
 EndChar
+
 StartChar: uni0648
-Encoding: 1608 1608 1608
+Encoding: 1608 1608 1202
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -548 basechar 0
@@ -44874,8 +46082,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEEE
 EndChar
+
 StartChar: uni0649
-Encoding: 1609 1609 1609
+Encoding: 1609 1609 1203
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -332 basechar 0
@@ -44917,22 +46126,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEF0
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBE9
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBE8
 EndChar
+
 StartChar: uni064A
-Encoding: 1610 1610 1610
+Encoding: 1610 1610 1204
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -544 basechar 0
 AnchorPoint: "rtl-above" 664 1072 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 370 -500 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 370 -500 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEF2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEF4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEF3
 EndChar
+
 StartChar: uni064B
-Encoding: 1611 1611 1611
+Encoding: 1611 1611 1205
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -44952,8 +46163,9 @@ SplineSet
  324 1210 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064C
-Encoding: 1612 1612 1612
+Encoding: 1612 1612 1206
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -44994,8 +46206,9 @@ SplineSet
  698 1566 698 1566 724 1558 c 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: uni064D
-Encoding: 1613 1613 1613
+Encoding: 1613 1613 1207
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 0 mark 0
@@ -45015,8 +46228,9 @@ SplineSet
  324 -250 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064E
-Encoding: 1614 1614 1614
+Encoding: 1614 1614 1208
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 605 1130 mark 0
@@ -45032,8 +46246,9 @@ SplineSet
  324 1210 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064F
-Encoding: 1615 1615 1615
+Encoding: 1615 1615 1209
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 605 1130 mark 0
@@ -45071,8 +46286,9 @@ SplineSet
  698 1566 698 1566 724 1558 c 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0650
-Encoding: 1616 1616 1616
+Encoding: 1616 1616 1210
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 616 0 mark 0
@@ -45088,8 +46304,9 @@ SplineSet
  324 -280 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0651
-Encoding: 1617 1617 1617
+Encoding: 1617 1617 1211
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 611 1826 basemark 0
@@ -45123,8 +46340,9 @@ SplineSet
  644 1359 644 1359 632 1412 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0652
-Encoding: 1618 1618 1618
+Encoding: 1618 1618 1212
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 610 1130 mark 0
@@ -45153,8 +46371,9 @@ SplineSet
  890 1639 890 1639 890 1524 c 128,-1,11
 EndSplineSet
 EndChar
+
 StartChar: uni0653
-Encoding: 1619 1619 1619
+Encoding: 1619 1619 1213
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -45177,8 +46396,9 @@ SplineSet
  256 1334 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0654
-Encoding: 1620 1620 1620
+Encoding: 1620 1620 1214
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 611 1760 basemark 0
@@ -45186,10 +46406,11 @@ AnchorPoint: "rtl-above" 605 1130 mark 0
 AnchorPoint: "Ligature rtl-above" 605 1130 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -115 2
+Refer: 1231 1652 N 1 0 0 1 0 -115 2
 EndChar
+
 StartChar: uni0655
-Encoding: 1621 1621 1621
+Encoding: 1621 1621 1215
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 624 -540 basemark 0
@@ -45197,10 +46418,11 @@ AnchorPoint: "rtl-below" 616 0 mark 0
 AnchorPoint: "Ligature rtl-below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -1830 2
+Refer: 1231 1652 N 1 0 0 1 0 -1830 2
 EndChar
+
 StartChar: uni065A
-Encoding: 1626 1626 1626
+Encoding: 1626 1626 1216
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 616.5 1200 mark 0
@@ -45218,8 +46440,9 @@ SplineSet
  542 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0660
-Encoding: 1632 1632 1632
+Encoding: 1632 1632 1217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45232,8 +46455,9 @@ SplineSet
  506 700 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0661
-Encoding: 1633 1633 1633
+Encoding: 1633 1633 1218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45248,8 +46472,9 @@ SplineSet
  828 490 828 490 828 0 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0662
-Encoding: 1634 1634 1634
+Encoding: 1634 1634 1219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45272,8 +46497,9 @@ SplineSet
  577 808 577 808 493 865 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0663
-Encoding: 1635 1635 1635
+Encoding: 1635 1635 1220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45303,8 +46529,9 @@ SplineSet
  520 817 520 817 484 821 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0664
-Encoding: 1636 1636 1636
+Encoding: 1636 1636 1221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45336,8 +46563,9 @@ SplineSet
  661 1286 661 1286 864 1312 c 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0665
-Encoding: 1637 1637 1637
+Encoding: 1637 1637 1222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45363,8 +46591,9 @@ SplineSet
  427 1317 427 1317 616 1316 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0666
-Encoding: 1638 1638 1638
+Encoding: 1638 1638 1223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45383,8 +46612,9 @@ SplineSet
  709 1250 709 1250 915 1300 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0667
-Encoding: 1639 1639 1639
+Encoding: 1639 1639 1224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45404,8 +46634,9 @@ SplineSet
  526 0 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0668
-Encoding: 1640 1640 1640
+Encoding: 1640 1640 1225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45425,8 +46656,9 @@ SplineSet
  510 1054 510 1054 526 1300 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0669
-Encoding: 1641 1641 1641
+Encoding: 1641 1641 1226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45455,8 +46687,9 @@ SplineSet
  591 781 591 781 748 778 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066A
-Encoding: 1642 1642 1642
+Encoding: 1642 1642 1227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45479,8 +46712,9 @@ SplineSet
  874 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066B
-Encoding: 1643 1643 1643
+Encoding: 1643 1643 1228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45499,8 +46733,9 @@ SplineSet
  310 -70 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni066C
-Encoding: 1644 1644 1644
+Encoding: 1644 1644 1229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45515,8 +46750,9 @@ SplineSet
  552 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066D
-Encoding: 1645 1645 1645
+Encoding: 1645 1645 1230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45535,8 +46771,9 @@ SplineSet
  146 759 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0674
-Encoding: 1652 1652 1652
+Encoding: 1652 1652 1231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45560,174 +46797,188 @@ SplineSet
  445 1430 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0679
-Encoding: 1657 1657 1657
+Encoding: 1657 1657 1232
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 41.5 -600 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 41.5 -600 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB69
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB68
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB67
 EndChar
+
 StartChar: uni067A
-Encoding: 1658 1658 1658
+Encoding: 1658 1658 1233
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 533.5 900 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 533.5 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB61
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB60
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB5F
 EndChar
+
 StartChar: uni067B
-Encoding: 1659 1659 1659
+Encoding: 1659 1659 1234
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -536 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 528 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 528 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB55
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB54
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB53
 EndChar
+
 StartChar: uni067E
-Encoding: 1662 1662 1662
+Encoding: 1662 1662 1235
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 414 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 414 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB59
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB58
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB57
 EndChar
+
 StartChar: uni067F
-Encoding: 1663 1663 1663
+Encoding: 1663 1663 1236
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 419.5 900 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 419.5 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB65
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB64
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB63
 EndChar
+
 StartChar: uni0680
-Encoding: 1664 1664 1664
+Encoding: 1664 1664 1237
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -532 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 414 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 414 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB5D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB5C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB5B
 EndChar
+
 StartChar: uni0683
-Encoding: 1667 1667 1667
+Encoding: 1667 1667 1238
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -537 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 554 81 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 554 81 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB79
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB78
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB77
 EndChar
+
 StartChar: uni0684
-Encoding: 1668 1668 1668
+Encoding: 1668 1668 1239
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -548 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 715 175 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 715 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB75
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB74
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB73
 EndChar
+
 StartChar: uni0686
-Encoding: 1670 1670 1670
+Encoding: 1670 1670 1240
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -548 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 618 150 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 618 150 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB7D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB7C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB7B
 EndChar
+
 StartChar: uni0687
-Encoding: 1671 1671 1671
+Encoding: 1671 1671 1241
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 610 175 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 610 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB81
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB80
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB7F
 EndChar
+
 StartChar: uni0691
-Encoding: 1681 1681 1681
+Encoding: 1681 1681 1242
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 558.5 -540.5 basechar 0
 AnchorPoint: "rtl-above" 700 1242.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 354.5 -585 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 354.5 -585 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8D
 EndChar
+
 StartChar: uni0698
-Encoding: 1688 1688 1688
+Encoding: 1688 1688 1243
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 529 -541.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 725 737 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 725 737 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8B
 EndChar
+
 StartChar: uni06A4
-Encoding: 1700 1700 1700
+Encoding: 1700 1700 1244
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 -188 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 624 1033 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 624 1033 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB6D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB6C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB6B
 EndChar
+
 StartChar: uni06A9
-Encoding: 1705 1705 1705
+Encoding: 1705 1705 1245
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 565 -150 basechar 0
@@ -45766,22 +47017,24 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB91
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB90
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8F
 EndChar
+
 StartChar: uni06AF
-Encoding: 1711 1711 1711
+Encoding: 1711 1711 1246
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596.5 -150 basechar 0
 AnchorPoint: "rtl-above" 430 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 681.5 0 2
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 681.5 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB95
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB94
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB93
 EndChar
+
 StartChar: uni06BE
-Encoding: 1726 1726 1726
+Encoding: 1726 1726 1247
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 607.5 1120 basechar 0
@@ -45834,53 +47087,59 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBAD
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBAC
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFBAB
 EndChar
+
 StartChar: uni06CC
-Encoding: 1740 1740 1740
+Encoding: 1740 1740 1248
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -400 basechar 0
 AnchorPoint: "rtl-above" 415 780 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBFF
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBFE
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFBFD
 EndChar
+
 StartChar: uni06F0
-Encoding: 1776 1776 1776
+Encoding: 1776 1776 1249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1632 1632 N 1 0 0 1 0 0 2
+Refer: 1217 1632 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F1
-Encoding: 1777 1777 1777
+Encoding: 1777 1777 1250
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1633 1633 N 1 0 0 1 0 0 2
+Refer: 1218 1633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F2
-Encoding: 1778 1778 1778
+Encoding: 1778 1778 1251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1634 1634 N 1 0 0 1 0 0 2
+Refer: 1219 1634 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F3
-Encoding: 1779 1779 1779
+Encoding: 1779 1779 1252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1635 1635 N 1 0 0 1 0 0 2
+Refer: 1220 1635 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F4
-Encoding: 1780 1780 1780
+Encoding: 1780 1780 1253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45911,8 +47170,9 @@ SplineSet
  470 1084 470 1084 549 1044 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F5
-Encoding: 1781 1781 1781
+Encoding: 1781 1781 1254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45943,8 +47203,9 @@ SplineSet
  657 -13 657 -13 616 138 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F6
-Encoding: 1782 1782 1782
+Encoding: 1782 1782 1255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45971,32 +47232,36 @@ SplineSet
  264 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F7
-Encoding: 1783 1783 1783
+Encoding: 1783 1783 1256
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1639 1639 N 1 0 0 1 0 0 2
+Refer: 1224 1639 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F8
-Encoding: 1784 1784 1784
+Encoding: 1784 1784 1257
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1640 1640 N 1 0 0 1 0 0 2
+Refer: 1225 1640 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F9
-Encoding: 1785 1785 1785
+Encoding: 1785 1785 1258
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1641 1641 N 1 0 0 1 0 0 2
+Refer: 1226 1641 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0E3F
-Encoding: 3647 3647 3647
+Encoding: 3647 3647 1259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46044,8 +47309,9 @@ SplineSet
  660 769 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0E81
-Encoding: 3713 3713 3713
+Encoding: 3713 3713 1260
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46146,8 +47412,9 @@ SplineSet
  490 184 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni0E82
-Encoding: 3714 3714 3714
+Encoding: 3714 3714 1261
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46186,8 +47453,9 @@ SplineSet
  542 603 542 603 318.5 603 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E84
-Encoding: 3716 3716 3716
+Encoding: 3716 3716 1262
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46232,8 +47500,9 @@ SplineSet
  121 -21 121 -21 121 349 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni0E87
-Encoding: 3719 3719 3719
+Encoding: 3719 3719 1263
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46265,8 +47534,9 @@ SplineSet
  524.634 1007.93 524.634 1007.93 459.503 1006 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni0E88
-Encoding: 3720 3720 3720
+Encoding: 3720 3720 1264
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46304,8 +47574,9 @@ SplineSet
  260.25 1178 260.25 1178 612.25 1178 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8A
-Encoding: 3722 3722 3722
+Encoding: 3722 3722 1265
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 -492 basechar 0
@@ -46349,8 +47620,9 @@ SplineSet
  494 631 494 631 307 603 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8D
-Encoding: 3725 3725 3725
+Encoding: 3725 3725 1266
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46389,8 +47661,9 @@ SplineSet
  309 416.021 309 416.021 309 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E94
-Encoding: 3732 3732 3732
+Encoding: 3732 3732 1267
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46444,11 +47717,11 @@ AnchorPoint: "lao-below" 1233 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-358.25 235 m 0,0,1
- 294.25 235 294.25 235 294.25 171 c 0,2,3
- 294.25 107 294.25 107 358.25 107 c 0,4,5
- 422.25 107 422.25 107 422.25 171 c 0,6,7
- 422.25 235 422.25 235 358.25 235 c 0,0,1
+358.25 235 m 256,0,1
+ 294.25 235 294.25 235 294.25 171 c 256,2,3
+ 294.25 107 294.25 107 358.25 107 c 256,4,5
+ 422.25 107 422.25 107 422.25 171 c 256,6,7
+ 422.25 235 422.25 235 358.25 235 c 256,0,1
 925.75 0 m 1,8,-1
  925.75 799 l 2,9,10
  925.75 999.84 925.75 999.84 616 997 c 0,11,12
@@ -46466,8 +47739,9 @@ SplineSet
  925.75 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E95
-Encoding: 3733 3733 3733
+Encoding: 3733 3733 1268
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46507,8 +47781,9 @@ SplineSet
  772 747 772 747 644 747 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E96
-Encoding: 3734 3734 3734
+Encoding: 3734 3734 1269
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 -492 basechar 0
@@ -46546,8 +47821,9 @@ SplineSet
  441 351 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E97
-Encoding: 3735 3735 3735
+Encoding: 3735 3735 1270
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46646,8 +47922,9 @@ SplineSet
  108 790 108 790 108 970 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E99
-Encoding: 3737 3737 3737
+Encoding: 3737 3737 1271
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46681,8 +47958,9 @@ SplineSet
  75 -29 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9A
-Encoding: 3738 3738 3738
+Encoding: 3738 3738 1272
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46711,8 +47989,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9B
-Encoding: 3739 3739 3739
+Encoding: 3739 3739 1273
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46741,8 +48020,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9C
-Encoding: 3740 3740 3740
+Encoding: 3740 3740 1274
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46801,8 +48081,9 @@ SplineSet
  945.441 -16.5908 945.441 -16.5908 822.5 -17 c 0,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9D
-Encoding: 3741 3741 3741
+Encoding: 3741 3741 1275
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46845,8 +48126,9 @@ SplineSet
  342.5 1017 342.5 1017 310.5 1017 c 0,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0E9E
-Encoding: 3742 3742 3742
+Encoding: 3742 3742 1276
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46886,8 +48168,9 @@ SplineSet
  285.5 133 285.5 133 434.5 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9F
-Encoding: 3743 3743 3743
+Encoding: 3743 3743 1277
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46927,8 +48210,9 @@ SplineSet
  285.5 133 285.5 133 434.5 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA1
-Encoding: 3745 3745 3745
+Encoding: 3745 3745 1278
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46954,8 +48238,9 @@ SplineSet
  355 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA2
-Encoding: 3746 3746 3746
+Encoding: 3746 3746 1279
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1552 basechar 0
@@ -46994,8 +48279,9 @@ SplineSet
  309 416.021 309 416.021 309 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA3
-Encoding: 3747 3747 3747
+Encoding: 3747 3747 1280
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47032,8 +48318,9 @@ SplineSet
  949.498 145 949.498 145 948.496 328 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA5
-Encoding: 3749 3749 3749
+Encoding: 3749 3749 1281
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47073,8 +48360,9 @@ SplineSet
  245 1165 245 1165 622 1164 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA7
-Encoding: 3751 3751 3751
+Encoding: 3751 3751 1282
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47105,8 +48393,9 @@ SplineSet
  136 802 l 1,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0EAA
-Encoding: 3754 3754 3754
+Encoding: 3754 3754 1283
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47153,8 +48442,9 @@ SplineSet
  268 856 268 856 598 855 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni0EAB
-Encoding: 3755 3755 3755
+Encoding: 3755 3755 1284
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47199,8 +48489,9 @@ SplineSet
  853.046 -24.9417 853.046 -24.9417 445.004 -24 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0EAD
-Encoding: 3757 3757 3757
+Encoding: 3757 3757 1285
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47239,8 +48530,9 @@ SplineSet
  940 696 940 696 940 857 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni0EAE
-Encoding: 3758 3758 3758
+Encoding: 3758 3758 1286
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47282,8 +48574,9 @@ SplineSet
  582.935 132 582.935 132 594 132 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAF
-Encoding: 3759 3759 3759
+Encoding: 3759 3759 1287
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47316,17 +48609,19 @@ SplineSet
  352.13 -217.5 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB0
-Encoding: 3760 3760 3760
+Encoding: 3760 3760 1288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3761 3761 N 1 0 0 1 1233 -1335 2
-Refer: 3761 3761 N 1 0 0 1 1233 -651 2
+Refer: 1289 3761 N 1 0 0 1 1233 -1335 2
+Refer: 1289 3761 N 1 0 0 1 1233 -651 2
 EndChar
+
 StartChar: uni0EB1
-Encoding: 3761 3761 3761
+Encoding: 3761 3761 1289
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" -9 1140 mark 0
@@ -47353,8 +48648,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB2
-Encoding: 3762 3762 3762
+Encoding: 3762 3762 1290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47378,17 +48674,19 @@ SplineSet
  323 772 323 772 323 717 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0EB3
-Encoding: 3763 3763 3763
+Encoding: 3763 3763 1291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3762 3762 N 1 0 0 1 0 0 2
-Refer: 3789 3789 N 1 0 0 1 -1233 0 2
+Refer: 1290 3762 N 1 0 0 1 0 0 2
+Refer: 1305 3789 N 1 0 0 1 -1233 0 2
 EndChar
+
 StartChar: uni0EB4
-Encoding: 3764 3764 3764
+Encoding: 3764 3764 1292
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47409,8 +48707,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB5
-Encoding: 3765 3765 3765
+Encoding: 3765 3765 1293
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47435,8 +48734,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB6
-Encoding: 3766 3766 3766
+Encoding: 3766 3766 1294
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47462,8 +48762,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB7
-Encoding: 3767 3767 3767
+Encoding: 3767 3767 1295
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47493,8 +48794,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB8
-Encoding: 3768 3768 3768
+Encoding: 3768 3768 1296
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47519,8 +48821,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB9
-Encoding: 3769 3769 3769
+Encoding: 3769 3769 1297
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47549,8 +48852,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EBB
-Encoding: 3771 3771 3771
+Encoding: 3771 3771 1298
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1140 mark 0
@@ -47577,8 +48881,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EBC
-Encoding: 3772 3772 3772
+Encoding: 3772 3772 1299
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47605,8 +48910,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EC8
-Encoding: 3784 3784 3784
+Encoding: 3784 3784 1300
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47621,8 +48927,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EC9
-Encoding: 3785 3785 3785
+Encoding: 3785 3785 1301
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
@@ -47651,8 +48958,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECA
-Encoding: 3786 3786 3786
+Encoding: 3786 3786 1302
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
@@ -47692,8 +49000,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECB
-Encoding: 3787 3787 3787
+Encoding: 3787 3787 1303
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47716,18 +49025,20 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECC
-Encoding: 3788 3788 3788
+Encoding: 3788 3788 1304
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
 LayerCount: 2
 Fore
-Refer: 3772 3772 N 1 0 0 1 0 1872 2
+Refer: 1299 3772 N 1 0 0 1 0 1872 2
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECD
-Encoding: 3789 3789 3789
+Encoding: 3789 3789 1305
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47747,8 +49058,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni10D0
-Encoding: 4304 4304 4304
+Encoding: 4304 4304 1306
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47769,8 +49081,9 @@ SplineSet
  1075 804 1075 804 1075 495 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D1
-Encoding: 4305 4305 4305
+Encoding: 4305 4305 1307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47795,8 +49108,9 @@ SplineSet
  888 145 888 145 888 545 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni10D2
-Encoding: 4306 4306 4306
+Encoding: 4306 4306 1308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47824,8 +49138,9 @@ SplineSet
  943 -277 943 -277 943 43 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D3
-Encoding: 4307 4307 4307
+Encoding: 4307 4307 1309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47864,8 +49179,9 @@ SplineSet
  989 185 989 185 989 441 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D4
-Encoding: 4308 4308 4308
+Encoding: 4308 4308 1310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47890,8 +49206,9 @@ SplineSet
  1075 -32 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D5
-Encoding: 4309 4309 4309
+Encoding: 4309 4309 1311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47924,8 +49241,9 @@ SplineSet
  1074 -45 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D6
-Encoding: 4310 4310 4310
+Encoding: 4310 4310 1312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47954,8 +49272,9 @@ SplineSet
  686 984 686 984 684 1202 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D7
-Encoding: 4311 4311 4311
+Encoding: 4311 4311 1313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47989,8 +49308,9 @@ SplineSet
  582 145 582 145 580 388 c 2,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D8
-Encoding: 4312 4312 4312
+Encoding: 4312 4312 1314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48009,8 +49329,9 @@ SplineSet
  1075 1045 1075 1045 1074 547 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D9
-Encoding: 4313 4313 4313
+Encoding: 4313 4313 1315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48039,8 +49360,9 @@ SplineSet
  1076 -30 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DA
-Encoding: 4314 4314 4314
+Encoding: 4314 4314 1316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48067,8 +49389,9 @@ SplineSet
  889 904 889 904 620 904 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DB
-Encoding: 4315 4315 4315
+Encoding: 4315 4315 1317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48096,8 +49419,9 @@ SplineSet
  888 145 888 145 888 495 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni10DC
-Encoding: 4316 4316 4316
+Encoding: 4316 4316 1318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48123,8 +49447,9 @@ SplineSet
  889 145 889 145 889 545 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10DD
-Encoding: 4317 4317 4317
+Encoding: 4317 4317 1319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48157,8 +49482,9 @@ SplineSet
  1178 454 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DE
-Encoding: 4318 4318 4318
+Encoding: 4318 4318 1320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48187,8 +49513,9 @@ SplineSet
  1076 748 1076 748 1076 474 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DF
-Encoding: 4319 4319 4319
+Encoding: 4319 4319 1321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48213,8 +49540,9 @@ SplineSet
  1075 -18 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E0
-Encoding: 4320 4320 4320
+Encoding: 4320 4320 1322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48252,8 +49580,9 @@ SplineSet
  1178 1035 1178 1035 1178 596 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10E1
-Encoding: 4321 4321 4321
+Encoding: 4321 4321 1323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48276,8 +49605,9 @@ SplineSet
  1075 733 1075 733 1075 515 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E2
-Encoding: 4322 4322 4322
+Encoding: 4322 4322 1324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48301,8 +49631,9 @@ SplineSet
  233 777 233 777 233 290 c 0,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni10E3
-Encoding: 4323 4323 4323
+Encoding: 4323 4323 1325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48337,8 +49668,9 @@ SplineSet
  1098 -43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E4
-Encoding: 4324 4324 4324
+Encoding: 4324 4324 1326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48385,8 +49717,9 @@ SplineSet
  578 727 l 2,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni10E5
-Encoding: 4325 4325 4325
+Encoding: 4325 4325 1327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48414,8 +49747,9 @@ SplineSet
  1073 67 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E6
-Encoding: 4326 4326 4326
+Encoding: 4326 4326 1328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48454,8 +49788,9 @@ SplineSet
  237 -201 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E7
-Encoding: 4327 4327 4327
+Encoding: 4327 4327 1329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48481,8 +49816,9 @@ SplineSet
  1074 -47 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E8
-Encoding: 4328 4328 4328
+Encoding: 4328 4328 1330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48516,8 +49852,9 @@ SplineSet
  889 145 889 145 890 515 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10E9
-Encoding: 4329 4329 4329
+Encoding: 4329 4329 1331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48545,8 +49882,9 @@ SplineSet
  778 1149 778 1149 778 1224 c 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10EA
-Encoding: 4330 4330 4330
+Encoding: 4330 4330 1332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48577,8 +49915,9 @@ SplineSet
  1116 799 1116 799 1116 645 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10EB
-Encoding: 4331 4331 4331
+Encoding: 4331 4331 1333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48600,8 +49939,9 @@ SplineSet
  889 145 889 145 889 519 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EC
-Encoding: 4332 4332 4332
+Encoding: 4332 4332 1334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48635,8 +49975,9 @@ SplineSet
  348 904 348 904 347 565 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10ED
-Encoding: 4333 4333 4333
+Encoding: 4333 4333 1335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48674,8 +50015,9 @@ SplineSet
  372 957 372 957 372 763 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni10EE
-Encoding: 4334 4334 4334
+Encoding: 4334 4334 1336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48697,8 +50039,9 @@ SplineSet
  889 145 889 145 889 525 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EF
-Encoding: 4335 4335 4335
+Encoding: 4335 4335 1337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48729,8 +50072,9 @@ SplineSet
  1075 234 1075 234 1076 41 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F0
-Encoding: 4336 4336 4336
+Encoding: 4336 4336 1338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48767,8 +50111,9 @@ SplineSet
  1076 497 1076 497 1076 360 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F1
-Encoding: 4337 4337 4337
+Encoding: 4337 4337 1339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48815,8 +50160,9 @@ SplineSet
  1074 81 1074 81 1075 -124 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F2
-Encoding: 4338 4338 4338
+Encoding: 4338 4338 1340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48840,8 +50186,9 @@ SplineSet
  345 902 345 902 345 519 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10F3
-Encoding: 4339 4339 4339
+Encoding: 4339 4339 1341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48872,8 +50219,9 @@ SplineSet
  1076 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F4
-Encoding: 4340 4340 4340
+Encoding: 4340 4340 1342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48905,8 +50253,9 @@ SplineSet
  1076 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F5
-Encoding: 4341 4341 4341
+Encoding: 4341 4341 1343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48945,8 +50294,9 @@ SplineSet
  329 1415 329 1415 329 1218 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10F6
-Encoding: 4342 4342 4342
+Encoding: 4342 4342 1344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48985,8 +50335,9 @@ SplineSet
  989 145 989 145 989 312 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F7
-Encoding: 4343 4343 4343
+Encoding: 4343 4343 1345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49013,8 +50364,9 @@ SplineSet
  1124 174 1124 174 1126 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F8
-Encoding: 4344 4344 4344
+Encoding: 4344 4344 1346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49041,8 +50393,9 @@ SplineSet
  161 1022 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F9
-Encoding: 4345 4345 4345
+Encoding: 4345 4345 1347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49069,8 +50422,9 @@ SplineSet
  301 917 301 917 301 619 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni10FA
-Encoding: 4346 4346 4346
+Encoding: 4346 4346 1348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49096,8 +50450,9 @@ SplineSet
  751 -135 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FB
-Encoding: 4347 4347 4347
+Encoding: 4347 4347 1349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49120,8 +50475,9 @@ SplineSet
  291 224 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FC
-Encoding: 4348 4348 4348
+Encoding: 4348 4348 1350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49146,524 +50502,611 @@ SplineSet
  734 836 734 836 734 1043 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni13A0
-Encoding: 5024 5024 5024
+Encoding: 5024 5024 1351
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A1
-Encoding: 5025 5025 5025
+Encoding: 5025 5025 1352
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A2
-Encoding: 5026 5026 5026
+Encoding: 5026 5026 1353
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A3
-Encoding: 5027 5027 5027
+Encoding: 5027 5027 1354
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A4
-Encoding: 5028 5028 5028
+Encoding: 5028 5028 1355
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A5
-Encoding: 5029 5029 5029
+Encoding: 5029 5029 1356
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A6
-Encoding: 5030 5030 5030
+Encoding: 5030 5030 1357
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A7
-Encoding: 5031 5031 5031
+Encoding: 5031 5031 1358
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A8
-Encoding: 5032 5032 5032
+Encoding: 5032 5032 1359
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A9
-Encoding: 5033 5033 5033
+Encoding: 5033 5033 1360
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AA
-Encoding: 5034 5034 5034
+Encoding: 5034 5034 1361
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AB
-Encoding: 5035 5035 5035
+Encoding: 5035 5035 1362
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AC
-Encoding: 5036 5036 5036
+Encoding: 5036 5036 1363
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AD
-Encoding: 5037 5037 5037
+Encoding: 5037 5037 1364
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AE
-Encoding: 5038 5038 5038
+Encoding: 5038 5038 1365
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AF
-Encoding: 5039 5039 5039
+Encoding: 5039 5039 1366
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B0
-Encoding: 5040 5040 5040
+Encoding: 5040 5040 1367
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B1
-Encoding: 5041 5041 5041
+Encoding: 5041 5041 1368
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B2
-Encoding: 5042 5042 5042
+Encoding: 5042 5042 1369
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B3
-Encoding: 5043 5043 5043
+Encoding: 5043 5043 1370
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B4
-Encoding: 5044 5044 5044
+Encoding: 5044 5044 1371
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B5
-Encoding: 5045 5045 5045
+Encoding: 5045 5045 1372
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B6
-Encoding: 5046 5046 5046
+Encoding: 5046 5046 1373
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B7
-Encoding: 5047 5047 5047
+Encoding: 5047 5047 1374
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B8
-Encoding: 5048 5048 5048
+Encoding: 5048 5048 1375
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B9
-Encoding: 5049 5049 5049
+Encoding: 5049 5049 1376
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BA
-Encoding: 5050 5050 5050
+Encoding: 5050 5050 1377
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BB
-Encoding: 5051 5051 5051
+Encoding: 5051 5051 1378
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BC
-Encoding: 5052 5052 5052
+Encoding: 5052 5052 1379
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BD
-Encoding: 5053 5053 5053
+Encoding: 5053 5053 1380
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BE
-Encoding: 5054 5054 5054
+Encoding: 5054 5054 1381
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BF
-Encoding: 5055 5055 5055
+Encoding: 5055 5055 1382
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C0
-Encoding: 5056 5056 5056
+Encoding: 5056 5056 1383
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C1
-Encoding: 5057 5057 5057
+Encoding: 5057 5057 1384
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C2
-Encoding: 5058 5058 5058
+Encoding: 5058 5058 1385
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C3
-Encoding: 5059 5059 5059
+Encoding: 5059 5059 1386
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C4
-Encoding: 5060 5060 5060
+Encoding: 5060 5060 1387
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C5
-Encoding: 5061 5061 5061
+Encoding: 5061 5061 1388
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C6
-Encoding: 5062 5062 5062
+Encoding: 5062 5062 1389
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C7
-Encoding: 5063 5063 5063
+Encoding: 5063 5063 1390
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C8
-Encoding: 5064 5064 5064
+Encoding: 5064 5064 1391
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C9
-Encoding: 5065 5065 5065
+Encoding: 5065 5065 1392
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CA
-Encoding: 5066 5066 5066
+Encoding: 5066 5066 1393
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CB
-Encoding: 5067 5067 5067
+Encoding: 5067 5067 1394
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CC
-Encoding: 5068 5068 5068
+Encoding: 5068 5068 1395
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CD
-Encoding: 5069 5069 5069
+Encoding: 5069 5069 1396
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CE
-Encoding: 5070 5070 5070
+Encoding: 5070 5070 1397
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CF
-Encoding: 5071 5071 5071
+Encoding: 5071 5071 1398
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D0
-Encoding: 5072 5072 5072
+Encoding: 5072 5072 1399
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D1
-Encoding: 5073 5073 5073
+Encoding: 5073 5073 1400
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D2
-Encoding: 5074 5074 5074
+Encoding: 5074 5074 1401
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D3
-Encoding: 5075 5075 5075
+Encoding: 5075 5075 1402
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D4
-Encoding: 5076 5076 5076
+Encoding: 5076 5076 1403
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D5
-Encoding: 5077 5077 5077
+Encoding: 5077 5077 1404
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D6
-Encoding: 5078 5078 5078
+Encoding: 5078 5078 1405
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D7
-Encoding: 5079 5079 5079
+Encoding: 5079 5079 1406
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D8
-Encoding: 5080 5080 5080
+Encoding: 5080 5080 1407
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D9
-Encoding: 5081 5081 5081
+Encoding: 5081 5081 1408
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DA
-Encoding: 5082 5082 5082
+Encoding: 5082 5082 1409
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DB
-Encoding: 5083 5083 5083
+Encoding: 5083 5083 1410
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DC
-Encoding: 5084 5084 5084
+Encoding: 5084 5084 1411
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DD
-Encoding: 5085 5085 5085
+Encoding: 5085 5085 1412
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DE
-Encoding: 5086 5086 5086
+Encoding: 5086 5086 1413
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DF
-Encoding: 5087 5087 5087
+Encoding: 5087 5087 1414
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E0
-Encoding: 5088 5088 5088
+Encoding: 5088 5088 1415
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E1
-Encoding: 5089 5089 5089
+Encoding: 5089 5089 1416
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E2
-Encoding: 5090 5090 5090
+Encoding: 5090 5090 1417
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E3
-Encoding: 5091 5091 5091
+Encoding: 5091 5091 1418
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E4
-Encoding: 5092 5092 5092
+Encoding: 5092 5092 1419
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E5
-Encoding: 5093 5093 5093
+Encoding: 5093 5093 1420
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E6
-Encoding: 5094 5094 5094
+Encoding: 5094 5094 1421
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E7
-Encoding: 5095 5095 5095
+Encoding: 5095 5095 1422
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E8
-Encoding: 5096 5096 5096
+Encoding: 5096 5096 1423
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E9
-Encoding: 5097 5097 5097
+Encoding: 5097 5097 1424
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EA
-Encoding: 5098 5098 5098
+Encoding: 5098 5098 1425
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EB
-Encoding: 5099 5099 5099
+Encoding: 5099 5099 1426
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EC
-Encoding: 5100 5100 5100
+Encoding: 5100 5100 1427
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13ED
-Encoding: 5101 5101 5101
+Encoding: 5101 5101 1428
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EE
-Encoding: 5102 5102 5102
+Encoding: 5102 5102 1429
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EF
-Encoding: 5103 5103 5103
+Encoding: 5103 5103 1430
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F0
-Encoding: 5104 5104 5104
+Encoding: 5104 5104 1431
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F1
-Encoding: 5105 5105 5105
+Encoding: 5105 5105 1432
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F2
-Encoding: 5106 5106 5106
+Encoding: 5106 5106 1433
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F3
-Encoding: 5107 5107 5107
+Encoding: 5107 5107 1434
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F4
-Encoding: 5108 5108 5108
+Encoding: 5108 5108 1435
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F5
-Encoding: 5109 5109 5109
+Encoding: 5109 5109 1436
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni1D02
-Encoding: 7426 7426 7426
+Encoding: 7426 7426 1437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49723,8 +51166,9 @@ SplineSet
  41 604 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D08
-Encoding: 7432 7432 7432
+Encoding: 7432 7432 1438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49762,8 +51206,9 @@ SplineSet
  916 541 916 541 784 518 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D09
-Encoding: 7433 7433 7433
+Encoding: 7433 7433 1439
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49787,8 +51232,9 @@ SplineSet
  727 -432 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D14
-Encoding: 7444 7444 7444
+Encoding: 7444 7444 1440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49839,8 +51285,9 @@ SplineSet
  14 604 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D16
-Encoding: 7446 7446 7446
+Encoding: 7446 7446 1441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49859,8 +51306,9 @@ SplineSet
  137 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D17
-Encoding: 7447 7447 7447
+Encoding: 7447 7447 1442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49879,8 +51327,9 @@ SplineSet
  1095 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D1D
-Encoding: 7453 7453 7453
+Encoding: 7453 7453 1443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49905,8 +51354,9 @@ SplineSet
  965 2.5 965 2.5 737 2.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1E
-Encoding: 7454 7454 7454
+Encoding: 7454 7454 1444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49941,8 +51391,9 @@ SplineSet
  1012.35 -1.5 1012.35 -1.5 852.75 -1.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1F
-Encoding: 7455 7455 7455
+Encoding: 7455 7455 1445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49978,8 +51429,9 @@ SplineSet
  1120 488 1120 488 1049 460 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2C
-Encoding: 7468 7468 7468
+Encoding: 7468 7468 1446
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.58 668 basechar 0
@@ -50002,8 +51454,9 @@ SplineSet
  540 1504 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2D
-Encoding: 7469 7469 7469
+Encoding: 7469 7469 1447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50033,8 +51486,9 @@ SplineSet
  579 1409 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2E
-Encoding: 7470 7470 7470
+Encoding: 7470 7470 1448
 Width: 1233
 Flags: W
 AnchorPoint: "above" 594.08 1504.08 basechar 0
@@ -50072,8 +51526,9 @@ SplineSet
  311 1504 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D30
-Encoding: 7472 7472 7472
+Encoding: 7472 7472 1449
 Width: 1233
 Flags: W
 AnchorPoint: "above" 581.58 1504.08 basechar 0
@@ -50099,8 +51554,9 @@ SplineSet
  502 1504 l 2,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni1D31
-Encoding: 7473 7473 7473
+Encoding: 7473 7473 1450
 Width: 1233
 Flags: W
 AnchorPoint: "above" 606.92 1504.08 basechar 0
@@ -50123,8 +51579,9 @@ SplineSet
  332 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D32
-Encoding: 7474 7474 7474
+Encoding: 7474 7474 1451
 Width: 1233
 Flags: W
 AnchorPoint: "above" 626.45 1504.08 basechar 0
@@ -50147,8 +51604,9 @@ SplineSet
  902 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D33
-Encoding: 7475 7475 7475
+Encoding: 7475 7475 1452
 Width: 1233
 Flags: W
 AnchorPoint: "above" 656.08 1504.08 basechar 0
@@ -50181,8 +51639,9 @@ SplineSet
  932 737 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D34
-Encoding: 7476 7476 7476
+Encoding: 7476 7476 1453
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616.58 1504.08 basechar 0
@@ -50205,8 +51664,9 @@ SplineSet
  314 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D35
-Encoding: 7477 7477 7477
+Encoding: 7477 7477 1454
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616.58 1504.08 basechar 0
@@ -50229,8 +51689,9 @@ SplineSet
  356 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D36
-Encoding: 7478 7478 7478
+Encoding: 7478 7478 1455
 Width: 1233
 Flags: W
 AnchorPoint: "above" 700.58 1504.08 basechar 0
@@ -50255,8 +51716,9 @@ SplineSet
  415 676 415 676 350 702 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D37
-Encoding: 7479 7479 7479
+Encoding: 7479 7479 1456
 Width: 1233
 Flags: W
 AnchorPoint: "below" 575.58 668 basechar 0
@@ -50279,8 +51741,9 @@ SplineSet
  274 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D38
-Encoding: 7480 7480 7480
+Encoding: 7480 7480 1457
 Width: 1233
 Flags: W
 AnchorPoint: "below" 609.58 668 basechar 0
@@ -50297,8 +51760,9 @@ SplineSet
  325 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D39
-Encoding: 7481 7481 7481
+Encoding: 7481 7481 1458
 Width: 1233
 Flags: W
 AnchorPoint: "below" 617.08 668 basechar 0
@@ -50322,8 +51786,9 @@ SplineSet
  283 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3A
-Encoding: 7482 7482 7482
+Encoding: 7482 7482 1459
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50344,8 +51809,9 @@ SplineSet
  316 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3B
-Encoding: 7483 7483 7483
+Encoding: 7483 7483 1460
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.71 668 basechar 0
@@ -50366,8 +51832,9 @@ SplineSet
  917 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3C
-Encoding: 7484 7484 7484
+Encoding: 7484 7484 1461
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50395,8 +51862,9 @@ SplineSet
  931 1304 931 1304 931 1085 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D3E
-Encoding: 7486 7486 7486
+Encoding: 7486 7486 1462
 Width: 1233
 Flags: W
 AnchorPoint: "below" 583.08 668 basechar 0
@@ -50424,8 +51892,9 @@ SplineSet
  319 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3F
-Encoding: 7487 7487 7487
+Encoding: 7487 7487 1463
 Width: 1233
 Flags: W
 AnchorPoint: "below" 539.58 668 basechar 0
@@ -50460,8 +51929,9 @@ SplineSet
  401 1411 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D40
-Encoding: 7488 7488 7488
+Encoding: 7488 7488 1464
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50480,8 +51950,9 @@ SplineSet
  258 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D41
-Encoding: 7489 7489 7489
+Encoding: 7489 7489 1465
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50514,8 +51985,9 @@ SplineSet
  321 862 321 862 321 989 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D42
-Encoding: 7490 7490 7490
+Encoding: 7490 7490 1466
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50539,8 +52011,9 @@ SplineSet
  228 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D43
-Encoding: 7491 7491 7491
+Encoding: 7491 7491 1467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50581,8 +52054,9 @@ SplineSet
  908 1108 908 1108 908 1026 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D44
-Encoding: 7492 7492 7492
+Encoding: 7492 7492 1468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50623,8 +52097,9 @@ SplineSet
  325 854 325 854 325 936 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D45
-Encoding: 7493 7493 7493
+Encoding: 7493 7493 1469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50655,8 +52130,9 @@ SplineSet
  449 1101 449 1101 449 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D46
-Encoding: 7494 7494 7494
+Encoding: 7494 7494 1470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50716,8 +52192,9 @@ SplineSet
  251 1006 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D47
-Encoding: 7495 7495 7495
+Encoding: 7495 7495 1471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50748,8 +52225,9 @@ SplineSet
  443 1215 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D48
-Encoding: 7496 7496 7496
+Encoding: 7496 7496 1472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50780,8 +52258,9 @@ SplineSet
  449 1101 449 1101 449 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D49
-Encoding: 7497 7497 7497
+Encoding: 7497 7497 1473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50812,8 +52291,9 @@ SplineSet
  812 1038 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni1D4A
-Encoding: 7498 7498 7498
+Encoding: 7498 7498 1474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50844,8 +52324,9 @@ SplineSet
  421 924 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni1D4B
-Encoding: 7499 7499 7499
+Encoding: 7499 7499 1475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50883,8 +52364,9 @@ SplineSet
  428 995 428 995 511 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4C
-Encoding: 7500 7500 7500
+Encoding: 7500 7500 1476
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50922,8 +52404,9 @@ SplineSet
  805 971 805 971 722 958 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4D
-Encoding: 7501 7501 7501
+Encoding: 7501 7501 1477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50963,8 +52446,9 @@ SplineSet
  906 708 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D4E
-Encoding: 7502 7502 7502
+Encoding: 7502 7502 1478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50988,8 +52472,9 @@ SplineSet
  674 426 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4F
-Encoding: 7503 7503 7503
+Encoding: 7503 7503 1479
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51010,8 +52495,9 @@ SplineSet
  312 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D50
-Encoding: 7504 7504 7504
+Encoding: 7504 7504 1480
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51047,8 +52533,9 @@ SplineSet
  633 1271 633 1271 651 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D51
-Encoding: 7505 7505 7505
+Encoding: 7505 7505 1481
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51079,8 +52566,9 @@ SplineSet
  886 1184 886 1184 886 1057 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D52
-Encoding: 7506 7506 7506
+Encoding: 7506 7506 1482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51106,8 +52594,9 @@ SplineSet
  469 1310 469 1310 616 1310 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D53
-Encoding: 7507 7507 7507
+Encoding: 7507 7507 1483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51134,8 +52623,9 @@ SplineSet
  344 1262 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D54
-Encoding: 7508 7508 7508
+Encoding: 7508 7508 1484
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51154,8 +52644,9 @@ SplineSet
  314 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D55
-Encoding: 7509 7509 7509
+Encoding: 7509 7509 1485
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51174,8 +52665,9 @@ SplineSet
  919 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D56
-Encoding: 7510 7510 7510
+Encoding: 7510 7510 1486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51206,8 +52698,9 @@ SplineSet
  784 861 784 861 784 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D57
-Encoding: 7511 7511 7511
+Encoding: 7511 7511 1487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51234,8 +52727,9 @@ SplineSet
  637 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D58
-Encoding: 7512 7512 7512
+Encoding: 7512 7512 1488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51260,8 +52754,9 @@ SplineSet
  347 778 347 778 347 905 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D59
-Encoding: 7513 7513 7513
+Encoding: 7513 7513 1489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51286,8 +52781,9 @@ SplineSet
  836 669 836 669 692 669 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5A
-Encoding: 7514 7514 7514
+Encoding: 7514 7514 1490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51323,8 +52819,9 @@ SplineSet
  600 707 600 707 582 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5B
-Encoding: 7515 7515 7515
+Encoding: 7515 7515 1491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51340,40 +52837,45 @@ SplineSet
  291 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D62
-Encoding: 7522 7522 7522
+Encoding: 7522 7522 1492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8305 8305 N 1 0 0 1 0 -668 3
+Refer: 2008 8305 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D63
-Encoding: 7523 7523 7523
+Encoding: 7523 7523 1493
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 691 691 N 1 0 0 1 0 -668 3
+Refer: 608 691 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D64
-Encoding: 7524 7524 7524
+Encoding: 7524 7524 1494
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7512 7512 N 1 0 0 1 0 -668 3
+Refer: 1488 7512 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D65
-Encoding: 7525 7525 7525
+Encoding: 7525 7525 1495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7515 7515 N 1 0 0 1 0 -668 3
+Refer: 1491 7515 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D77
-Encoding: 7543 7543 7543
+Encoding: 7543 7543 1496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51413,16 +52915,18 @@ SplineSet
  123 635 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D78
-Encoding: 7544 7544 7544
+Encoding: 7544 7544 1497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7476 7476 N 1 0 0 1 0 0 2
+Refer: 1453 7476 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1D7B
-Encoding: 7547 7547 7547
+Encoding: 7547 7547 1498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51451,8 +52955,9 @@ SplineSet
  1076.75 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D85
-Encoding: 7557 7557 7557
+Encoding: 7557 7557 1499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51483,8 +52988,9 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9B
-Encoding: 7579 7579 7579
+Encoding: 7579 7579 1500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51515,8 +53021,9 @@ SplineSet
  784 861 784 861 784 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D9C
-Encoding: 7580 7580 7580
+Encoding: 7580 7580 1501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51543,8 +53050,9 @@ SplineSet
  889 700 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9D
-Encoding: 7581 7581 7581
+Encoding: 7581 7581 1502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51578,8 +53086,9 @@ SplineSet
  634 647 634 647 589 657 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni1D9E
-Encoding: 7582 7582 7582
+Encoding: 7582 7582 1503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51620,8 +53129,9 @@ SplineSet
  759 1143 759 1143 728 1182 c 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni1D9F
-Encoding: 7583 7583 7583
+Encoding: 7583 7583 1504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51659,8 +53169,9 @@ SplineSet
  796 1022 796 1022 721 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA0
-Encoding: 7584 7584 7584
+Encoding: 7584 7584 1505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51687,8 +53198,9 @@ SplineSet
  890 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA1
-Encoding: 7585 7585 7585
+Encoding: 7585 7585 1506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51717,8 +53229,9 @@ SplineSet
  462 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA2
-Encoding: 7586 7586 7586
+Encoding: 7586 7586 1507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51755,8 +53268,9 @@ SplineSet
  906 708 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1DA3
-Encoding: 7587 7587 7587
+Encoding: 7587 7587 1508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51781,8 +53295,9 @@ SplineSet
  347 778 347 778 347 905 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA4
-Encoding: 7588 7588 7588
+Encoding: 7588 7588 1509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51814,8 +53329,9 @@ SplineSet
  383 1295 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA5
-Encoding: 7589 7589 7589
+Encoding: 7589 7589 1510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51836,8 +53352,9 @@ SplineSet
  880 668 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DA6
-Encoding: 7590 7590 7590
+Encoding: 7590 7590 1511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51858,8 +53375,9 @@ SplineSet
  329 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA7
-Encoding: 7591 7591 7591
+Encoding: 7591 7591 1512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51888,8 +53406,9 @@ SplineSet
  906 1013 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA8
-Encoding: 7592 7592 7592
+Encoding: 7592 7592 1513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51920,8 +53439,9 @@ SplineSet
  634 557 634 557 640 582 c 1,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni1DA9
-Encoding: 7593 7593 7593
+Encoding: 7593 7593 1514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51942,8 +53462,9 @@ SplineSet
  643 657 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAA
-Encoding: 7594 7594 7594
+Encoding: 7594 7594 1515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51972,8 +53493,9 @@ SplineSet
  643 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAB
-Encoding: 7595 7595 7595
+Encoding: 7595 7595 1516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51988,8 +53510,9 @@ SplineSet
  382 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAC
-Encoding: 7596 7596 7596
+Encoding: 7596 7596 1517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52034,8 +53557,9 @@ SplineSet
  633 1271 633 1271 650 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAD
-Encoding: 7597 7597 7597
+Encoding: 7597 7597 1518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52071,8 +53595,9 @@ SplineSet
  600 707 600 707 582 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAE
-Encoding: 7598 7598 7598
+Encoding: 7598 7598 1519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52103,8 +53628,9 @@ SplineSet
  536 657 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAF
-Encoding: 7599 7599 7599
+Encoding: 7599 7599 1520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52139,8 +53665,9 @@ SplineSet
  697 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB0
-Encoding: 7600 7600 7600
+Encoding: 7600 7600 1521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52159,8 +53686,9 @@ SplineSet
  319 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB1
-Encoding: 7601 7601 7601
+Encoding: 7601 7601 1522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52189,8 +53717,9 @@ SplineSet
  783 844 783 844 792 918 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB2
-Encoding: 7602 7602 7602
+Encoding: 7602 7602 1523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52233,8 +53762,9 @@ SplineSet
  513 759 513 759 563 746 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB3
-Encoding: 7603 7603 7603
+Encoding: 7603 7603 1524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52281,8 +53811,9 @@ SplineSet
  800 1294 800 1294 848 1277 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB4
-Encoding: 7604 7604 7604
+Encoding: 7604 7604 1525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52307,8 +53838,9 @@ SplineSet
  521 571 521 571 521 657 c 0,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB5
-Encoding: 7605 7605 7605
+Encoding: 7605 7605 1526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52343,8 +53875,9 @@ SplineSet
  637 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB6
-Encoding: 7606 7606 7606
+Encoding: 7606 7606 1527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52381,8 +53914,9 @@ SplineSet
  787 842 787 842 792 921 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB7
-Encoding: 7607 7607 7607
+Encoding: 7607 7607 1528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52415,8 +53949,9 @@ SplineSet
  288 1203 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB9
-Encoding: 7609 7609 7609
+Encoding: 7609 7609 1529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52445,8 +53980,9 @@ SplineSet
  592 1213 592 1213 563 1220 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DBA
-Encoding: 7610 7610 7610
+Encoding: 7610 7610 1530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52462,8 +53998,9 @@ SplineSet
  960 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBB
-Encoding: 7611 7611 7611
+Encoding: 7611 7611 1531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52482,8 +54019,9 @@ SplineSet
  368 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBC
-Encoding: 7612 7612 7612
+Encoding: 7612 7612 1532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52512,8 +54050,9 @@ SplineSet
  362 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBD
-Encoding: 7613 7613 7613
+Encoding: 7613 7613 1533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52543,8 +54082,9 @@ SplineSet
  693 831 693 831 671 750 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1DBE
-Encoding: 7614 7614 7614
+Encoding: 7614 7614 1534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52575,8 +54115,9 @@ SplineSet
  612 935 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DBF
-Encoding: 7615 7615 7615
+Encoding: 7615 7615 1535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52605,3178 +54146,3537 @@ SplineSet
  469 1508 469 1508 616 1508 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1E00
-Encoding: 7680 7680 7680
+Encoding: 7680 7680 1536
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E01
-Encoding: 7681 7681 7681
+Encoding: 7681 7681 1537
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E02
-Encoding: 7682 7682 7682
+Encoding: 7682 7682 1538
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E03
-Encoding: 7683 7683 7683
+Encoding: 7683 7683 1539
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 50 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 50 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E04
-Encoding: 7684 7684 7684
+Encoding: 7684 7684 1540
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E05
-Encoding: 7685 7685 7685
+Encoding: 7685 7685 1541
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E06
-Encoding: 7686 7686 7686
+Encoding: 7686 7686 1542
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E07
-Encoding: 7687 7687 7687
+Encoding: 7687 7687 1543
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E08
-Encoding: 7688 7688 7688
+Encoding: 7688 7688 1544
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E09
-Encoding: 7689 7689 7689
+Encoding: 7689 7689 1545
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 90 0 2
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0A
-Encoding: 7690 7690 7690
+Encoding: 7690 7690 1546
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0B
-Encoding: 7691 7691 7691
+Encoding: 7691 7691 1547
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 -50 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 -50 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0C
-Encoding: 7692 7692 7692
+Encoding: 7692 7692 1548
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0D
-Encoding: 7693 7693 7693
+Encoding: 7693 7693 1549
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0E
-Encoding: 7694 7694 7694
+Encoding: 7694 7694 1550
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0F
-Encoding: 7695 7695 7695
+Encoding: 7695 7695 1551
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E10
-Encoding: 7696 7696 7696
+Encoding: 7696 7696 1552
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -270 0 2
-Refer: 68 68 N 1 0 0 1 0 0 3
+Refer: 694 807 N 1 0 0 1 -270 0 2
+Refer: 37 68 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E11
-Encoding: 7697 7697 7697
+Encoding: 7697 7697 1553
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -20 0 2
-Refer: 100 100 N 1 0 0 1 0 0 3
+Refer: 694 807 N 1 0 0 1 -20 0 2
+Refer: 69 100 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E12
-Encoding: 7698 7698 7698
+Encoding: 7698 7698 1554
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E13
-Encoding: 7699 7699 7699
+Encoding: 7699 7699 1555
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E18
-Encoding: 7704 7704 7704
+Encoding: 7704 7704 1556
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E19
-Encoding: 7705 7705 7705
+Encoding: 7705 7705 1557
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1A
-Encoding: 7706 7706 7706
+Encoding: 7706 7706 1558
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1B
-Encoding: 7707 7707 7707
+Encoding: 7707 7707 1559
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1C
-Encoding: 7708 7708 7708
+Encoding: 7708 7708 1560
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1D
-Encoding: 7709 7709 7709
+Encoding: 7709 7709 1561
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1E
-Encoding: 7710 7710 7710
+Encoding: 7710 7710 1562
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 54 0 2
-Refer: 70 70 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 54 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1F
-Encoding: 7711 7711 7711
+Encoding: 7711 7711 1563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 102 102 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E20
-Encoding: 7712 7712 7712
+Encoding: 7712 7712 1564
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E21
-Encoding: 7713 7713 7713
+Encoding: 7713 7713 1565
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E22
-Encoding: 7714 7714 7714
+Encoding: 7714 7714 1566
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E23
-Encoding: 7715 7715 7715
+Encoding: 7715 7715 1567
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E24
-Encoding: 7716 7716 7716
+Encoding: 7716 7716 1568
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E25
-Encoding: 7717 7717 7717
+Encoding: 7717 7717 1569
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E26
-Encoding: 7718 7718 7718
+Encoding: 7718 7718 1570
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0.5 348 2
-Refer: 72 72 N 1 0 0 1 0 0 3
+Refer: 3727 -1 N 1 0 0 1 0.5 348 2
+Refer: 41 72 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E27
-Encoding: 7719 7719 7719
+Encoding: 7719 7719 1571
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 7 328 2
-Refer: 104 104 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 7 328 2
+Refer: 73 104 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E28
-Encoding: 7720 7720 7720
+Encoding: 7720 7720 1572
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -375 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -375 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E29
-Encoding: 7721 7721 7721
+Encoding: 7721 7721 1573
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -340 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -340 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2A
-Encoding: 7722 7722 7722
+Encoding: 7722 7722 1574
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2B
-Encoding: 7723 7723 7723
+Encoding: 7723 7723 1575
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2C
-Encoding: 7724 7724 7724
+Encoding: 7724 7724 1576
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2D
-Encoding: 7725 7725 7725
+Encoding: 7725 7725 1577
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E30
-Encoding: 7728 7728 7728
+Encoding: 7728 7728 1578
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E31
-Encoding: 7729 7729 7729
+Encoding: 7729 7729 1579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -219 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 -219 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E32
-Encoding: 7730 7730 7730
+Encoding: 7730 7730 1580
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E33
-Encoding: 7731 7731 7731
+Encoding: 7731 7731 1581
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E34
-Encoding: 7732 7732 7732
+Encoding: 7732 7732 1582
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E35
-Encoding: 7733 7733 7733
+Encoding: 7733 7733 1583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E36
-Encoding: 7734 7734 7734
+Encoding: 7734 7734 1584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E37
-Encoding: 7735 7735 7735
+Encoding: 7735 7735 1585
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E38
-Encoding: 7736 7736 7736
+Encoding: 7736 7736 1586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 7734 7734 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 1584 7734 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E39
-Encoding: 7737 7737 7737
+Encoding: 7737 7737 1587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 7735 7735 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 1585 7735 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3A
-Encoding: 7738 7738 7738
+Encoding: 7738 7738 1588
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3B
-Encoding: 7739 7739 7739
+Encoding: 7739 7739 1589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3C
-Encoding: 7740 7740 7740
+Encoding: 7740 7740 1590
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3D
-Encoding: 7741 7741 7741
+Encoding: 7741 7741 1591
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3E
-Encoding: 7742 7742 7742
+Encoding: 7742 7742 1592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3F
-Encoding: 7743 7743 7743
+Encoding: 7743 7743 1593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E40
-Encoding: 7744 7744 7744
+Encoding: 7744 7744 1594
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E41
-Encoding: 7745 7745 7745
+Encoding: 7745 7745 1595
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E42
-Encoding: 7746 7746 7746
+Encoding: 7746 7746 1596
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E43
-Encoding: 7747 7747 7747
+Encoding: 7747 7747 1597
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E44
-Encoding: 7748 7748 7748
+Encoding: 7748 7748 1598
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E45
-Encoding: 7749 7749 7749
+Encoding: 7749 7749 1599
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E46
-Encoding: 7750 7750 7750
+Encoding: 7750 7750 1600
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E47
-Encoding: 7751 7751 7751
+Encoding: 7751 7751 1601
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E48
-Encoding: 7752 7752 7752
+Encoding: 7752 7752 1602
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E49
-Encoding: 7753 7753 7753
+Encoding: 7753 7753 1603
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4A
-Encoding: 7754 7754 7754
+Encoding: 7754 7754 1604
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4B
-Encoding: 7755 7755 7755
+Encoding: 7755 7755 1605
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4C
-Encoding: 7756 7756 7756
+Encoding: 7756 7756 1606
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 262 2
+Refer: 3728 -1 N 1 0 0 1 50 515 2
 EndChar
+
 StartChar: uni1E4D
-Encoding: 7757 7757 7757
+Encoding: 7757 7757 1607
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 404 2
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E54
-Encoding: 7764 7764 7764
+Encoding: 7764 7764 1608
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -137 380 2
-Refer: 80 80 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -137 380 2
+Refer: 49 80 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E55
-Encoding: 7765 7765 7765
+Encoding: 7765 7765 1609
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 0 2
-Refer: 112 112 N 1 0 0 1 0 0 3
+Refer: 656 769 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E56
-Encoding: 7766 7766 7766
+Encoding: 7766 7766 1610
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E57
-Encoding: 7767 7767 7767
+Encoding: 7767 7767 1611
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 112 112 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E58
-Encoding: 7768 7768 7768
+Encoding: 7768 7768 1612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E59
-Encoding: 7769 7769 7769
+Encoding: 7769 7769 1613
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5A
-Encoding: 7770 7770 7770
+Encoding: 7770 7770 1614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5B
-Encoding: 7771 7771 7771
+Encoding: 7771 7771 1615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5C
-Encoding: 7772 7772 7772
+Encoding: 7772 7772 1616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 -50 0 2
-Refer: 7770 7770 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 -50 0 2
+Refer: 1614 7770 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5D
-Encoding: 7773 7773 7773
+Encoding: 7773 7773 1617
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 7771 7771 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 1615 7771 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5E
-Encoding: 7774 7774 7774
+Encoding: 7774 7774 1618
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5F
-Encoding: 7775 7775 7775
+Encoding: 7775 7775 1619
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E60
-Encoding: 7776 7776 7776
+Encoding: 7776 7776 1620
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E61
-Encoding: 7777 7777 7777
+Encoding: 7777 7777 1621
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E62
-Encoding: 7778 7778 7778
+Encoding: 7778 7778 1622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E63
-Encoding: 7779 7779 7779
+Encoding: 7779 7779 1623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E68
-Encoding: 7784 7784 7784
+Encoding: 7784 7784 1624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E69
-Encoding: 7785 7785 7785
+Encoding: 7785 7785 1625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6A
-Encoding: 7786 7786 7786
+Encoding: 7786 7786 1626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6B
-Encoding: 7787 7787 7787
+Encoding: 7787 7787 1627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6C
-Encoding: 7788 7788 7788
+Encoding: 7788 7788 1628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6D
-Encoding: 7789 7789 7789
+Encoding: 7789 7789 1629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6E
-Encoding: 7790 7790 7790
+Encoding: 7790 7790 1630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6F
-Encoding: 7791 7791 7791
+Encoding: 7791 7791 1631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E70
-Encoding: 7792 7792 7792
+Encoding: 7792 7792 1632
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E71
-Encoding: 7793 7793 7793
+Encoding: 7793 7793 1633
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E72
-Encoding: 7794 7794 7794
+Encoding: 7794 7794 1634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E73
-Encoding: 7795 7795 7795
+Encoding: 7795 7795 1635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E74
-Encoding: 7796 7796 7796
+Encoding: 7796 7796 1636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E75
-Encoding: 7797 7797 7797
+Encoding: 7797 7797 1637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E76
-Encoding: 7798 7798 7798
+Encoding: 7798 7798 1638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E77
-Encoding: 7799 7799 7799
+Encoding: 7799 7799 1639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E78
-Encoding: 7800 7800 7800
+Encoding: 7800 7800 1640
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 262 2
+Refer: 3728 -1 N 1 0 0 1 50 515 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E79
-Encoding: 7801 7801 7801
+Encoding: 7801 7801 1641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 404 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7C
-Encoding: 7804 7804 7804
+Encoding: 7804 7804 1642
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 348 2
-Refer: 86 86 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 0 348 2
+Refer: 55 86 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E7D
-Encoding: 7805 7805 7805
+Encoding: 7805 7805 1643
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 -40 2
-Refer: 118 118 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 0 -40 2
+Refer: 87 118 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E7E
-Encoding: 7806 7806 7806
+Encoding: 7806 7806 1644
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 86 86 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7F
-Encoding: 7807 7807 7807
+Encoding: 7807 7807 1645
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 118 118 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wgrave
-Encoding: 7808 7808 7808
+Encoding: 7808 7808 1646
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wgrave
-Encoding: 7809 7809 7809
+Encoding: 7809 7809 1647
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -64 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -64 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wacute
-Encoding: 7810 7810 7810
+Encoding: 7810 7810 1648
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wacute
-Encoding: 7811 7811 7811
+Encoding: 7811 7811 1649
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 64 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 64 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wdieresis
-Encoding: 7812 7812 7812
+Encoding: 7812 7812 1650
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 292 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 292 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wdieresis
-Encoding: 7813 7813 7813
+Encoding: 7813 7813 1651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -81 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -81 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E86
-Encoding: 7814 7814 7814
+Encoding: 7814 7814 1652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E87
-Encoding: 7815 7815 7815
+Encoding: 7815 7815 1653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E88
-Encoding: 7816 7816 7816
+Encoding: 7816 7816 1654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E89
-Encoding: 7817 7817 7817
+Encoding: 7817 7817 1655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8A
-Encoding: 7818 7818 7818
+Encoding: 7818 7818 1656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8B
-Encoding: 7819 7819 7819
+Encoding: 7819 7819 1657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8C
-Encoding: 7820 7820 7820
+Encoding: 7820 7820 1658
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 18 348 2
-Refer: 88 88 N 1 0 0 1 0 0 3
+Refer: 3727 -1 N 1 0 0 1 18 348 2
+Refer: 57 88 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8D
-Encoding: 7821 7821 7821
+Encoding: 7821 7821 1659
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0.5 -81 2
-Refer: 120 120 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 0.5 -81 2
+Refer: 89 120 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8E
-Encoding: 7822 7822 7822
+Encoding: 7822 7822 1660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8F
-Encoding: 7823 7823 7823
+Encoding: 7823 7823 1661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E90
-Encoding: 7824 7824 7824
+Encoding: 7824 7824 1662
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 46 380 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 46 380 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E91
-Encoding: 7825 7825 7825
+Encoding: 7825 7825 1663
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 17 7 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 17 7 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E92
-Encoding: 7826 7826 7826
+Encoding: 7826 7826 1664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E93
-Encoding: 7827 7827 7827
+Encoding: 7827 7827 1665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E94
-Encoding: 7828 7828 7828
+Encoding: 7828 7828 1666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E95
-Encoding: 7829 7829 7829
+Encoding: 7829 7829 1667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E96
-Encoding: 7830 7830 7830
+Encoding: 7830 7830 1668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E97
-Encoding: 7831 7831 7831
+Encoding: 7831 7831 1669
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -94 210 2
-Refer: 116 116 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 -94 210 2
+Refer: 85 116 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E98
-Encoding: 7832 7832 7832
+Encoding: 7832 7832 1670
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 20 2
-Refer: 119 119 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 0 20 2
+Refer: 88 119 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E99
-Encoding: 7833 7833 7833
+Encoding: 7833 7833 1671
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 12 20 2
-Refer: 121 121 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 12 20 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E9B
-Encoding: 7835 7835 7835
+Encoding: 7835 7835 1672
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 383 383 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 319 383 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E9F
-Encoding: 7839 7839 7839
+Encoding: 7839 7839 1673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 948 948 N 1 0 0 1 0 0 2
+Refer: 777 948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA0
-Encoding: 7840 7840 7840
+Encoding: 7840 7840 1674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA1
-Encoding: 7841 7841 7841
+Encoding: 7841 7841 1675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EAC
-Encoding: 7852 7852 7852
+Encoding: 7852 7852 1676
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 7840 7840 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EAD
-Encoding: 7853 7853 7853
+Encoding: 7853 7853 1677
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -24.5 7 2
-Refer: 7841 7841 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -24.5 7 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB0
-Encoding: 7856 7856 7856
+Encoding: 7856 7856 1678
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 -128 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 515 2
+Refer: 3735 -1 N 1 0 0 1 0 -128 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni1EB1
-Encoding: 7857 7857 7857
+Encoding: 7857 7857 1679
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 0 316 2
-Refer: 259 259 N 1 0 0 1 0 0 3
+Refer: 655 768 N 1 0 0 1 0 316 2
+Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB6
-Encoding: 7862 7862 7862
+Encoding: 7862 7862 1680
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 7840 7840 N 1 0 0 1 0 0 3
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB7
-Encoding: 7863 7863 7863
+Encoding: 7863 7863 1681
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 728 728 N 1 0 0 1 -24.5 -52 2
-Refer: 7841 7841 N 1 0 0 1 0 0 3
+Refer: 636 728 N 1 0 0 1 -24.5 -52 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB8
-Encoding: 7864 7864 7864
+Encoding: 7864 7864 1682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB9
-Encoding: 7865 7865 7865
+Encoding: 7865 7865 1683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBC
-Encoding: 7868 7868 7868
+Encoding: 7868 7868 1684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 42 373 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 42 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBD
-Encoding: 7869 7869 7869
+Encoding: 7869 7869 1685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EC6
-Encoding: 7878 7878 7878
+Encoding: 7878 7878 1686
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 23.5 380 2
-Refer: 7864 7864 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 23.5 380 2
+Refer: 1682 7864 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EC7
-Encoding: 7879 7879 7879
+Encoding: 7879 7879 1687
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 34.5 7 2
-Refer: 7865 7865 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 34.5 7 2
+Refer: 1683 7865 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1ECA
-Encoding: 7882 7882 7882
+Encoding: 7882 7882 1688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECB
-Encoding: 7883 7883 7883
+Encoding: 7883 7883 1689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECC
-Encoding: 7884 7884 7884
+Encoding: 7884 7884 1690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECD
-Encoding: 7885 7885 7885
+Encoding: 7885 7885 1691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ED8
-Encoding: 7896 7896 7896
+Encoding: 7896 7896 1692
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 -0.5 380 2
-Refer: 7884 7884 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 -0.5 380 2
+Refer: 1690 7884 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1ED9
-Encoding: 7897 7897 7897
+Encoding: 7897 7897 1693
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -0.5 7 2
-Refer: 7885 7885 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -0.5 7 2
+Refer: 1691 7885 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDA
-Encoding: 7898 7898 7898
+Encoding: 7898 7898 1694
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDB
-Encoding: 7899 7899 7899
+Encoding: 7899 7899 1695
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDC
-Encoding: 7900 7900 7900
+Encoding: 7900 7900 1696
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3730 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDD
-Encoding: 7901 7901 7901
+Encoding: 7901 7901 1697
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE0
-Encoding: 7904 7904 7904
+Encoding: 7904 7904 1698
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE1
-Encoding: 7905 7905 7905
+Encoding: 7905 7905 1699
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE2
-Encoding: 7906 7906 7906
+Encoding: 7906 7906 1700
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -111 0 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -111 0 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE3
-Encoding: 7907 7907 7907
+Encoding: 7907 7907 1701
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE4
-Encoding: 7908 7908 7908
+Encoding: 7908 7908 1702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE5
-Encoding: 7909 7909 7909
+Encoding: 7909 7909 1703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE8
-Encoding: 7912 7912 7912
+Encoding: 7912 7912 1704
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE9
-Encoding: 7913 7913 7913
+Encoding: 7913 7913 1705
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEA
-Encoding: 7914 7914 7914
+Encoding: 7914 7914 1706
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3730 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEB
-Encoding: 7915 7915 7915
+Encoding: 7915 7915 1707
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEE
-Encoding: 7918 7918 7918
+Encoding: 7918 7918 1708
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEF
-Encoding: 7919 7919 7919
+Encoding: 7919 7919 1709
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EF0
-Encoding: 7920 7920 7920
+Encoding: 7920 7920 1710
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -138 0 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -138 0 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EF1
-Encoding: 7921 7921 7921
+Encoding: 7921 7921 1711
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: Ygrave
-Encoding: 7922 7922 7922
+Encoding: 7922 7922 1712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ygrave
-Encoding: 7923 7923 7923
+Encoding: 7923 7923 1713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -52 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -52 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF4
-Encoding: 7924 7924 7924
+Encoding: 7924 7924 1714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF5
-Encoding: 7925 7925 7925
+Encoding: 7925 7925 1715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 250 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 250 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF8
-Encoding: 7928 7928 7928
+Encoding: 7928 7928 1716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF9
-Encoding: 7929 7929 7929
+Encoding: 7929 7929 1717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F00
-Encoding: 7936 7936 7936
+Encoding: 7936 7936 1718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F01
-Encoding: 7937 7937 7937
+Encoding: 7937 7937 1719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F02
-Encoding: 7938 7938 7938
+Encoding: 7938 7938 1720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F03
-Encoding: 7939 7939 7939
+Encoding: 7939 7939 1721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F04
-Encoding: 7940 7940 7940
+Encoding: 7940 7940 1722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F05
-Encoding: 7941 7941 7941
+Encoding: 7941 7941 1723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F06
-Encoding: 7942 7942 7942
+Encoding: 7942 7942 1724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F07
-Encoding: 7943 7943 7943
+Encoding: 7943 7943 1725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F08
-Encoding: 7944 7944 7944
+Encoding: 7944 7944 1726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -350 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -350 0 2
 EndChar
+
 StartChar: uni1F09
-Encoding: 7945 7945 7945
+Encoding: 7945 7945 1727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1F0A
-Encoding: 7946 7946 7946
+Encoding: 7946 7946 1728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -650 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F0B
-Encoding: 7947 7947 7947
+Encoding: 7947 7947 1729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -650 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F0C
-Encoding: 7948 7948 7948
+Encoding: 7948 7948 1730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -525 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: uni1F0D
-Encoding: 7949 7949 7949
+Encoding: 7949 7949 1731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -525 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: uni1F0E
-Encoding: 7950 7950 7950
+Encoding: 7950 7950 1732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -350 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -350 0 2
 EndChar
+
 StartChar: uni1F0F
-Encoding: 7951 7951 7951
+Encoding: 7951 7951 1733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1F10
-Encoding: 7952 7952 7952
+Encoding: 7952 7952 1734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F11
-Encoding: 7953 7953 7953
+Encoding: 7953 7953 1735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F12
-Encoding: 7954 7954 7954
+Encoding: 7954 7954 1736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F13
-Encoding: 7955 7955 7955
+Encoding: 7955 7955 1737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F14
-Encoding: 7956 7956 7956
+Encoding: 7956 7956 1738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F15
-Encoding: 7957 7957 7957
+Encoding: 7957 7957 1739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F18
-Encoding: 7960 7960 7960
+Encoding: 7960 7960 1740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F19
-Encoding: 7961 7961 7961
+Encoding: 7961 7961 1741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F1A
-Encoding: 7962 7962 7962
+Encoding: 7962 7962 1742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F1B
-Encoding: 7963 7963 7963
+Encoding: 7963 7963 1743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F1C
-Encoding: 7964 7964 7964
+Encoding: 7964 7964 1744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F1D
-Encoding: 7965 7965 7965
+Encoding: 7965 7965 1745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F20
-Encoding: 7968 7968 7968
+Encoding: 7968 7968 1746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F21
-Encoding: 7969 7969 7969
+Encoding: 7969 7969 1747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F22
-Encoding: 7970 7970 7970
+Encoding: 7970 7970 1748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F23
-Encoding: 7971 7971 7971
+Encoding: 7971 7971 1749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F24
-Encoding: 7972 7972 7972
+Encoding: 7972 7972 1750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F25
-Encoding: 7973 7973 7973
+Encoding: 7973 7973 1751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F26
-Encoding: 7974 7974 7974
+Encoding: 7974 7974 1752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F27
-Encoding: 7975 7975 7975
+Encoding: 7975 7975 1753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F28
-Encoding: 7976 7976 7976
+Encoding: 7976 7976 1754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -675 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -675 0 2
 EndChar
+
 StartChar: uni1F29
-Encoding: 7977 7977 7977
+Encoding: 7977 7977 1755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -675 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -675 0 2
 EndChar
+
 StartChar: uni1F2A
-Encoding: 7978 7978 7978
+Encoding: 7978 7978 1756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -950 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F2B
-Encoding: 7979 7979 7979
+Encoding: 7979 7979 1757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F2C
-Encoding: 7980 7980 7980
+Encoding: 7980 7980 1758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -900 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -900 0 2
 EndChar
+
 StartChar: uni1F2D
-Encoding: 7981 7981 7981
+Encoding: 7981 7981 1759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -900 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -900 0 2
 EndChar
+
 StartChar: uni1F2E
-Encoding: 7982 7982 7982
+Encoding: 7982 7982 1760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1F2F
-Encoding: 7983 7983 7983
+Encoding: 7983 7983 1761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1F30
-Encoding: 7984 7984 7984
+Encoding: 7984 7984 1762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F31
-Encoding: 7985 7985 7985
+Encoding: 7985 7985 1763
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F32
-Encoding: 7986 7986 7986
+Encoding: 7986 7986 1764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F33
-Encoding: 7987 7987 7987
+Encoding: 7987 7987 1765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F34
-Encoding: 7988 7988 7988
+Encoding: 7988 7988 1766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F35
-Encoding: 7989 7989 7989
+Encoding: 7989 7989 1767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F36
-Encoding: 7990 7990 7990
+Encoding: 7990 7990 1768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F37
-Encoding: 7991 7991 7991
+Encoding: 7991 7991 1769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F38
-Encoding: 7992 7992 7992
+Encoding: 7992 7992 1770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F39
-Encoding: 7993 7993 7993
+Encoding: 7993 7993 1771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F3A
-Encoding: 7994 7994 7994
+Encoding: 7994 7994 1772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -850 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -850 0 2
 EndChar
+
 StartChar: uni1F3B
-Encoding: 7995 7995 7995
+Encoding: 7995 7995 1773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -850 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -850 0 2
 EndChar
+
 StartChar: uni1F3C
-Encoding: 7996 7996 7996
+Encoding: 7996 7996 1774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F3D
-Encoding: 7997 7997 7997
+Encoding: 7997 7997 1775
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F3E
-Encoding: 7998 7998 7998
+Encoding: 7998 7998 1776
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F3F
-Encoding: 7999 7999 7999
+Encoding: 7999 7999 1777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F40
-Encoding: 8000 8000 8000
+Encoding: 8000 8000 1778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F41
-Encoding: 8001 8001 8001
+Encoding: 8001 8001 1779
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F42
-Encoding: 8002 8002 8002
+Encoding: 8002 8002 1780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F43
-Encoding: 8003 8003 8003
+Encoding: 8003 8003 1781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F44
-Encoding: 8004 8004 8004
+Encoding: 8004 8004 1782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F45
-Encoding: 8005 8005 8005
+Encoding: 8005 8005 1783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F48
-Encoding: 8008 8008 8008
+Encoding: 8008 8008 1784
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F49
-Encoding: 8009 8009 8009
+Encoding: 8009 8009 1785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F4A
-Encoding: 8010 8010 8010
+Encoding: 8010 8010 1786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F4B
-Encoding: 8011 8011 8011
+Encoding: 8011 8011 1787
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F4C
-Encoding: 8012 8012 8012
+Encoding: 8012 8012 1788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -650 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F4D
-Encoding: 8013 8013 8013
+Encoding: 8013 8013 1789
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -650 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F50
-Encoding: 8016 8016 8016
+Encoding: 8016 8016 1790
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F51
-Encoding: 8017 8017 8017
+Encoding: 8017 8017 1791
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F52
-Encoding: 8018 8018 8018
+Encoding: 8018 8018 1792
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F53
-Encoding: 8019 8019 8019
+Encoding: 8019 8019 1793
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F54
-Encoding: 8020 8020 8020
+Encoding: 8020 8020 1794
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F55
-Encoding: 8021 8021 8021
+Encoding: 8021 8021 1795
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F56
-Encoding: 8022 8022 8022
+Encoding: 8022 8022 1796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F57
-Encoding: 8023 8023 8023
+Encoding: 8023 8023 1797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F59
-Encoding: 8025 8025 8025
+Encoding: 8025 8025 1798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -775 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -775 0 2
 EndChar
+
 StartChar: uni1F5B
-Encoding: 8027 8027 8027
+Encoding: 8027 8027 1799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F5D
-Encoding: 8029 8029 8029
+Encoding: 8029 8029 1800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -975 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -975 0 2
 EndChar
+
 StartChar: uni1F5F
-Encoding: 8031 8031 8031
+Encoding: 8031 8031 1801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -775 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -775 0 2
 EndChar
+
 StartChar: uni1F60
-Encoding: 8032 8032 8032
+Encoding: 8032 8032 1802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F61
-Encoding: 8033 8033 8033
+Encoding: 8033 8033 1803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F62
-Encoding: 8034 8034 8034
+Encoding: 8034 8034 1804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F63
-Encoding: 8035 8035 8035
+Encoding: 8035 8035 1805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F64
-Encoding: 8036 8036 8036
+Encoding: 8036 8036 1806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F65
-Encoding: 8037 8037 8037
+Encoding: 8037 8037 1807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F66
-Encoding: 8038 8038 8038
+Encoding: 8038 8038 1808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F67
-Encoding: 8039 8039 8039
+Encoding: 8039 8039 1809
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F68
-Encoding: 8040 8040 8040
+Encoding: 8040 8040 1810
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F69
-Encoding: 8041 8041 8041
+Encoding: 8041 8041 1811
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -650 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F6A
-Encoding: 8042 8042 8042
+Encoding: 8042 8042 1812
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F6B
-Encoding: 8043 8043 8043
+Encoding: 8043 8043 1813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F6C
-Encoding: 8044 8044 8044
+Encoding: 8044 8044 1814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F6D
-Encoding: 8045 8045 8045
+Encoding: 8045 8045 1815
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F6E
-Encoding: 8046 8046 8046
+Encoding: 8046 8046 1816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -550 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F6F
-Encoding: 8047 8047 8047
+Encoding: 8047 8047 1817
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F70
-Encoding: 8048 8048 8048
+Encoding: 8048 8048 1818
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F71
-Encoding: 8049 8049 8049
+Encoding: 8049 8049 1819
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F72
-Encoding: 8050 8050 8050
+Encoding: 8050 8050 1820
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F73
-Encoding: 8051 8051 8051
+Encoding: 8051 8051 1821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 941 941 N 1 0 0 1 0 0 2
+Refer: 770 941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F74
-Encoding: 8052 8052 8052
+Encoding: 8052 8052 1822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F75
-Encoding: 8053 8053 8053
+Encoding: 8053 8053 1823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F76
-Encoding: 8054 8054 8054
+Encoding: 8054 8054 1824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F77
-Encoding: 8055 8055 8055
+Encoding: 8055 8055 1825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 943 943 N 1 0 0 1 0 0 2
+Refer: 772 943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F78
-Encoding: 8056 8056 8056
+Encoding: 8056 8056 1826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F79
-Encoding: 8057 8057 8057
+Encoding: 8057 8057 1827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 972 972 N 1 0 0 1 0 0 2
+Refer: 801 972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7A
-Encoding: 8058 8058 8058
+Encoding: 8058 8058 1828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7B
-Encoding: 8059 8059 8059
+Encoding: 8059 8059 1829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 973 973 N 1 0 0 1 0 0 2
+Refer: 802 973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7C
-Encoding: 8060 8060 8060
+Encoding: 8060 8060 1830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7D
-Encoding: 8061 8061 8061
+Encoding: 8061 8061 1831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F80
-Encoding: 8064 8064 8064
+Encoding: 8064 8064 1832
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7936 7936 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1718 7936 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F81
-Encoding: 8065 8065 8065
+Encoding: 8065 8065 1833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7937 7937 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1719 7937 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F82
-Encoding: 8066 8066 8066
+Encoding: 8066 8066 1834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7938 7938 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1720 7938 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F83
-Encoding: 8067 8067 8067
+Encoding: 8067 8067 1835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7939 7939 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1721 7939 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F84
-Encoding: 8068 8068 8068
+Encoding: 8068 8068 1836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7940 7940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1722 7940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F85
-Encoding: 8069 8069 8069
+Encoding: 8069 8069 1837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7941 7941 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1723 7941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F86
-Encoding: 8070 8070 8070
+Encoding: 8070 8070 1838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7942 7942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1724 7942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F87
-Encoding: 8071 8071 8071
+Encoding: 8071 8071 1839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7943 7943 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1725 7943 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F88
-Encoding: 8072 8072 8072
+Encoding: 8072 8072 1840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7944 7944 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1726 7944 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F89
-Encoding: 8073 8073 8073
+Encoding: 8073 8073 1841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7945 7945 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1727 7945 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8A
-Encoding: 8074 8074 8074
+Encoding: 8074 8074 1842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7946 7946 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1728 7946 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8B
-Encoding: 8075 8075 8075
+Encoding: 8075 8075 1843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7947 7947 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1729 7947 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8C
-Encoding: 8076 8076 8076
+Encoding: 8076 8076 1844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7948 7948 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1730 7948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8D
-Encoding: 8077 8077 8077
+Encoding: 8077 8077 1845
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7949 7949 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1731 7949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8E
-Encoding: 8078 8078 8078
+Encoding: 8078 8078 1846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7950 7950 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1732 7950 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8F
-Encoding: 8079 8079 8079
+Encoding: 8079 8079 1847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7951 7951 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1733 7951 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F90
-Encoding: 8080 8080 8080
+Encoding: 8080 8080 1848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7968 7968 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1746 7968 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F91
-Encoding: 8081 8081 8081
+Encoding: 8081 8081 1849
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7969 7969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1747 7969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F92
-Encoding: 8082 8082 8082
+Encoding: 8082 8082 1850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7970 7970 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1748 7970 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F93
-Encoding: 8083 8083 8083
+Encoding: 8083 8083 1851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7971 7971 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1749 7971 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F94
-Encoding: 8084 8084 8084
+Encoding: 8084 8084 1852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7972 7972 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1750 7972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F95
-Encoding: 8085 8085 8085
+Encoding: 8085 8085 1853
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7973 7973 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1751 7973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F96
-Encoding: 8086 8086 8086
+Encoding: 8086 8086 1854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7974 7974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1752 7974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F97
-Encoding: 8087 8087 8087
+Encoding: 8087 8087 1855
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7975 7975 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1753 7975 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F98
-Encoding: 8088 8088 8088
+Encoding: 8088 8088 1856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7976 7976 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1754 7976 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F99
-Encoding: 8089 8089 8089
+Encoding: 8089 8089 1857
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7977 7977 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1755 7977 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9A
-Encoding: 8090 8090 8090
+Encoding: 8090 8090 1858
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7978 7978 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1756 7978 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9B
-Encoding: 8091 8091 8091
+Encoding: 8091 8091 1859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7979 7979 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1757 7979 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9C
-Encoding: 8092 8092 8092
+Encoding: 8092 8092 1860
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7980 7980 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1758 7980 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9D
-Encoding: 8093 8093 8093
+Encoding: 8093 8093 1861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7981 7981 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1759 7981 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9E
-Encoding: 8094 8094 8094
+Encoding: 8094 8094 1862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7982 7982 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1760 7982 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9F
-Encoding: 8095 8095 8095
+Encoding: 8095 8095 1863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7983 7983 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1761 7983 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA0
-Encoding: 8096 8096 8096
+Encoding: 8096 8096 1864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8032 8032 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1802 8032 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA1
-Encoding: 8097 8097 8097
+Encoding: 8097 8097 1865
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8033 8033 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1803 8033 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA2
-Encoding: 8098 8098 8098
+Encoding: 8098 8098 1866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8034 8034 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1804 8034 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA3
-Encoding: 8099 8099 8099
+Encoding: 8099 8099 1867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8035 8035 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1805 8035 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA4
-Encoding: 8100 8100 8100
+Encoding: 8100 8100 1868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8036 8036 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1806 8036 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA5
-Encoding: 8101 8101 8101
+Encoding: 8101 8101 1869
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8037 8037 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1807 8037 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA6
-Encoding: 8102 8102 8102
+Encoding: 8102 8102 1870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8038 8038 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1808 8038 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA7
-Encoding: 8103 8103 8103
+Encoding: 8103 8103 1871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8039 8039 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1809 8039 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA8
-Encoding: 8104 8104 8104
+Encoding: 8104 8104 1872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8040 8040 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1810 8040 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA9
-Encoding: 8105 8105 8105
+Encoding: 8105 8105 1873
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8041 8041 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1811 8041 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAA
-Encoding: 8106 8106 8106
+Encoding: 8106 8106 1874
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8042 8042 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1812 8042 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAB
-Encoding: 8107 8107 8107
+Encoding: 8107 8107 1875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8043 8043 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1813 8043 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAC
-Encoding: 8108 8108 8108
+Encoding: 8108 8108 1876
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8044 8044 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1814 8044 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAD
-Encoding: 8109 8109 8109
+Encoding: 8109 8109 1877
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8045 8045 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1815 8045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAE
-Encoding: 8110 8110 8110
+Encoding: 8110 8110 1878
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8046 8046 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1816 8046 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAF
-Encoding: 8111 8111 8111
+Encoding: 8111 8111 1879
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8047 8047 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1817 8047 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB0
-Encoding: 8112 8112 8112
+Encoding: 8112 8112 1880
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB1
-Encoding: 8113 8113 8113
+Encoding: 8113 8113 1881
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB2
-Encoding: 8114 8114 8114
+Encoding: 8114 8114 1882
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8048 8048 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1818 8048 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB3
-Encoding: 8115 8115 8115
+Encoding: 8115 8115 1883
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB4
-Encoding: 8116 8116 8116
+Encoding: 8116 8116 1884
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB6
-Encoding: 8118 8118 8118
+Encoding: 8118 8118 1885
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB7
-Encoding: 8119 8119 8119
+Encoding: 8119 8119 1886
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8118 8118 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1885 8118 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB8
-Encoding: 8120 8120 8120
+Encoding: 8120 8120 1887
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB9
-Encoding: 8121 8121 8121
+Encoding: 8121 8121 1888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBA
-Encoding: 8122 8122 8122
+Encoding: 8122 8122 1889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1FBB
-Encoding: 8123 8123 8123
+Encoding: 8123 8123 1890
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 902 902 N 1 0 0 1 0 0 2
+Refer: 734 902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBC
-Encoding: 8124 8124 8124
+Encoding: 8124 8124 1891
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBD
-Encoding: 8125 8125 8125
+Encoding: 8125 8125 1892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBE
-Encoding: 8126 8126 8126
+Encoding: 8126 8126 1893
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBF
-Encoding: 8127 8127 8127
+Encoding: 8127 8127 1894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55792,491 +57692,547 @@ SplineSet
  737 1475 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1FC0
-Encoding: 8128 8128 8128
+Encoding: 8128 8128 1895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC1
-Encoding: 8129 8129 8129
+Encoding: 8129 8129 1896
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 340 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 340 2
 EndChar
+
 StartChar: uni1FC2
-Encoding: 8130 8130 8130
+Encoding: 8130 8130 1897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8052 8052 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1822 8052 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC3
-Encoding: 8131 8131 8131
+Encoding: 8131 8131 1898
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC4
-Encoding: 8132 8132 8132
+Encoding: 8132 8132 1899
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC6
-Encoding: 8134 8134 8134
+Encoding: 8134 8134 1900
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC7
-Encoding: 8135 8135 8135
+Encoding: 8135 8135 1901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8134 8134 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1900 8134 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC8
-Encoding: 8136 8136 8136
+Encoding: 8136 8136 1902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -650 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1FC9
-Encoding: 8137 8137 8137
+Encoding: 8137 8137 1903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 904 904 N 1 0 0 1 0 0 2
+Refer: 736 904 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCA
-Encoding: 8138 8138 8138
+Encoding: 8138 8138 1904
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1FCB
-Encoding: 8139 8139 8139
+Encoding: 8139 8139 1905
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 905 905 N 1 0 0 1 0 0 2
+Refer: 737 905 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCC
-Encoding: 8140 8140 8140
+Encoding: 8140 8140 1906
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCD
-Encoding: 8141 8141 8141
+Encoding: 8141 8141 1907
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -250 0 2
-Refer: 8175 8175 N 1 0 0 1 250 0 2
+Refer: 1894 8127 N 1 0 0 1 -250 0 2
+Refer: 1938 8175 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni1FCE
-Encoding: 8142 8142 8142
+Encoding: 8142 8142 1908
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -200 0 2
-Refer: 8189 8189 N 1 0 0 1 100 0 2
+Refer: 1894 8127 N 1 0 0 1 -200 0 2
+Refer: 1949 8189 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1FCF
-Encoding: 8143 8143 8143
+Encoding: 8143 8143 1909
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 410 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
 EndChar
+
 StartChar: uni1FD0
-Encoding: 8144 8144 8144
+Encoding: 8144 8144 1910
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD1
-Encoding: 8145 8145 8145
+Encoding: 8145 8145 1911
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD2
-Encoding: 8146 8146 8146
+Encoding: 8146 8146 1912
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD3
-Encoding: 8147 8147 8147
+Encoding: 8147 8147 1913
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 912 912 N 1 0 0 1 0 0 2
+Refer: 742 912 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD6
-Encoding: 8150 8150 8150
+Encoding: 8150 8150 1914
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD7
-Encoding: 8151 8151 8151
+Encoding: 8151 8151 1915
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD8
-Encoding: 8152 8152 8152
+Encoding: 8152 8152 1916
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD9
-Encoding: 8153 8153 8153
+Encoding: 8153 8153 1917
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDA
-Encoding: 8154 8154 8154
+Encoding: 8154 8154 1918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -600 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -600 0 2
 EndChar
+
 StartChar: uni1FDB
-Encoding: 8155 8155 8155
+Encoding: 8155 8155 1919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 906 906 N 1 0 0 1 0 0 2
+Refer: 738 906 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDD
-Encoding: 8157 8157 8157
+Encoding: 8157 8157 1920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -250 0 2
-Refer: 8175 8175 N 1 0 0 1 250 0 2
+Refer: 1950 8190 N 1 0 0 1 -250 0 2
+Refer: 1938 8175 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni1FDE
-Encoding: 8158 8158 8158
+Encoding: 8158 8158 1921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -220 0 2
-Refer: 8189 8189 N 1 0 0 1 100 0 2
+Refer: 1950 8190 N 1 0 0 1 -220 0 2
+Refer: 1949 8189 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1FDF
-Encoding: 8159 8159 8159
+Encoding: 8159 8159 1922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 410 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
 EndChar
+
 StartChar: uni1FE0
-Encoding: 8160 8160 8160
+Encoding: 8160 8160 1923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE1
-Encoding: 8161 8161 8161
+Encoding: 8161 8161 1924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE2
-Encoding: 8162 8162 8162
+Encoding: 8162 8162 1925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE3
-Encoding: 8163 8163 8163
+Encoding: 8163 8163 1926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 944 944 N 1 0 0 1 0 0 2
+Refer: 773 944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE4
-Encoding: 8164 8164 8164
+Encoding: 8164 8164 1927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE5
-Encoding: 8165 8165 8165
+Encoding: 8165 8165 1928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE6
-Encoding: 8166 8166 8166
+Encoding: 8166 8166 1929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE7
-Encoding: 8167 8167 8167
+Encoding: 8167 8167 1930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE8
-Encoding: 8168 8168 8168
+Encoding: 8168 8168 1931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE9
-Encoding: 8169 8169 8169
+Encoding: 8169 8169 1932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEA
-Encoding: 8170 8170 8170
+Encoding: 8170 8170 1933
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1FEB
-Encoding: 8171 8171 8171
+Encoding: 8171 8171 1934
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 910 910 N 1 0 0 1 0 0 2
+Refer: 740 910 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEC
-Encoding: 8172 8172 8172
+Encoding: 8172 8172 1935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 929 929 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 759 929 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FED
-Encoding: 8173 8173 8173
+Encoding: 8173 8173 1936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 0 370 2
 EndChar
+
 StartChar: uni1FEE
-Encoding: 8174 8174 8174
+Encoding: 8174 8174 1937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEF
-Encoding: 8175 8175 8175
+Encoding: 8175 8175 1938
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF2
-Encoding: 8178 8178 8178
+Encoding: 8178 8178 1939
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8060 8060 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1830 8060 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF3
-Encoding: 8179 8179 8179
+Encoding: 8179 8179 1940
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF4
-Encoding: 8180 8180 8180
+Encoding: 8180 8180 1941
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF6
-Encoding: 8182 8182 8182
+Encoding: 8182 8182 1942
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF7
-Encoding: 8183 8183 8183
+Encoding: 8183 8183 1943
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8182 8182 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1942 8182 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF8
-Encoding: 8184 8184 8184
+Encoding: 8184 8184 1944
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FF9
-Encoding: 8185 8185 8185
+Encoding: 8185 8185 1945
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 908 908 N 1 0 0 1 0 0 2
+Refer: 739 908 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFA
-Encoding: 8186 8186 8186
+Encoding: 8186 8186 1946
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FFB
-Encoding: 8187 8187 8187
+Encoding: 8187 8187 1947
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 911 911 N 1 0 0 1 0 0 2
+Refer: 741 911 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFC
-Encoding: 8188 8188 8188
+Encoding: 8188 8188 1948
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFD
-Encoding: 8189 8189 8189
+Encoding: 8189 8189 1949
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFE
-Encoding: 8190 8190 8190
+Encoding: 8190 8190 1950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56292,74 +58248,86 @@ SplineSet
  495.5 1218 495.5 1218 495.5 1475 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2000
-Encoding: 8192 8192 8192
+Encoding: 8192 8192 1951
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2001
-Encoding: 8193 8193 8193
+Encoding: 8193 8193 1952
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2002
-Encoding: 8194 8194 8194
+Encoding: 8194 8194 1953
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2003
-Encoding: 8195 8195 8195
+Encoding: 8195 8195 1954
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2004
-Encoding: 8196 8196 8196
+Encoding: 8196 8196 1955
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2005
-Encoding: 8197 8197 8197
+Encoding: 8197 8197 1956
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2006
-Encoding: 8198 8198 8198
+Encoding: 8198 8198 1957
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2007
-Encoding: 8199 8199 8199
+Encoding: 8199 8199 1958
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2008
-Encoding: 8200 8200 8200
+Encoding: 8200 8200 1959
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2009
-Encoding: 8201 8201 8201
+Encoding: 8201 8201 1960
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni200A
-Encoding: 8202 8202 8202
+Encoding: 8202 8202 1961
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2010
-Encoding: 8208 8208 8208
+Encoding: 8208 8208 1962
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56391,16 +58359,18 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2011
-Encoding: 8209 8209 8209
+Encoding: 8209 8209 1963
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8208 8208 N 1 0 0 1 0 0 2
+Refer: 1962 8208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: figuredash
-Encoding: 8210 8210 8210
+Encoding: 8210 8210 1964
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56431,8 +58401,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: endash
-Encoding: 8211 8211 8211
+Encoding: 8211 8211 1965
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56463,8 +58434,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: emdash
-Encoding: 8212 8212 8212
+Encoding: 8212 8212 1966
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56494,8 +58466,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2015
-Encoding: 8213 8213 8213
+Encoding: 8213 8213 1967
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56525,26 +58498,29 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2016
-Encoding: 8214 8214 8214
+Encoding: 8214 8214 1968
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 245 0 2
-Refer: 124 124 N 1 0 0 1 -245 0 2
+Refer: 93 124 N 1 0 0 1 245 0 2
+Refer: 93 124 N 1 0 0 1 -245 0 2
 EndChar
+
 StartChar: underscoredbl
-Encoding: 8215 8215 8215
+Encoding: 8215 8215 1969
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
-Refer: 95 95 N 1 0 0 1 0 240 2
+Refer: 64 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 240 2
 EndChar
+
 StartChar: quoteleft
-Encoding: 8216 8216 8216
+Encoding: 8216 8216 1970
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56585,8 +58561,9 @@ SplineSet
  715 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quoteright
-Encoding: 8217 8217 8217
+Encoding: 8217 8217 1971
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56627,8 +58604,9 @@ SplineSet
  561 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotesinglbase
-Encoding: 8218 8218 8218
+Encoding: 8218 8218 1972
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56670,8 +58648,9 @@ SplineSet
  502 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotereversed
-Encoding: 8219 8219 8219
+Encoding: 8219 8219 1973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56686,8 +58665,9 @@ SplineSet
  715 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblleft
-Encoding: 8220 8220 8220
+Encoding: 8220 8220 1974
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56748,8 +58728,9 @@ SplineSet
  465 967 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblright
-Encoding: 8221 8221 8221
+Encoding: 8221 8221 1975
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56812,8 +58793,9 @@ SplineSet
  309 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblbase
-Encoding: 8222 8222 8222
+Encoding: 8222 8222 1976
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56878,8 +58860,9 @@ SplineSet
  309 303 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni201F
-Encoding: 8223 8223 8223
+Encoding: 8223 8223 1977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56901,8 +58884,9 @@ SplineSet
  922 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: dagger
-Encoding: 8224 8224 8224
+Encoding: 8224 8224 1978
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56964,8 +58948,9 @@ SplineSet
  528 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: daggerdbl
-Encoding: 8225 8225 8225
+Encoding: 8225 8225 1979
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57056,8 +59041,9 @@ SplineSet
  1071 223 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bullet
-Encoding: 8226 8226 8226
+Encoding: 8226 8226 1980
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57094,8 +59080,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2023
-Encoding: 8227 8227 8227
+Encoding: 8227 8227 1981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57107,20 +59094,23 @@ SplineSet
  319 385 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: onedotenleader
-Encoding: 8228 8228 8228
+Encoding: 8228 8228 1982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: twodotenleader
-Encoding: 8229 8229 8229
+Encoding: 8229 8229 1983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: ellipsis
-Encoding: 8230 8230 8230
+Encoding: 8230 8230 1984
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57180,14 +59170,16 @@ SplineSet
  489 305 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni202F
-Encoding: 8239 8239 8239
+Encoding: 8239 8239 1985
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: perthousand
-Encoding: 8240 8240 8240
+Encoding: 8240 8240 1986
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57325,22 +59317,22 @@ SplineSet
  166 358 166 358 166 289 c 0,4,5
 45 289 m 0,16,17
  45 410 45 410 127.5 492.5 c 128,-1,18
- 210 575 210 575 330 575 c 0,19,20
+ 210 575 210 575 330 575 c 256,19,20
  450 575 450 575 533 492 c 128,-1,21
  616 409 616 409 616 289 c 0,22,23
  616 168 616 168 532.5 84 c 128,-1,24
  449 0 449 0 330 0 c 0,25,26
  209 0 209 0 127 83 c 128,-1,27
  45 166 45 166 45 289 c 0,16,17
-121 1145 m 0,28,29
+121 1145 m 256,28,29
  121 1076 121 1076 169.5 1027.5 c 128,-1,30
- 218 979 218 979 287 979 c 0,31,32
+ 218 979 218 979 287 979 c 256,31,32
  356 979 356 979 404.5 1027.5 c 128,-1,33
  453 1076 453 1076 453 1145 c 0,34,35
  453 1212 453 1212 403.5 1261.5 c 128,-1,36
  354 1311 354 1311 287 1311 c 0,37,38
  218 1311 218 1311 169.5 1262.5 c 128,-1,39
- 121 1214 121 1214 121 1145 c 0,28,29
+ 121 1214 121 1214 121 1145 c 256,28,29
 0 1145 m 0,40,41
  0 1265 0 1265 83 1348.5 c 128,-1,42
  166 1432 166 1432 287 1432 c 0,43,44
@@ -57370,8 +59362,9 @@ SplineSet
  659 167 659 167 659 289 c 0,64,65
 EndSplineSet
 EndChar
+
 StartChar: uni2031
-Encoding: 8241 8241 8241
+Encoding: 8241 8241 1987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57454,8 +59447,9 @@ SplineSet
  855.091 358 855.091 358 855.091 289 c 0,93,94
 EndSplineSet
 EndChar
+
 StartChar: minute
-Encoding: 8242 8242 8242
+Encoding: 8242 8242 1988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57468,27 +59462,30 @@ SplineSet
  428 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: second
-Encoding: 8243 8243 8243
+Encoding: 8243 8243 1989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 150 0 2
-Refer: 8242 8242 N 1 0 0 1 -150 0 2
+Refer: 1988 8242 N 1 0 0 1 150 0 2
+Refer: 1988 8242 N 1 0 0 1 -150 0 2
 EndChar
+
 StartChar: uni2034
-Encoding: 8244 8244 8244
+Encoding: 8244 8244 1990
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 300 0 2
-Refer: 8242 8242 N 1 0 0 1 -300 0 2
-Refer: 8242 8242 N 1 0 0 1 0 0 2
+Refer: 1988 8242 N 1 0 0 1 300 0 2
+Refer: 1988 8242 N 1 0 0 1 -300 0 2
+Refer: 1988 8242 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2035
-Encoding: 8245 8245 8245
+Encoding: 8245 8245 1991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57501,27 +59498,30 @@ SplineSet
  804 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2036
-Encoding: 8246 8246 8246
+Encoding: 8246 8246 1992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 150 0 2
-Refer: 8245 8245 N 1 0 0 1 -150 0 2
+Refer: 1991 8245 N 1 0 0 1 150 0 2
+Refer: 1991 8245 N 1 0 0 1 -150 0 2
 EndChar
+
 StartChar: uni2037
-Encoding: 8247 8247 8247
+Encoding: 8247 8247 1993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 0 0 2
-Refer: 8245 8245 N 1 0 0 1 300 0 2
-Refer: 8245 8245 N 1 0 0 1 -300 0 2
+Refer: 1991 8245 N 1 0 0 1 0 0 2
+Refer: 1991 8245 N 1 0 0 1 300 0 2
+Refer: 1991 8245 N 1 0 0 1 -300 0 2
 EndChar
+
 StartChar: guilsinglleft
-Encoding: 8249 8249 8249
+Encoding: 8249 8249 1994
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57565,8 +59565,9 @@ SplineSet
  815 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: guilsinglright
-Encoding: 8250 8250 8250
+Encoding: 8250 8250 1995
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57610,18 +59611,20 @@ SplineSet
  420 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdbl
-Encoding: 8252 8252 8252
+Encoding: 8252 8252 1996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni203D
-Encoding: 8253 8253 8253
+Encoding: 8253 8253 1997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57657,16 +59660,18 @@ SplineSet
  735 1332 735 1332 684 1346 c 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni203E
-Encoding: 8254 8254 8254
+Encoding: 8254 8254 1998
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 1950 2
+Refer: 64 95 N 1 0 0 1 0 1950 2
 EndChar
+
 StartChar: uni203F
-Encoding: 8255 8255 8255
+Encoding: 8255 8255 1999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57685,82 +59690,94 @@ SplineSet
  442 -331 442 -331 615 -331 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2045
-Encoding: 8261 8261 8261
-Width: 1233
+Encoding: 8261 8261 2000
+Width: 600
+VWidth: 1000
 Flags: W
+HStem: -198.69 73.2607 270.95 52.1699 699.41 76.5898
+VStem: 194 74<-125.43 270.95 323.12 699.41> 194 267<270.95 323.12 699.41 776>
 LayerCount: 2
 Fore
 SplineSet
-463 1556 m 1,0,-1
- 887 1556 l 1,1,-1
- 887 1413 l 1,2,-1
- 647 1413 l 1,3,-1
- 647 714 l 25,0,0
- 887 714 l 25,0,0
- 887 571 l 25,0,0
- 647 571 l 25,0,0
- 647 -127 l 1,4,-1
- 887 -127 l 1,5,-1
- 887 -270 l 1,6,-1
- 463 -270 l 25,0,0
- 463 1556 l 1,0,-1
+446.51953125 1555.40039062 m 5,0,-1
+ 857.700195312 1555.40039062 l 5,1,-1
+ 857.700195312 1409.87890625 l 5,2,-1
+ 560.48046875 1409.87890625 l 5,3,-1
+ 560.48046875 694.927734375 l 5,4,-1
+ 857.700195312 694.927734375 l 5,5,-1
+ 857.700195312 595.805664062 l 5,6,-1
+ 560.48046875 595.805664062 l 5,7,-1
+ 560.48046875 -157.31640625 l 5,8,-1
+ 859.240234375 -157.31640625 l 5,9,-1
+ 859.240234375 -296.51171875 l 5,10,-1
+ 446.51953125 -296.51171875 l 5,11,-1
+ 446.51953125 1555.40039062 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2046
-Encoding: 8262 8262 8262
-Width: 1233
+Encoding: 8262 8262 2001
+Width: 600
+VWidth: 1000
 Flags: W
+HStem: -198.69 73.2607 270.95 52.1699 699.41 76.5898
+VStem: 136.83 269.67 331.76 74.7402
 LayerCount: 2
 Fore
 SplineSet
-770 1556 m 1,0,-1
- 770 -270 l 1,1,-1
- 346 -270 l 1,2,-1
- 346 -127 l 1,3,-1
- 586 -127 l 1,4,-1
- 586 571 l 25,0,0
- 346 571 l 25,0,0
- 346 714 l 25,0,0
- 586 714 l 25,0,0
- 586 1413 l 1,5,-1
- 346 1413 l 1,6,-1
- 346 1556 l 1,7,-1
- 770 1556 l 1,0,-1
+753.48046875 1555.40039062 m 5,0,-1
+ 342.299804688 1555.40039062 l 5,1,-1
+ 342.299804688 1409.87890625 l 5,2,-1
+ 639.51953125 1409.87890625 l 5,3,-1
+ 639.51953125 694.927734375 l 5,4,-1
+ 342.299804688 694.927734375 l 5,5,-1
+ 342.299804688 595.805664062 l 5,6,-1
+ 639.51953125 595.805664062 l 5,7,-1
+ 639.51953125 -157.31640625 l 5,8,-1
+ 340.759765625 -157.31640625 l 5,9,-1
+ 340.759765625 -296.51171875 l 5,10,-1
+ 753.48046875 -296.51171875 l 5,11,-1
+ 753.48046875 1555.40039062 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2047
-Encoding: 8263 8263 8263
+Encoding: 8263 8263 2002
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -324.5 0 2
-Refer: 1114126 -1 N 1 0 0 1 283.5 0 2
-LCarets2: 1 0 
+Refer: 3739 -1 N 1 0 0 1 -324.5 0 2
+Refer: 3739 -1 N 1 0 0 1 283.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2048
-Encoding: 8264 8264 8264
+Encoding: 8264 8264 2003
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -324.5 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3739 -1 N 1 0 0 1 -324.5 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2049
-Encoding: 8265 8265 8265
+Encoding: 8265 8265 2004
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 1114126 -1 N 1 0 0 1 283.5 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 3739 -1 N 1 0 0 1 283.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni204B
-Encoding: 8267 8267 8267
+Encoding: 8267 8267 2005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57781,14 +59798,16 @@ SplineSet
  651 1493 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni205F
-Encoding: 8287 8287 8287
+Encoding: 8287 8287 2006
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2070
-Encoding: 8304 8304 8304
+Encoding: 8304 8304 2007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57823,8 +59842,9 @@ SplineSet
  468.004 1520 468.004 1520 616 1520 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2071
-Encoding: 8305 8305 8305
+Encoding: 8305 8305 2008
 Width: 1233
 Flags: W
 AnchorPoint: "below" 604.58 668 basechar 0
@@ -57849,8 +59869,9 @@ SplineSet
  558 1539 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2074
-Encoding: 8308 8308 8308
+Encoding: 8308 8308 2009
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57925,8 +59946,9 @@ SplineSet
  655 1378 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2075
-Encoding: 8309 8309 8309
+Encoding: 8309 8309 2010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57957,8 +59979,9 @@ SplineSet
  358 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2076
-Encoding: 8310 8310 8310
+Encoding: 8310 8310 2011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57993,8 +60016,9 @@ SplineSet
  720.996 1133 720.996 1133 638 1133 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2077
-Encoding: 8311 8311 8311
+Encoding: 8311 8311 2012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58010,8 +60034,9 @@ SplineSet
  317 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2078
-Encoding: 8312 8312 8312
+Encoding: 8312 8312 2013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58054,8 +60079,9 @@ SplineSet
  462 1359 462 1359 462 1291 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2079
-Encoding: 8313 8313 8313
+Encoding: 8313 8313 2014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58090,8 +60116,9 @@ SplineSet
  413.999 670 413.999 670 371 686 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni207A
-Encoding: 8314 8314 8314
+Encoding: 8314 8314 2015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58112,8 +60139,9 @@ SplineSet
  670 1324 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207B
-Encoding: 8315 8315 8315
+Encoding: 8315 8315 2016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58126,8 +60154,9 @@ SplineSet
  284 1075 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207C
-Encoding: 8316 8316 8316
+Encoding: 8316 8316 2017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58145,8 +60174,9 @@ SplineSet
  284 1189 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207D
-Encoding: 8317 8317 8317
+Encoding: 8317 8317 2018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58165,8 +60195,9 @@ SplineSet
  762 1538 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207E
-Encoding: 8318 8318 8318
+Encoding: 8318 8318 2019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58185,8 +60216,9 @@ SplineSet
  556 1410 556 1410 472 1538 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207F
-Encoding: 8319 8319 8319
+Encoding: 8319 8319 2020
 Width: 1233
 Flags: W
 TtInstrs:
@@ -58245,232 +60277,261 @@ SplineSet
  911.97 1176.48 911.97 1176.48 911.97 1046.56 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2080
-Encoding: 8320 8320 8320
+Encoding: 8320 8320 2021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 0 -668 3
+Refer: 2007 8304 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2081
-Encoding: 8321 8321 8321
+Encoding: 8321 8321 2022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 0 -668 3
+Refer: 121 185 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2082
-Encoding: 8322 8322 8322
+Encoding: 8322 8322 2023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 0 -668 3
+Refer: 114 178 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2083
-Encoding: 8323 8323 8323
+Encoding: 8323 8323 2024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 0 -668 3
+Refer: 115 179 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2084
-Encoding: 8324 8324 8324
+Encoding: 8324 8324 2025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 0 -668 3
+Refer: 2009 8308 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2085
-Encoding: 8325 8325 8325
+Encoding: 8325 8325 2026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 0 -668 3
+Refer: 2010 8309 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2086
-Encoding: 8326 8326 8326
+Encoding: 8326 8326 2027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 0 -668 3
+Refer: 2011 8310 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2087
-Encoding: 8327 8327 8327
+Encoding: 8327 8327 2028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 0 -668 3
+Refer: 2012 8311 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2088
-Encoding: 8328 8328 8328
+Encoding: 8328 8328 2029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 0 -668 3
+Refer: 2013 8312 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2089
-Encoding: 8329 8329 8329
+Encoding: 8329 8329 2030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8313 8313 N 1 0 0 1 0 -668 3
+Refer: 2014 8313 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208A
-Encoding: 8330 8330 8330
+Encoding: 8330 8330 2031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8314 8314 N 1 0 0 1 0 -668 3
+Refer: 2015 8314 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208B
-Encoding: 8331 8331 8331
+Encoding: 8331 8331 2032
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8315 8315 N 1 0 0 1 0 -668 3
+Refer: 2016 8315 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208C
-Encoding: 8332 8332 8332
+Encoding: 8332 8332 2033
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8316 8316 N 1 0 0 1 0 -668 3
+Refer: 2017 8316 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208D
-Encoding: 8333 8333 8333
+Encoding: 8333 8333 2034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8317 8317 N 1 0 0 1 0 -668 3
+Refer: 2018 8317 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208E
-Encoding: 8334 8334 8334
+Encoding: 8334 8334 2035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8318 8318 N 1 0 0 1 0 -668 3
+Refer: 2019 8318 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2090
-Encoding: 8336 8336 8336
+Encoding: 8336 8336 2036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7491 7491 N 1 0 0 1 0 -668 3
+Refer: 1467 7491 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2091
-Encoding: 8337 8337 8337
+Encoding: 8337 8337 2037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7497 7497 N 1 0 0 1 0 -668 3
+Refer: 1473 7497 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2092
-Encoding: 8338 8338 8338
+Encoding: 8338 8338 2038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7506 7506 N 1 0 0 1 0 -668 3
+Refer: 1482 7506 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2093
-Encoding: 8339 8339 8339
+Encoding: 8339 8339 2039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 739 739 N 1 0 0 1 0 -668 3
+Refer: 646 739 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2094
-Encoding: 8340 8340 8340
+Encoding: 8340 8340 2040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7498 7498 N 1 0 0 1 0 -668 3
+Refer: 1474 7498 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2095
-Encoding: 8341 8341 8341
+Encoding: 8341 8341 2041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 688 688 N 1 0 0 1 0 -668 3
+Refer: 605 688 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2096
-Encoding: 8342 8342 8342
+Encoding: 8342 8342 2042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7503 7503 N 1 0 0 1 0 -668 3
+Refer: 1479 7503 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2097
-Encoding: 8343 8343 8343
+Encoding: 8343 8343 2043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 737 737 N 1 0 0 1 0 -668 3
+Refer: 644 737 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2098
-Encoding: 8344 8344 8344
+Encoding: 8344 8344 2044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7504 7504 N 1 0 0 1 0 -668 3
+Refer: 1480 7504 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2099
-Encoding: 8345 8345 8345
+Encoding: 8345 8345 2045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8319 8319 N 1 0 0 1 0 -668 3
+Refer: 2020 8319 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209A
-Encoding: 8346 8346 8346
+Encoding: 8346 8346 2046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7510 7510 N 1 0 0 1 0 -668 3
+Refer: 1486 7510 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209B
-Encoding: 8347 8347 8347
+Encoding: 8347 8347 2047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 738 738 N 1 0 0 1 0 -668 3
+Refer: 645 738 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209C
-Encoding: 8348 8348 8348
+Encoding: 8348 8348 2048
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7511 7511 N 1 0 0 1 0 -668 3
+Refer: 1487 7511 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni20A0
-Encoding: 8352 8352 8352
+Encoding: 8352 8352 2049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58509,8 +60570,9 @@ SplineSet
  687 428 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: colonmonetary
-Encoding: 8353 8353 8353
+Encoding: 8353 8353 2050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58558,8 +60620,9 @@ SplineSet
  887 1330 l 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni20A2
-Encoding: 8354 8354 8354
+Encoding: 8354 8354 2051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58599,8 +60662,9 @@ SplineSet
  755 138 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: franc
-Encoding: 8355 8355 8355
+Encoding: 8355 8355 2052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58627,8 +60691,9 @@ SplineSet
  233 382 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: lira
-Encoding: 8356 8356 8356
+Encoding: 8356 8356 2053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58669,8 +60734,9 @@ SplineSet
  575 492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A5
-Encoding: 8357 8357 8357
+Encoding: 8357 8357 2054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58711,8 +60777,9 @@ SplineSet
  778 1122 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20A6
-Encoding: 8358 8358 8358
+Encoding: 8358 8358 2055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58767,8 +60834,9 @@ SplineSet
  795.935 550 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: peseta
-Encoding: 8359 8359 8359
+Encoding: 8359 8359 2056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58839,8 +60907,9 @@ SplineSet
  488 1019 l 1,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni20A8
-Encoding: 8360 8360 8360
+Encoding: 8360 8360 2057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58901,8 +60970,9 @@ SplineSet
  781 -3 781 -3 752 7 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A9
-Encoding: 8361 8361 8361
+Encoding: 8361 8361 2058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58965,8 +61035,9 @@ SplineSet
  616 1156 l 1,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AA
-Encoding: 8362 8362 8362
+Encoding: 8362 8362 2059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59000,17 +61071,19 @@ SplineSet
  1190 -29 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dong
-Encoding: 8363 8363 8363
+Encoding: 8363 8363 2060
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 273 273 N 1 0 0 1 0 0 3
-Refer: 717 717 N 1 0 0 1 122 0 2
+Refer: 209 273 N 1 0 0 1 0 0 3
+Refer: 627 717 N 1 0 0 1 122 0 2
 EndChar
+
 StartChar: Euro
-Encoding: 8364 8364 8364
+Encoding: 8364 8364 2061
 Width: 1233
 Flags: W
 TtInstrs:
@@ -59171,8 +61244,9 @@ SplineSet
  211 948 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20AD
-Encoding: 8365 8365 8365
+Encoding: 8365 8365 2062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59199,8 +61273,9 @@ SplineSet
  180 852 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AE
-Encoding: 8366 8366 8366
+Encoding: 8366 8366 2063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59233,8 +61308,9 @@ SplineSet
  516 909 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AF
-Encoding: 8367 8367 8367
+Encoding: 8367 8367 2064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59322,8 +61398,9 @@ SplineSet
  185 142 185 142 201 204 c 1,113,114
 EndSplineSet
 EndChar
+
 StartChar: uni20B0
-Encoding: 8368 8368 8368
+Encoding: 8368 8368 2065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59361,8 +61438,9 @@ SplineSet
  680 998 680 998 834 881 c 1,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni20B1
-Encoding: 8369 8369 8369
+Encoding: 8369 8369 2066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59409,8 +61487,9 @@ SplineSet
  926.968 997 l 1,35,36
 EndSplineSet
 EndChar
+
 StartChar: uni20B2
-Encoding: 8370 8370 8370
+Encoding: 8370 8370 2067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59450,8 +61529,9 @@ SplineSet
  448 182 448 182 581 150 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B3
-Encoding: 8371 8371 8371
+Encoding: 8371 8371 2068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59493,8 +61573,9 @@ SplineSet
  521 973 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B4
-Encoding: 8372 8372 8372
+Encoding: 8372 8372 2069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59542,8 +61623,9 @@ SplineSet
  830.93 943 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B5
-Encoding: 8373 8373 8373
+Encoding: 8373 8373 2070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59581,8 +61663,9 @@ SplineSet
  550.043 164.957 550.043 164.957 641.761 142.417 c 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B8
-Encoding: 8376 8376 8376
+Encoding: 8376 8376 2071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59604,8 +61687,9 @@ SplineSet
  47 1203 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B9
-Encoding: 8377 8377 8377
+Encoding: 8377 8377 2072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59642,8 +61726,9 @@ SplineSet
  1137 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20BA
-Encoding: 8378 8378 8378
+Encoding: 8378 8378 2073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59677,8 +61762,9 @@ SplineSet
  1180 748 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20BD
-Encoding: 8381 8381 8381
+Encoding: 8381 8381 2074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59716,8 +61802,9 @@ SplineSet
  506 1327 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2102
-Encoding: 8450 8450 8450
+Encoding: 8450 8450 2075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59749,8 +61836,9 @@ SplineSet
  408 1282 l 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2105
-Encoding: 8453 8453 8453
+Encoding: 8453 8453 2076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59800,8 +61888,9 @@ SplineSet
  854 880 854 880 975 880 c 128,-1,43
 EndSplineSet
 EndChar
+
 StartChar: uni210D
-Encoding: 8461 8461 8461
+Encoding: 8461 8461 2077
 Width: 1233
 Flags: W
 AnchorPoint: "below" 609 0 basechar 0
@@ -59834,8 +61923,9 @@ SplineSet
  58 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210E
-Encoding: 8462 8462 8462
+Encoding: 8462 8462 2078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59864,8 +61954,9 @@ SplineSet
  1085 746 1085 746 1075 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210F
-Encoding: 8463 8463 8463
+Encoding: 8463 8463 2079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59899,8 +61990,9 @@ SplineSet
  455 952 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2115
-Encoding: 8469 8469 8469
+Encoding: 8469 8469 2080
 Width: 1233
 Flags: W
 AnchorPoint: "above" 612 1506 basechar 0
@@ -59926,8 +62018,9 @@ SplineSet
  74 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2116
-Encoding: 8470 8470 8470
+Encoding: 8470 8470 2081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59969,8 +62062,9 @@ SplineSet
  133 246 133 246 133 305 c 2,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2117
-Encoding: 8471 8471 8471
+Encoding: 8471 8471 2082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60030,8 +62124,9 @@ SplineSet
  411 1113 l 1,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2119
-Encoding: 8473 8473 8473
+Encoding: 8473 8473 2083
 Width: 1233
 Flags: W
 AnchorPoint: "below" 565 0 basechar 0
@@ -60069,8 +62164,9 @@ SplineSet
  943 1348 943 1348 883 1370 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211A
-Encoding: 8474 8474 8474
+Encoding: 8474 8474 2084
 Width: 1233
 Flags: W
 AnchorPoint: "below" 807 0 basechar 0
@@ -60113,8 +62209,9 @@ SplineSet
  947 1269 947 1269 917 1298 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211D
-Encoding: 8477 8477 8477
+Encoding: 8477 8477 2085
 Width: 1233
 Flags: W
 AnchorPoint: "below" 613 0 basechar 0
@@ -60167,8 +62264,9 @@ SplineSet
  122 1393 l 1,47,-1
 EndSplineSet
 EndChar
+
 StartChar: trademark
-Encoding: 8482 8482 8482
+Encoding: 8482 8482 2086
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60305,8 +62403,9 @@ SplineSet
  692 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2124
-Encoding: 8484 8484 8484
+Encoding: 8484 8484 2087
 Width: 1233
 Flags: W
 AnchorPoint: "below" 608 0 basechar 0
@@ -60332,32 +62431,36 @@ SplineSet
  67 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2126
-Encoding: 8486 8486 8486
+Encoding: 8486 8486 2088
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212A
-Encoding: 8490 8490 8490
+Encoding: 8490 8490 2089
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212B
-Encoding: 8491 8491 8491
+Encoding: 8491 8491 2090
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 197 197 N 1 0 0 1 0 0 2
+Refer: 133 197 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: estimated
-Encoding: 8494 8494 8494
+Encoding: 8494 8494 2091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60395,8 +62498,9 @@ SplineSet
  233 704 l 2,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2148
-Encoding: 8520 8520 8520
+Encoding: 8520 8520 2092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60425,169 +62529,186 @@ SplineSet
  693 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2150
-Encoding: 8528 8528 8528
+Encoding: 8528 8528 2093
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8311 8311 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 2012 8311 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2151
-Encoding: 8529 8529 8529
+Encoding: 8529 8529 2094
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8313 8313 N 1 0 0 1 201 -928 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 2014 8313 N 1 0 0 1 201 -928 2
 EndChar
+
 StartChar: onethird
-Encoding: 8531 8531 8531
+Encoding: 8531 8531 2095
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: twothirds
-Encoding: 8532 8532 8532
+Encoding: 8532 8532 2096
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2155
-Encoding: 8533 8533 8533
+Encoding: 8533 8533 2097
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2156
-Encoding: 8534 8534 8534
+Encoding: 8534 8534 2098
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2157
-Encoding: 8535 8535 8535
+Encoding: 8535 8535 2099
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2158
-Encoding: 8536 8536 8536
+Encoding: 8536 8536 2100
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8308 8308 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2009 8308 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2159
-Encoding: 8537 8537 8537
+Encoding: 8537 8537 2101
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni215A
-Encoding: 8538 8538 8538
+Encoding: 8538 8538 2102
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: oneeighth
-Encoding: 8539 8539 8539
+Encoding: 8539 8539 2103
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: threeeighths
-Encoding: 8540 8540 8540
+Encoding: 8540 8540 2104
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: fiveeighths
-Encoding: 8541 8541 8541
+Encoding: 8541 8541 2105
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: seveneighths
-Encoding: 8542 8542 8542
+Encoding: 8542 8542 2106
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 -258 156 2
-LCarets2: 2 0 0 
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2012 8311 N 1 0 0 1 -258 156 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni215F
-Encoding: 8543 8543 8543
+Encoding: 8543 8543 2107
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-LCarets2: 1 0 
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2189
-Encoding: 8585 8585 8585
+Encoding: 8585 8585 2108
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 201 -938 2
+Refer: 2007 8304 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: arrowleft
-Encoding: 8592 8592 8592
+Encoding: 8592 8592 2109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60606,8 +62727,9 @@ SplineSet
  66 520 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowup
-Encoding: 8593 8593 8593
+Encoding: 8593 8593 2110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60626,8 +62748,9 @@ SplineSet
  657.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowright
-Encoding: 8594 8594 8594
+Encoding: 8594 8594 2111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60646,8 +62769,9 @@ SplineSet
  1167 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdown
-Encoding: 8595 8595 8595
+Encoding: 8595 8595 2112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60666,8 +62790,9 @@ SplineSet
  575.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowboth
-Encoding: 8596 8596 8596
+Encoding: 8596 8596 2113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60692,8 +62817,9 @@ SplineSet
  946 479 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdn
-Encoding: 8597 8597 8597
+Encoding: 8597 8597 2114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60718,8 +62844,9 @@ SplineSet
  698.5 221 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2196
-Encoding: 8598 8598 8598
+Encoding: 8598 8598 2115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60738,8 +62865,9 @@ SplineSet
  184 807 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2197
-Encoding: 8599 8599 8599
+Encoding: 8599 8599 2116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60758,8 +62886,9 @@ SplineSet
  1049 807 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2198
-Encoding: 8600 8600 8600
+Encoding: 8600 8600 2117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60778,8 +62907,9 @@ SplineSet
  991 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2199
-Encoding: 8601 8601 8601
+Encoding: 8601 8601 2118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60798,8 +62928,9 @@ SplineSet
  184 58 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219A
-Encoding: 8602 8602 8602
+Encoding: 8602 8602 2119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60826,8 +62957,9 @@ SplineSet
  961 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219B
-Encoding: 8603 8603 8603
+Encoding: 8603 8603 2120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60854,8 +62986,9 @@ SplineSet
  272 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219C
-Encoding: 8604 8604 8604
+Encoding: 8604 8604 2121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60896,8 +63029,9 @@ SplineSet
  292.277 738 l 17,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219D
-Encoding: 8605 8605 8605
+Encoding: 8605 8605 2122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60938,8 +63072,9 @@ SplineSet
  933.723 726 933.723 726 940.723 738 c 9,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219E
-Encoding: 8606 8606 8606
+Encoding: 8606 8606 2123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60966,8 +63101,9 @@ SplineSet
  617 643 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219F
-Encoding: 8607 8607 8607
+Encoding: 8607 8607 2124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60994,8 +63130,9 @@ SplineSet
  534.5 550 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A0
-Encoding: 8608 8608 8608
+Encoding: 8608 8608 2125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61022,8 +63159,9 @@ SplineSet
  616 643 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A1
-Encoding: 8609 8609 8609
+Encoding: 8609 8609 2126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61050,8 +63188,9 @@ SplineSet
  698.5 551 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A2
-Encoding: 8610 8610 8610
+Encoding: 8610 8610 2127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61075,8 +63214,9 @@ SplineSet
  925 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A3
-Encoding: 8611 8611 8611
+Encoding: 8611 8611 2128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61100,8 +63240,9 @@ SplineSet
  308 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A4
-Encoding: 8612 8612 8612
+Encoding: 8612 8612 2129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61124,8 +63265,9 @@ SplineSet
  1003 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A5
-Encoding: 8613 8613 8613
+Encoding: 8613 8613 2130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61148,8 +63290,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A6
-Encoding: 8614 8614 8614
+Encoding: 8614 8614 2131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61172,8 +63315,9 @@ SplineSet
  230 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A7
-Encoding: 8615 8615 8615
+Encoding: 8615 8615 2132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61196,8 +63340,9 @@ SplineSet
  698.5 937 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdnbse
-Encoding: 8616 8616 8616
+Encoding: 8616 8616 2133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61226,8 +63371,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A9
-Encoding: 8617 8617 8617
+Encoding: 8617 8617 2134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61262,8 +63408,9 @@ SplineSet
  868 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AA
-Encoding: 8618 8618 8618
+Encoding: 8618 8618 2135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61298,8 +63445,9 @@ SplineSet
  334.689 643.263 334.689 643.263 365 643 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AB
-Encoding: 8619 8619 8619
+Encoding: 8619 8619 2136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61349,8 +63497,9 @@ SplineSet
  901.207 894.534 901.207 894.534 876 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AC
-Encoding: 8620 8620 8620
+Encoding: 8620 8620 2137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61400,8 +63549,9 @@ SplineSet
  373.894 895.312 373.894 895.312 357 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AD
-Encoding: 8621 8621 8621
+Encoding: 8621 8621 2138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61468,8 +63618,9 @@ SplineSet
  287 643.002 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AE
-Encoding: 8622 8622 8622
+Encoding: 8622 8622 2139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61502,8 +63653,9 @@ SplineSet
  946 479 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AF
-Encoding: 8623 8623 8623
+Encoding: 8623 8623 2140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61526,8 +63678,9 @@ SplineSet
  860.688 210.873 l 9,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B0
-Encoding: 8624 8624 8624
+Encoding: 8624 8624 2141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61548,8 +63701,9 @@ SplineSet
  404.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B1
-Encoding: 8625 8625 8625
+Encoding: 8625 8625 2142
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61570,8 +63724,9 @@ SplineSet
  828.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B2
-Encoding: 8626 8626 8626
+Encoding: 8626 8626 2143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61592,8 +63747,9 @@ SplineSet
  404.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B3
-Encoding: 8627 8627 8627
+Encoding: 8627 8627 2144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61614,8 +63770,9 @@ SplineSet
  828.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B4
-Encoding: 8628 8628 8628
+Encoding: 8628 8628 2145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61636,8 +63793,9 @@ SplineSet
  633 221 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: carriagereturn
-Encoding: 8629 8629 8629
+Encoding: 8629 8629 2146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61658,8 +63816,9 @@ SplineSet
  284.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B6
-Encoding: 8630 8630 8630
+Encoding: 8630 8630 2147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61694,8 +63853,9 @@ SplineSet
  331.244 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B7
-Encoding: 8631 8631 8631
+Encoding: 8631 8631 2148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61730,8 +63890,9 @@ SplineSet
  901.756 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B8
-Encoding: 8632 8632 8632
+Encoding: 8632 8632 2149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61755,8 +63916,9 @@ SplineSet
  50.5 970 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B9
-Encoding: 8633 8633 8633
+Encoding: 8633 8633 2150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61794,8 +63956,9 @@ SplineSet
  1003 373.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21BA
-Encoding: 8634 8634 8634
+Encoding: 8634 8634 2151
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61838,8 +64001,9 @@ SplineSet
  917.375 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BB
-Encoding: 8635 8635 8635
+Encoding: 8635 8635 2152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61882,8 +64046,9 @@ SplineSet
  315.625 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BC
-Encoding: 8636 8636 8636
+Encoding: 8636 8636 2153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61899,8 +64064,9 @@ SplineSet
  66 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BD
-Encoding: 8637 8637 8637
+Encoding: 8637 8637 2154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61916,8 +64082,9 @@ SplineSet
  66 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BE
-Encoding: 8638 8638 8638
+Encoding: 8638 8638 2155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61933,8 +64100,9 @@ SplineSet
  534.5 1101 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BF
-Encoding: 8639 8639 8639
+Encoding: 8639 8639 2156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61950,8 +64118,9 @@ SplineSet
  698.5 1101 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C0
-Encoding: 8640 8640 8640
+Encoding: 8640 8640 2157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61967,8 +64136,9 @@ SplineSet
  1167 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C1
-Encoding: 8641 8641 8641
+Encoding: 8641 8641 2158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61984,8 +64154,9 @@ SplineSet
  1167 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C2
-Encoding: 8642 8642 8642
+Encoding: 8642 8642 2159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62001,8 +64172,9 @@ SplineSet
  534.5 0 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C3
-Encoding: 8643 8643 8643
+Encoding: 8643 8643 2160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62018,8 +64190,9 @@ SplineSet
  741 0 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C4
-Encoding: 8644 8644 8644
+Encoding: 8644 8644 2161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62049,8 +64222,9 @@ SplineSet
  66 291 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C5
-Encoding: 8645 8645 8645
+Encoding: 8645 8645 2162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62080,8 +64254,9 @@ SplineSet
  333.5 1101 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C6
-Encoding: 8646 8646 8646
+Encoding: 8646 8646 2163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62111,8 +64286,9 @@ SplineSet
  66 857 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C7
-Encoding: 8647 8647 8647
+Encoding: 8647 8647 2164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62139,8 +64315,9 @@ SplineSet
  267 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C8
-Encoding: 8648 8648 8648
+Encoding: 8648 8648 2165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62167,8 +64344,9 @@ SplineSet
  616.5 900 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C9
-Encoding: 8649 8649 8649
+Encoding: 8649 8649 2166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62195,8 +64373,9 @@ SplineSet
  966 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CA
-Encoding: 8650 8650 8650
+Encoding: 8650 8650 2167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62223,8 +64402,9 @@ SplineSet
  616.5 201 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CB
-Encoding: 8651 8651 8651
+Encoding: 8651 8651 2168
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62248,8 +64428,9 @@ SplineSet
  66 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CC
-Encoding: 8652 8652 8652
+Encoding: 8652 8652 2169
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62273,8 +64454,9 @@ SplineSet
  1167 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CD
-Encoding: 8653 8653 8653
+Encoding: 8653 8653 2170
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62311,8 +64493,9 @@ SplineSet
  737 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CE
-Encoding: 8654 8654 8654
+Encoding: 8654 8654 2171
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62357,8 +64540,9 @@ SplineSet
  692 643.001 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CF
-Encoding: 8655 8655 8655
+Encoding: 8655 8655 2172
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62395,8 +64579,9 @@ SplineSet
  496 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblleft
-Encoding: 8656 8656 8656
+Encoding: 8656 8656 2173
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62420,8 +64605,9 @@ SplineSet
  287 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblup
-Encoding: 8657 8657 8657
+Encoding: 8657 8657 2174
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62445,8 +64631,9 @@ SplineSet
  534.499 880 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblright
-Encoding: 8658 8658 8658
+Encoding: 8658 8658 2175
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62470,8 +64657,9 @@ SplineSet
  946 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdbldown
-Encoding: 8659 8659 8659
+Encoding: 8659 8659 2176
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62495,8 +64683,9 @@ SplineSet
  698.501 221 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblboth
-Encoding: 8660 8660 8660
+Encoding: 8660 8660 2177
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62528,8 +64717,9 @@ SplineSet
  864 725 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D5
-Encoding: 8661 8661 8661
+Encoding: 8661 8661 2178
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62561,8 +64751,9 @@ SplineSet
  780.5 798 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D6
-Encoding: 8662 8662 8662
+Encoding: 8662 8662 2179
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62586,8 +64777,9 @@ SplineSet
  398 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D7
-Encoding: 8663 8663 8663
+Encoding: 8663 8663 2180
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62611,8 +64803,9 @@ SplineSet
  835 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D8
-Encoding: 8664 8664 8664
+Encoding: 8664 8664 2181
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62636,8 +64829,9 @@ SplineSet
  951 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D9
-Encoding: 8665 8665 8665
+Encoding: 8665 8665 2182
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62661,8 +64855,9 @@ SplineSet
  398 127 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DA
-Encoding: 8666 8666 8666
+Encoding: 8666 8666 2183
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62687,8 +64882,9 @@ SplineSet
  447 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DB
-Encoding: 8667 8667 8667
+Encoding: 8667 8667 2184
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62713,8 +64909,9 @@ SplineSet
  786 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DC
-Encoding: 8668 8668 8668
+Encoding: 8668 8668 2185
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62746,8 +64943,9 @@ SplineSet
  287 643 l 17,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DD
-Encoding: 8669 8669 8669
+Encoding: 8669 8669 2186
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62779,8 +64977,9 @@ SplineSet
  946 643 l 9,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DE
-Encoding: 8670 8670 8670
+Encoding: 8670 8670 2187
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62815,8 +65014,9 @@ SplineSet
  698.5 188.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DF
-Encoding: 8671 8671 8671
+Encoding: 8671 8671 2188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62851,8 +65051,9 @@ SplineSet
  534.5 912.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E0
-Encoding: 8672 8672 8672
+Encoding: 8672 8672 2189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62881,8 +65082,9 @@ SplineSet
  980.001 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E1
-Encoding: 8673 8673 8673
+Encoding: 8673 8673 2190
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62911,8 +65113,9 @@ SplineSet
  698.499 186.999 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E2
-Encoding: 8674 8674 8674
+Encoding: 8674 8674 2191
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62941,8 +65144,9 @@ SplineSet
  252.999 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E3
-Encoding: 8675 8675 8675
+Encoding: 8675 8675 2192
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62971,8 +65175,9 @@ SplineSet
  534.501 914.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E4
-Encoding: 8676 8676 8676
+Encoding: 8676 8676 2193
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62995,8 +65200,9 @@ SplineSet
  230.001 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E5
-Encoding: 8677 8677 8677
+Encoding: 8677 8677 2194
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63019,8 +65225,9 @@ SplineSet
  1003 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E6
-Encoding: 8678 8678 8678
+Encoding: 8678 8678 2195
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63044,8 +65251,9 @@ SplineSet
  398 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E7
-Encoding: 8679 8679 8679
+Encoding: 8679 8679 2196
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63069,8 +65277,9 @@ SplineSet
  989.5 769 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E8
-Encoding: 8680 8680 8680
+Encoding: 8680 8680 2197
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63094,8 +65303,9 @@ SplineSet
  835.5 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E9
-Encoding: 8681 8681 8681
+Encoding: 8681 8681 2198
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63119,8 +65329,9 @@ SplineSet
  243.5 373 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EA
-Encoding: 8682 8682 8682
+Encoding: 8682 8682 2199
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63154,8 +65365,9 @@ SplineSet
  444.5 410 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EB
-Encoding: 8683 8683 8683
+Encoding: 8683 8683 2200
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63187,8 +65399,9 @@ SplineSet
  444.495 280 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EC
-Encoding: 8684 8684 8684
+Encoding: 8684 8684 2201
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63225,8 +65438,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21ED
-Encoding: 8685 8685 8685
+Encoding: 8685 8685 2202
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63262,8 +65476,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EE
-Encoding: 8686 8686 8686
+Encoding: 8686 8686 2203
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63298,8 +65513,9 @@ SplineSet
  443.5 769 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EF
-Encoding: 8687 8687 8687
+Encoding: 8687 8687 2204
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63342,8 +65558,9 @@ SplineSet
  444.5 569 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F0
-Encoding: 8688 8688 8688
+Encoding: 8688 8688 2205
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63375,8 +65592,9 @@ SplineSet
  346.5 388.995 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F1
-Encoding: 8689 8689 8689
+Encoding: 8689 8689 2206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63402,8 +65620,9 @@ SplineSet
  1162.74 1094 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F2
-Encoding: 8690 8690 8690
+Encoding: 8690 8690 2207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63429,8 +65648,9 @@ SplineSet
  1163.5 1093 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F3
-Encoding: 8691 8691 8691
+Encoding: 8691 8691 2208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63460,8 +65680,9 @@ SplineSet
  444.5 769 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F4
-Encoding: 8692 8692 8692
+Encoding: 8692 8692 2209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63504,8 +65725,9 @@ SplineSet
  576.115 460.271 576.115 460.271 587 479 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F5
-Encoding: 8693 8693 8693
+Encoding: 8693 8693 2210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63535,8 +65757,9 @@ SplineSet
  899.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F6
-Encoding: 8694 8694 8694
+Encoding: 8694 8694 2211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63571,8 +65794,9 @@ SplineSet
  786.001 319 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F7
-Encoding: 8695 8695 8695
+Encoding: 8695 8695 2212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63599,8 +65823,9 @@ SplineSet
  798.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F8
-Encoding: 8696 8696 8696
+Encoding: 8696 8696 2213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63627,8 +65852,9 @@ SplineSet
  434.5 479 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F9
-Encoding: 8697 8697 8697
+Encoding: 8697 8697 2214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63661,8 +65887,9 @@ SplineSet
  534.5 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FA
-Encoding: 8698 8698 8698
+Encoding: 8698 8698 2215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63697,8 +65924,9 @@ SplineSet
  978.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FB
-Encoding: 8699 8699 8699
+Encoding: 8699 8699 2216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63733,8 +65961,9 @@ SplineSet
  254.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FC
-Encoding: 8700 8700 8700
+Encoding: 8700 8700 2217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63775,8 +66004,9 @@ SplineSet
  287 479 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FD
-Encoding: 8701 8701 8701
+Encoding: 8701 8701 2218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63796,8 +66026,9 @@ SplineSet
  398 643 l 9,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FE
-Encoding: 8702 8702 8702
+Encoding: 8702 8702 2219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63817,8 +66048,9 @@ SplineSet
  835 643 l 17,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FF
-Encoding: 8703 8703 8703
+Encoding: 8703 8703 2220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63845,8 +66077,9 @@ SplineSet
  398 479 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: universal
-Encoding: 8704 8704 8704
+Encoding: 8704 8704 2221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63867,8 +66100,9 @@ SplineSet
  494 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2201
-Encoding: 8705 8705 8705
+Encoding: 8705 8705 2222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63895,8 +66129,9 @@ SplineSet
  117 367 117 367 117 745 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: partialdiff
-Encoding: 8706 8706 8706
+Encoding: 8706 8706 2223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63931,8 +66166,9 @@ SplineSet
  353 412 353 412 353 310 c 0,33,34
 EndSplineSet
 EndChar
+
 StartChar: existential
-Encoding: 8707 8707 8707
+Encoding: 8707 8707 2224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63953,8 +66189,9 @@ SplineSet
  178 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2204
-Encoding: 8708 8708 8708
+Encoding: 8708 8708 2225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63993,8 +66230,9 @@ SplineSet
  609 662 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: emptyset
-Encoding: 8709 8709 8709
+Encoding: 8709 8709 2226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64045,8 +66283,9 @@ SplineSet
  967.676 833.623 967.676 833.623 942.785 868.669 c 1,49,-1
 EndSplineSet
 EndChar
+
 StartChar: Delta
-Encoding: 8710 8710 8710
+Encoding: 8710 8710 2227
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64144,8 +66383,9 @@ SplineSet
  616 1219 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: gradient
-Encoding: 8711 8711 8711
+Encoding: 8711 8711 2228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64162,8 +66402,9 @@ SplineSet
  616 204 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: element
-Encoding: 8712 8712 8712
+Encoding: 8712 8712 2229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64193,8 +66434,9 @@ SplineSet
  304.5 647 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: notelement
-Encoding: 8713 8713 8713
+Encoding: 8713 8713 2230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64240,8 +66482,9 @@ SplineSet
  554 647 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220A
-Encoding: 8714 8714 8714
+Encoding: 8714 8714 2231
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -64338,8 +66581,9 @@ SplineSet
  1102 726 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: suchthat
-Encoding: 8715 8715 8715
+Encoding: 8715 8715 2232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64369,8 +66613,9 @@ SplineSet
  928.5 817 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220C
-Encoding: 8716 8716 8716
+Encoding: 8716 8716 2233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64416,8 +66661,9 @@ SplineSet
  679 817 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220D
-Encoding: 8717 8717 8717
+Encoding: 8717 8717 2234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64445,8 +66691,9 @@ SplineSet
  131 556 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220E
-Encoding: 8718 8718 8718
+Encoding: 8718 8718 2235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64459,8 +66706,9 @@ SplineSet
  250 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: product
-Encoding: 8719 8719 8719
+Encoding: 8719 8719 2236
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64508,8 +66756,9 @@ SplineSet
  152 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2210
-Encoding: 8720 8720 8720
+Encoding: 8720 8720 2237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64526,8 +66775,9 @@ SplineSet
  1081 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: summation
-Encoding: 8721 8721 8721
+Encoding: 8721 8721 2238
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64597,8 +66847,9 @@ SplineSet
  332 -299 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: minus
-Encoding: 8722 8722 8722
+Encoding: 8722 8722 2239
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64630,8 +66881,9 @@ SplineSet
  88 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2213
-Encoding: 8723 8723 8723
+Encoding: 8723 8723 2240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64657,40 +66909,45 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2215
-Encoding: 8725 8725 8725
+Encoding: 8725 8725 2241
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 47 47 N 1 0 0 1 0 0 2
+Refer: 16 47 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: asteriskmath
-Encoding: 8727 8727 8727
+Encoding: 8727 8727 2242
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42 42 N 1 0 0 1 0 -411 2
+Refer: 11 42 N 1 0 0 1 0 -411 2
 EndChar
+
 StartChar: uni2218
-Encoding: 8728 8728 8728
+Encoding: 8728 8728 2243
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 176 176 N 1 0 0 1 0 -558 2
+Refer: 112 176 N 1 0 0 1 0 -558 2
 EndChar
+
 StartChar: uni2219
-Encoding: 8729 8729 8729
+Encoding: 8729 8729 2244
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8226 8226 N 1 0 0 1 0 -55 2
+Refer: 1980 8226 N 1 0 0 1 0 -55 2
 EndChar
+
 StartChar: radical
-Encoding: 8730 8730 8730
+Encoding: 8730 8730 2245
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64759,26 +67016,29 @@ SplineSet
  100 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221B
-Encoding: 8731 8731 8731
+Encoding: 8731 8731 2246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 -155 390 2
-Refer: 8730 8730 N 1 0 0 1 0 0 3
+Refer: 115 179 N 1 0 0 1 -155 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni221C
-Encoding: 8732 8732 8732
+Encoding: 8732 8732 2247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 -155 390 2
-Refer: 8730 8730 N 1 0 0 1 0 0 3
+Refer: 2009 8308 N 1 0 0 1 -155 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: proportional
-Encoding: 8733 8733 8733
+Encoding: 8733 8733 2248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64814,8 +67074,9 @@ SplineSet
  1046.5 250 l 17,33,34
 EndSplineSet
 EndChar
+
 StartChar: infinity
-Encoding: 8734 8734 8734
+Encoding: 8734 8734 2249
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64915,8 +67176,9 @@ SplineSet
  560 893 560 893 616 764 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: orthogonal
-Encoding: 8735 8735 8735
+Encoding: 8735 8735 2250
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64931,8 +67193,9 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: angle
-Encoding: 8736 8736 8736
+Encoding: 8736 8736 2251
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64947,16 +67210,18 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2223
-Encoding: 8739 8739 8739
+Encoding: 8739 8739 2252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 0 0 3
+Refer: 93 124 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: logicaland
-Encoding: 8743 8743 8743
+Encoding: 8743 8743 2253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64972,8 +67237,9 @@ SplineSet
  164.25 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalor
-Encoding: 8744 8744 8744
+Encoding: 8744 8744 2254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64989,8 +67255,9 @@ SplineSet
  164.25 1186 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: intersection
-Encoding: 8745 8745 8745
+Encoding: 8745 8745 2255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65021,8 +67288,9 @@ SplineSet
  164.25 580 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: union
-Encoding: 8746 8746 8746
+Encoding: 8746 8746 2256
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65053,8 +67321,9 @@ SplineSet
  164.25 376 164.25 376 164.25 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integral
-Encoding: 8747 8747 8747
+Encoding: 8747 8747 2257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65105,8 +67374,9 @@ SplineSet
  524.5 -213.72 524.5 -213.72 524.5 -68 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni222C
-Encoding: 8748 8748 8748
+Encoding: 8748 8748 2258
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65143,10 +67413,11 @@ SplineSet
  206.738 -247.167 206.738 -247.167 255 -232 c 0,22,23
  308.5 -215.188 308.5 -215.188 308.5 -68 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uni222D
-Encoding: 8749 8749 8749
+Encoding: 8749 8749 2259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65198,59 +67469,65 @@ SplineSet
  123.223 -205 123.223 -205 173 -205 c 0,11,12
  200.5 -204.972 200.5 -204.972 200.5 -127 c 2,13,-1
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
+
 StartChar: therefore
-Encoding: 8756 8756 8756
+Encoding: 8756 8756 2260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
 EndChar
+
 StartChar: uni2235
-Encoding: 8757 8757 8757
+Encoding: 8757 8757 2261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2236
-Encoding: 8758 8758 8758
+Encoding: 8758 8758 2262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
 EndChar
+
 StartChar: uni2237
-Encoding: 8759 8759 8759
+Encoding: 8759 8759 2263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2238
-Encoding: 8760 8760 8760
+Encoding: 8760 8760 2264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1.5 292 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1.5 292 2
 EndChar
+
 StartChar: uni2239
-Encoding: 8761 8761 8761
+Encoding: 8761 8761 2265
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65273,30 +67550,33 @@ SplineSet
  74 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni223A
-Encoding: 8762 8762 8762
+Encoding: 8762 8762 2266
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 404 292 2
-Refer: 8901 8901 N 1 0 0 1 408 -425 2
-Refer: 8901 8901 N 1 0 0 1 -401 292 2
-Refer: 8901 8901 N 1 0 0 1 -402 -425 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 404 292 2
+Refer: 2375 8901 N 1 0 0 1 408 -425 2
+Refer: 2375 8901 N 1 0 0 1 -401 292 2
+Refer: 2375 8901 N 1 0 0 1 -402 -425 2
 EndChar
+
 StartChar: uni223B
-Encoding: 8763 8763 8763
+Encoding: 8763 8763 2267
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 292 2
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 292 2
+Refer: 2375 8901 N 1 0 0 1 1 -425 2
 EndChar
+
 StartChar: similar
-Encoding: 8764 8764 8764
+Encoding: 8764 8764 2268
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65323,8 +67603,9 @@ SplineSet
  1071.01 723 1071.01 723 1145 786 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni223D
-Encoding: 8765 8765 8765
+Encoding: 8765 8765 2269
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65351,8 +67632,9 @@ SplineSet
  88 786 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2241
-Encoding: 8769 8769 8769
+Encoding: 8769 8769 2270
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65383,8 +67665,9 @@ SplineSet
  536 592.401 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2242
-Encoding: 8770 8770 8770
+Encoding: 8770 8770 2271
 Width: 1233
 LayerCount: 2
 Fore
@@ -65415,8 +67698,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2243
-Encoding: 8771 8771 8771
+Encoding: 8771 8771 2272
 Width: 1233
 LayerCount: 2
 Fore
@@ -65447,8 +67731,9 @@ SplineSet
  1071.01 900 1071.01 900 1145 963 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2244
-Encoding: 8772 8772 8772
+Encoding: 8772 8772 2273
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65486,8 +67771,9 @@ SplineSet
  967.079 1137.1 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: congruent
-Encoding: 8773 8773 8773
+Encoding: 8773 8773 2274
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65524,8 +67810,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2246
-Encoding: 8774 8774 8774
+Encoding: 8774 8774 2275
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65573,8 +67860,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2247
-Encoding: 8775 8775 8775
+Encoding: 8775 8775 2276
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65623,8 +67911,9 @@ SplineSet
  360 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: approxequal
-Encoding: 8776 8776 8776
+Encoding: 8776 8776 2277
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65747,8 +68036,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2249
-Encoding: 8777 8777 8777
+Encoding: 8777 8777 2278
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65796,8 +68086,9 @@ SplineSet
  477 419.074 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224A
-Encoding: 8778 8778 8778
+Encoding: 8778 8778 2279
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65848,8 +68139,9 @@ SplineSet
  88 364 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224B
-Encoding: 8779 8779 8779
+Encoding: 8779 8779 2280
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65914,8 +68206,9 @@ SplineSet
  1070 740 1070 740 1145 804 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224C
-Encoding: 8780 8780 8780
+Encoding: 8780 8780 2281
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65952,8 +68245,9 @@ SplineSet
  88 1167 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224D
-Encoding: 8781 8781 8781
+Encoding: 8781 8781 2282
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65975,8 +68269,9 @@ SplineSet
  416 555 416 555 616 555 c 129,-1,4
 EndSplineSet
 EndChar
+
 StartChar: uni224E
-Encoding: 8782 8782 8782
+Encoding: 8782 8782 2283
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66022,8 +68317,9 @@ SplineSet
  666 1062 666 1062 617 1059 c 24,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224F
-Encoding: 8783 8783 8783
+Encoding: 8783 8783 2284
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66055,48 +68351,53 @@ SplineSet
  88 522 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2250
-Encoding: 8784 8784 8784
+Encoding: 8784 8784 2285
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1.5 441 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1.5 441 2
 EndChar
+
 StartChar: uni2251
-Encoding: 8785 8785 8785
+Encoding: 8785 8785 2286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 441 2
-Refer: 8901 8901 N 1 0 0 1 2 441 2
-Refer: 8901 8901 N 1 0 0 1 1 -582 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 441 2
+Refer: 2375 8901 N 1 0 0 1 2 441 2
+Refer: 2375 8901 N 1 0 0 1 1 -582 2
 EndChar
+
 StartChar: uni2252
-Encoding: 8786 8786 8786
+Encoding: 8786 8786 2287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 404 -579 2
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 -401 441 2
+Refer: 2375 8901 N 1 0 0 1 404 -579 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -401 441 2
 EndChar
+
 StartChar: uni2253
-Encoding: 8787 8787 8787
+Encoding: 8787 8787 2288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 404.5 441 2
-Refer: 61 61 N 1 0 0 1 -0.5 0 2
-Refer: 8901 8901 N 1 0 0 1 -401.5 -579 2
+Refer: 2375 8901 N 1 0 0 1 404.5 441 2
+Refer: 30 61 N 1 0 0 1 -0.5 0 2
+Refer: 2375 8901 N 1 0 0 1 -401.5 -579 2
 EndChar
+
 StartChar: uni2254
-Encoding: 8788 8788 8788
+Encoding: 8788 8788 2289
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66124,8 +68425,9 @@ SplineSet
  1159 930 l 17,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2255
-Encoding: 8789 8789 8789
+Encoding: 8789 8789 2290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66153,8 +68455,9 @@ SplineSet
  74 930 l 9,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2256
-Encoding: 8790 8790 8790
+Encoding: 8790 8790 2291
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66184,8 +68487,9 @@ SplineSet
  860 585 860 585 833 522 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2257
-Encoding: 8791 8791 8791
+Encoding: 8791 8791 2292
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66223,8 +68527,9 @@ SplineSet
  495.949 1556.95 495.949 1556.95 617 1556.95 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2258
-Encoding: 8792 8792 8792
+Encoding: 8792 8792 2293
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66249,8 +68554,9 @@ SplineSet
  392.396 1355 392.396 1355 617.85 1355 c 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni2259
-Encoding: 8793 8793 8793
+Encoding: 8793 8793 2294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66276,8 +68582,9 @@ SplineSet
  302 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225A
-Encoding: 8794 8794 8794
+Encoding: 8794 8794 2295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66303,8 +68610,9 @@ SplineSet
  302 1604 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225B
-Encoding: 8795 8795 8795
+Encoding: 8795 8795 2296
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66333,8 +68641,9 @@ SplineSet
  264.2 1445.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225C
-Encoding: 8796 8796 8796
+Encoding: 8796 8796 2297
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66361,8 +68670,9 @@ SplineSet
  566.1 1711.15 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225D
-Encoding: 8797 8797 8797
+Encoding: 8797 8797 2298
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66444,8 +68754,9 @@ SplineSet
  137.64 1278.51 137.64 1278.51 137.64 1205.43 c 0,73,74
 EndSplineSet
 EndChar
+
 StartChar: uni225E
-Encoding: 8798 8798 8798
+Encoding: 8798 8798 2299
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66491,8 +68802,9 @@ SplineSet
  626.424 1495.24 626.424 1495.24 646.267 1437.43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni225F
-Encoding: 8799 8799 8799
+Encoding: 8799 8799 2300
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66540,8 +68852,9 @@ SplineSet
  637.75 1194.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notequal
-Encoding: 8800 8800 8800
+Encoding: 8800 8800 2301
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66632,8 +68945,9 @@ SplineSet
  88 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equivalence
-Encoding: 8801 8801 8801
+Encoding: 8801 8801 2302
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66656,8 +68970,9 @@ SplineSet
  88 1090 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2262
-Encoding: 8802 8802 8802
+Encoding: 8802 8802 2303
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66694,8 +69009,9 @@ SplineSet
  327 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2263
-Encoding: 8803 8803 8803
+Encoding: 8803 8803 2304
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66723,8 +69039,9 @@ SplineSet
  88 1262 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: lessequal
-Encoding: 8804 8804 8804
+Encoding: 8804 8804 2305
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66787,8 +69104,9 @@ SplineSet
  1145 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: greaterequal
-Encoding: 8805 8805 8805
+Encoding: 8805 8805 2306
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66851,8 +69169,9 @@ SplineSet
  88 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2266
-Encoding: 8806 8806 8806
+Encoding: 8806 8806 2307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66878,8 +69197,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2267
-Encoding: 8807 8807 8807
+Encoding: 8807 8807 2308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66905,8 +69225,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2268
-Encoding: 8808 8808 8808
+Encoding: 8808 8808 2309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66943,8 +69264,9 @@ SplineSet
  1143 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2269
-Encoding: 8809 8809 8809
+Encoding: 8809 8809 2310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66981,8 +69303,9 @@ SplineSet
  86 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni226D
-Encoding: 8813 8813 8813
+Encoding: 8813 8813 2311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67011,8 +69334,9 @@ SplineSet
  564 731 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226E
-Encoding: 8814 8814 8814
+Encoding: 8814 8814 2312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67041,8 +69365,9 @@ SplineSet
  590 751.908 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226F
-Encoding: 8815 8815 8815
+Encoding: 8815 8815 2313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67071,8 +69396,9 @@ SplineSet
  643 531 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2270
-Encoding: 8816 8816 8816
+Encoding: 8816 8816 2314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67109,8 +69435,9 @@ SplineSet
  356 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2271
-Encoding: 8817 8817 8817
+Encoding: 8817 8817 2315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67147,8 +69474,9 @@ SplineSet
  643 599.856 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2272
-Encoding: 8818 8818 8818
+Encoding: 8818 8818 2316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67183,8 +69511,9 @@ SplineSet
  1143 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2273
-Encoding: 8819 8819 8819
+Encoding: 8819 8819 2317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67219,8 +69548,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2274
-Encoding: 8820 8820 8820
+Encoding: 8820 8820 2318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67267,8 +69597,9 @@ SplineSet
  601 746.693 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2275
-Encoding: 8821 8821 8821
+Encoding: 8821 8821 2319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67315,8 +69646,9 @@ SplineSet
  736 883.452 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2276
-Encoding: 8822 8822 8822
+Encoding: 8822 8822 2320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67340,8 +69672,9 @@ SplineSet
  1143 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2277
-Encoding: 8823 8823 8823
+Encoding: 8823 8823 2321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67365,8 +69698,9 @@ SplineSet
  86 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2278
-Encoding: 8824 8824 8824
+Encoding: 8824 8824 2322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67411,8 +69745,9 @@ SplineSet
  587 146.067 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2279
-Encoding: 8825 8825 8825
+Encoding: 8825 8825 2323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67457,8 +69792,9 @@ SplineSet
  801.872 844.55 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227A
-Encoding: 8826 8826 8826
+Encoding: 8826 8826 2324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67474,8 +69810,9 @@ SplineSet
  1143 1088 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227B
-Encoding: 8827 8827 8827
+Encoding: 8827 8827 2325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67491,8 +69828,9 @@ SplineSet
  415 728 415 728 88 1088 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227C
-Encoding: 8828 8828 8828
+Encoding: 8828 8828 2326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67517,8 +69855,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227D
-Encoding: 8829 8829 8829
+Encoding: 8829 8829 2327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67543,8 +69882,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227E
-Encoding: 8830 8830 8830
+Encoding: 8830 8830 2328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67581,8 +69921,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227F
-Encoding: 8831 8831 8831
+Encoding: 8831 8831 2329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67619,8 +69960,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2280
-Encoding: 8832 8832 8832
+Encoding: 8832 8832 2330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67649,8 +69991,9 @@ SplineSet
  480.263 621.903 480.263 621.903 560.301 593 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2281
-Encoding: 8833 8833 8833
+Encoding: 8833 8833 2331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67679,8 +70022,9 @@ SplineSet
  748.737 660.097 748.737 660.097 668.699 689 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: propersubset
-Encoding: 8834 8834 8834
+Encoding: 8834 8834 2332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67703,8 +70047,9 @@ SplineSet
  1145 163 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: propersuperset
-Encoding: 8835 8835 8835
+Encoding: 8835 8835 2333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67727,8 +70072,9 @@ SplineSet
  88 163 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notsubset
-Encoding: 8836 8836 8836
+Encoding: 8836 8836 2334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67763,8 +70109,9 @@ SplineSet
  379 198.472 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2285
-Encoding: 8837 8837 8837
+Encoding: 8837 8837 2335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67799,8 +70146,9 @@ SplineSet
  854 1083.53 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: reflexsubset
-Encoding: 8838 8838 8838
+Encoding: 8838 8838 2336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67828,8 +70176,9 @@ SplineSet
  1145 324 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: reflexsuperset
-Encoding: 8839 8839 8839
+Encoding: 8839 8839 2337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67857,8 +70206,9 @@ SplineSet
  88 324 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2288
-Encoding: 8840 8840 8840
+Encoding: 8840 8840 2338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67900,8 +70250,9 @@ SplineSet
  692 1130 l 17,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2289
-Encoding: 8841 8841 8841
+Encoding: 8841 8841 2339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67945,8 +70296,9 @@ SplineSet
  648 474 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni228A
-Encoding: 8842 8842 8842
+Encoding: 8842 8842 2340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67982,8 +70334,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228B
-Encoding: 8843 8843 8843
+Encoding: 8843 8843 2341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68019,8 +70372,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228D
-Encoding: 8845 8845 8845
+Encoding: 8845 8845 2342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68048,8 +70402,9 @@ SplineSet
  131 199 131 199 131 495 c 2,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228E
-Encoding: 8846 8846 8846
+Encoding: 8846 8846 2343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68085,8 +70440,9 @@ SplineSet
  667 779 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228F
-Encoding: 8847 8847 8847
+Encoding: 8847 8847 2344
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68154,8 +70510,9 @@ SplineSet
  88 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2290
-Encoding: 8848 8848 8848
+Encoding: 8848 8848 2345
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68223,8 +70580,9 @@ SplineSet
  1145 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2291
-Encoding: 8849 8849 8849
+Encoding: 8849 8849 2346
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68320,8 +70678,9 @@ SplineSet
  88 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2292
-Encoding: 8850 8850 8850
+Encoding: 8850 8850 2347
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68419,8 +70778,9 @@ SplineSet
  1145 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2293
-Encoding: 8851 8851 8851
+Encoding: 8851 8851 2348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68437,8 +70797,9 @@ SplineSet
  1138 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2294
-Encoding: 8852 8852 8852
+Encoding: 8852 8852 2349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68455,8 +70816,9 @@ SplineSet
  94 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circleplus
-Encoding: 8853 8853 8853
+Encoding: 8853 8853 2350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68511,8 +70873,9 @@ SplineSet
  546 989 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2296
-Encoding: 8854 8854 8854
+Encoding: 8854 8854 2351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68559,8 +70922,9 @@ SplineSet
  962 712 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: circlemultiply
-Encoding: 8855 8855 8855
+Encoding: 8855 8855 2352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68615,8 +70979,9 @@ SplineSet
  322.344 837.954 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2298
-Encoding: 8856 8856 8856
+Encoding: 8856 8856 2353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68663,8 +71028,9 @@ SplineSet
  812.368 936.242 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2299
-Encoding: 8857 8857 8857
+Encoding: 8857 8857 2354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68711,8 +71077,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,33
 EndSplineSet
 EndChar
+
 StartChar: uni229A
-Encoding: 8858 8858 8858
+Encoding: 8858 8858 2355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68774,8 +71141,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229B
-Encoding: 8859 8859 8859
+Encoding: 8859 8859 2356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68834,8 +71202,9 @@ SplineSet
  318.758 905.499 318.758 905.499 303.521 886.352 c 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229C
-Encoding: 8860 8860 8860
+Encoding: 8860 8860 2357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68887,8 +71256,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,35
 EndSplineSet
 EndChar
+
 StartChar: uni229D
-Encoding: 8861 8861 8861
+Encoding: 8861 8861 2358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68935,8 +71305,9 @@ SplineSet
  818 572 l 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229E
-Encoding: 8862 8862 8862
+Encoding: 8862 8862 2359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68967,8 +71338,9 @@ SplineSet
  546 1025 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229F
-Encoding: 8863 8863 8863
+Encoding: 8863 8863 2360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68991,8 +71363,9 @@ SplineSet
  962 712 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A0
-Encoding: 8864 8864 8864
+Encoding: 8864 8864 2361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69023,8 +71396,9 @@ SplineSet
  252.072 907.604 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A1
-Encoding: 8865 8865 8865
+Encoding: 8865 8865 2362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69047,8 +71421,9 @@ SplineSet
  80 1180 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A2
-Encoding: 8866 8866 8866
+Encoding: 8866 8866 2363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69065,8 +71440,9 @@ SplineSet
  256 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A3
-Encoding: 8867 8867 8867
+Encoding: 8867 8867 2364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69083,8 +71459,9 @@ SplineSet
  977 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A4
-Encoding: 8868 8868 8868
+Encoding: 8868 8868 2365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69101,8 +71478,9 @@ SplineSet
  533 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: perpendicular
-Encoding: 8869 8869 8869
+Encoding: 8869 8869 2366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69119,8 +71497,9 @@ SplineSet
  701 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B2
-Encoding: 8882 8882 8882
+Encoding: 8882 8882 2367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69137,8 +71516,9 @@ SplineSet
  1145 141 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B3
-Encoding: 8883 8883 8883
+Encoding: 8883 8883 2368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69155,8 +71535,9 @@ SplineSet
  256 387 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B4
-Encoding: 8884 8884 8884
+Encoding: 8884 8884 2369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69178,8 +71559,9 @@ SplineSet
  1145 256 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B5
-Encoding: 8885 8885 8885
+Encoding: 8885 8885 2370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69201,8 +71583,9 @@ SplineSet
  256 487 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B8
-Encoding: 8888 8888 8888
+Encoding: 8888 8888 2371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69231,8 +71614,9 @@ SplineSet
  1057 700 1057 700 1017.5 740 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni22C2
-Encoding: 8898 8898 8898
+Encoding: 8898 8898 2372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69255,8 +71639,9 @@ SplineSet
  1102 1319 1102 1319 1102 1023 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C3
-Encoding: 8899 8899 8899
+Encoding: 8899 8899 2373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69279,8 +71664,9 @@ SplineSet
  131 -237 131 -237 131 59 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C4
-Encoding: 8900 8900 8900
+Encoding: 8900 8900 2374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69298,8 +71684,9 @@ SplineSet
  105 642 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dotmath
-Encoding: 8901 8901 8901
+Encoding: 8901 8901 2375
 Width: 1233
 Flags: W
 TtInstrs:
@@ -69333,8 +71720,9 @@ SplineSet
  489 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C6
-Encoding: 8902 8902 8902
+Encoding: 8902 8902 2376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69353,8 +71741,9 @@ SplineSet
  264.907 823.703 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22CD
-Encoding: 8909 8909 8909
+Encoding: 8909 8909 2377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69386,8 +71775,9 @@ SplineSet
  88 963 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni22CE
-Encoding: 8910 8910 8910
+Encoding: 8910 8910 2378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69403,8 +71793,9 @@ SplineSet
  532 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22CF
-Encoding: 8911 8911 8911
+Encoding: 8911 8911 2379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69420,8 +71811,9 @@ SplineSet
  698 1284 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22D0
-Encoding: 8912 8912 8912
+Encoding: 8912 8912 2380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69459,8 +71851,9 @@ SplineSet
  1143 -6 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22D1
-Encoding: 8913 8913 8913
+Encoding: 8913 8913 2381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69498,8 +71891,9 @@ SplineSet
  90 1290 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DA
-Encoding: 8922 8922 8922
+Encoding: 8922 8922 2382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69528,8 +71922,9 @@ SplineSet
  1145 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DB
-Encoding: 8923 8923 8923
+Encoding: 8923 8923 2383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69558,8 +71953,9 @@ SplineSet
  88 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DC
-Encoding: 8924 8924 8924
+Encoding: 8924 8924 2384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69580,8 +71976,9 @@ SplineSet
  1143 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DD
-Encoding: 8925 8925 8925
+Encoding: 8925 8925 2385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69602,8 +71999,9 @@ SplineSet
  88 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DE
-Encoding: 8926 8926 8926
+Encoding: 8926 8926 2386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69628,8 +72026,9 @@ SplineSet
  852 291 852 291 1143 -13 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DF
-Encoding: 8927 8927 8927
+Encoding: 8927 8927 2387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69654,8 +72053,9 @@ SplineSet
  86 -13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E0
-Encoding: 8928 8928 8928
+Encoding: 8928 8928 2388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69695,8 +72095,9 @@ SplineSet
  536.138 814.711 536.138 814.711 618.897 785.045 c 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E1
-Encoding: 8929 8929 8929
+Encoding: 8929 8929 2389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69735,8 +72136,9 @@ SplineSet
  766.207 837.893 766.207 837.893 751.566 841.087 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E2
-Encoding: 8930 8930 8930
+Encoding: 8930 8930 2390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69766,8 +72168,9 @@ SplineSet
  383.753 289 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E3
-Encoding: 8931 8931 8931
+Encoding: 8931 8931 2391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69797,8 +72200,9 @@ SplineSet
  849.247 993 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E4
-Encoding: 8932 8932 8932
+Encoding: 8932 8932 2392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69828,8 +72232,9 @@ SplineSet
  88 1268 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E5
-Encoding: 8933 8933 8933
+Encoding: 8933 8933 2393
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69859,8 +72264,9 @@ SplineSet
  1145 184 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E6
-Encoding: 8934 8934 8934
+Encoding: 8934 8934 2394
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69898,8 +72304,9 @@ SplineSet
  534 51.4014 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22E7
-Encoding: 8935 8935 8935
+Encoding: 8935 8935 2395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69938,8 +72345,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E8
-Encoding: 8936 8936 8936
+Encoding: 8936 8936 2396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69980,8 +72388,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E9
-Encoding: 8937 8937 8937
+Encoding: 8937 8937 2397
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70022,23 +72431,26 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22EF
-Encoding: 8943 8943 8943
+Encoding: 8943 8943 2398
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 8230 8230 N 1 0 0 1 0 490 2
+Refer: 1984 8230 N 1 0 0 1 0 490 2
 EndChar
+
 StartChar: uni2300
-Encoding: 8960 8960 8960
+Encoding: 8960 8960 2399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8709 8709 N 1 0 0 1 0 0 2
+Refer: 2226 8709 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2301
-Encoding: 8961 8961 8961
+Encoding: 8961 8961 2400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70055,8 +72467,9 @@ SplineSet
  674 634 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: house
-Encoding: 8962 8962 8962
+Encoding: 8962 8962 2401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70076,8 +72489,9 @@ SplineSet
  268.5 122 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2303
-Encoding: 8963 8963 8963
+Encoding: 8963 8963 2402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70092,8 +72506,9 @@ SplineSet
  616 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2304
-Encoding: 8964 8964 8964
+Encoding: 8964 8964 2403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70108,8 +72523,9 @@ SplineSet
  616 -269.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2305
-Encoding: 8965 8965 8965
+Encoding: 8965 8965 2404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70129,8 +72545,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2306
-Encoding: 8966 8966 8966
+Encoding: 8966 8966 2405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70155,8 +72572,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2308
-Encoding: 8968 8968 8968
+Encoding: 8968 8968 2406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70171,8 +72589,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2309
-Encoding: 8969 8969 8969
+Encoding: 8969 8969 2407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70187,8 +72606,9 @@ SplineSet
  770 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230A
-Encoding: 8970 8970 8970
+Encoding: 8970 8970 2408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70203,8 +72623,9 @@ SplineSet
  463 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230B
-Encoding: 8971 8971 8971
+Encoding: 8971 8971 2409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70219,8 +72640,9 @@ SplineSet
  770 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230C
-Encoding: 8972 8972 8972
+Encoding: 8972 8972 2410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70238,8 +72660,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230D
-Encoding: 8973 8973 8973
+Encoding: 8973 8973 2411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70257,8 +72680,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230E
-Encoding: 8974 8974 8974
+Encoding: 8974 8974 2412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70276,8 +72700,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230F
-Encoding: 8975 8975 8975
+Encoding: 8975 8975 2413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70295,8 +72720,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: revlogicalnot
-Encoding: 8976 8976 8976
+Encoding: 8976 8976 2414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70311,8 +72737,9 @@ SplineSet
  1145 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2311
-Encoding: 8977 8977 8977
+Encoding: 8977 8977 2415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70330,16 +72757,18 @@ SplineSet
  616 435.5 616 435.5 97 258.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2312
-Encoding: 8978 8978 8978
+Encoding: 8978 8978 2416
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9696 9696 N 1 0 0 1 0 -100 2
+Refer: 2760 9696 N 1 0 0 1 0 -100 2
 EndChar
+
 StartChar: uni2313
-Encoding: 8979 8979 8979
+Encoding: 8979 8979 2417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70359,8 +72788,9 @@ SplineSet
  180.288 743.534 180.288 743.534 139.268 546 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2314
-Encoding: 8980 8980 8980
+Encoding: 8980 8980 2418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70380,8 +72810,9 @@ SplineSet
  740 925 740 925 616 925 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2315
-Encoding: 8981 8981 8981
+Encoding: 8981 8981 2419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70411,8 +72842,9 @@ SplineSet
  518.878 1103.87 518.878 1103.87 674.11 1103.87 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2318
-Encoding: 8984 8984 8984
+Encoding: 8984 8984 2420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70498,8 +72930,9 @@ SplineSet
  824 570 l 1,85,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2319
-Encoding: 8985 8985 8985
+Encoding: 8985 8985 2421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70514,8 +72947,9 @@ SplineSet
  1145 371 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni231C
-Encoding: 8988 8988 8988
+Encoding: 8988 8988 2422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70530,8 +72964,9 @@ SplineSet
  949 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231D
-Encoding: 8989 8989 8989
+Encoding: 8989 8989 2423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70546,8 +72981,9 @@ SplineSet
  284 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231E
-Encoding: 8990 8990 8990
+Encoding: 8990 8990 2424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70562,8 +72998,9 @@ SplineSet
  949 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231F
-Encoding: 8991 8991 8991
+Encoding: 8991 8991 2425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70578,8 +73015,9 @@ SplineSet
  284 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: integraltp
-Encoding: 8992 8992 8992
+Encoding: 8992 8992 2426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70604,8 +73042,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integralbt
-Encoding: 8993 8993 8993
+Encoding: 8993 8993 2427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70630,8 +73069,9 @@ SplineSet
  711 1929 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2325
-Encoding: 8997 8997 8997
+Encoding: 8997 8997 2428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70653,8 +73093,9 @@ SplineSet
  713 1225 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2326
-Encoding: 8998 8998 8998
+Encoding: 8998 8998 2429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70689,8 +73130,9 @@ SplineSet
  578.025 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2327
-Encoding: 8999 8999 8999
+Encoding: 8999 8999 2430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70723,8 +73165,9 @@ SplineSet
  747.024 410 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2328
-Encoding: 9000 9000 9000
+Encoding: 9000 9000 2431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71122,8 +73565,9 @@ SplineSet
  402 535 l 2,509,510
 EndSplineSet
 EndChar
+
 StartChar: uni232B
-Encoding: 9003 9003 9003
+Encoding: 9003 9003 2432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71158,8 +73602,9 @@ SplineSet
  654.976 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2335
-Encoding: 9013 9013 9013
+Encoding: 9013 9013 2433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71174,8 +73619,9 @@ SplineSet
  616 -45 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2336
-Encoding: 9014 9014 9014
+Encoding: 9014 9014 2434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71196,8 +73642,9 @@ SplineSet
  532 1114 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2337
-Encoding: 9015 9015 9015
+Encoding: 9015 9015 2435
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71215,8 +73662,9 @@ SplineSet
  256 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2338
-Encoding: 9016 9016 9016
+Encoding: 9016 9016 2436
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71244,8 +73692,9 @@ SplineSet
  120 930 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2339
-Encoding: 9017 9017 9017
+Encoding: 9017 9017 2437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71278,8 +73727,9 @@ SplineSet
  120 727 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233A
-Encoding: 9018 9018 9018
+Encoding: 9018 9018 2438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71309,17 +73759,19 @@ SplineSet
  120 846.093 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233B
-Encoding: 9019 9019 9019
+Encoding: 9019 9019 2439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233C
-Encoding: 9020 9020 9020
+Encoding: 9020 9020 2440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71357,8 +73809,9 @@ SplineSet
  120 1096.51 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni233D
-Encoding: 9021 9021 9021
+Encoding: 9021 9021 2441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71393,17 +73846,19 @@ SplineSet
  775.861 1202.85 775.861 1202.85 692 1217.96 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233E
-Encoding: 9022 9022 9022
+Encoding: 9022 9022 2442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni233F
-Encoding: 9023 9023 9023
+Encoding: 9023 9023 2443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71424,8 +73879,9 @@ SplineSet
  889 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2340
-Encoding: 9024 9024 9024
+Encoding: 9024 9024 2444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71446,8 +73902,9 @@ SplineSet
  460 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2341
-Encoding: 9025 9025 9025
+Encoding: 9025 9025 2445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71468,8 +73925,9 @@ SplineSet
  1113 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2342
-Encoding: 9026 9026 9026
+Encoding: 9026 9026 2446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71490,8 +73948,9 @@ SplineSet
  120 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2343
-Encoding: 9027 9027 9027
+Encoding: 9027 9027 2447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71518,8 +73977,9 @@ SplineSet
  1113 435.934 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2344
-Encoding: 9028 9028 9028
+Encoding: 9028 9028 2448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71546,8 +74006,9 @@ SplineSet
  120 1230.35 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2345
-Encoding: 9029 9029 9029
+Encoding: 9029 9029 2449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71574,8 +74035,9 @@ SplineSet
  66 682 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2346
-Encoding: 9030 9030 9030
+Encoding: 9030 9030 2450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71602,8 +74064,9 @@ SplineSet
  1167 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2347
-Encoding: 9031 9031 9031
+Encoding: 9031 9031 2451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71632,8 +74095,9 @@ SplineSet
  120 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2348
-Encoding: 9032 9032 9032
+Encoding: 9032 9032 2452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71662,8 +74126,9 @@ SplineSet
  1113 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2349
-Encoding: 9033 9033 9033
+Encoding: 9033 9033 2453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71698,8 +74163,9 @@ SplineSet
  553.559 1224.8 553.559 1224.8 491.148 1206.37 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234A
-Encoding: 9034 9034 9034
+Encoding: 9034 9034 2454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71721,8 +74187,9 @@ SplineSet
  701 1284 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234B
-Encoding: 9035 9035 9035
+Encoding: 9035 9035 2455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71751,8 +74218,9 @@ SplineSet
  692 170 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234C
-Encoding: 9036 9036 9036
+Encoding: 9036 9036 2456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71778,8 +74246,9 @@ SplineSet
  120 909.059 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234D
-Encoding: 9037 9037 9037
+Encoding: 9037 9037 2457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71808,8 +74277,9 @@ SplineSet
  120 90.9297 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234E
-Encoding: 9038 9038 9038
+Encoding: 9038 9038 2458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71844,8 +74314,9 @@ SplineSet
  700 616 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni234F
-Encoding: 9039 9039 9039
+Encoding: 9039 9039 2459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71872,8 +74343,9 @@ SplineSet
  658 1550 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2350
-Encoding: 9040 9040 9040
+Encoding: 9040 9040 2460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71902,8 +74374,9 @@ SplineSet
  534.5 -90 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2351
-Encoding: 9041 9041 9041
+Encoding: 9041 9041 2461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71925,8 +74398,9 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2352
-Encoding: 9042 9042 9042
+Encoding: 9042 9042 2462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71955,8 +74429,9 @@ SplineSet
  692 1323 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2353
-Encoding: 9043 9043 9043
+Encoding: 9043 9043 2463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71982,8 +74457,9 @@ SplineSet
  120 583.942 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2354
-Encoding: 9044 9044 9044
+Encoding: 9044 9044 2464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72012,8 +74488,9 @@ SplineSet
  120 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2355
-Encoding: 9045 9045 9045
+Encoding: 9045 9045 2465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72048,8 +74525,9 @@ SplineSet
  532 850 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2356
-Encoding: 9046 9046 9046
+Encoding: 9046 9046 2466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72076,8 +74554,9 @@ SplineSet
  576 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2357
-Encoding: 9047 9047 9047
+Encoding: 9047 9047 2467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72106,53 +74585,59 @@ SplineSet
  534.5 1583 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2358
-Encoding: 9048 9048 9048
+Encoding: 9048 9048 2468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 39 39 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2359
-Encoding: 9049 9049 9049
+Encoding: 9049 9049 2469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 916 916 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 746 916 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235A
-Encoding: 9050 9050 9050
+Encoding: 9050 9050 2470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 9671 9671 N 1 0 0 1 0 200 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 2735 9671 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235B
-Encoding: 9051 9051 9051
+Encoding: 9051 9051 2471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235C
-Encoding: 9052 9052 9052
+Encoding: 9052 9052 2472
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235D
-Encoding: 9053 9053 9053
+Encoding: 9053 9053 2473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72195,35 +74680,39 @@ SplineSet
  761 792 761 792 718 834.5 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni235E
-Encoding: 9054 9054 9054
+Encoding: 9054 9054 2474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235F
-Encoding: 9055 9055 9055
+Encoding: 9055 9055 2475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9711 9711 N 1 0 0 1 0 200 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 2775 9711 N 1 0 0 1 0 200 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2360
-Encoding: 9056 9056 9056
+Encoding: 9056 9056 2476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 27 58 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2361
-Encoding: 9057 9057 9057
+Encoding: 9057 9057 2477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72250,8 +74739,9 @@ SplineSet
  533 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2362
-Encoding: 9058 9058 9058
+Encoding: 9058 9058 2478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72278,35 +74768,39 @@ SplineSet
  616 211 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2363
-Encoding: 9059 9059 9059
+Encoding: 9059 9059 2479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -250 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -250 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2364
-Encoding: 9060 9060 9060
+Encoding: 9060 9060 2480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2365
-Encoding: 9061 9061 9061
+Encoding: 9061 9061 2481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 150 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3745 -1 N 1 0 0 1 0 150 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni2366
-Encoding: 9062 9062 9062
+Encoding: 9062 9062 2482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72343,8 +74837,9 @@ SplineSet
  164 376 164 376 164 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2367
-Encoding: 9063 9063 9063
+Encoding: 9063 9063 2483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72376,26 +74871,29 @@ SplineSet
  420 314 420 314 540 314 c 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2368
-Encoding: 9064 9064 9064
+Encoding: 9064 9064 2484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2369
-Encoding: 9065 9065 9065
+Encoding: 9065 9065 2485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 62 62 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 31 62 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni236A
-Encoding: 9066 9066 9066
+Encoding: 9066 9066 2486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72415,8 +74913,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236B
-Encoding: 9067 9067 9067
+Encoding: 9067 9067 2487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72455,8 +74954,9 @@ SplineSet
  474.095 714.191 474.095 714.191 464.707 715.983 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236C
-Encoding: 9068 9068 9068
+Encoding: 9068 9068 2488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72501,8 +75001,9 @@ SplineSet
  358.197 724 358.197 724 336.101 721.542 c 1,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni236D
-Encoding: 9069 9069 9069
+Encoding: 9069 9069 2489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72533,8 +75034,9 @@ SplineSet
  1071 828 1071 828 1145 890 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236E
-Encoding: 9070 9070 9070
+Encoding: 9070 9070 2490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72562,8 +75064,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236F
-Encoding: 9071 9071 9071
+Encoding: 9071 9071 2491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72602,17 +75105,19 @@ SplineSet
  193.7 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2370
-Encoding: 9072 9072 9072
+Encoding: 9072 9072 2492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 63 63 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 32 63 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2371
-Encoding: 9073 9073 9073
+Encoding: 9073 9073 2493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72644,8 +75149,9 @@ SplineSet
  574 575 574 575 520 592 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2372
-Encoding: 9074 9074 9074
+Encoding: 9074 9074 2494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72677,76 +75183,85 @@ SplineSet
  669 705 669 705 683 699 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2373
-Encoding: 9075 9075 9075
+Encoding: 9075 9075 2495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2374
-Encoding: 9076 9076 9076
+Encoding: 9076 9076 2496
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2375
-Encoding: 9077 9077 9077
+Encoding: 9077 9077 2497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2376
-Encoding: 9078 9078 9078
+Encoding: 9078 9078 2498
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2377
-Encoding: 9079 9079 9079
+Encoding: 9079 9079 2499
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
-Refer: 1013 1013 N 1 0 0 1 0 0 2
+Refer: 3741 -1 N 1 0 0 1 0 0 2
+Refer: 827 1013 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2378
-Encoding: 9080 9080 9080
+Encoding: 9080 9080 2500
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2379
-Encoding: 9081 9081 9081
+Encoding: 9081 9081 2501
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237A
-Encoding: 9082 9082 9082
+Encoding: 9082 9082 2502
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237D
-Encoding: 9085 9085 9085
+Encoding: 9085 9085 2503
 Width: 1233
 Flags: W
 TtInstrs:
@@ -72802,8 +75317,9 @@ SplineSet
  225 -466 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2380
-Encoding: 9088 9088 9088
+Encoding: 9088 9088 2504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72851,8 +75367,9 @@ SplineSet
  874 880 874 880 874 798 c 2,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2381
-Encoding: 9089 9089 9089
+Encoding: 9089 9089 2505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72913,8 +75430,9 @@ SplineSet
  588 880 588 880 588 798 c 2,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2382
-Encoding: 9090 9090 9090
+Encoding: 9090 9090 2506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72998,8 +75516,9 @@ SplineSet
  1174 880 1174 880 1174 798 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2383
-Encoding: 9091 9091 9091
+Encoding: 9091 9091 2507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73070,8 +75589,9 @@ SplineSet
  306 624 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2388
-Encoding: 9096 9096 9096
+Encoding: 9096 9096 2508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73151,8 +75671,9 @@ SplineSet
  902 695.508 902 695.508 885.367 741.284 c 1,91,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2389
-Encoding: 9097 9097 9097
+Encoding: 9097 9097 2509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73204,8 +75725,9 @@ SplineSet
  498.478 216.579 498.478 216.579 554.11 208.772 c 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238A
-Encoding: 9098 9098 9098
+Encoding: 9098 9098 2510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73258,8 +75780,9 @@ SplineSet
  1013.7 817.67 1013.7 817.67 1009.82 825.874 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238B
-Encoding: 9099 9099 9099
+Encoding: 9099 9099 2511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73306,8 +75829,9 @@ SplineSet
  70 528.7 70 528.7 70 640 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2395
-Encoding: 9109 9109 9109
+Encoding: 9109 9109 2512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73325,8 +75849,9 @@ SplineSet
  6 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni239B
-Encoding: 9115 9115 9115
+Encoding: 9115 9115 2513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73343,8 +75868,9 @@ SplineSet
  475 -528 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239C
-Encoding: 9116 9116 9116
+Encoding: 9116 9116 2514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73357,8 +75883,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni239D
-Encoding: 9117 9117 9117
+Encoding: 9117 9117 2515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73375,8 +75902,9 @@ SplineSet
  475 1929 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239E
-Encoding: 9118 9118 9118
+Encoding: 9118 9118 2516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73393,8 +75921,9 @@ SplineSet
  758 -528 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239F
-Encoding: 9119 9119 9119
+Encoding: 9119 9119 2517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73407,8 +75936,9 @@ SplineSet
  953 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A0
-Encoding: 9120 9120 9120
+Encoding: 9120 9120 2518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73425,8 +75955,9 @@ SplineSet
  758 1929 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A1
-Encoding: 9121 9121 9121
+Encoding: 9121 9121 2519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73441,8 +75972,9 @@ SplineSet
  475 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A2
-Encoding: 9122 9122 9122
+Encoding: 9122 9122 2520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73455,8 +75987,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A3
-Encoding: 9123 9123 9123
+Encoding: 9123 9123 2521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73471,8 +76004,9 @@ SplineSet
  475 1929 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A4
-Encoding: 9124 9124 9124
+Encoding: 9124 9124 2522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73487,8 +76021,9 @@ SplineSet
  757 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A5
-Encoding: 9125 9125 9125
+Encoding: 9125 9125 2523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73501,8 +76036,9 @@ SplineSet
  757 1914 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A6
-Encoding: 9126 9126 9126
+Encoding: 9126 9126 2524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73517,8 +76053,9 @@ SplineSet
  757 1914 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A7
-Encoding: 9127 9127 9127
+Encoding: 9127 9127 2525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73537,8 +76074,9 @@ SplineSet
  710 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23A8
-Encoding: 9128 9128 9128
+Encoding: 9128 9128 2526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73564,8 +76102,9 @@ SplineSet
  569 738 569 738 509 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23A9
-Encoding: 9129 9129 9129
+Encoding: 9129 9129 2527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73584,8 +76123,9 @@ SplineSet
  710 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AA
-Encoding: 9130 9130 9130
+Encoding: 9130 9130 2528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73598,8 +76138,9 @@ SplineSet
  710 -524 l 25,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23AB
-Encoding: 9131 9131 9131
+Encoding: 9131 9131 2529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73618,8 +76159,9 @@ SplineSet
  523 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AC
-Encoding: 9132 9132 9132
+Encoding: 9132 9132 2530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73645,8 +76187,9 @@ SplineSet
  665.971 673.084 665.971 673.084 724 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23AD
-Encoding: 9133 9133 9133
+Encoding: 9133 9133 2531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73665,8 +76208,9 @@ SplineSet
  523 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AE
-Encoding: 9134 9134 9134
+Encoding: 9134 9134 2532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73679,8 +76223,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CE
-Encoding: 9166 9166 9166
+Encoding: 9166 9166 2533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73708,8 +76253,9 @@ SplineSet
  893 663 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CF
-Encoding: 9167 9167 9167
+Encoding: 9167 9167 2534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73726,8 +76272,9 @@ SplineSet
  1227 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2423
-Encoding: 9251 9251 9251
+Encoding: 9251 9251 2535
 Width: 1233
 Flags: W
 TtInstrs:
@@ -73774,8 +76321,9 @@ SplineSet
  150 -466 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF100000
-Encoding: 9472 9472 9472
+Encoding: 9472 9472 2536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73788,8 +76336,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2501
-Encoding: 9473 9473 9473
+Encoding: 9473 9473 2537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73802,8 +76351,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF110000
-Encoding: 9474 9474 9474
+Encoding: 9474 9474 2538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73816,8 +76366,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2503
-Encoding: 9475 9475 9475
+Encoding: 9475 9475 2539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73830,8 +76381,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2504
-Encoding: 9476 9476 9476
+Encoding: 9476 9476 2540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73854,8 +76406,9 @@ SplineSet
  60 618 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2505
-Encoding: 9477 9477 9477
+Encoding: 9477 9477 2541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73878,8 +76431,9 @@ SplineSet
  60 532 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2506
-Encoding: 9478 9478 9478
+Encoding: 9478 9478 2542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73902,8 +76456,9 @@ SplineSet
  536 1193 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2507
-Encoding: 9479 9479 9479
+Encoding: 9479 9479 2543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73926,8 +76481,9 @@ SplineSet
  456 1193 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2508
-Encoding: 9480 9480 9480
+Encoding: 9480 9480 2544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73955,8 +76511,9 @@ SplineSet
  984 618 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2509
-Encoding: 9481 9481 9481
+Encoding: 9481 9481 2545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73984,8 +76541,9 @@ SplineSet
  984 532 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250A
-Encoding: 9482 9482 9482
+Encoding: 9482 9482 2546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74013,8 +76571,9 @@ SplineSet
  536 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250B
-Encoding: 9483 9483 9483
+Encoding: 9483 9483 2547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74042,8 +76601,9 @@ SplineSet
  456 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF010000
-Encoding: 9484 9484 9484
+Encoding: 9484 9484 2548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74058,8 +76618,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250D
-Encoding: 9485 9485 9485
+Encoding: 9485 9485 2549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74074,8 +76635,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250E
-Encoding: 9486 9486 9486
+Encoding: 9486 9486 2550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74090,8 +76652,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250F
-Encoding: 9487 9487 9487
+Encoding: 9487 9487 2551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74106,8 +76669,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF030000
-Encoding: 9488 9488 9488
+Encoding: 9488 9488 2552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74122,8 +76686,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2511
-Encoding: 9489 9489 9489
+Encoding: 9489 9489 2553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74138,8 +76703,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2512
-Encoding: 9490 9490 9490
+Encoding: 9490 9490 2554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74154,8 +76720,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2513
-Encoding: 9491 9491 9491
+Encoding: 9491 9491 2555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74170,8 +76737,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF020000
-Encoding: 9492 9492 9492
+Encoding: 9492 9492 2556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74186,8 +76754,9 @@ SplineSet
  536 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2515
-Encoding: 9493 9493 9493
+Encoding: 9493 9493 2557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74202,8 +76771,9 @@ SplineSet
  536 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2516
-Encoding: 9494 9494 9494
+Encoding: 9494 9494 2558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74218,8 +76788,9 @@ SplineSet
  456 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2517
-Encoding: 9495 9495 9495
+Encoding: 9495 9495 2559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74234,8 +76805,9 @@ SplineSet
  456 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF040000
-Encoding: 9496 9496 9496
+Encoding: 9496 9496 2560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74250,8 +76822,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2519
-Encoding: 9497 9497 9497
+Encoding: 9497 9497 2561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74266,8 +76839,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251A
-Encoding: 9498 9498 9498
+Encoding: 9498 9498 2562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74282,8 +76856,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251B
-Encoding: 9499 9499 9499
+Encoding: 9499 9499 2563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74298,8 +76873,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF080000
-Encoding: 9500 9500 9500
+Encoding: 9500 9500 2564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74316,8 +76892,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251D
-Encoding: 9501 9501 9501
+Encoding: 9501 9501 2565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74334,8 +76911,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251E
-Encoding: 9502 9502 9502
+Encoding: 9502 9502 2566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74354,8 +76932,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251F
-Encoding: 9503 9503 9503
+Encoding: 9503 9503 2567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74374,8 +76953,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2520
-Encoding: 9504 9504 9504
+Encoding: 9504 9504 2568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74392,8 +76972,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2521
-Encoding: 9505 9505 9505
+Encoding: 9505 9505 2569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74412,8 +76993,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2522
-Encoding: 9506 9506 9506
+Encoding: 9506 9506 2570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74432,8 +77014,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2523
-Encoding: 9507 9507 9507
+Encoding: 9507 9507 2571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74450,8 +77033,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF090000
-Encoding: 9508 9508 9508
+Encoding: 9508 9508 2572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74468,8 +77052,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2525
-Encoding: 9509 9509 9509
+Encoding: 9509 9509 2573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74486,8 +77071,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2526
-Encoding: 9510 9510 9510
+Encoding: 9510 9510 2574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74506,8 +77092,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2527
-Encoding: 9511 9511 9511
+Encoding: 9511 9511 2575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74526,8 +77113,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2528
-Encoding: 9512 9512 9512
+Encoding: 9512 9512 2576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74544,8 +77132,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2529
-Encoding: 9513 9513 9513
+Encoding: 9513 9513 2577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74564,8 +77153,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252A
-Encoding: 9514 9514 9514
+Encoding: 9514 9514 2578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74584,8 +77174,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252B
-Encoding: 9515 9515 9515
+Encoding: 9515 9515 2579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74602,8 +77193,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF060000
-Encoding: 9516 9516 9516
+Encoding: 9516 9516 2580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74620,8 +77212,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252D
-Encoding: 9517 9517 9517
+Encoding: 9517 9517 2581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74640,8 +77233,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252E
-Encoding: 9518 9518 9518
+Encoding: 9518 9518 2582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74660,8 +77254,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252F
-Encoding: 9519 9519 9519
+Encoding: 9519 9519 2583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74678,8 +77273,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2530
-Encoding: 9520 9520 9520
+Encoding: 9520 9520 2584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74696,8 +77292,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2531
-Encoding: 9521 9521 9521
+Encoding: 9521 9521 2585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74716,8 +77313,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2532
-Encoding: 9522 9522 9522
+Encoding: 9522 9522 2586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74736,8 +77334,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2533
-Encoding: 9523 9523 9523
+Encoding: 9523 9523 2587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74754,8 +77353,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF070000
-Encoding: 9524 9524 9524
+Encoding: 9524 9524 2588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74772,8 +77372,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2535
-Encoding: 9525 9525 9525
+Encoding: 9525 9525 2589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74792,8 +77393,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2536
-Encoding: 9526 9526 9526
+Encoding: 9526 9526 2590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74812,8 +77414,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2537
-Encoding: 9527 9527 9527
+Encoding: 9527 9527 2591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74830,8 +77433,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2538
-Encoding: 9528 9528 9528
+Encoding: 9528 9528 2592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74848,8 +77452,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2539
-Encoding: 9529 9529 9529
+Encoding: 9529 9529 2593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74868,8 +77473,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253A
-Encoding: 9530 9530 9530
+Encoding: 9530 9530 2594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74888,8 +77494,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253B
-Encoding: 9531 9531 9531
+Encoding: 9531 9531 2595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74906,8 +77513,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF050000
-Encoding: 9532 9532 9532
+Encoding: 9532 9532 2596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74928,8 +77536,9 @@ SplineSet
  696 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253D
-Encoding: 9533 9533 9533
+Encoding: 9533 9533 2597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74950,8 +77559,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253E
-Encoding: 9534 9534 9534
+Encoding: 9534 9534 2598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74972,8 +77582,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253F
-Encoding: 9535 9535 9535
+Encoding: 9535 9535 2599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74994,8 +77605,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2540
-Encoding: 9536 9536 9536
+Encoding: 9536 9536 2600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75016,8 +77628,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2541
-Encoding: 9537 9537 9537
+Encoding: 9537 9537 2601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75038,8 +77651,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2542
-Encoding: 9538 9538 9538
+Encoding: 9538 9538 2602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75060,8 +77674,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2543
-Encoding: 9539 9539 9539
+Encoding: 9539 9539 2603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75084,8 +77699,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2544
-Encoding: 9540 9540 9540
+Encoding: 9540 9540 2604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75108,8 +77724,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2545
-Encoding: 9541 9541 9541
+Encoding: 9541 9541 2605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75132,8 +77749,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2546
-Encoding: 9542 9542 9542
+Encoding: 9542 9542 2606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75156,8 +77774,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2547
-Encoding: 9543 9543 9543
+Encoding: 9543 9543 2607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75178,8 +77797,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2548
-Encoding: 9544 9544 9544
+Encoding: 9544 9544 2608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75200,8 +77820,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2549
-Encoding: 9545 9545 9545
+Encoding: 9545 9545 2609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75222,8 +77843,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254A
-Encoding: 9546 9546 9546
+Encoding: 9546 9546 2610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75244,8 +77866,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254B
-Encoding: 9547 9547 9547
+Encoding: 9547 9547 2611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75266,8 +77889,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254C
-Encoding: 9548 9548 9548
+Encoding: 9548 9548 2612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75285,8 +77909,9 @@ SplineSet
  677 618 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254D
-Encoding: 9549 9549 9549
+Encoding: 9549 9549 2613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75304,8 +77929,9 @@ SplineSet
  60 532 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254E
-Encoding: 9550 9550 9550
+Encoding: 9550 9550 2614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75323,8 +77949,9 @@ SplineSet
  536 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254F
-Encoding: 9551 9551 9551
+Encoding: 9551 9551 2615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75342,8 +77969,9 @@ SplineSet
  456 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF430000
-Encoding: 9552 9552 9552
+Encoding: 9552 9552 2616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75361,8 +77989,9 @@ SplineSet
  -20 446 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF240000
-Encoding: 9553 9553 9553
+Encoding: 9553 9553 2617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75380,8 +78009,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF510000
-Encoding: 9554 9554 9554
+Encoding: 9554 9554 2618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75400,8 +78030,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF520000
-Encoding: 9555 9555 9555
+Encoding: 9555 9555 2619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75420,8 +78051,9 @@ SplineSet
  376 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF390000
-Encoding: 9556 9556 9556
+Encoding: 9556 9556 2620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75443,8 +78075,9 @@ SplineSet
  696 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF220000
-Encoding: 9557 9557 9557
+Encoding: 9557 9557 2621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75463,8 +78096,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF210000
-Encoding: 9558 9558 9558
+Encoding: 9558 9558 2622
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75483,8 +78117,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF250000
-Encoding: 9559 9559 9559
+Encoding: 9559 9559 2623
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75506,8 +78141,9 @@ SplineSet
  376 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF500000
-Encoding: 9560 9560 9560
+Encoding: 9560 9560 2624
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75526,8 +78162,9 @@ SplineSet
  536 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF490000
-Encoding: 9561 9561 9561
+Encoding: 9561 9561 2625
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75546,8 +78183,9 @@ SplineSet
  376 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF380000
-Encoding: 9562 9562 9562
+Encoding: 9562 9562 2626
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75569,8 +78207,9 @@ SplineSet
  376 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF280000
-Encoding: 9563 9563 9563
+Encoding: 9563 9563 2627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75589,8 +78228,9 @@ SplineSet
  -20 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF270000
-Encoding: 9564 9564 9564
+Encoding: 9564 9564 2628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75609,8 +78249,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF260000
-Encoding: 9565 9565 9565
+Encoding: 9565 9565 2629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75632,8 +78273,9 @@ SplineSet
  -20 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF360000
-Encoding: 9566 9566 9566
+Encoding: 9566 9566 2630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75654,8 +78296,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF370000
-Encoding: 9567 9567 9567
+Encoding: 9567 9567 2631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75677,8 +78320,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF420000
-Encoding: 9568 9568 9568
+Encoding: 9568 9568 2632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75705,8 +78349,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF190000
-Encoding: 9569 9569 9569
+Encoding: 9569 9569 2633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75727,8 +78372,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF200000
-Encoding: 9570 9570 9570
+Encoding: 9570 9570 2634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75750,8 +78396,9 @@ SplineSet
  696 -512 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF230000
-Encoding: 9571 9571 9571
+Encoding: 9571 9571 2635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75778,8 +78425,9 @@ SplineSet
  696 -512 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF470000
-Encoding: 9572 9572 9572
+Encoding: 9572 9572 2636
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75801,8 +78449,9 @@ SplineSet
  -20 790 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF480000
-Encoding: 9573 9573 9573
+Encoding: 9573 9573 2637
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75823,8 +78472,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF410000
-Encoding: 9574 9574 9574
+Encoding: 9574 9574 2638
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75851,8 +78501,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF450000
-Encoding: 9575 9575 9575
+Encoding: 9575 9575 2639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75874,8 +78525,9 @@ SplineSet
  -20 790 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF460000
-Encoding: 9576 9576 9576
+Encoding: 9576 9576 2640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75896,8 +78548,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF400000
-Encoding: 9577 9577 9577
+Encoding: 9577 9577 2641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75924,8 +78577,9 @@ SplineSet
  696 790 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF540000
-Encoding: 9578 9578 9578
+Encoding: 9578 9578 2642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75954,8 +78608,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF530000
-Encoding: 9579 9579 9579
+Encoding: 9579 9579 2643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75984,8 +78639,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF440000
-Encoding: 9580 9580 9580
+Encoding: 9580 9580 2644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76021,8 +78677,9 @@ SplineSet
  696 790 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256D
-Encoding: 9581 9581 9581
+Encoding: 9581 9581 2645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76041,8 +78698,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256E
-Encoding: 9582 9582 9582
+Encoding: 9582 9582 2646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76061,8 +78719,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256F
-Encoding: 9583 9583 9583
+Encoding: 9583 9583 2647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76081,8 +78740,9 @@ SplineSet
  -20 618 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2570
-Encoding: 9584 9584 9584
+Encoding: 9584 9584 2648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76101,8 +78761,9 @@ SplineSet
  1253 618 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2571
-Encoding: 9585 9585 9585
+Encoding: 9585 9585 2649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76115,8 +78776,9 @@ SplineSet
  -89 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2572
-Encoding: 9586 9586 9586
+Encoding: 9586 9586 2650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76129,8 +78791,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2573
-Encoding: 9587 9587 9587
+Encoding: 9587 9587 2651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76151,8 +78814,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2574
-Encoding: 9588 9588 9588
+Encoding: 9588 9588 2652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76165,8 +78829,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2575
-Encoding: 9589 9589 9589
+Encoding: 9589 9589 2653
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76179,8 +78844,9 @@ SplineSet
  536 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2576
-Encoding: 9590 9590 9590
+Encoding: 9590 9590 2654
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76193,8 +78859,9 @@ SplineSet
  616 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2577
-Encoding: 9591 9591 9591
+Encoding: 9591 9591 2655
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76207,8 +78874,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2578
-Encoding: 9592 9592 9592
+Encoding: 9592 9592 2656
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76221,8 +78889,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2579
-Encoding: 9593 9593 9593
+Encoding: 9593 9593 2657
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76235,8 +78904,9 @@ SplineSet
  456 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257A
-Encoding: 9594 9594 9594
+Encoding: 9594 9594 2658
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76249,8 +78919,9 @@ SplineSet
  616 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257B
-Encoding: 9595 9595 9595
+Encoding: 9595 9595 2659
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76263,8 +78934,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257C
-Encoding: 9596 9596 9596
+Encoding: 9596 9596 2660
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76281,8 +78953,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257D
-Encoding: 9597 9597 9597
+Encoding: 9597 9597 2661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76299,8 +78972,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257E
-Encoding: 9598 9598 9598
+Encoding: 9598 9598 2662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76317,8 +78991,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257F
-Encoding: 9599 9599 9599
+Encoding: 9599 9599 2663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76335,16 +79010,18 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: upblock
-Encoding: 9600 9600 9600
+Encoding: 9600 9600 2664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9604 9604 N 1 0 0 1 0 1216 2
+Refer: 2668 9604 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2581
-Encoding: 9601 9601 9601
+Encoding: 9601 9601 2665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76357,8 +79034,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2582
-Encoding: 9602 9602 9602
+Encoding: 9602 9602 2666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76371,8 +79049,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2583
-Encoding: 9603 9603 9603
+Encoding: 9603 9603 2667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76385,8 +79064,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dnblock
-Encoding: 9604 9604 9604
+Encoding: 9604 9604 2668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76399,8 +79079,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2585
-Encoding: 9605 9605 9605
+Encoding: 9605 9605 2669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76413,8 +79094,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2586
-Encoding: 9606 9606 9606
+Encoding: 9606 9606 2670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76427,8 +79109,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2587
-Encoding: 9607 9607 9607
+Encoding: 9607 9607 2671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76441,8 +79124,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: block
-Encoding: 9608 9608 9608
+Encoding: 9608 9608 2672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76455,8 +79139,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2589
-Encoding: 9609 9609 9609
+Encoding: 9609 9609 2673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76469,8 +79154,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258A
-Encoding: 9610 9610 9610
+Encoding: 9610 9610 2674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76483,8 +79169,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258B
-Encoding: 9611 9611 9611
+Encoding: 9611 9611 2675
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76497,8 +79184,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lfblock
-Encoding: 9612 9612 9612
+Encoding: 9612 9612 2676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76511,8 +79199,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258D
-Encoding: 9613 9613 9613
+Encoding: 9613 9613 2677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76525,8 +79214,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258E
-Encoding: 9614 9614 9614
+Encoding: 9614 9614 2678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76539,8 +79229,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258F
-Encoding: 9615 9615 9615
+Encoding: 9615 9615 2679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76553,16 +79244,18 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rtblock
-Encoding: 9616 9616 9616
+Encoding: 9616 9616 2680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9612 9612 N 1 0 0 1 637 0 2
+Refer: 2676 9612 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: ltshade
-Encoding: 9617 9617 9617
+Encoding: 9617 9617 2681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76650,8 +79343,9 @@ SplineSet
  0 1059 l 25,60,-1
 EndSplineSet
 EndChar
+
 StartChar: shade
-Encoding: 9618 9618 9618
+Encoding: 9618 9618 2682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76809,8 +79503,9 @@ SplineSet
  0 1661 l 1,116,-1
 EndSplineSet
 EndChar
+
 StartChar: dkshade
-Encoding: 9619 9619 9619
+Encoding: 9619 9619 2683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76894,24 +79589,27 @@ SplineSet
  770 1901 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2594
-Encoding: 9620 9620 9620
+Encoding: 9620 9620 2684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9601 9601 N 1 0 0 1 0 2114 2
+Refer: 2665 9601 N 1 0 0 1 0 2114 2
 EndChar
+
 StartChar: uni2595
-Encoding: 9621 9621 9621
+Encoding: 9621 9621 2685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9615 9615 N 1 0 0 1 1114 0 2
+Refer: 2679 9615 N 1 0 0 1 1114 0 2
 EndChar
+
 StartChar: uni2596
-Encoding: 9622 9622 9622
+Encoding: 9622 9622 2686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76924,24 +79622,27 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2597
-Encoding: 9623 9623 9623
+Encoding: 9623 9623 2687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 0 2
+Refer: 2686 9622 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: uni2598
-Encoding: 9624 9624 9624
+Encoding: 9624 9624 2688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 1216 2
+Refer: 2686 9622 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2599
-Encoding: 9625 9625 9625
+Encoding: 9625 9625 2689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76956,17 +79657,19 @@ SplineSet
  -20 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259A
-Encoding: 9626 9626 9626
+Encoding: 9626 9626 2690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9623 9623 N 1 0 0 1 0 0 2
-Refer: 9624 9624 N 1 0 0 1 0 0 2
+Refer: 2687 9623 N 1 0 0 1 0 0 2
+Refer: 2688 9624 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259B
-Encoding: 9627 9627 9627
+Encoding: 9627 9627 2691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76981,8 +79684,9 @@ SplineSet
  -20 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259C
-Encoding: 9628 9628 9628
+Encoding: 9628 9628 2692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76997,25 +79701,28 @@ SplineSet
  1254 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259D
-Encoding: 9629 9629 9629
+Encoding: 9629 9629 2693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 1216 2
+Refer: 2686 9622 N 1 0 0 1 637 1216 2
 EndChar
+
 StartChar: uni259E
-Encoding: 9630 9630 9630
+Encoding: 9630 9630 2694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9629 9629 N 1 0 0 1 0 0 2
-Refer: 9622 9622 N 1 0 0 1 0 0 2
+Refer: 2693 9629 N 1 0 0 1 0 0 2
+Refer: 2686 9622 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259F
-Encoding: 9631 9631 9631
+Encoding: 9631 9631 2695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77030,8 +79737,9 @@ SplineSet
  1254 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: filledbox
-Encoding: 9632 9632 9632
+Encoding: 9632 9632 2696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77044,8 +79752,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H22073
-Encoding: 9633 9633 9633
+Encoding: 9633 9633 2697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77063,8 +79772,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A2
-Encoding: 9634 9634 9634
+Encoding: 9634 9634 2698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77090,17 +79800,19 @@ SplineSet
  6 -78.5 6 -78.5 6 263.5 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A3
-Encoding: 9635 9635 9635
+Encoding: 9635 9635 2699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9642 9642 N 1 0 0 1 0 0 2
-Refer: 9633 9633 N 1 0 0 1 0 0 2
+Refer: 2706 9642 N 1 0 0 1 0 0 2
+Refer: 2697 9633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni25A4
-Encoding: 9636 9636 9636
+Encoding: 9636 9636 2700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77138,8 +79850,9 @@ SplineSet
  120 922 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A5
-Encoding: 9637 9637 9637
+Encoding: 9637 9637 2701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77177,8 +79890,9 @@ SplineSet
  120 36 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A6
-Encoding: 9638 9638 9638
+Encoding: 9638 9638 2702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77316,8 +80030,9 @@ SplineSet
  6 -78.5 l 1,100,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A7
-Encoding: 9639 9639 9639
+Encoding: 9639 9639 2703
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77365,8 +80080,9 @@ SplineSet
  120 182 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A8
-Encoding: 9640 9640 9640
+Encoding: 9640 9640 2704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77414,8 +80130,9 @@ SplineSet
  967 36 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A9
-Encoding: 9641 9641 9641
+Encoding: 9641 9641 2705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77565,8 +80282,9 @@ SplineSet
  6 -78.5 l 1,112,-1
 EndSplineSet
 EndChar
+
 StartChar: H18543
-Encoding: 9642 9642 9642
+Encoding: 9642 9642 2706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77579,8 +80297,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H18551
-Encoding: 9643 9643 9643
+Encoding: 9643 9643 2707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77598,8 +80317,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: filledrect
-Encoding: 9644 9644 9644
+Encoding: 9644 9644 2708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77612,8 +80332,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AD
-Encoding: 9645 9645 9645
+Encoding: 9645 9645 2709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77631,8 +80352,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AE
-Encoding: 9646 9646 9646
+Encoding: 9646 9646 2710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77645,8 +80367,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AF
-Encoding: 9647 9647 9647
+Encoding: 9647 9647 2711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77664,8 +80387,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B0
-Encoding: 9648 9648 9648
+Encoding: 9648 9648 2712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77678,8 +80402,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B1
-Encoding: 9649 9649 9649
+Encoding: 9649 9649 2713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77697,8 +80422,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagup
-Encoding: 9650 9650 9650
+Encoding: 9650 9650 2714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77710,8 +80436,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B3
-Encoding: 9651 9651 9651
+Encoding: 9651 9651 2715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77727,8 +80454,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B4
-Encoding: 9652 9652 9652
+Encoding: 9652 9652 2716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77740,8 +80468,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B5
-Encoding: 9653 9653 9653
+Encoding: 9653 9653 2717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77757,8 +80486,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B6
-Encoding: 9654 9654 9654
+Encoding: 9654 9654 2718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77770,8 +80500,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B7
-Encoding: 9655 9655 9655
+Encoding: 9655 9655 2719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77787,8 +80518,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B8
-Encoding: 9656 9656 9656
+Encoding: 9656 9656 2720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77800,8 +80532,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B9
-Encoding: 9657 9657 9657
+Encoding: 9657 9657 2721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77817,8 +80550,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagrt
-Encoding: 9658 9658 9658
+Encoding: 9658 9658 2722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77830,8 +80564,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BB
-Encoding: 9659 9659 9659
+Encoding: 9659 9659 2723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77847,8 +80582,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagdn
-Encoding: 9660 9660 9660
+Encoding: 9660 9660 2724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77860,8 +80596,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BD
-Encoding: 9661 9661 9661
+Encoding: 9661 9661 2725
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77877,8 +80614,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BE
-Encoding: 9662 9662 9662
+Encoding: 9662 9662 2726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77890,8 +80628,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BF
-Encoding: 9663 9663 9663
+Encoding: 9663 9663 2727
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77907,8 +80646,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C0
-Encoding: 9664 9664 9664
+Encoding: 9664 9664 2728
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77920,8 +80660,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C1
-Encoding: 9665 9665 9665
+Encoding: 9665 9665 2729
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77937,8 +80678,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C2
-Encoding: 9666 9666 9666
+Encoding: 9666 9666 2730
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77950,8 +80692,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C3
-Encoding: 9667 9667 9667
+Encoding: 9667 9667 2731
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77967,8 +80710,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triaglf
-Encoding: 9668 9668 9668
+Encoding: 9668 9668 2732
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77980,8 +80724,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C5
-Encoding: 9669 9669 9669
+Encoding: 9669 9669 2733
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77997,8 +80742,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C6
-Encoding: 9670 9670 9670
+Encoding: 9670 9670 2734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78011,8 +80757,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C7
-Encoding: 9671 9671 9671
+Encoding: 9671 9671 2735
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78030,8 +80777,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C8
-Encoding: 9672 9672 9672
+Encoding: 9672 9672 2736
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78054,8 +80802,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C9
-Encoding: 9673 9673 9673
+Encoding: 9673 9673 2737
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78090,8 +80839,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: lozenge
-Encoding: 9674 9674 9674
+Encoding: 9674 9674 2738
 Width: 1233
 Flags: W
 TtInstrs:
@@ -78145,8 +80895,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: circle
-Encoding: 9675 9675 9675
+Encoding: 9675 9675 2739
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78172,8 +80923,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25CC
-Encoding: 9676 9676 9676
+Encoding: 9676 9676 2740
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78237,8 +80989,9 @@ SplineSet
  141 652 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25CD
-Encoding: 9677 9677 9677
+Encoding: 9677 9677 2741
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78284,8 +81037,9 @@ SplineSet
  1105 714 1105 714 1002 838 c 1,51,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25CE
-Encoding: 9678 9678 9678
+Encoding: 9678 9678 2742
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78329,8 +81083,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: H18533
-Encoding: 9679 9679 9679
+Encoding: 9679 9679 2743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78347,8 +81102,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D0
-Encoding: 9680 9680 9680
+Encoding: 9680 9680 2744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78371,8 +81127,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D1
-Encoding: 9681 9681 9681
+Encoding: 9681 9681 2745
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78395,8 +81152,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D2
-Encoding: 9682 9682 9682
+Encoding: 9682 9682 2746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78419,8 +81177,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D3
-Encoding: 9683 9683 9683
+Encoding: 9683 9683 2747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78443,8 +81202,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D4
-Encoding: 9684 9684 9684
+Encoding: 9684 9684 2748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78470,8 +81230,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D5
-Encoding: 9685 9685 9685
+Encoding: 9685 9685 2749
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78493,8 +81254,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D6
-Encoding: 9686 9686 9686
+Encoding: 9686 9686 2750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78508,8 +81270,9 @@ SplineSet
  921.5 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25D7
-Encoding: 9687 9687 9687
+Encoding: 9687 9687 2751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78523,8 +81286,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: invbullet
-Encoding: 9688 9688 9688
+Encoding: 9688 9688 2752
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78546,8 +81310,9 @@ SplineSet
  -20 -20 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: invcircle
-Encoding: 9689 9689 9689
+Encoding: 9689 9689 2753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78578,8 +81343,9 @@ SplineSet
  -20 -512 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DA
-Encoding: 9690 9690 9690
+Encoding: 9690 9690 2754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78603,8 +81369,9 @@ SplineSet
  1104.9 813.293 1104.9 813.293 1104.9 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DB
-Encoding: 9691 9691 9691
+Encoding: 9691 9691 2755
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78628,8 +81395,9 @@ SplineSet
  128.1 250.631 128.1 250.631 128.1 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DC
-Encoding: 9692 9692 9692
+Encoding: 9692 9692 2756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78644,8 +81412,9 @@ SplineSet
  311.45 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25DD
-Encoding: 9693 9693 9693
+Encoding: 9693 9693 2757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78660,8 +81429,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DE
-Encoding: 9694 9694 9694
+Encoding: 9694 9694 2758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78676,8 +81446,9 @@ SplineSet
  462.5 -84 462.5 -84 311.5 -84 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DF
-Encoding: 9695 9695 9695
+Encoding: 9695 9695 2759
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78692,8 +81463,9 @@ SplineSet
  921.45 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E0
-Encoding: 9696 9696 9696
+Encoding: 9696 9696 2760
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78712,8 +81484,9 @@ SplineSet
  6 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E1
-Encoding: 9697 9697 9697
+Encoding: 9697 9697 2761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78732,8 +81505,9 @@ SplineSet
  6 180 6 180 6 532 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E2
-Encoding: 9698 9698 9698
+Encoding: 9698 9698 2762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78745,8 +81519,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E3
-Encoding: 9699 9699 9699
+Encoding: 9699 9699 2763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78758,8 +81533,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E4
-Encoding: 9700 9700 9700
+Encoding: 9700 9700 2764
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78771,8 +81547,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E5
-Encoding: 9701 9701 9701
+Encoding: 9701 9701 2765
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78784,8 +81561,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: openbullet
-Encoding: 9702 9702 9702
+Encoding: 9702 9702 2766
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78811,8 +81589,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E7
-Encoding: 9703 9703 9703
+Encoding: 9703 9703 2767
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78830,8 +81609,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E8
-Encoding: 9704 9704 9704
+Encoding: 9704 9704 2768
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78849,8 +81629,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E9
-Encoding: 9705 9705 9705
+Encoding: 9705 9705 2769
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78867,8 +81648,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EA
-Encoding: 9706 9706 9706
+Encoding: 9706 9706 2770
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78885,8 +81667,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EB
-Encoding: 9707 9707 9707
+Encoding: 9707 9707 2771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78909,8 +81692,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EC
-Encoding: 9708 9708 9708
+Encoding: 9708 9708 2772
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78935,8 +81719,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25ED
-Encoding: 9709 9709 9709
+Encoding: 9709 9709 2773
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78952,8 +81737,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EE
-Encoding: 9710 9710 9710
+Encoding: 9710 9710 2774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78969,8 +81755,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EF
-Encoding: 9711 9711 9711
+Encoding: 9711 9711 2775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78996,8 +81783,9 @@ SplineSet
  -20 165 -20 165 -20 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25F0
-Encoding: 9712 9712 9712
+Encoding: 9712 9712 2776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79022,8 +81810,9 @@ SplineSet
  120 35.5 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F1
-Encoding: 9713 9713 9713
+Encoding: 9713 9713 2777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79048,8 +81837,9 @@ SplineSet
  120 588.5 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F2
-Encoding: 9714 9714 9714
+Encoding: 9714 9714 2778
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79074,8 +81864,9 @@ SplineSet
  120 35.5 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F3
-Encoding: 9715 9715 9715
+Encoding: 9715 9715 2779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79100,8 +81891,9 @@ SplineSet
  120 35.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F4
-Encoding: 9716 9716 9716
+Encoding: 9716 9716 2780
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79132,8 +81924,9 @@ SplineSet
  130.784 474.5 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni25F5
-Encoding: 9717 9717 9717
+Encoding: 9717 9717 2781
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79164,8 +81957,9 @@ SplineSet
  130.784 474.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F6
-Encoding: 9718 9718 9718
+Encoding: 9718 9718 2782
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79196,8 +81990,9 @@ SplineSet
  673 43.0479 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F7
-Encoding: 9719 9719 9719
+Encoding: 9719 9719 2783
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79228,8 +82023,9 @@ SplineSet
  1102.3 588.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F8
-Encoding: 9720 9720 9720
+Encoding: 9720 9720 2784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79245,8 +82041,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25F9
-Encoding: 9721 9721 9721
+Encoding: 9721 9721 2785
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79262,8 +82059,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FA
-Encoding: 9722 9722 9722
+Encoding: 9722 9722 2786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79279,8 +82077,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FB
-Encoding: 9723 9723 9723
+Encoding: 9723 9723 2787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79298,8 +82097,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FC
-Encoding: 9724 9724 9724
+Encoding: 9724 9724 2788
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79312,8 +82112,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FD
-Encoding: 9725 9725 9725
+Encoding: 9725 9725 2789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79331,8 +82132,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FE
-Encoding: 9726 9726 9726
+Encoding: 9726 9726 2790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79345,8 +82147,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FF
-Encoding: 9727 9727 9727
+Encoding: 9727 9727 2791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79362,8 +82165,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2600
-Encoding: 9728 9728 9728
+Encoding: 9728 9728 2792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79445,8 +82249,9 @@ SplineSet
  590 446 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2601
-Encoding: 9729 9729 9729
+Encoding: 9729 9729 2793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79478,8 +82283,9 @@ SplineSet
  685.098 465 685.098 465 767.539 465 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2602
-Encoding: 9730 9730 9730
+Encoding: 9730 9730 2794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79535,8 +82341,9 @@ SplineSet
  608.679 1068.13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2603
-Encoding: 9731 9731 9731
+Encoding: 9731 9731 2795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79791,8 +82598,9 @@ SplineSet
  106.419 947 106.419 947 110 944 c 2,822,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2604
-Encoding: 9732 9732 9732
+Encoding: 9732 9732 2796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79966,8 +82774,9 @@ SplineSet
  1158.24 928.015 1158.24 928.015 1166.45 928.015 c 0,238,239
 EndSplineSet
 EndChar
+
 StartChar: uni2605
-Encoding: 9733 9733 9733
+Encoding: 9733 9733 2797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79986,8 +82795,9 @@ SplineSet
  58.4141 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2606
-Encoding: 9734 9734 9734
+Encoding: 9734 9734 2798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80017,8 +82827,9 @@ SplineSet
  450.852 439.516 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2607
-Encoding: 9735 9735 9735
+Encoding: 9735 9735 2799
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80040,8 +82851,9 @@ SplineSet
  935 1494 935 1494 974 1494 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2608
-Encoding: 9736 9736 9736
+Encoding: 9736 9736 2800
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80069,8 +82881,9 @@ SplineSet
  59.1592 1497 59.1592 1497 121.972 1497 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2609
-Encoding: 9737 9737 9737
+Encoding: 9737 9737 2801
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80111,8 +82924,9 @@ SplineSet
  759.672 617.719 759.672 617.719 759.672 580.203 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni260A
-Encoding: 9738 9738 9738
+Encoding: 9738 9738 2802
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80167,8 +82981,9 @@ SplineSet
  1199.91 630 1199.91 630 1111.86 507.5 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260B
-Encoding: 9739 9739 9739
+Encoding: 9739 9739 2803
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80223,8 +83038,9 @@ SplineSet
  1196.93 720.938 1196.93 720.938 1196.93 556.875 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260C
-Encoding: 9740 9740 9740
+Encoding: 9740 9740 2804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80254,8 +83070,9 @@ SplineSet
  909 926 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni260D
-Encoding: 9741 9741 9741
+Encoding: 9741 9741 2805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80302,8 +83119,9 @@ SplineSet
  571.188 625 l 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260E
-Encoding: 9742 9742 9742
+Encoding: 9742 9742 2806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80449,8 +83267,9 @@ SplineSet
  684.987 660.66 684.987 660.66 691.811 676.24 c 0,174,175
 EndSplineSet
 EndChar
+
 StartChar: uni260F
-Encoding: 9743 9743 9743
+Encoding: 9743 9743 2807
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80629,8 +83448,9 @@ SplineSet
  942.763 1038.94 l 1,207,208
 EndSplineSet
 EndChar
+
 StartChar: uni2610
-Encoding: 9744 9744 9744
+Encoding: 9744 9744 2808
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80652,8 +83472,9 @@ SplineSet
  187.157 955 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2611
-Encoding: 9745 9745 9745
+Encoding: 9745 9745 2809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80690,8 +83511,9 @@ SplineSet
  867.865 841.719 867.865 841.719 959.974 859.297 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2612
-Encoding: 9746 9746 9746
+Encoding: 9746 9746 2810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80729,8 +83551,9 @@ SplineSet
  347.768 825 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2613
-Encoding: 9747 9747 9747
+Encoding: 9747 9747 2811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80757,8 +83580,9 @@ SplineSet
  294.031 1347.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2614
-Encoding: 9748 9748 9748
+Encoding: 9748 9748 2812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80863,8 +83687,9 @@ SplineSet
  593.062 925.823 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2615
-Encoding: 9749 9749 9749
+Encoding: 9749 9749 2813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80966,8 +83791,9 @@ SplineSet
  737.088 1005 737.088 1005 735.682 940.312 c 0,120,121
 EndSplineSet
 EndChar
+
 StartChar: uni2616
-Encoding: 9750 9750 9750
+Encoding: 9750 9750 2814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80990,8 +83816,9 @@ SplineSet
  197.625 1044 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2617
-Encoding: 9751 9751 9751
+Encoding: 9751 9751 2815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81009,8 +83836,9 @@ SplineSet
  619.926 1490 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2618
-Encoding: 9752 9752 9752
+Encoding: 9752 9752 2816
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81059,8 +83887,9 @@ SplineSet
  593.65 637.562 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2619
-Encoding: 9753 9753 9753
+Encoding: 9753 9753 2817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81106,8 +83935,9 @@ SplineSet
  1050.67 821.25 1050.67 821.25 901.382 852.125 c 1,58,59
 EndSplineSet
 EndChar
+
 StartChar: uni261A
-Encoding: 9754 9754 9754
+Encoding: 9754 9754 2818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81153,8 +83983,9 @@ SplineSet
  1127.99 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261B
-Encoding: 9755 9755 9755
+Encoding: 9755 9755 2819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81200,8 +84031,9 @@ SplineSet
  105.004 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261C
-Encoding: 9756 9756 9756
+Encoding: 9756 9756 2820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81259,8 +84091,9 @@ SplineSet
  559.22 282.062 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261D
-Encoding: 9757 9757 9757
+Encoding: 9757 9757 2821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81319,8 +84152,9 @@ SplineSet
  141 812 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261E
-Encoding: 9758 9758 9758
+Encoding: 9758 9758 2822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81378,8 +84212,9 @@ SplineSet
  749.345 282.875 749.345 282.875 673.783 282.062 c 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261F
-Encoding: 9759 9759 9759
+Encoding: 9759 9759 2823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81437,8 +84272,9 @@ SplineSet
  140 1399 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2620
-Encoding: 9760 9760 9760
+Encoding: 9760 9760 2824
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81698,8 +84534,9 @@ SplineSet
  726.951 305.125 l 1,306,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2621
-Encoding: 9761 9761 9761
+Encoding: 9761 9761 2825
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81733,8 +84570,9 @@ SplineSet
  755.843 1491 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2622
-Encoding: 9762 9762 9762
+Encoding: 9762 9762 2826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81800,8 +84638,9 @@ SplineSet
  577.5 740.562 577.5 740.562 614.062 740.562 c 0,71,72
 EndSplineSet
 EndChar
+
 StartChar: uni2623
-Encoding: 9763 9763 9763
+Encoding: 9763 9763 2827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81879,8 +84718,9 @@ SplineSet
  76.8975 426.156 76.8975 426.156 37.7959 289.656 c 1,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2624
-Encoding: 9764 9764 9764
+Encoding: 9764 9764 2828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82066,8 +84906,9 @@ SplineSet
  714.02 1077.92 714.02 1077.92 652.38 1012.6 c 1,210,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2625
-Encoding: 9765 9765 9765
+Encoding: 9765 9765 2829
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82100,8 +84941,9 @@ SplineSet
  553.497 966 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2626
-Encoding: 9766 9766 9766
+Encoding: 9766 9766 2830
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82157,8 +84999,9 @@ SplineSet
  573.5 579 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2627
-Encoding: 9767 9767 9767
+Encoding: 9767 9767 2831
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82198,8 +85041,9 @@ SplineSet
  485.709 567.6 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2628
-Encoding: 9768 9768 9768
+Encoding: 9768 9768 2832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82240,8 +85084,9 @@ SplineSet
  524.061 1485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2629
-Encoding: 9769 9769 9769
+Encoding: 9769 9769 2833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82294,8 +85139,9 @@ SplineSet
  452.25 1123.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262A
-Encoding: 9770 9770 9770
+Encoding: 9770 9770 2834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82337,8 +85183,9 @@ SplineSet
  980.764 913.609 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262B
-Encoding: 9771 9771 9771
+Encoding: 9771 9771 2835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82424,8 +85271,9 @@ SplineSet
  868.784 1079.81 l 1,99,100
 EndSplineSet
 EndChar
+
 StartChar: uni262C
-Encoding: 9772 9772 9772
+Encoding: 9772 9772 2836
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82497,8 +85345,9 @@ SplineSet
  863.52 1046.96 863.52 1046.96 702.52 1113.2 c 1,96,97
 EndSplineSet
 EndChar
+
 StartChar: uni262D
-Encoding: 9773 9773 9773
+Encoding: 9773 9773 2837
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82540,8 +85389,9 @@ SplineSet
  507.019 1313.12 507.019 1313.12 682.509 1313.12 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni262E
-Encoding: 9774 9774 9774
+Encoding: 9774 9774 2838
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82578,8 +85428,9 @@ SplineSet
  998.438 312.013 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni262F
-Encoding: 9775 9775 9775
+Encoding: 9775 9775 2839
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82628,8 +85479,9 @@ SplineSet
  1218.64 856.245 1218.64 856.245 1218.64 605.891 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni2638
-Encoding: 9784 9784 9784
+Encoding: 9784 9784 2840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82719,8 +85571,9 @@ SplineSet
  563 548 l 1,106,107
 EndSplineSet
 EndChar
+
 StartChar: uni2639
-Encoding: 9785 9785 9785
+Encoding: 9785 9785 2841
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82763,8 +85616,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: smileface
-Encoding: 9786 9786 9786
+Encoding: 9786 9786 2842
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82807,8 +85661,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: invsmileface
-Encoding: 9787 9787 9787
+Encoding: 9787 9787 2843
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82842,8 +85697,9 @@ SplineSet
  496 860 496 860 501 970 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: sun
-Encoding: 9788 9788 9788
+Encoding: 9788 9788 2844
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82934,8 +85790,9 @@ SplineSet
  592 924 592 924 556 910 c 0,74,75
 EndSplineSet
 EndChar
+
 StartChar: uni263D
-Encoding: 9789 9789 9789
+Encoding: 9789 9789 2845
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82972,8 +85829,9 @@ SplineSet
  342.844 1416.19 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263E
-Encoding: 9790 9790 9790
+Encoding: 9790 9790 2846
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83010,8 +85868,9 @@ SplineSet
  894.5 69 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263F
-Encoding: 9791 9791 9791
+Encoding: 9791 9791 2847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83064,8 +85923,9 @@ SplineSet
  744 1012 744 1012 635 1018 c 2,50,-1
 EndSplineSet
 EndChar
+
 StartChar: female
-Encoding: 9792 9792 9792
+Encoding: 9792 9792 2848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83102,8 +85962,9 @@ SplineSet
  397 443 397 443 284 548 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2641
-Encoding: 9793 9793 9793
+Encoding: 9793 9793 2849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83140,8 +86001,9 @@ SplineSet
  397 798 397 798 550 811 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: male
-Encoding: 9794 9794 9794
+Encoding: 9794 9794 2850
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83177,8 +86039,9 @@ SplineSet
  910 411 910 411 781 282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2643
-Encoding: 9795 9795 9795
+Encoding: 9795 9795 2851
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83210,8 +86073,9 @@ SplineSet
  488 543 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2644
-Encoding: 9796 9796 9796
+Encoding: 9796 9796 2852
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83246,8 +86110,9 @@ SplineSet
  274 1141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2645
-Encoding: 9797 9797 9797
+Encoding: 9797 9797 2853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83300,8 +86165,9 @@ SplineSet
  679 553 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2646
-Encoding: 9798 9798 9798
+Encoding: 9798 9798 2854
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83363,8 +86229,9 @@ SplineSet
  679 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2647
-Encoding: 9799 9799 9799
+Encoding: 9799 9799 2855
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83396,8 +86263,9 @@ SplineSet
  352 1322 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2648
-Encoding: 9800 9800 9800
+Encoding: 9800 9800 2856
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83427,8 +86295,9 @@ SplineSet
  570.919 1.8125 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2649
-Encoding: 9801 9801 9801
+Encoding: 9801 9801 2857
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83470,8 +86339,9 @@ SplineSet
  516.966 824.688 516.966 824.688 615.731 820.586 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264A
-Encoding: 9802 9802 9802
+Encoding: 9802 9802 2858
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83499,8 +86369,9 @@ SplineSet
  425.56 202.312 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni264B
-Encoding: 9803 9803 9803
+Encoding: 9803 9803 2859
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83554,8 +86425,9 @@ SplineSet
  399.116 1293.75 399.116 1293.75 499.193 1294.69 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni264C
-Encoding: 9804 9804 9804
+Encoding: 9804 9804 2860
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83604,8 +86476,9 @@ SplineSet
  400.728 931.328 400.728 931.328 400.728 994.609 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264D
-Encoding: 9805 9805 9805
+Encoding: 9805 9805 2861
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83659,8 +86532,9 @@ SplineSet
  921.845 596.469 921.845 596.469 899.305 478.562 c 2,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264E
-Encoding: 9806 9806 9806
+Encoding: 9806 9806 2862
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83697,8 +86571,9 @@ SplineSet
  481.424 530.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264F
-Encoding: 9807 9807 9807
+Encoding: 9807 9807 2863
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83747,8 +86622,9 @@ SplineSet
  857.441 226.344 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2650
-Encoding: 9808 9808 9808
+Encoding: 9808 9808 2864
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83777,8 +86653,9 @@ SplineSet
  981.282 1098.94 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2651
-Encoding: 9809 9809 9809
+Encoding: 9809 9809 2865
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83819,8 +86696,9 @@ SplineSet
  858.493 608.398 858.493 608.398 796.969 421.367 c 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni2652
-Encoding: 9810 9810 9810
+Encoding: 9810 9810 2866
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83868,8 +86746,9 @@ SplineSet
  89.3398 726.484 l 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni2653
-Encoding: 9811 9811 9811
+Encoding: 9811 9811 2867
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83899,8 +86778,9 @@ SplineSet
  721.938 587.625 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2654
-Encoding: 9812 9812 9812
+Encoding: 9812 9812 2868
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83987,8 +86867,9 @@ SplineSet
  545.296 903.977 545.296 903.977 545.296 885.602 c 0,86,87
 EndSplineSet
 EndChar
+
 StartChar: uni2655
-Encoding: 9813 9813 9813
+Encoding: 9813 9813 2869
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84146,8 +87027,9 @@ SplineSet
  840.062 398.125 l 1,170,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2656
-Encoding: 9814 9814 9814
+Encoding: 9814 9814 2870
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84211,8 +87093,9 @@ SplineSet
  896.94 402.5 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2657
-Encoding: 9815 9815 9815
+Encoding: 9815 9815 2871
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84292,8 +87175,9 @@ SplineSet
  525.446 1115.9 525.446 1115.9 525.446 1092.11 c 0,83,84
 EndSplineSet
 EndChar
+
 StartChar: uni2658
-Encoding: 9816 9816 9816
+Encoding: 9816 9816 2872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84360,8 +87244,9 @@ SplineSet
  419.874 1010.81 l 1,52,53
 EndSplineSet
 EndChar
+
 StartChar: uni2659
-Encoding: 9817 9817 9817
+Encoding: 9817 9817 2873
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84437,8 +87322,9 @@ SplineSet
  998.625 105 l 1,85,86
 EndSplineSet
 EndChar
+
 StartChar: uni265A
-Encoding: 9818 9818 9818
+Encoding: 9818 9818 2874
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84554,8 +87440,9 @@ SplineSet
  702.521 662.305 l 2,123,124
 EndSplineSet
 EndChar
+
 StartChar: uni265B
-Encoding: 9819 9819 9819
+Encoding: 9819 9819 2875
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84627,8 +87514,9 @@ SplineSet
  911.438 51.75 l 1,77,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265C
-Encoding: 9820 9820 9820
+Encoding: 9820 9820 2876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84682,8 +87570,9 @@ SplineSet
  1040.22 50.5 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265D
-Encoding: 9821 9821 9821
+Encoding: 9821 9821 2877
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84736,8 +87625,9 @@ SplineSet
  664.439 606.5 l 1,53,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265E
-Encoding: 9822 9822 9822
+Encoding: 9822 9822 2878
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84789,8 +87679,9 @@ SplineSet
  1026.88 792 1026.88 792 620 1030 c 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265F
-Encoding: 9823 9823 9823
+Encoding: 9823 9823 2879
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84828,8 +87719,9 @@ SplineSet
  126.971 5.9375 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: spade
-Encoding: 9824 9824 9824
+Encoding: 9824 9824 2880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84862,8 +87754,9 @@ SplineSet
  619 1359 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2661
-Encoding: 9825 9825 9825
+Encoding: 9825 9825 2881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84903,8 +87796,9 @@ SplineSet
  56 1112 56 1112 56 1053 c 2,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2662
-Encoding: 9826 9826 9826
+Encoding: 9826 9826 2882
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84925,8 +87819,9 @@ SplineSet
  614 1293 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: club
-Encoding: 9827 9827 9827
+Encoding: 9827 9827 2883
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84970,8 +87865,9 @@ SplineSet
  586 1359 586 1359 618 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2664
-Encoding: 9828 9828 9828
+Encoding: 9828 9828 2884
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85024,8 +87920,9 @@ SplineSet
  592 176 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: heart
-Encoding: 9829 9829 9829
+Encoding: 9829 9829 2885
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85048,8 +87945,9 @@ SplineSet
  244 1359 244 1359 315 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: diamond
-Encoding: 9830 9830 9830
+Encoding: 9830 9830 2886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85064,8 +87962,9 @@ SplineSet
  617 1359 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2667
-Encoding: 9831 9831 9831
+Encoding: 9831 9831 2887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85140,8 +88039,9 @@ SplineSet
  617 277 l 1,97,98
 EndSplineSet
 EndChar
+
 StartChar: uni2668
-Encoding: 9832 9832 9832
+Encoding: 9832 9832 2888
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85205,8 +88105,9 @@ SplineSet
  895.998 570.281 l 2,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni2669
-Encoding: 9833 9833 9833
+Encoding: 9833 9833 2889
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85229,8 +88130,9 @@ SplineSet
  789 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnote
-Encoding: 9834 9834 9834
+Encoding: 9834 9834 2890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85259,8 +88161,9 @@ SplineSet
  566 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnotedbl
-Encoding: 9835 9835 9835
+Encoding: 9835 9835 2891
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85292,8 +88195,9 @@ SplineSet
  473 1445 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266C
-Encoding: 9836 9836 9836
+Encoding: 9836 9836 2892
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85324,8 +88228,9 @@ SplineSet
  438 1189 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266D
-Encoding: 9837 9837 9837
+Encoding: 9837 9837 2893
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85349,8 +88254,9 @@ SplineSet
  519 658 519 658 376 441 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266E
-Encoding: 9838 9838 9838
+Encoding: 9838 9838 2894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85380,8 +88286,9 @@ SplineSet
  483 870 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266F
-Encoding: 9839 9839 9839
+Encoding: 9839 9839 2895
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85433,8 +88340,9 @@ SplineSet
  482 867 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2670
-Encoding: 9840 9840 9840
+Encoding: 9840 9840 2896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85491,8 +88399,9 @@ SplineSet
  553.5 685 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2671
-Encoding: 9841 9841 9841
+Encoding: 9841 9841 2897
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85562,8 +88471,9 @@ SplineSet
  593.75 894.375 l 1,60,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2672
-Encoding: 9842 9842 9842
+Encoding: 9842 9842 2898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85719,8 +88629,9 @@ SplineSet
  319.811 333.77 l 1,167,168
 EndSplineSet
 EndChar
+
 StartChar: uni2673
-Encoding: 9843 9843 9843
+Encoding: 9843 9843 2899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85786,8 +88697,9 @@ SplineSet
  549.741 1076.68 549.741 1076.68 592.787 1079.6 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni2674
-Encoding: 9844 9844 9844
+Encoding: 9844 9844 2900
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85863,8 +88775,9 @@ SplineSet
  551.45 1048.24 551.45 1048.24 593.396 1051.09 c 0,69,70
 EndSplineSet
 EndChar
+
 StartChar: uni2675
-Encoding: 9845 9845 9845
+Encoding: 9845 9845 2901
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85948,8 +88861,9 @@ SplineSet
  550.62 1062.8 550.62 1062.8 593.1 1065.68 c 0,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2676
-Encoding: 9846 9846 9846
+Encoding: 9846 9846 2902
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86019,8 +88933,9 @@ SplineSet
  546.805 1120.55 546.805 1120.55 591.745 1123.59 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: uni2677
-Encoding: 9847 9847 9847
+Encoding: 9847 9847 2903
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86097,8 +89012,9 @@ SplineSet
  549.938 1072.09 549.938 1072.09 592.857 1075 c 0,70,71
 EndSplineSet
 EndChar
+
 StartChar: uni2678
-Encoding: 9848 9848 9848
+Encoding: 9848 9848 2904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86179,8 +89095,9 @@ SplineSet
  551.449 1039.09 551.449 1039.09 593.395 1041.94 c 0,77,78
 EndSplineSet
 EndChar
+
 StartChar: uni2679
-Encoding: 9849 9849 9849
+Encoding: 9849 9849 2905
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86242,8 +89159,9 @@ SplineSet
  547.875 1108.25 547.875 1108.25 592.125 1111.25 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni267A
-Encoding: 9850 9850 9850
+Encoding: 9850 9850 2906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86297,8 +89215,9 @@ SplineSet
  547.875 1095.75 547.875 1095.75 592.125 1098.75 c 0,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni267B
-Encoding: 9851 9851 9851
+Encoding: 9851 9851 2907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86373,8 +89292,9 @@ SplineSet
  583.125 351.25 l 1,73,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267C
-Encoding: 9852 9852 9852
+Encoding: 9852 9852 2908
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86461,8 +89381,9 @@ SplineSet
  338.853 421.074 l 1,93,94
 EndSplineSet
 EndChar
+
 StartChar: uni267D
-Encoding: 9853 9853 9853
+Encoding: 9853 9853 2909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86554,8 +89475,9 @@ SplineSet
  301.125 334 301.125 334 354.375 402.25 c 1,97,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267E
-Encoding: 9854 9854 9854
+Encoding: 9854 9854 2910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86609,8 +89531,9 @@ SplineSet
  79.1064 729.297 79.1064 729.297 79.1064 576.191 c 0,56,57
 EndSplineSet
 EndChar
+
 StartChar: uni267F
-Encoding: 9855 9855 9855
+Encoding: 9855 9855 2911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86652,8 +89575,9 @@ SplineSet
  757.812 92.875 757.812 92.875 702.688 63.125 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni2680
-Encoding: 9856 9856 9856
+Encoding: 9856 9856 2912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86684,8 +89608,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2681
-Encoding: 9857 9857 9857
+Encoding: 9857 9857 2913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86729,8 +89654,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2682
-Encoding: 9858 9858 9858
+Encoding: 9858 9858 2914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86787,8 +89713,9 @@ SplineSet
  184.5 128.75 l 1,76,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2683
-Encoding: 9859 9859 9859
+Encoding: 9859 9859 2915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86858,8 +89785,9 @@ SplineSet
  184.5 125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2684
-Encoding: 9860 9860 9860
+Encoding: 9860 9860 2916
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86942,8 +89870,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2685
-Encoding: 9861 9861 9861
+Encoding: 9861 9861 2917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87039,8 +89968,9 @@ SplineSet
  184.5 120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2686
-Encoding: 9862 9862 9862
+Encoding: 9862 9862 2918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87087,8 +90017,9 @@ SplineSet
  809.214 544.863 809.214 544.863 809.214 570 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni2687
-Encoding: 9863 9863 9863
+Encoding: 9863 9863 2919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87148,8 +90079,9 @@ SplineSet
  298.101 670.977 298.101 670.977 322.476 670.977 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni2688
-Encoding: 9864 9864 9864
+Encoding: 9864 9864 2920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87183,8 +90115,9 @@ SplineSet
  880.816 474.023 880.816 474.023 905.953 474.023 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2689
-Encoding: 9865 9865 9865
+Encoding: 9865 9865 2921
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87231,8 +90164,9 @@ SplineSet
  226.5 585.137 226.5 585.137 226.5 560 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni268A
-Encoding: 9866 9866 9866
+Encoding: 9866 9866 2922
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87245,8 +90179,9 @@ SplineSet
  82.3447 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni268B
-Encoding: 9867 9867 9867
+Encoding: 9867 9867 2923
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87264,8 +90199,9 @@ SplineSet
  716.476 150 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2690
-Encoding: 9872 9872 9872
+Encoding: 9872 9872 2924
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87296,8 +90232,9 @@ SplineSet
  212.689 1167.25 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2691
-Encoding: 9873 9873 9873
+Encoding: 9873 9873 2925
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87320,8 +90257,9 @@ SplineSet
  181.625 1263.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2692
-Encoding: 9874 9874 9874
+Encoding: 9874 9874 2926
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87361,8 +90299,9 @@ SplineSet
  548.606 451.891 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2693
-Encoding: 9875 9875 9875
+Encoding: 9875 9875 2927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87434,8 +90373,9 @@ SplineSet
  793.222 11.375 793.222 11.375 692.472 4.0625 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2694
-Encoding: 9876 9876 9876
+Encoding: 9876 9876 2928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87513,8 +90453,9 @@ SplineSet
  651 511.5 l 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2695
-Encoding: 9877 9877 9877
+Encoding: 9877 9877 2929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87583,8 +90524,9 @@ SplineSet
  663.5 1032 l 1,68,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2696
-Encoding: 9878 9878 9878
+Encoding: 9878 9878 2930
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87636,8 +90578,9 @@ SplineSet
  980.625 900 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2697
-Encoding: 9879 9879 9879
+Encoding: 9879 9879 2931
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87672,8 +90615,9 @@ SplineSet
  1139.62 457.75 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2698
-Encoding: 9880 9880 9880
+Encoding: 9880 9880 2932
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87722,8 +90666,9 @@ SplineSet
  723.25 744 723.25 744 671.625 736.125 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2699
-Encoding: 9881 9881 9881
+Encoding: 9881 9881 2933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87794,8 +90739,9 @@ SplineSet
  749 673 749 673 749 618 c 128,-1,70
 EndSplineSet
 EndChar
+
 StartChar: uni269A
-Encoding: 9882 9882 9882
+Encoding: 9882 9882 2934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87909,8 +90855,9 @@ SplineSet
  544.312 1119.88 544.312 1119.88 589.812 1128.62 c 1,82,-1
 EndSplineSet
 EndChar
+
 StartChar: uni269B
-Encoding: 9883 9883 9883
+Encoding: 9883 9883 2935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88049,8 +90996,9 @@ SplineSet
  683.936 353.938 683.936 353.938 614.874 388.062 c 1,204,205
 EndSplineSet
 EndChar
+
 StartChar: uni269C
-Encoding: 9884 9884 9884
+Encoding: 9884 9884 2936
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88150,8 +91098,9 @@ SplineSet
  542.562 833.375 542.562 833.375 616.938 833.375 c 0,131,132
 EndSplineSet
 EndChar
+
 StartChar: uni26A0
-Encoding: 9888 9888 9888
+Encoding: 9888 9888 2937
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88191,8 +91140,9 @@ SplineSet
  607.968 235.414 607.968 235.414 622.187 235.414 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni26A1
-Encoding: 9889 9889 9889
+Encoding: 9889 9889 2938
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88216,8 +91166,9 @@ SplineSet
  1066.25 1313.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B0
-Encoding: 9904 9904 9904
+Encoding: 9904 9904 2939
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88232,8 +91183,9 @@ SplineSet
  430 1496 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B1
-Encoding: 9905 9905 9905
+Encoding: 9905 9905 2940
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88256,8 +91208,9 @@ SplineSet
  714.812 1033.5 714.812 1033.5 810.688 1014 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2701
-Encoding: 9985 9985 9985
+Encoding: 9985 9985 2941
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88351,8 +91304,9 @@ SplineSet
  371.175 939.535 371.175 939.535 353.531 948.359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2702
-Encoding: 9986 9986 9986
+Encoding: 9986 9986 2942
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88447,8 +91401,9 @@ SplineSet
  206.625 975 206.625 975 189.375 975 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2703
-Encoding: 9987 9987 9987
+Encoding: 9987 9987 2943
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88542,8 +91497,9 @@ SplineSet
  340.812 374.5 340.812 374.5 359.375 380.688 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2704
-Encoding: 9988 9988 9988
+Encoding: 9988 9988 2944
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88741,8 +91697,9 @@ SplineSet
  601.031 686 601.031 686 601.031 678.438 c 152,-1,335
 EndSplineSet
 EndChar
+
 StartChar: uni2706
-Encoding: 9990 9990 9990
+Encoding: 9990 9990 2945
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88828,8 +91785,9 @@ SplineSet
  793.273 994.133 793.273 994.133 788.891 1013.12 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2707
-Encoding: 9991 9991 9991
+Encoding: 9991 9991 2946
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88917,8 +91875,9 @@ SplineSet
  499.5 1225 499.5 1225 616.5 1225 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2708
-Encoding: 9992 9992 9992
+Encoding: 9992 9992 2947
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88966,8 +91925,9 @@ SplineSet
  82.125 572.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2709
-Encoding: 9993 9993 9993
+Encoding: 9993 9993 2948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89012,8 +91972,9 @@ SplineSet
  63.4922 115.469 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270C
-Encoding: 9996 9996 9996
+Encoding: 9996 9996 2949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89156,8 +92117,9 @@ SplineSet
  386.49 675.2 l 1,5,6
 EndSplineSet
 EndChar
+
 StartChar: uni270D
-Encoding: 9997 9997 9997
+Encoding: 9997 9997 2950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89256,8 +92218,9 @@ SplineSet
  186.961 280.123 186.961 280.123 159.826 296.548 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270E
-Encoding: 9998 9998 9998
+Encoding: 9998 9998 2951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89330,8 +92293,9 @@ SplineSet
  279.719 812.875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270F
-Encoding: 9999 9999 9999
+Encoding: 9999 9999 2952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89402,8 +92366,9 @@ SplineSet
  272.762 352.531 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2710
-Encoding: 10000 10000 10000
+Encoding: 10000 10000 2953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89476,8 +92441,9 @@ SplineSet
  279.719 564.125 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2711
-Encoding: 10001 10001 10001
+Encoding: 10001 10001 2954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89531,8 +92497,9 @@ SplineSet
  176.227 632.793 176.227 632.793 176.227 580.234 c 152,-1,0
 EndSplineSet
 EndChar
+
 StartChar: uni2712
-Encoding: 10002 10002 10002
+Encoding: 10002 10002 2955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89565,8 +92532,9 @@ SplineSet
  738.727 489.023 738.727 489.023 744.469 502.969 c 9,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni2713
-Encoding: 10003 10003 10003
+Encoding: 10003 10003 2956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89590,8 +92558,9 @@ SplineSet
  251.273 591.5 251.273 591.5 280.5 591.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2714
-Encoding: 10004 10004 10004
+Encoding: 10004 10004 2957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89615,8 +92584,9 @@ SplineSet
  220.845 654.375 220.845 654.375 263 653.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2715
-Encoding: 10005 10005 10005
+Encoding: 10005 10005 2958
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89637,8 +92607,9 @@ SplineSet
  731.062 599.625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2716
-Encoding: 10006 10006 10006
+Encoding: 10006 10006 2959
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89659,8 +92630,9 @@ SplineSet
  821.312 709.043 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2717
-Encoding: 10007 10007 10007
+Encoding: 10007 10007 2960
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89703,8 +92675,9 @@ SplineSet
  957.344 1213.62 957.344 1213.62 968.719 1213.62 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2718
-Encoding: 10008 10008 10008
+Encoding: 10008 10008 2961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89754,8 +92727,9 @@ SplineSet
  1012 1322.25 1012 1322.25 1024.25 1322.25 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2719
-Encoding: 10009 10009 10009
+Encoding: 10009 10009 2962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89802,8 +92776,9 @@ SplineSet
  690.438 631.274 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271A
-Encoding: 10010 10010 10010
+Encoding: 10010 10010 2963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89824,8 +92799,9 @@ SplineSet
  758.688 655 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271B
-Encoding: 10011 10011 10011
+Encoding: 10011 10011 2964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89851,8 +92827,9 @@ SplineSet
  527 477 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni271C
-Encoding: 10012 10012 10012
+Encoding: 10012 10012 2965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89878,8 +92855,9 @@ SplineSet
  768.844 720.762 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271D
-Encoding: 10013 10013 10013
+Encoding: 10013 10013 2966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89900,8 +92878,9 @@ SplineSet
  715 960 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271E
-Encoding: 10014 10014 10014
+Encoding: 10014 10014 2967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89939,8 +92918,9 @@ SplineSet
  669 957.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271F
-Encoding: 10015 10015 10015
+Encoding: 10015 10015 2968
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89987,8 +92967,9 @@ SplineSet
  704 860 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2720
-Encoding: 10016 10016 10016
+Encoding: 10016 10016 2969
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90049,8 +93030,9 @@ SplineSet
  559.371 515.742 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2721
-Encoding: 10017 10017 10017
+Encoding: 10017 10017 2970
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90102,8 +93084,9 @@ SplineSet
  299.625 713.062 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2722
-Encoding: 10018 10018 10018
+Encoding: 10018 10018 2971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90152,8 +93135,9 @@ SplineSet
  578.731 603.182 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2723
-Encoding: 10019 10019 10019
+Encoding: 10019 10019 2972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90242,8 +93226,9 @@ SplineSet
  562.418 492.695 562.418 492.695 549.469 504.883 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2724
-Encoding: 10020 10020 10020
+Encoding: 10020 10020 2973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90332,8 +93317,9 @@ SplineSet
  530.426 610 530.426 610 578.414 610 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2725
-Encoding: 10021 10021 10021
+Encoding: 10021 10021 2974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90502,8 +93488,9 @@ SplineSet
  592.766 1159.3 592.766 1159.3 616.5 1159.3 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2726
-Encoding: 10022 10022 10022
+Encoding: 10022 10022 2975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90528,8 +93515,9 @@ SplineSet
  158.27 552.941 158.27 552.941 43.1543 552.941 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2727
-Encoding: 10023 10023 10023
+Encoding: 10023 10023 2976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90571,8 +93559,9 @@ SplineSet
  153.75 557.25 153.75 557.25 37.5 557.25 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2729
-Encoding: 10025 10025 10025
+Encoding: 10025 10025 2977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90602,8 +93591,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272A
-Encoding: 10026 10026 10026
+Encoding: 10026 10026 2978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90639,8 +93629,9 @@ SplineSet
  505.594 1076.06 505.594 1076.06 616.5 1076.06 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni272B
-Encoding: 10027 10027 10027
+Encoding: 10027 10027 2979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90676,8 +93667,9 @@ SplineSet
  616.5 1070 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272C
-Encoding: 10028 10028 10028
+Encoding: 10028 10028 2980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90724,8 +93716,9 @@ SplineSet
  616.5 1083.74 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272D
-Encoding: 10029 10029 10029
+Encoding: 10029 10029 2981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90766,8 +93759,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272E
-Encoding: 10030 10030 10030
+Encoding: 10030 10030 2982
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90808,8 +93802,9 @@ SplineSet
  616.5 820 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272F
-Encoding: 10031 10031 10031
+Encoding: 10031 10031 2983
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90848,8 +93843,9 @@ SplineSet
  616.5 1086.43 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2730
-Encoding: 10032 10032 10032
+Encoding: 10032 10032 2984
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90883,8 +93879,9 @@ SplineSet
  559.547 909.375 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2731
-Encoding: 10033 10033 10033
+Encoding: 10033 10033 2985
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90911,8 +93908,9 @@ SplineSet
  492.75 790.773 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2732
-Encoding: 10034 10034 10034
+Encoding: 10034 10034 2986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90946,8 +93944,9 @@ SplineSet
  436.5 559.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2733
-Encoding: 10035 10035 10035
+Encoding: 10035 10035 2987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90980,8 +93979,9 @@ SplineSet
  709.43 527.91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2734
-Encoding: 10036 10036 10036
+Encoding: 10036 10036 2988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91006,8 +94006,9 @@ SplineSet
  616.5 1146 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2735
-Encoding: 10037 10037 10037
+Encoding: 10037 10037 2989
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91064,8 +94065,9 @@ SplineSet
  616.5 1157.77 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2736
-Encoding: 10038 10038 10038
+Encoding: 10038 10038 2990
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91086,8 +94088,9 @@ SplineSet
  616.5 1279.38 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2737
-Encoding: 10039 10039 10039
+Encoding: 10039 10039 2991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91112,8 +94115,9 @@ SplineSet
  616.499 1138.44 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2738
-Encoding: 10040 10040 10040
+Encoding: 10040 10040 2992
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91138,8 +94142,9 @@ SplineSet
  616.5 1157.91 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2739
-Encoding: 10041 10041 10041
+Encoding: 10041 10041 2993
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91172,8 +94177,9 @@ SplineSet
  616.5 1127.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni273A
-Encoding: 10042 10042 10042
+Encoding: 10042 10042 2994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91230,8 +94236,9 @@ SplineSet
  570.797 800 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273B
-Encoding: 10043 10043 10043
+Encoding: 10043 10043 2995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91328,8 +94335,9 @@ SplineSet
  568.922 757.695 568.922 757.695 574.664 760.156 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273C
-Encoding: 10044 10044 10044
+Encoding: 10044 10044 2996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91443,8 +94451,9 @@ SplineSet
  569.375 747.562 569.375 747.562 575.062 750 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273D
-Encoding: 10045 10045 10045
+Encoding: 10045 10045 2997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91513,8 +94522,9 @@ SplineSet
  530.469 613.646 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273E
-Encoding: 10046 10046 10046
+Encoding: 10046 10046 2998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91634,8 +94644,9 @@ SplineSet
  843.25 485.769 843.25 485.769 785.949 500 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni273F
-Encoding: 10047 10047 10047
+Encoding: 10047 10047 2999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91717,8 +94728,9 @@ SplineSet
  818.244 808.656 818.244 808.656 812.812 798.569 c 1,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni2740
-Encoding: 10048 10048 10048
+Encoding: 10048 10048 3000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91862,8 +94874,9 @@ SplineSet
  893.682 527.473 893.682 527.473 891.299 510 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2741
-Encoding: 10049 10049 10049
+Encoding: 10049 10049 3001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92169,8 +95182,9 @@ SplineSet
  644.141 807.139 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2742
-Encoding: 10050 10050 10050
+Encoding: 10050 10050 3002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92246,8 +95260,9 @@ SplineSet
  616.5 1123.25 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2743
-Encoding: 10051 10051 10051
+Encoding: 10051 10051 3003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92376,8 +95391,9 @@ SplineSet
  836.482 541.685 836.482 541.685 780.891 557.25 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2744
-Encoding: 10052 10052 10052
+Encoding: 10052 10052 3004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92452,8 +95468,9 @@ SplineSet
  512.906 685.062 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2745
-Encoding: 10053 10053 10053
+Encoding: 10053 10053 3005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92522,8 +95539,9 @@ SplineSet
  665.06 515 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2746
-Encoding: 10054 10054 10054
+Encoding: 10054 10054 3006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92598,8 +95616,9 @@ SplineSet
  568.562 1215.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2747
-Encoding: 10055 10055 10055
+Encoding: 10055 10055 3007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92692,8 +95711,9 @@ SplineSet
  1143.29 960.151 1143.29 960.151 1160.88 924.938 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2748
-Encoding: 10056 10056 10056
+Encoding: 10056 10056 3008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92782,8 +95802,9 @@ SplineSet
  824.982 511.552 824.982 511.552 779.66 554.607 c 1,104,105
 EndSplineSet
 EndChar
+
 StartChar: uni2749
-Encoding: 10057 10057 10057
+Encoding: 10057 10057 3009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92872,8 +95893,9 @@ SplineSet
  976.344 692.312 976.344 692.312 1019.22 692.312 c 152,-1,105
 EndSplineSet
 EndChar
+
 StartChar: uni274A
-Encoding: 10058 10058 10058
+Encoding: 10058 10058 3010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92970,8 +95992,9 @@ SplineSet
  647.891 -21.4375 647.891 -21.4375 616.5 -21.4375 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni274B
-Encoding: 10059 10059 10059
+Encoding: 10059 10059 3011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93044,8 +96067,9 @@ SplineSet
  583.785 1050.28 583.785 1050.28 616.5 1050.28 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni274D
-Encoding: 10061 10061 10061
+Encoding: 10061 10061 3012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93079,8 +96103,9 @@ SplineSet
  633.562 -10.1484 633.562 -10.1484 615.789 -8.72656 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni274F
-Encoding: 10063 10063 10063
+Encoding: 10063 10063 3013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93102,8 +96127,9 @@ SplineSet
  138 6.3125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2750
-Encoding: 10064 10064 10064
+Encoding: 10064 10064 3014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93125,8 +96151,9 @@ SplineSet
  1101.72 69.8516 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2751
-Encoding: 10065 10065 10065
+Encoding: 10065 10065 3015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93146,8 +96173,9 @@ SplineSet
  56.8125 -0.703125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2752
-Encoding: 10066 10066 10066
+Encoding: 10066 10066 3016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93167,8 +96195,9 @@ SplineSet
  1113.15 0.989258 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2756
-Encoding: 10070 10070 10070
+Encoding: 10070 10070 3017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93196,8 +96225,9 @@ SplineSet
  358.484 254.031 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2758
-Encoding: 10072 10072 10072
+Encoding: 10072 10072 3018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93210,8 +96240,9 @@ SplineSet
  693.85 1435.92 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2759
-Encoding: 10073 10073 10073
+Encoding: 10073 10073 3019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93224,8 +96255,9 @@ SplineSet
  771.2 1433 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275A
-Encoding: 10074 10074 10074
+Encoding: 10074 10074 3020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93238,8 +96270,9 @@ SplineSet
  895.3 1386.98 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275B
-Encoding: 10075 10075 10075
+Encoding: 10075 10075 3021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93255,8 +96288,9 @@ SplineSet
  755.895 975.215 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275C
-Encoding: 10076 10076 10076
+Encoding: 10076 10076 3022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93272,26 +96306,29 @@ SplineSet
  467.812 1478.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275D
-Encoding: 10077 10077 10077
+Encoding: 10077 10077 3023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10075 10075 N 1 0 0 1 221 0 2
-Refer: 10075 10075 N 1 0 0 1 -221 0 2
+Refer: 3021 10075 N 1 0 0 1 221 0 2
+Refer: 3021 10075 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni275E
-Encoding: 10078 10078 10078
+Encoding: 10078 10078 3024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10076 10076 N 1 0 0 1 221 0 2
-Refer: 10076 10076 N 1 0 0 1 -221 0 2
+Refer: 3022 10076 N 1 0 0 1 221 0 2
+Refer: 3022 10076 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni2761
-Encoding: 10081 10081 10081
+Encoding: 10081 10081 3025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93351,8 +96388,9 @@ SplineSet
  738.781 619.188 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2762
-Encoding: 10082 10082 10082
+Encoding: 10082 10082 3026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93390,8 +96428,9 @@ SplineSet
  566.125 449.875 566.125 449.875 616.5 449.875 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2763
-Encoding: 10083 10083 10083
+Encoding: 10083 10083 3027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93437,8 +96476,9 @@ SplineSet
  566.125 459.375 566.125 459.375 616.5 459.375 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2764
-Encoding: 10084 10084 10084
+Encoding: 10084 10084 3028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93467,8 +96507,9 @@ SplineSet
  720.855 299.188 720.855 299.188 616.5 105 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2765
-Encoding: 10085 10085 10085
+Encoding: 10085 10085 3029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93497,8 +96538,9 @@ SplineSet
  910.5 769.25 910.5 769.25 1118.75 650.25 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2766
-Encoding: 10086 10086 10086
+Encoding: 10086 10086 3030
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93562,8 +96604,9 @@ SplineSet
  824.094 798.625 824.094 798.625 758.281 810 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2767
-Encoding: 10087 10087 10087
+Encoding: 10087 10087 3031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93614,8 +96657,9 @@ SplineSet
  839.531 307.688 839.531 307.688 724.156 307.688 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2768
-Encoding: 10088 10088 10088
+Encoding: 10088 10088 3032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93642,8 +96686,9 @@ SplineSet
  992.688 -100.812 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2769
-Encoding: 10089 10089 10089
+Encoding: 10089 10089 3033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93670,8 +96715,9 @@ SplineSet
  391.438 -100.625 391.438 -100.625 240.312 -100.625 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276A
-Encoding: 10090 10090 10090
+Encoding: 10090 10090 3034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93690,8 +96736,9 @@ SplineSet
  874.469 1361.38 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276B
-Encoding: 10091 10091 10091
+Encoding: 10091 10091 3035
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93710,8 +96757,9 @@ SplineSet
  471.993 1134.7 471.993 1134.7 366.469 1315.82 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276C
-Encoding: 10092 10092 10092
+Encoding: 10092 10092 3036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93726,8 +96774,9 @@ SplineSet
  909.23 -130.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276D
-Encoding: 10093 10093 10093
+Encoding: 10093 10093 3037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93742,8 +96791,9 @@ SplineSet
  324.135 -130.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276E
-Encoding: 10094 10094 10094
+Encoding: 10094 10094 3038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93758,8 +96808,9 @@ SplineSet
  1022.38 -169.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276F
-Encoding: 10095 10095 10095
+Encoding: 10095 10095 3039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93774,8 +96825,9 @@ SplineSet
  210.62 -169.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2770
-Encoding: 10096 10096 10096
+Encoding: 10096 10096 3040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93790,8 +96842,9 @@ SplineSet
  1027.32 -190.36 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2771
-Encoding: 10097 10097 10097
+Encoding: 10097 10097 3041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93806,8 +96859,9 @@ SplineSet
  206.09 -189.68 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2772
-Encoding: 10098 10098 10098
+Encoding: 10098 10098 3042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93824,8 +96878,9 @@ SplineSet
  580.42 -0.0996094 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2773
-Encoding: 10099 10099 10099
+Encoding: 10099 10099 3043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93842,8 +96897,9 @@ SplineSet
  652.58 1121.92 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2774
-Encoding: 10100 10100 10100
+Encoding: 10100 10100 3044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93881,8 +96937,9 @@ SplineSet
  951.73 -198.35 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2775
-Encoding: 10101 10101 10101
+Encoding: 10101 10101 3045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93920,8 +96977,9 @@ SplineSet
  249.51 -204.12 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2794
-Encoding: 10132 10132 10132
+Encoding: 10132 10132 3046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93939,8 +96997,9 @@ SplineSet
  1149.35 650 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2798
-Encoding: 10136 10136 10136
+Encoding: 10136 10136 3047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93956,8 +97015,9 @@ SplineSet
  783.625 393.875 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2799
-Encoding: 10137 10137 10137
+Encoding: 10137 10137 3048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93973,8 +97033,9 @@ SplineSet
  815.206 680.234 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279A
-Encoding: 10138 10138 10138
+Encoding: 10138 10138 3049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93990,8 +97051,9 @@ SplineSet
  870.25 860.75 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279B
-Encoding: 10139 10139 10139
+Encoding: 10139 10139 3050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94007,8 +97069,9 @@ SplineSet
  45.5918 750.703 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279C
-Encoding: 10140 10140 10140
+Encoding: 10140 10140 3051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94051,8 +97114,9 @@ SplineSet
  1159.5 710 1159.5 710 1159.5 691.25 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni279D
-Encoding: 10141 10141 10141
+Encoding: 10141 10141 3052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94068,8 +97132,9 @@ SplineSet
  837.957 721.562 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279E
-Encoding: 10142 10142 10142
+Encoding: 10142 10142 3053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94085,8 +97150,9 @@ SplineSet
  853.775 626.211 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279F
-Encoding: 10143 10143 10143
+Encoding: 10143 10143 3054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94117,8 +97183,9 @@ SplineSet
  850.125 551.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A0
-Encoding: 10144 10144 10144
+Encoding: 10144 10144 3055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94149,8 +97216,9 @@ SplineSet
  126.31 510.328 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A1
-Encoding: 10145 10145 10145
+Encoding: 10145 10145 3056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94166,8 +97234,9 @@ SplineSet
  837.957 557.812 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A2
-Encoding: 10146 10146 10146
+Encoding: 10146 10146 3057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94184,8 +97253,9 @@ SplineSet
  433.5 710 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A3
-Encoding: 10147 10147 10147
+Encoding: 10147 10147 3058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94202,8 +97272,9 @@ SplineSet
  443.03 740 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A4
-Encoding: 10148 10148 10148
+Encoding: 10148 10148 3059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94216,8 +97287,9 @@ SplineSet
  371.938 750 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A5
-Encoding: 10149 10149 10149
+Encoding: 10149 10149 3060
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94241,8 +97313,9 @@ SplineSet
  54.375 689 54.375 689 54.375 725 c 10,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A6
-Encoding: 10150 10150 10150
+Encoding: 10150 10150 3061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94266,8 +97339,9 @@ SplineSet
  54.375 755 l 18,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A7
-Encoding: 10151 10151 10151
+Encoding: 10151 10151 3062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94283,8 +97357,9 @@ SplineSet
  613.125 530 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A8
-Encoding: 10152 10152 10152
+Encoding: 10152 10152 3063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94300,8 +97375,9 @@ SplineSet
  737.625 905 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A9
-Encoding: 10153 10153 10153
+Encoding: 10153 10153 3064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94327,8 +97403,9 @@ SplineSet
  663.777 589.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AA
-Encoding: 10154 10154 10154
+Encoding: 10154 10154 3065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94354,8 +97431,9 @@ SplineSet
  770.418 529.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AB
-Encoding: 10155 10155 10155
+Encoding: 10155 10155 3066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94384,8 +97462,9 @@ SplineSet
  748.38 552.203 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AC
-Encoding: 10156 10156 10156
+Encoding: 10156 10156 3067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94414,8 +97493,9 @@ SplineSet
  738.237 619.59 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AD
-Encoding: 10157 10157 10157
+Encoding: 10157 10157 3068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94443,8 +97523,9 @@ SplineSet
  643.875 547.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AE
-Encoding: 10158 10158 10158
+Encoding: 10158 10158 3069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94472,8 +97553,9 @@ SplineSet
  646.159 730 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AF
-Encoding: 10159 10159 10159
+Encoding: 10159 10159 3070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94504,8 +97586,9 @@ SplineSet
  232.125 775 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B1
-Encoding: 10161 10161 10161
+Encoding: 10161 10161 3071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94536,8 +97619,9 @@ SplineSet
  226.118 625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B2
-Encoding: 10162 10162 10162
+Encoding: 10162 10162 3072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94566,8 +97650,9 @@ SplineSet
  145.247 935 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B3
-Encoding: 10163 10163 10163
+Encoding: 10163 10163 3073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94629,8 +97714,9 @@ SplineSet
  263.877 590 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B4
-Encoding: 10164 10164 10164
+Encoding: 10164 10164 3074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94658,8 +97744,9 @@ SplineSet
  393.472 955.375 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B5
-Encoding: 10165 10165 10165
+Encoding: 10165 10165 3075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94685,8 +97772,9 @@ SplineSet
  225.84 698.438 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B6
-Encoding: 10166 10166 10166
+Encoding: 10166 10166 3076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94714,8 +97802,9 @@ SplineSet
  347.156 406.875 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B7
-Encoding: 10167 10167 10167
+Encoding: 10167 10167 3077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94752,8 +97841,9 @@ SplineSet
  1118.32 309.875 1118.32 309.875 1154.19 185.625 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B8
-Encoding: 10168 10168 10168
+Encoding: 10168 10168 3078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94788,8 +97878,9 @@ SplineSet
  1050.23 692.328 1050.23 692.328 1190.34 615 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B9
-Encoding: 10169 10169 10169
+Encoding: 10169 10169 3079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94826,8 +97917,9 @@ SplineSet
  999.593 1140.88 999.593 1140.88 1115.78 1175 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27BA
-Encoding: 10170 10170 10170
+Encoding: 10170 10170 3080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94874,8 +97966,9 @@ SplineSet
  906.375 725.75 906.375 725.75 770.625 785.75 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27BB
-Encoding: 10171 10171 10171
+Encoding: 10171 10171 3081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94909,8 +98002,9 @@ SplineSet
  889.5 623.312 889.5 623.312 919.562 655 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni27BC
-Encoding: 10172 10172 10172
+Encoding: 10172 10172 3082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94983,8 +98077,9 @@ SplineSet
  1195 697.312 1195 697.312 1195 690 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BD
-Encoding: 10173 10173 10173
+Encoding: 10173 10173 3083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95057,8 +98152,9 @@ SplineSet
  1195 690.312 1195 690.312 1195 683 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BE
-Encoding: 10174 10174 10174
+Encoding: 10174 10174 3084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95097,16 +98193,18 @@ SplineSet
  653.89 945.203 l 17,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni27C2
-Encoding: 10178 10178 10178
+Encoding: 10178 10178 3085
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8869 8869 N 1 0 0 1 0 0 2
+Refer: 2366 8869 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni27C5
-Encoding: 10181 10181 10181
+Encoding: 10181 10181 3086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95131,8 +98229,9 @@ SplineSet
  922 -334 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27C6
-Encoding: 10182 10182 10182
+Encoding: 10182 10182 3087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95157,8 +98256,9 @@ SplineSet
  320 -334 320 -334 311 -334 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27DC
-Encoding: 10204 10204 10204
+Encoding: 10204 10204 3088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95187,8 +98287,9 @@ SplineSet
  176 589 176 589 215.5 549 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni27E0
-Encoding: 10208 10208 10208
+Encoding: 10208 10208 3089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95209,104 +98310,155 @@ SplineSet
  616 -233 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E6
-Encoding: 10214 10214 10214
-Width: 1233
+Encoding: 10214 10214 3090
+Width: 596
+VWidth: 1000
 Flags: W
+HStem: -197.69 73.2607 699.41 76.5898
+VStem: 181 86<-124.43 -124.43 -124.43 699.41> 334 53<-124.43 699.41>
 LayerCount: 2
 Fore
 SplineSet
-397 1456 m 1,0,-1
- 397 -170 l 1,1,-1
- 597 -170 l 1,2,-1
- 597 1456 l 1,3,-1
- 397 1456 l 1,0,-1
-297 1556 m 1,4,-1
- 937 1556 l 1,5,-1
- 937 1456 l 1,6,-1
- 697 1456 l 1,7,-1
- 697 -170 l 1,8,-1
- 937 -170 l 1,9,-1
- 937 -270 l 1,10,-1
- 297 -270 l 1,11,-1
- 297 1556 l 1,4,-1
+499.870117188 -112.924804688 m 5,0,-1
+ 610.084960938 -112.924804688 l 5,1,-1
+ 610.084960938 1353.50976562 l 5,2,-1
+ 499.870117188 1353.50976562 l 5,3,-1
+ 499.870117188 -112.924804688 l 5,0,-1
+697.26953125 -112.924804688 m 5,4,-1
+ 904.540039062 -112.924804688 l 5,5,-1
+ 904.540039062 -243.329101562 l 5,6,-1
+ 358.400390625 -243.329101562 l 5,7,-1
+ 358.400390625 1489.83984375 l 5,8,-1
+ 902.89453125 1489.83984375 l 5,9,-1
+ 902.89453125 1353.50976562 l 5,10,-1
+ 697.26953125 1353.50976562 l 5,11,-1
+ 697.26953125 -112.924804688 l 5,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E7
-Encoding: 10215 10215 10215
-Width: 1233
+Encoding: 10215 10215 3091
+Width: 596
+VWidth: 1000
 Flags: W
+HStem: -198 66<110 236 289 356 110 236> 707 69<111 236 111 442 289 356 289 289>
+VStem: 236 53<-132 707 -132 707> 356 86<-132 707 707 707>
 LayerCount: 2
 Fore
 SplineSet
-836 1456 m 1,0,-1
- 636 1456 l 1,1,-1
- 636 -170 l 1,2,-1
- 836 -170 l 1,3,-1
- 836 1456 l 1,0,-1
-936 1556 m 1,4,-1
- 936 -270 l 1,5,-1
- 296 -270 l 1,6,-1
- 296 -170 l 1,7,-1
- 536 -170 l 1,8,-1
- 536 1456 l 1,9,-1
- 296 1456 l 1,10,-1
- 296 1556 l 1,11,-1
- 936 1556 l 1,4,-1
+688.129882812 -108.924804688 m 5,0,-1
+ 577.915039062 -108.924804688 l 5,1,-1
+ 577.915039062 1357.50976562 l 5,2,-1
+ 688.129882812 1357.50976562 l 5,3,-1
+ 688.129882812 -108.924804688 l 5,0,-1
+490.73046875 -108.924804688 m 5,4,-1
+ 283.459960938 -108.924804688 l 5,5,-1
+ 283.459960938 -239.329101562 l 5,6,-1
+ 829.599609375 -239.329101562 l 5,7,-1
+ 829.599609375 1493.83984375 l 5,8,-1
+ 285.10546875 1493.83984375 l 5,9,-1
+ 285.10546875 1357.50976562 l 5,10,-1
+ 490.73046875 1357.50976562 l 5,11,-1
+ 490.73046875 -108.924804688 l 5,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E8
-Encoding: 10216 10216 10216
-Width: 1233
+Encoding: 10216 10216 3092
+Width: 600
+VWidth: 1000
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-390.609 642 m 1,0,-1
- 672.391 1554 l 1,5,-1
- 842.391 1554 l 1,4,-1
- 560.608 642 l 1,3,-1
- 842.391 -270 l 1,2,-1
- 672.391 -270 l 1,1,-1
- 390.609 642 l 1,0,-1
+870.719726562 1215.41015625 m 5,0,-1
+ 870.719726562 1543.22949219 l 5,1,-1
+ 340.3203125 710.389648438 l 5,2,-1
+ 340.3203125 586.349609375 l 5,3,-1
+ 876.959960938 -224.33984375 l 5,4,-1
+ 876.959960938 112.33984375 l 5,5,-1
+ 525.440429688 646.155273438 l 5,6,-1
+ 870.719726562 1215.41015625 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E9
-Encoding: 10217 10217 10217
-Width: 1233
+Encoding: 10217 10217 3093
+Width: 600
+VWidth: 1000
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-842.391 642 m 1,0,-1
- 560.609 -270 l 1,1,-1
- 390.609 -270 l 1,2,-1
- 672.391 642 l 1,3,-1
- 390.609 1554 l 1,4,-1
- 560.609 1554 l 1,5,-1
- 842.391 642 l 1,0,-1
+329.280273438 1215.41015625 m 5,0,-1
+ 329.280273438 1543.22949219 l 5,1,-1
+ 859.6796875 710.389648438 l 5,2,-1
+ 859.6796875 586.349609375 l 5,3,-1
+ 323.040039062 -224.33984375 l 5,4,-1
+ 323.040039062 112.33984375 l 5,5,-1
+ 674.559570312 646.155273438 l 5,6,-1
+ 329.280273438 1215.41015625 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27EA
-Encoding: 10218 10218 10218
-Width: 1233
+Encoding: 10218 10218 3094
+Width: 600
+VWidth: 1000
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10216 10216 N 1 0 0 1 190 0 2
-Refer: 10216 10216 N 1 0 0 1 -200 0 2
+SplineSet
+1054.95605469 1205.82128906 m 5,0,-1
+ 1054.95605469 1542.45703125 l 5,1,-1
+ 550.938476562 687.220703125 l 5,2,-1
+ 550.938476562 559.84375 l 5,3,-1
+ 1060.88574219 -272.6484375 l 5,4,-1
+ 1060.88574219 73.0859375 l 5,5,-1
+ 726.850585938 621.256835938 l 5,6,-1
+ 1054.95605469 1205.82128906 l 5,0,-1
+675.4609375 1205.82128906 m 5,7,-1
+ 675.4609375 1542.45703125 l 5,8,-1
+ 171.4453125 687.220703125 l 5,9,-1
+ 171.4453125 559.84375 l 5,10,-1
+ 681.389648438 -272.6484375 l 5,11,-1
+ 681.389648438 73.0859375 l 5,12,-1
+ 347.356445312 621.256835938 l 5,13,-1
+ 675.4609375 1205.82128906 l 5,7,-1
+EndSplineSet
 EndChar
+
 StartChar: uni27EB
-Encoding: 10219 10219 10219
-Width: 1233
+Encoding: 10219 10219 3095
+Width: 600
+VWidth: 1000
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10217 10217 N 1 0 0 1 200 0 2
-Refer: 10217 10217 N 1 0 0 1 -200 0 2
+SplineSet
+145.043945312 1205.82128906 m 5,0,-1
+ 145.043945312 1542.45703125 l 5,1,-1
+ 649.061523438 687.220703125 l 5,2,-1
+ 649.061523438 559.84375 l 5,3,-1
+ 139.114257812 -272.6484375 l 5,4,-1
+ 139.114257812 73.0859375 l 5,5,-1
+ 473.149414062 621.256835938 l 5,6,-1
+ 145.043945312 1205.82128906 l 5,0,-1
+524.5390625 1205.82128906 m 5,7,-1
+ 524.5390625 1542.45703125 l 5,8,-1
+ 1028.5546875 687.220703125 l 5,9,-1
+ 1028.5546875 559.84375 l 5,10,-1
+ 518.610351562 -272.6484375 l 5,11,-1
+ 518.610351562 73.0859375 l 5,12,-1
+ 852.643554688 621.256835938 l 5,13,-1
+ 524.5390625 1205.82128906 l 5,7,-1
+EndSplineSet
 EndChar
+
 StartChar: uni27F5
-Encoding: 10229 10229 10229
+Encoding: 10229 10229 3096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95325,8 +98477,9 @@ SplineSet
  -100 602 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F6
-Encoding: 10230 10230 10230
+Encoding: 10230 10230 3097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95345,8 +98498,9 @@ SplineSet
  1333 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F7
-Encoding: 10231 10231 10231
+Encoding: 10231 10231 3098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95371,1565 +98525,1823 @@ SplineSet
  1333 520 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2800
-Encoding: 10240 10240 10240
+Encoding: 10240 10240 3099
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2801
-Encoding: 10241 10241 10241
+Encoding: 10241 10241 3100
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2802
-Encoding: 10242 10242 10242
+Encoding: 10242 10242 3101
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2803
-Encoding: 10243 10243 10243
+Encoding: 10243 10243 3102
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2804
-Encoding: 10244 10244 10244
+Encoding: 10244 10244 3103
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2805
-Encoding: 10245 10245 10245
+Encoding: 10245 10245 3104
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2806
-Encoding: 10246 10246 10246
+Encoding: 10246 10246 3105
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2807
-Encoding: 10247 10247 10247
+Encoding: 10247 10247 3106
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2808
-Encoding: 10248 10248 10248
+Encoding: 10248 10248 3107
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2809
-Encoding: 10249 10249 10249
+Encoding: 10249 10249 3108
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280A
-Encoding: 10250 10250 10250
+Encoding: 10250 10250 3109
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280B
-Encoding: 10251 10251 10251
+Encoding: 10251 10251 3110
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280C
-Encoding: 10252 10252 10252
+Encoding: 10252 10252 3111
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280D
-Encoding: 10253 10253 10253
+Encoding: 10253 10253 3112
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280E
-Encoding: 10254 10254 10254
+Encoding: 10254 10254 3113
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280F
-Encoding: 10255 10255 10255
+Encoding: 10255 10255 3114
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2810
-Encoding: 10256 10256 10256
+Encoding: 10256 10256 3115
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2811
-Encoding: 10257 10257 10257
+Encoding: 10257 10257 3116
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2812
-Encoding: 10258 10258 10258
+Encoding: 10258 10258 3117
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2813
-Encoding: 10259 10259 10259
+Encoding: 10259 10259 3118
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2814
-Encoding: 10260 10260 10260
+Encoding: 10260 10260 3119
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2815
-Encoding: 10261 10261 10261
+Encoding: 10261 10261 3120
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2816
-Encoding: 10262 10262 10262
+Encoding: 10262 10262 3121
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2817
-Encoding: 10263 10263 10263
+Encoding: 10263 10263 3122
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2818
-Encoding: 10264 10264 10264
+Encoding: 10264 10264 3123
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2819
-Encoding: 10265 10265 10265
+Encoding: 10265 10265 3124
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281A
-Encoding: 10266 10266 10266
+Encoding: 10266 10266 3125
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281B
-Encoding: 10267 10267 10267
+Encoding: 10267 10267 3126
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281C
-Encoding: 10268 10268 10268
+Encoding: 10268 10268 3127
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281D
-Encoding: 10269 10269 10269
+Encoding: 10269 10269 3128
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281E
-Encoding: 10270 10270 10270
+Encoding: 10270 10270 3129
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281F
-Encoding: 10271 10271 10271
+Encoding: 10271 10271 3130
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2820
-Encoding: 10272 10272 10272
+Encoding: 10272 10272 3131
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2821
-Encoding: 10273 10273 10273
+Encoding: 10273 10273 3132
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2822
-Encoding: 10274 10274 10274
+Encoding: 10274 10274 3133
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2823
-Encoding: 10275 10275 10275
+Encoding: 10275 10275 3134
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2824
-Encoding: 10276 10276 10276
+Encoding: 10276 10276 3135
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2825
-Encoding: 10277 10277 10277
+Encoding: 10277 10277 3136
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2826
-Encoding: 10278 10278 10278
+Encoding: 10278 10278 3137
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2827
-Encoding: 10279 10279 10279
+Encoding: 10279 10279 3138
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2828
-Encoding: 10280 10280 10280
+Encoding: 10280 10280 3139
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2829
-Encoding: 10281 10281 10281
+Encoding: 10281 10281 3140
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282A
-Encoding: 10282 10282 10282
+Encoding: 10282 10282 3141
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282B
-Encoding: 10283 10283 10283
+Encoding: 10283 10283 3142
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282C
-Encoding: 10284 10284 10284
+Encoding: 10284 10284 3143
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282D
-Encoding: 10285 10285 10285
+Encoding: 10285 10285 3144
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282E
-Encoding: 10286 10286 10286
+Encoding: 10286 10286 3145
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282F
-Encoding: 10287 10287 10287
+Encoding: 10287 10287 3146
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2830
-Encoding: 10288 10288 10288
+Encoding: 10288 10288 3147
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2831
-Encoding: 10289 10289 10289
+Encoding: 10289 10289 3148
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2832
-Encoding: 10290 10290 10290
+Encoding: 10290 10290 3149
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2833
-Encoding: 10291 10291 10291
+Encoding: 10291 10291 3150
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2834
-Encoding: 10292 10292 10292
+Encoding: 10292 10292 3151
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2835
-Encoding: 10293 10293 10293
+Encoding: 10293 10293 3152
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2836
-Encoding: 10294 10294 10294
+Encoding: 10294 10294 3153
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2837
-Encoding: 10295 10295 10295
+Encoding: 10295 10295 3154
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2838
-Encoding: 10296 10296 10296
+Encoding: 10296 10296 3155
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2839
-Encoding: 10297 10297 10297
+Encoding: 10297 10297 3156
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283A
-Encoding: 10298 10298 10298
+Encoding: 10298 10298 3157
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283B
-Encoding: 10299 10299 10299
+Encoding: 10299 10299 3158
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283C
-Encoding: 10300 10300 10300
+Encoding: 10300 10300 3159
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283D
-Encoding: 10301 10301 10301
+Encoding: 10301 10301 3160
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283E
-Encoding: 10302 10302 10302
+Encoding: 10302 10302 3161
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283F
-Encoding: 10303 10303 10303
+Encoding: 10303 10303 3162
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2840
-Encoding: 10304 10304 10304
+Encoding: 10304 10304 3163
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2841
-Encoding: 10305 10305 10305
+Encoding: 10305 10305 3164
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2842
-Encoding: 10306 10306 10306
+Encoding: 10306 10306 3165
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2843
-Encoding: 10307 10307 10307
+Encoding: 10307 10307 3166
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2844
-Encoding: 10308 10308 10308
+Encoding: 10308 10308 3167
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2845
-Encoding: 10309 10309 10309
+Encoding: 10309 10309 3168
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2846
-Encoding: 10310 10310 10310
+Encoding: 10310 10310 3169
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2847
-Encoding: 10311 10311 10311
+Encoding: 10311 10311 3170
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2848
-Encoding: 10312 10312 10312
+Encoding: 10312 10312 3171
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2849
-Encoding: 10313 10313 10313
+Encoding: 10313 10313 3172
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284A
-Encoding: 10314 10314 10314
+Encoding: 10314 10314 3173
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284B
-Encoding: 10315 10315 10315
+Encoding: 10315 10315 3174
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284C
-Encoding: 10316 10316 10316
+Encoding: 10316 10316 3175
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284D
-Encoding: 10317 10317 10317
+Encoding: 10317 10317 3176
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284E
-Encoding: 10318 10318 10318
+Encoding: 10318 10318 3177
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284F
-Encoding: 10319 10319 10319
+Encoding: 10319 10319 3178
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2850
-Encoding: 10320 10320 10320
+Encoding: 10320 10320 3179
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2851
-Encoding: 10321 10321 10321
+Encoding: 10321 10321 3180
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2852
-Encoding: 10322 10322 10322
+Encoding: 10322 10322 3181
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2853
-Encoding: 10323 10323 10323
+Encoding: 10323 10323 3182
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2854
-Encoding: 10324 10324 10324
+Encoding: 10324 10324 3183
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2855
-Encoding: 10325 10325 10325
+Encoding: 10325 10325 3184
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2856
-Encoding: 10326 10326 10326
+Encoding: 10326 10326 3185
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2857
-Encoding: 10327 10327 10327
+Encoding: 10327 10327 3186
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2858
-Encoding: 10328 10328 10328
+Encoding: 10328 10328 3187
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2859
-Encoding: 10329 10329 10329
+Encoding: 10329 10329 3188
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285A
-Encoding: 10330 10330 10330
+Encoding: 10330 10330 3189
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285B
-Encoding: 10331 10331 10331
+Encoding: 10331 10331 3190
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285C
-Encoding: 10332 10332 10332
+Encoding: 10332 10332 3191
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285D
-Encoding: 10333 10333 10333
+Encoding: 10333 10333 3192
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285E
-Encoding: 10334 10334 10334
+Encoding: 10334 10334 3193
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285F
-Encoding: 10335 10335 10335
+Encoding: 10335 10335 3194
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2860
-Encoding: 10336 10336 10336
+Encoding: 10336 10336 3195
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2861
-Encoding: 10337 10337 10337
+Encoding: 10337 10337 3196
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2862
-Encoding: 10338 10338 10338
+Encoding: 10338 10338 3197
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2863
-Encoding: 10339 10339 10339
+Encoding: 10339 10339 3198
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2864
-Encoding: 10340 10340 10340
+Encoding: 10340 10340 3199
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2865
-Encoding: 10341 10341 10341
+Encoding: 10341 10341 3200
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2866
-Encoding: 10342 10342 10342
+Encoding: 10342 10342 3201
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2867
-Encoding: 10343 10343 10343
+Encoding: 10343 10343 3202
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2868
-Encoding: 10344 10344 10344
+Encoding: 10344 10344 3203
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2869
-Encoding: 10345 10345 10345
+Encoding: 10345 10345 3204
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286A
-Encoding: 10346 10346 10346
+Encoding: 10346 10346 3205
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286B
-Encoding: 10347 10347 10347
+Encoding: 10347 10347 3206
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286C
-Encoding: 10348 10348 10348
+Encoding: 10348 10348 3207
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286D
-Encoding: 10349 10349 10349
+Encoding: 10349 10349 3208
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286E
-Encoding: 10350 10350 10350
+Encoding: 10350 10350 3209
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286F
-Encoding: 10351 10351 10351
+Encoding: 10351 10351 3210
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2870
-Encoding: 10352 10352 10352
+Encoding: 10352 10352 3211
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2871
-Encoding: 10353 10353 10353
+Encoding: 10353 10353 3212
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2872
-Encoding: 10354 10354 10354
+Encoding: 10354 10354 3213
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2873
-Encoding: 10355 10355 10355
+Encoding: 10355 10355 3214
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2874
-Encoding: 10356 10356 10356
+Encoding: 10356 10356 3215
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2875
-Encoding: 10357 10357 10357
+Encoding: 10357 10357 3216
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2876
-Encoding: 10358 10358 10358
+Encoding: 10358 10358 3217
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2877
-Encoding: 10359 10359 10359
+Encoding: 10359 10359 3218
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2878
-Encoding: 10360 10360 10360
+Encoding: 10360 10360 3219
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2879
-Encoding: 10361 10361 10361
+Encoding: 10361 10361 3220
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287A
-Encoding: 10362 10362 10362
+Encoding: 10362 10362 3221
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287B
-Encoding: 10363 10363 10363
+Encoding: 10363 10363 3222
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287C
-Encoding: 10364 10364 10364
+Encoding: 10364 10364 3223
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287D
-Encoding: 10365 10365 10365
+Encoding: 10365 10365 3224
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287E
-Encoding: 10366 10366 10366
+Encoding: 10366 10366 3225
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287F
-Encoding: 10367 10367 10367
+Encoding: 10367 10367 3226
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2880
-Encoding: 10368 10368 10368
+Encoding: 10368 10368 3227
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2881
-Encoding: 10369 10369 10369
+Encoding: 10369 10369 3228
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2882
-Encoding: 10370 10370 10370
+Encoding: 10370 10370 3229
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2883
-Encoding: 10371 10371 10371
+Encoding: 10371 10371 3230
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2884
-Encoding: 10372 10372 10372
+Encoding: 10372 10372 3231
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2885
-Encoding: 10373 10373 10373
+Encoding: 10373 10373 3232
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2886
-Encoding: 10374 10374 10374
+Encoding: 10374 10374 3233
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2887
-Encoding: 10375 10375 10375
+Encoding: 10375 10375 3234
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2888
-Encoding: 10376 10376 10376
+Encoding: 10376 10376 3235
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2889
-Encoding: 10377 10377 10377
+Encoding: 10377 10377 3236
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288A
-Encoding: 10378 10378 10378
+Encoding: 10378 10378 3237
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288B
-Encoding: 10379 10379 10379
+Encoding: 10379 10379 3238
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288C
-Encoding: 10380 10380 10380
+Encoding: 10380 10380 3239
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288D
-Encoding: 10381 10381 10381
+Encoding: 10381 10381 3240
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288E
-Encoding: 10382 10382 10382
+Encoding: 10382 10382 3241
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288F
-Encoding: 10383 10383 10383
+Encoding: 10383 10383 3242
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2890
-Encoding: 10384 10384 10384
+Encoding: 10384 10384 3243
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2891
-Encoding: 10385 10385 10385
+Encoding: 10385 10385 3244
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2892
-Encoding: 10386 10386 10386
+Encoding: 10386 10386 3245
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2893
-Encoding: 10387 10387 10387
+Encoding: 10387 10387 3246
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2894
-Encoding: 10388 10388 10388
+Encoding: 10388 10388 3247
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2895
-Encoding: 10389 10389 10389
+Encoding: 10389 10389 3248
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2896
-Encoding: 10390 10390 10390
+Encoding: 10390 10390 3249
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2897
-Encoding: 10391 10391 10391
+Encoding: 10391 10391 3250
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2898
-Encoding: 10392 10392 10392
+Encoding: 10392 10392 3251
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2899
-Encoding: 10393 10393 10393
+Encoding: 10393 10393 3252
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289A
-Encoding: 10394 10394 10394
+Encoding: 10394 10394 3253
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289B
-Encoding: 10395 10395 10395
+Encoding: 10395 10395 3254
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289C
-Encoding: 10396 10396 10396
+Encoding: 10396 10396 3255
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289D
-Encoding: 10397 10397 10397
+Encoding: 10397 10397 3256
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289E
-Encoding: 10398 10398 10398
+Encoding: 10398 10398 3257
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289F
-Encoding: 10399 10399 10399
+Encoding: 10399 10399 3258
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A0
-Encoding: 10400 10400 10400
+Encoding: 10400 10400 3259
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A1
-Encoding: 10401 10401 10401
+Encoding: 10401 10401 3260
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A2
-Encoding: 10402 10402 10402
+Encoding: 10402 10402 3261
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A3
-Encoding: 10403 10403 10403
+Encoding: 10403 10403 3262
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A4
-Encoding: 10404 10404 10404
+Encoding: 10404 10404 3263
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A5
-Encoding: 10405 10405 10405
+Encoding: 10405 10405 3264
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A6
-Encoding: 10406 10406 10406
+Encoding: 10406 10406 3265
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A7
-Encoding: 10407 10407 10407
+Encoding: 10407 10407 3266
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A8
-Encoding: 10408 10408 10408
+Encoding: 10408 10408 3267
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A9
-Encoding: 10409 10409 10409
+Encoding: 10409 10409 3268
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AA
-Encoding: 10410 10410 10410
+Encoding: 10410 10410 3269
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AB
-Encoding: 10411 10411 10411
+Encoding: 10411 10411 3270
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AC
-Encoding: 10412 10412 10412
+Encoding: 10412 10412 3271
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AD
-Encoding: 10413 10413 10413
+Encoding: 10413 10413 3272
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AE
-Encoding: 10414 10414 10414
+Encoding: 10414 10414 3273
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AF
-Encoding: 10415 10415 10415
+Encoding: 10415 10415 3274
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B0
-Encoding: 10416 10416 10416
+Encoding: 10416 10416 3275
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B1
-Encoding: 10417 10417 10417
+Encoding: 10417 10417 3276
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B2
-Encoding: 10418 10418 10418
+Encoding: 10418 10418 3277
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B3
-Encoding: 10419 10419 10419
+Encoding: 10419 10419 3278
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B4
-Encoding: 10420 10420 10420
+Encoding: 10420 10420 3279
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B5
-Encoding: 10421 10421 10421
+Encoding: 10421 10421 3280
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B6
-Encoding: 10422 10422 10422
+Encoding: 10422 10422 3281
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B7
-Encoding: 10423 10423 10423
+Encoding: 10423 10423 3282
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B8
-Encoding: 10424 10424 10424
+Encoding: 10424 10424 3283
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B9
-Encoding: 10425 10425 10425
+Encoding: 10425 10425 3284
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BA
-Encoding: 10426 10426 10426
+Encoding: 10426 10426 3285
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BB
-Encoding: 10427 10427 10427
+Encoding: 10427 10427 3286
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BC
-Encoding: 10428 10428 10428
+Encoding: 10428 10428 3287
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BD
-Encoding: 10429 10429 10429
+Encoding: 10429 10429 3288
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BE
-Encoding: 10430 10430 10430
+Encoding: 10430 10430 3289
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BF
-Encoding: 10431 10431 10431
+Encoding: 10431 10431 3290
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C0
-Encoding: 10432 10432 10432
+Encoding: 10432 10432 3291
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C1
-Encoding: 10433 10433 10433
+Encoding: 10433 10433 3292
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C2
-Encoding: 10434 10434 10434
+Encoding: 10434 10434 3293
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C3
-Encoding: 10435 10435 10435
+Encoding: 10435 10435 3294
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C4
-Encoding: 10436 10436 10436
+Encoding: 10436 10436 3295
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C5
-Encoding: 10437 10437 10437
+Encoding: 10437 10437 3296
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C6
-Encoding: 10438 10438 10438
+Encoding: 10438 10438 3297
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C7
-Encoding: 10439 10439 10439
+Encoding: 10439 10439 3298
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C8
-Encoding: 10440 10440 10440
+Encoding: 10440 10440 3299
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C9
-Encoding: 10441 10441 10441
+Encoding: 10441 10441 3300
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CA
-Encoding: 10442 10442 10442
+Encoding: 10442 10442 3301
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CB
-Encoding: 10443 10443 10443
+Encoding: 10443 10443 3302
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CC
-Encoding: 10444 10444 10444
+Encoding: 10444 10444 3303
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CD
-Encoding: 10445 10445 10445
+Encoding: 10445 10445 3304
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CE
-Encoding: 10446 10446 10446
+Encoding: 10446 10446 3305
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CF
-Encoding: 10447 10447 10447
+Encoding: 10447 10447 3306
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D0
-Encoding: 10448 10448 10448
+Encoding: 10448 10448 3307
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D1
-Encoding: 10449 10449 10449
+Encoding: 10449 10449 3308
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D2
-Encoding: 10450 10450 10450
+Encoding: 10450 10450 3309
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D3
-Encoding: 10451 10451 10451
+Encoding: 10451 10451 3310
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D4
-Encoding: 10452 10452 10452
+Encoding: 10452 10452 3311
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D5
-Encoding: 10453 10453 10453
+Encoding: 10453 10453 3312
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D6
-Encoding: 10454 10454 10454
+Encoding: 10454 10454 3313
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D7
-Encoding: 10455 10455 10455
+Encoding: 10455 10455 3314
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D8
-Encoding: 10456 10456 10456
+Encoding: 10456 10456 3315
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D9
-Encoding: 10457 10457 10457
+Encoding: 10457 10457 3316
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DA
-Encoding: 10458 10458 10458
+Encoding: 10458 10458 3317
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DB
-Encoding: 10459 10459 10459
+Encoding: 10459 10459 3318
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DC
-Encoding: 10460 10460 10460
+Encoding: 10460 10460 3319
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DD
-Encoding: 10461 10461 10461
+Encoding: 10461 10461 3320
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DE
-Encoding: 10462 10462 10462
+Encoding: 10462 10462 3321
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DF
-Encoding: 10463 10463 10463
+Encoding: 10463 10463 3322
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E0
-Encoding: 10464 10464 10464
+Encoding: 10464 10464 3323
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E1
-Encoding: 10465 10465 10465
+Encoding: 10465 10465 3324
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E2
-Encoding: 10466 10466 10466
+Encoding: 10466 10466 3325
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E3
-Encoding: 10467 10467 10467
+Encoding: 10467 10467 3326
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E4
-Encoding: 10468 10468 10468
+Encoding: 10468 10468 3327
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E5
-Encoding: 10469 10469 10469
+Encoding: 10469 10469 3328
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E6
-Encoding: 10470 10470 10470
+Encoding: 10470 10470 3329
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E7
-Encoding: 10471 10471 10471
+Encoding: 10471 10471 3330
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E8
-Encoding: 10472 10472 10472
+Encoding: 10472 10472 3331
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E9
-Encoding: 10473 10473 10473
+Encoding: 10473 10473 3332
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EA
-Encoding: 10474 10474 10474
+Encoding: 10474 10474 3333
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EB
-Encoding: 10475 10475 10475
+Encoding: 10475 10475 3334
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EC
-Encoding: 10476 10476 10476
+Encoding: 10476 10476 3335
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28ED
-Encoding: 10477 10477 10477
+Encoding: 10477 10477 3336
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EE
-Encoding: 10478 10478 10478
+Encoding: 10478 10478 3337
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EF
-Encoding: 10479 10479 10479
+Encoding: 10479 10479 3338
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F0
-Encoding: 10480 10480 10480
+Encoding: 10480 10480 3339
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F1
-Encoding: 10481 10481 10481
+Encoding: 10481 10481 3340
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F2
-Encoding: 10482 10482 10482
+Encoding: 10482 10482 3341
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F3
-Encoding: 10483 10483 10483
+Encoding: 10483 10483 3342
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F4
-Encoding: 10484 10484 10484
+Encoding: 10484 10484 3343
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F5
-Encoding: 10485 10485 10485
+Encoding: 10485 10485 3344
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F6
-Encoding: 10486 10486 10486
+Encoding: 10486 10486 3345
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F7
-Encoding: 10487 10487 10487
+Encoding: 10487 10487 3346
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F8
-Encoding: 10488 10488 10488
+Encoding: 10488 10488 3347
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F9
-Encoding: 10489 10489 10489
+Encoding: 10489 10489 3348
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FA
-Encoding: 10490 10490 10490
+Encoding: 10490 10490 3349
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FB
-Encoding: 10491 10491 10491
+Encoding: 10491 10491 3350
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FC
-Encoding: 10492 10492 10492
+Encoding: 10492 10492 3351
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FD
-Encoding: 10493 10493 10493
+Encoding: 10493 10493 3352
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FE
-Encoding: 10494 10494 10494
+Encoding: 10494 10494 3353
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FF
-Encoding: 10495 10495 10495
+Encoding: 10495 10495 3354
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2987
-Encoding: 10631 10631 10631
+Encoding: 10631 10631 3355
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-933 -270 m 1,0,1
- 597 -189 597 -189 448.5 76.5 c 128,-1,2
- 300 342 300 342 300 643 c 0,3,4
- 300 943 300 943 444.5 1207 c 128,-1,5
- 589 1471 589 1471 933 1554 c 1,6,-1
- 933 -270 l 1,0,1
-833 1373 m 1,7,8
- 688 1334 688 1334 581.5 1114 c 128,-1,9
- 475 894 475 894 475 643 c 0,10,11
- 475 391 475 391 581.5 171 c 128,-1,12
- 688 -49 688 -49 833 -89 c 1,13,-1
- 833 1373 l 1,7,8
+933 -270 m 5,0,1
+ 597 -189 597 -189 448.5 76.5 c 132,-1,2
+ 300 342 300 342 300 643 c 4,3,4
+ 300 943 300 943 444.5 1207 c 132,-1,5
+ 589 1471 589 1471 933 1554 c 5,6,-1
+ 933 -270 l 5,0,1
+833 1373 m 5,7,8
+ 688 1334 688 1334 581.5 1114 c 132,-1,9
+ 475 894 475 894 475 643 c 4,10,11
+ 475 391 475 391 581.5 171 c 132,-1,12
+ 688 -49 688 -49 833 -89 c 5,13,-1
+ 833 1373 l 5,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2988
-Encoding: 10632 10632 10632
+Encoding: 10632 10632 3356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96949,44 +100361,51 @@ SplineSet
  400 -89 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2997
-Encoding: 10647 10647 10647
-Width: 1233
+Encoding: 10647 10647 3357
+Width: 600
+VWidth: 1000
 Flags: W
+VStem: 168 87<29 545 29 589 29 589>
 LayerCount: 2
 Fore
 SplineSet
-882 -322 m 1,0,-1
- 400 159 l 1,1,-1
- 400 1127 l 1,2,-1
- 882 1608 l 1,3,-1
- 983 1507 l 1,4,-1
- 704 1229 l 1,5,-1
- 704 57 l 1,6,-1
- 983 -221 l 1,7,-1
- 882 -322 l 1,0,-1
+412.538085938 110.450195312 m 5,0,-1
+ 412.538085938 1212.75 l 5,1,-1
+ 903.00390625 1548.54980469 l 5,2,-1
+ 903.00390625 1369.70019531 l 5,3,-1
+ 579.873046875 1132.45019531 l 5,4,-1
+ 579.873046875 190.75 l 5,5,-1
+ 903.00390625 -46.5 l 5,6,-1
+ 903.00390625 -225.349609375 l 5,7,-1
+ 412.538085938 110.450195312 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2998
-Encoding: 10648 10648 10648
-Width: 1233
+Encoding: 10648 10648 3358
+Width: 600
+VWidth: 1000
 Flags: W
+VStem: 370 87<29 545 545 545>
 LayerCount: 2
 Fore
 SplineSet
-351 1608 m 1,0,-1
- 833 1127 l 1,1,-1
- 833 159 l 1,2,-1
- 351 -322 l 1,3,-1
- 250 -221 l 1,4,-1
- 529 57 l 1,5,-1
- 529 1229 l 1,6,-1
- 250 1507 l 1,7,-1
- 351 1608 l 1,0,-1
+786.461914062 110.450195312 m 5,0,-1
+ 786.461914062 1212.75 l 5,1,-1
+ 295.99609375 1548.54980469 l 5,2,-1
+ 295.99609375 1369.70019531 l 5,3,-1
+ 619.126953125 1132.45019531 l 5,4,-1
+ 619.126953125 190.75 l 5,5,-1
+ 295.99609375 -46.5 l 5,6,-1
+ 295.99609375 -225.349609375 l 5,7,-1
+ 786.461914062 110.450195312 l 5,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29EB
-Encoding: 10731 10731 10731
+Encoding: 10731 10731 3359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96999,8 +100418,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FA
-Encoding: 10746 10746 10746
+Encoding: 10746 10746 3360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97029,8 +100449,9 @@ SplineSet
  732 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FB
-Encoding: 10747 10747 10747
+Encoding: 10747 10747 3361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97067,8 +100488,9 @@ SplineSet
  202 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2A00
-Encoding: 10752 10752 10752
+Encoding: 10752 10752 3362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97091,35 +100513,39 @@ SplineSet
  80 1547 80 1547 616 1547 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2A2F
-Encoding: 10799 10799 10799
+Encoding: 10799 10799 3363
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 215 215 N 1 0 0 1 0 0 2
+Refer: 151 215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6A
-Encoding: 10858 10858 10858
+Encoding: 10858 10858 3364
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 292 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 292 2
 EndChar
+
 StartChar: uni2A6B
-Encoding: 10859 10859 10859
+Encoding: 10859 10859 3365
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 242 292 2
-Refer: 8901 8901 N 1 0 0 1 -239 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 242 292 2
+Refer: 2375 8901 N 1 0 0 1 -239 -425 2
 EndChar
+
 StartChar: uni2B05
-Encoding: 11013 11013 11013
+Encoding: 11013 11013 3366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97135,8 +100561,9 @@ SplineSet
  395 842 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B06
-Encoding: 11014 11014 11014
+Encoding: 11014 11014 3367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97152,8 +100579,9 @@ SplineSet
  759 921 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B07
-Encoding: 11015 11015 11015
+Encoding: 11015 11015 3368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97169,8 +100597,9 @@ SplineSet
  474 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B08
-Encoding: 11016 11016 11016
+Encoding: 11016 11016 3369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97186,8 +100615,9 @@ SplineSet
  874 756 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B09
-Encoding: 11017 11017 11017
+Encoding: 11017 11017 3370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97203,8 +100633,9 @@ SplineSet
  560 957 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0A
-Encoding: 11018 11018 11018
+Encoding: 11018 11018 3371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97220,8 +100651,9 @@ SplineSet
  773 342 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0B
-Encoding: 11019 11019 11019
+Encoding: 11019 11019 3372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97237,8 +100669,9 @@ SplineSet
  259 543 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0C
-Encoding: 11020 11020 11020
+Encoding: 11020 11020 3373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97257,8 +100690,9 @@ SplineSet
  395 842 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0D
-Encoding: 11021 11021 11021
+Encoding: 11021 11021 3374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97277,8 +100711,9 @@ SplineSet
  474 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B12
-Encoding: 11026 11026 11026
+Encoding: 11026 11026 3375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97296,8 +100731,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B13
-Encoding: 11027 11027 11027
+Encoding: 11027 11027 3376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97315,8 +100751,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B14
-Encoding: 11028 11028 11028
+Encoding: 11028 11028 3377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97333,8 +100770,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B15
-Encoding: 11029 11029 11029
+Encoding: 11029 11029 3378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97351,8 +100789,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B16
-Encoding: 11030 11030 11030
+Encoding: 11030 11030 3379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97369,8 +100808,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B17
-Encoding: 11031 11031 11031
+Encoding: 11031 11031 3380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97387,8 +100827,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B18
-Encoding: 11032 11032 11032
+Encoding: 11032 11032 3381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97405,8 +100846,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B19
-Encoding: 11033 11033 11033
+Encoding: 11033 11033 3382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97423,8 +100865,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B1A
-Encoding: 11034 11034 11034
+Encoding: 11034 11034 3383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97500,8 +100943,9 @@ SplineSet
  206 1142.5 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C64
-Encoding: 11364 11364 11364
+Encoding: 11364 11364 3384
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
@@ -97543,8 +100987,9 @@ SplineSet
  346 1327 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6D
-Encoding: 11373 11373 11373
+Encoding: 11373 11373 3385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97575,8 +101020,9 @@ SplineSet
  317 1047.18 317 1047.18 317 745.5 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C6E
-Encoding: 11374 11374 11374
+Encoding: 11374 11374 3386
 Width: 1233
 Flags: W
 AnchorPoint: "below" 676 -426 basechar 0
@@ -97607,8 +101053,9 @@ SplineSet
  958 1319 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6F
-Encoding: 11375 11375 11375
+Encoding: 11375 11375 3387
 Width: 1233
 Flags: W
 AnchorPoint: "above" 617 1493 basechar 0
@@ -97631,8 +101078,9 @@ SplineSet
  739 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C70
-Encoding: 11376 11376 11376
+Encoding: 11376 11376 3388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97663,8 +101111,9 @@ SplineSet
  895 443.821 895 443.821 895 745.5 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C75
-Encoding: 11381 11381 11381
+Encoding: 11381 11381 3389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97681,8 +101130,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C76
-Encoding: 11382 11382 11382
+Encoding: 11382 11382 3390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97699,8 +101149,9 @@ SplineSet
  379 515 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C77
-Encoding: 11383 11383 11383
+Encoding: 11383 11383 3391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97732,8 +101183,9 @@ SplineSet
  525 1128 525 1128 773 1128 c 8,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni2C79
-Encoding: 11385 11385 11385
+Encoding: 11385 11385 3392
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -97764,8 +101216,9 @@ SplineSet
  945 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7A
-Encoding: 11386 11386 11386
+Encoding: 11386 11386 3393
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -97803,16 +101256,18 @@ SplineSet
  901 498 901 498 901 559 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C7C
-Encoding: 11388 11388 11388
+Encoding: 11388 11388 3394
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 690 690 N 1 0 0 1 0 -668 3
+Refer: 607 690 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2C7D
-Encoding: 11389 11389 11389
+Encoding: 11389 11389 3395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97828,8 +101283,9 @@ SplineSet
  616 763 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7E
-Encoding: 11390 11390 11390
+Encoding: 11390 11390 3396
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -97881,8 +101337,9 @@ SplineSet
  907 1481 907 1481 1012 1442 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7F
-Encoding: 11391 11391 11391
+Encoding: 11391 11391 3397
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
@@ -97917,8 +101374,9 @@ SplineSet
  156 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18
-Encoding: 11800 11800 11800
+Encoding: 11800 11800 3398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97955,17 +101413,19 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" uni2E18.case
 EndChar
+
 StartChar: uni2E1F
-Encoding: 11807 11807 11807
+Encoding: 11807 11807 3399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 -425 2
 EndChar
+
 StartChar: uni2E22
-Encoding: 11810 11810 11810
+Encoding: 11810 11810 3400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97980,8 +101440,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E23
-Encoding: 11811 11811 11811
+Encoding: 11811 11811 3401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97996,8 +101457,9 @@ SplineSet
  586 1413 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E24
-Encoding: 11812 11812 11812
+Encoding: 11812 11812 3402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98012,8 +101474,9 @@ SplineSet
  647 -127 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E25
-Encoding: 11813 11813 11813
+Encoding: 11813 11813 3403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98028,16 +101491,18 @@ SplineSet
  770 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E2E
-Encoding: 11822 11822 11822
+Encoding: 11822 11822 3404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1567 1567 N 1 0 0 1 0 0 2
+Refer: 1167 1567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniA708
-Encoding: 42760 42760 42760
+Encoding: 42760 42760 3405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98055,8 +101520,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA709
-Encoding: 42761 42761 42761
+Encoding: 42761 42761 3406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98074,8 +101540,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70A
-Encoding: 42762 42762 42762
+Encoding: 42762 42762 3407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98093,8 +101560,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70B
-Encoding: 42763 42763 42763
+Encoding: 42763 42763 3408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98112,8 +101580,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70C
-Encoding: 42764 42764 42764
+Encoding: 42764 42764 3409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98131,8 +101600,9 @@ SplineSet
  797 1368 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70D
-Encoding: 42765 42765 42765
+Encoding: 42765 42765 3410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98150,8 +101620,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70E
-Encoding: 42766 42766 42766
+Encoding: 42766 42766 3411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98169,8 +101640,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70F
-Encoding: 42767 42767 42767
+Encoding: 42767 42767 3412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98188,8 +101660,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA710
-Encoding: 42768 42768 42768
+Encoding: 42768 42768 3413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98207,8 +101680,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA711
-Encoding: 42769 42769 42769
+Encoding: 42769 42769 3414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98226,8 +101700,9 @@ SplineSet
  436 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA712
-Encoding: 42770 42770 42770
+Encoding: 42770 42770 3415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98242,8 +101717,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA713
-Encoding: 42771 42771 42771
+Encoding: 42771 42771 3416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98260,8 +101736,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA714
-Encoding: 42772 42772 42772
+Encoding: 42772 42772 3417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98278,8 +101755,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA715
-Encoding: 42773 42773 42773
+Encoding: 42773 42773 3418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98296,8 +101774,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA716
-Encoding: 42774 42774 42774
+Encoding: 42774 42774 3419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98312,8 +101791,9 @@ SplineSet
  436 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71B
-Encoding: 42779 42779 42779
+Encoding: 42779 42779 3420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98332,8 +101812,9 @@ SplineSet
  588 1508 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71C
-Encoding: 42780 42780 42780
+Encoding: 42780 42780 3421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98352,8 +101833,9 @@ SplineSet
  646 664 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71D
-Encoding: 42781 42781 42781
+Encoding: 42781 42781 3422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98373,8 +101855,9 @@ SplineSet
  552 1504 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71E
-Encoding: 42782 42782 42782
+Encoding: 42782 42782 3423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98394,16 +101877,18 @@ SplineSet
  680 668 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71F
-Encoding: 42783 42783 42783
+Encoding: 42783 42783 3424
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42782 42782 N 1 0 0 1 0 -668 2
+Refer: 3423 42782 N 1 0 0 1 0 -668 2
 EndChar
+
 StartChar: uniA722
-Encoding: 42786 42786 42786
+Encoding: 42786 42786 3425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98423,8 +101908,9 @@ SplineSet
  961 0 961 0 391 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA723
-Encoding: 42787 42787 42787
+Encoding: 42787 42787 3426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98444,8 +101930,9 @@ SplineSet
  936 0 936 0 416 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA724
-Encoding: 42788 42788 42788
+Encoding: 42788 42788 3427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98460,8 +101947,9 @@ SplineSet
  421 1301 421 1301 421 973 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA725
-Encoding: 42789 42789 42789
+Encoding: 42789 42789 3428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98476,8 +101964,9 @@ SplineSet
  421 958 421 958 421 600 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA726
-Encoding: 42790 42790 42790
+Encoding: 42790 42790 3429
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -98507,8 +101996,9 @@ SplineSet
  1096 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA727
-Encoding: 42791 42791 42791
+Encoding: 42791 42791 3430
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -98542,16 +102032,18 @@ SplineSet
  866 694 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA789
-Encoding: 42889 42889 42889
+Encoding: 42889 42889 3431
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 3
+Refer: 27 58 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78A
-Encoding: 42890 42890 42890
+Encoding: 42890 42890 3432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98569,8 +102061,9 @@ SplineSet
  842 629 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78B
-Encoding: 42891 42891 42891
+Encoding: 42891 42891 3433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98585,8 +102078,9 @@ SplineSet
  516 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78C
-Encoding: 42892 42892 42892
+Encoding: 42892 42892 3434
 Width: 1233
 Flags: W
 TtInstrs:
@@ -98619,16 +102113,18 @@ SplineSet
  702 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78D
-Encoding: 42893 42893 42893
+Encoding: 42893 42893 3435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1063 1063 N 1 0 0 1 0 0 3
+Refer: 877 1063 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78E
-Encoding: 42894 42894 42894
+Encoding: 42894 42894 3436
 Width: 1233
 Flags: W
 AnchorPoint: "below" 617 -426 basechar 0
@@ -98665,8 +102161,9 @@ SplineSet
  498 786 l 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uniA790
-Encoding: 42896 42896 42896
+Encoding: 42896 42896 3437
 Width: 1233
 Flags: W
 AnchorPoint: "above" 561 1493 basechar 0
@@ -98691,8 +102188,9 @@ SplineSet
  84 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA791
-Encoding: 42897 42897 42897
+Encoding: 42897 42897 3438
 Width: 1233
 Flags: W
 AnchorPoint: "below" 543 0 basechar 0
@@ -98723,8 +102221,9 @@ SplineSet
  978 922 978 922 978 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7AA
-Encoding: 42922 42922 42922
+Encoding: 42922 42922 3439
 Width: 1233
 Flags: W
 AnchorPoint: "below" 768 0 basechar 0
@@ -98755,8 +102254,9 @@ SplineSet
  338 1327 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F8
-Encoding: 43000 43000 43000
+Encoding: 43000 43000 3440
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1504 basechar 0
@@ -98793,8 +102293,9 @@ SplineSet
  442 1287 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F9
-Encoding: 43001 43001 43001
+Encoding: 43001 43001 3441
 Width: 1233
 Flags: W
 AnchorPoint: "below" 619 668 basechar 0
@@ -98844,8 +102345,9 @@ SplineSet
  1054 1038 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uniF6C5
-Encoding: 63173 63173 63173
+Encoding: 63173 63173 3442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98881,8 +102383,9 @@ SplineSet
  478.101 1146.41 478.101 1146.41 616 1147 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: fi
-Encoding: 64257 64257 64257
+Encoding: 64257 64257 3443
 Width: 1233
 Flags: W
 TtInstrs:
@@ -98995,11 +102498,12 @@ SplineSet
  405 1556 405 1556 584 1556 c 2,25,-1
  776 1556 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 10" f i
 EndChar
+
 StartChar: fl
-Encoding: 64258 64258 64258
+Encoding: 64258 64258 3444
 Width: 1233
 Flags: W
 TtInstrs:
@@ -99095,593 +102599,647 @@ SplineSet
  405 1556 405 1556 584 1556 c 2,21,-1
  1079 1556 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 10" f l
 EndChar
+
 StartChar: uniFB52
-Encoding: 64338 64338 64338
+Encoding: 64338 64338 3445
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 617.5 -600 basechar 0
 AnchorPoint: "rtl-above" 617.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 542.5 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 542.5 -250 2
 EndChar
+
 StartChar: uniFB53
-Encoding: 64339 64339 64339
+Encoding: 64339 64339 3446
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 582.5 -600 basechar 0
 AnchorPoint: "rtl-above" 582.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 507.5 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 507.5 -250 2
 EndChar
+
 StartChar: uniFB54
-Encoding: 64340 64340 64340
+Encoding: 64340 64340 3447
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -550 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 524 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 524 -250 2
 EndChar
+
 StartChar: uniFB55
-Encoding: 64341 64341 64341
+Encoding: 64341 64341 3448
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -550 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 524 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 524 -250 2
 EndChar
+
 StartChar: uniFB56
-Encoding: 64342 64342 64342
+Encoding: 64342 64342 3449
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 645 -600 basechar 0
 AnchorPoint: "rtl-above" 645 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 445 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 445 -250 2
 EndChar
+
 StartChar: uniFB57
-Encoding: 64343 64343 64343
+Encoding: 64343 64343 3450
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -600 basechar 0
 AnchorPoint: "rtl-above" 576 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 376 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 376 -250 2
 EndChar
+
 StartChar: uniFB58
-Encoding: 64344 64344 64344
+Encoding: 64344 64344 3451
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -550 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 396 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 396 -250 2
 EndChar
+
 StartChar: uniFB59
-Encoding: 64345 64345 64345
+Encoding: 64345 64345 3452
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 593 -550 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 396 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 396 -250 2
 EndChar
+
 StartChar: uniFB5A
-Encoding: 64346 64346 64346
+Encoding: 64346 64346 3453
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -600 basechar 0
 AnchorPoint: "rtl-above" 603 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 403 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 403 -250 2
 EndChar
+
 StartChar: uniFB5B
-Encoding: 64347 64347 64347
+Encoding: 64347 64347 3454
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 570 -600 basechar 0
 AnchorPoint: "rtl-above" 570 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 370 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 370 -250 2
 EndChar
+
 StartChar: uniFB5C
-Encoding: 64348 64348 64348
+Encoding: 64348 64348 3455
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 578 -550 basechar 0
 AnchorPoint: "rtl-above" 578 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 378 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 378 -250 2
 EndChar
+
 StartChar: uniFB5D
-Encoding: 64349 64349 64349
+Encoding: 64349 64349 3456
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -550 basechar 0
 AnchorPoint: "rtl-above" 608 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 408 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 408 -250 2
 EndChar
+
 StartChar: uniFB5E
-Encoding: 64350 64350 64350
+Encoding: 64350 64350 3457
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 642 -150 basechar 0
 AnchorPoint: "rtl-above" 642 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 567 807 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 567 807 2
 EndChar
+
 StartChar: uniFB5F
-Encoding: 64351 64351 64351
+Encoding: 64351 64351 3458
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 588 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 513 813 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 513 813 2
 EndChar
+
 StartChar: uniFB60
-Encoding: 64352 64352 64352
+Encoding: 64352 64352 3459
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -101 basechar 0
 AnchorPoint: "rtl-above" 603 1299 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 528 994 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 528 994 2
 EndChar
+
 StartChar: uniFB61
-Encoding: 64353 64353 64353
+Encoding: 64353 64353 3460
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 602 -100 basechar 0
 AnchorPoint: "rtl-above" 602 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 527 983 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 527 983 2
 EndChar
+
 StartChar: uniFB62
-Encoding: 64354 64354 64354
+Encoding: 64354 64354 3461
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -150 basechar 0
 AnchorPoint: "rtl-above" 603 1181 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 403 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 403 900 2
 EndChar
+
 StartChar: uniFB63
-Encoding: 64355 64355 64355
+Encoding: 64355 64355 3462
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 585 -150 basechar 0
 AnchorPoint: "rtl-above" 585 1199 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 385 900 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 385 900 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB64
-Encoding: 64356 64356 64356
+Encoding: 64356 64356 3463
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -100 basechar 0
 AnchorPoint: "rtl-above" 599 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 399 995 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 399 995 2
 EndChar
+
 StartChar: uniFB65
-Encoding: 64357 64357 64357
+Encoding: 64357 64357 3464
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -100 basechar 0
 AnchorPoint: "rtl-above" 596 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 396 998 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 396 998 2
 EndChar
+
 StartChar: uniFB66
-Encoding: 64358 64358 64358
+Encoding: 64358 64358 3465
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 588 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 76 -666 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 76 -666 2
 EndChar
+
 StartChar: uniFB67
-Encoding: 64359 64359 64359
+Encoding: 64359 64359 3466
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -150 basechar 0
 AnchorPoint: "rtl-above" 564 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 52 -681 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 52 -681 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB68
-Encoding: 64360 64360 64360
+Encoding: 64360 64360 3467
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 587 -100 basechar 0
 AnchorPoint: "rtl-above" 587 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 75 -508 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 75 -508 2
 EndChar
+
 StartChar: uniFB69
-Encoding: 64361 64361 64361
+Encoding: 64361 64361 3468
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -100 basechar 0
 AnchorPoint: "rtl-above" 605 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 93 -493 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 93 -493 2
 EndChar
+
 StartChar: uniFB6A
-Encoding: 64362 64362 64362
+Encoding: 64362 64362 3469
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 -180 basechar 0
 AnchorPoint: "rtl-above" 400 1388 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 628 994 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 628 994 2
 EndChar
+
 StartChar: uniFB6B
-Encoding: 64363 64363 64363
+Encoding: 64363 64363 3470
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 404 -192 basechar 0
 AnchorPoint: "rtl-above" 312 1268 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 644 886 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 644 886 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6C
-Encoding: 64364 64364 64364
+Encoding: 64364 64364 3471
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 500 1600 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 300 1150 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 300 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6D
-Encoding: 64365 64365 64365
+Encoding: 64365 64365 3472
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 598 -150 basechar 0
 AnchorPoint: "rtl-above" 606 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 406 896 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 406 896 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6E
-Encoding: 64366 64366 64366
+Encoding: 64366 64366 3473
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -200 basechar 0
 AnchorPoint: "rtl-above" 288 1312 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 648 1256 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 648 1256 2
 EndChar
+
 StartChar: uniFB6F
-Encoding: 64367 64367 64367
+Encoding: 64367 64367 3474
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 392 -200 basechar 0
 AnchorPoint: "rtl-above" 264 1252 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 652 1140 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 652 1140 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB70
-Encoding: 64368 64368 64368
+Encoding: 64368 64368 3475
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 500 1600 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 300 1400 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 300 1400 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB71
-Encoding: 64369 64369 64369
+Encoding: 64369 64369 3476
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 610 -150 basechar 0
 AnchorPoint: "rtl-above" 610 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 410 1162 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 410 1162 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB72
-Encoding: 64370 64370 64370
+Encoding: 64370 64370 3477
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -600 basechar 0
 AnchorPoint: "rtl-above" 466 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 635 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 635 175 2
 EndChar
+
 StartChar: uniFB73
-Encoding: 64371 64371 64371
+Encoding: 64371 64371 3478
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -600 basechar 0
 AnchorPoint: "rtl-above" 442 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 559 125 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 559 125 2
 EndChar
+
 StartChar: uniFB74
-Encoding: 64372 64372 64372
+Encoding: 64372 64372 3479
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 428 -500 basechar 0
 AnchorPoint: "rtl-above" 428 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 353 -200 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 353 -200 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB75
-Encoding: 64373 64373 64373
+Encoding: 64373 64373 3480
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 525 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 525 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB76
-Encoding: 64374 64374 64374
+Encoding: 64374 64374 3481
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -600 basechar 0
 AnchorPoint: "rtl-above" 434 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 650 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 650 25 2
 EndChar
+
 StartChar: uniFB77
-Encoding: 64375 64375 64375
+Encoding: 64375 64375 3482
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -600 basechar 0
 AnchorPoint: "rtl-above" 422 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 550 -25 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 550 -25 2
 EndChar
+
 StartChar: uniFB78
-Encoding: 64376 64376 64376
+Encoding: 64376 64376 3483
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 388 -250 basechar 0
 AnchorPoint: "rtl-above" 388 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 188 -200 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 188 -200 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB79
-Encoding: 64377 64377 64377
+Encoding: 64377 64377 3484
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -250 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7A
-Encoding: 64378 64378 64378
+Encoding: 64378 64378 3485
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -600 basechar 0
 AnchorPoint: "rtl-above" 434 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 554 150 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 554 150 2
 EndChar
+
 StartChar: uniFB7B
-Encoding: 64379 64379 64379
+Encoding: 64379 64379 3486
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -601 basechar 0
 AnchorPoint: "rtl-above" 406 999 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 453 66 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 453 66 2
 EndChar
+
 StartChar: uniFB7C
-Encoding: 64380 64380 64380
+Encoding: 64380 64380 3487
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 440 -540 basechar 0
 AnchorPoint: "rtl-above" 440 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 240 -240 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 240 -240 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7D
-Encoding: 64381 64381 64381
+Encoding: 64381 64381 3488
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7E
-Encoding: 64382 64382 64382
+Encoding: 64382 64382 3489
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -600 basechar 0
 AnchorPoint: "rtl-above" 454 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 562 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 562 175 2
 EndChar
+
 StartChar: uniFB7F
-Encoding: 64383 64383 64383
+Encoding: 64383 64383 3490
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -600 basechar 0
 AnchorPoint: "rtl-above" 450 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 453 94 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 453 94 2
 EndChar
+
 StartChar: uniFB80
-Encoding: 64384 64384 64384
+Encoding: 64384 64384 3491
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 452 -540 basechar 0
 AnchorPoint: "rtl-above" 452 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 252 -240 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 252 -240 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB81
-Encoding: 64385 64385 64385
+Encoding: 64385 64385 3492
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8A
-Encoding: 64394 64394 64394
+Encoding: 64394 64394 3493
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 623.5 1101.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 720.5 678.5 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 720.5 678.5 2
 EndChar
+
 StartChar: uniFB8B
-Encoding: 64395 64395 64395
+Encoding: 64395 64395 3494
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 700 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 603.5 692 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 603.5 692 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8C
-Encoding: 64396 64396 64396
+Encoding: 64396 64396 3495
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 682 1215.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 341 -598.5 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 341 -598.5 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8D
-Encoding: 64397 64397 64397
+Encoding: 64397 64397 3496
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 664 1265 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 233 -621 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 233 -621 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8E
-Encoding: 64398 64398 64398
+Encoding: 64398 64398 3497
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 575 -150 basechar 0
 AnchorPoint: "rtl-above" 545 1364 basechar 0
 LayerCount: 2
 Fore
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8F
-Encoding: 64399 64399 64399
+Encoding: 64399 64399 3498
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 454 -150 basechar 0
@@ -99723,80 +103281,88 @@ SplineSet
  1013 182 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFB90
-Encoding: 64400 64400 64400
+Encoding: 64400 64400 3499
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 511 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65243 65243 N 1 0 0 1 0 0 2
+Refer: 3623 65243 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB91
-Encoding: 64401 64401 64401
+Encoding: 64401 64401 3500
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 497.5 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65244 65244 N 1 0 0 1 0 0 2
+Refer: 3624 65244 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB92
-Encoding: 64402 64402 64402
+Encoding: 64402 64402 3501
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596.5 -161 basechar 0
 AnchorPoint: "rtl-above" 396.5 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1705 1705 N 1 0 0 1 0 0 2
-Refer: 1114144 -1 N 1 0 0 1 684 14.5 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 684 14.5 2
 EndChar
+
 StartChar: uniFB93
-Encoding: 64403 64403 64403
+Encoding: 64403 64403 3502
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 494 -150 basechar 0
 AnchorPoint: "rtl-above" 243.5 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 596.5 18 2
-Refer: 64399 64399 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 596.5 18 2
+Refer: 3498 64399 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB94
-Encoding: 64404 64404 64404
+Encoding: 64404 64404 3503
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1700 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114145 -1 N 1 0 0 1 143 0 2
-Refer: 64400 64400 N 1 0 0 1 0 0 2
+Refer: 3758 -1 N 1 0 0 1 143 0 2
+Refer: 3499 64400 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB95
-Encoding: 64405 64405 64405
+Encoding: 64405 64405 3504
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1700 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114145 -1 N 1 0 0 1 156 0 2
-Refer: 64401 64401 N 1 0 0 1 0 0 2
+Refer: 3758 -1 N 1 0 0 1 156 0 2
+Refer: 3500 64401 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB9E
-Encoding: 64414 64414 64414
+Encoding: 64414 64414 3505
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB9F
-Encoding: 64415 64415 64415
+Encoding: 64415 64415 3506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99827,18 +103393,20 @@ SplineSet
  1053 -125 1053 -125 968 -265 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBAA
-Encoding: 64426 64426 64426
+Encoding: 64426 64426 3507
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -156 basechar 0
 AnchorPoint: "rtl-above" 596 1152 basechar 0
 LayerCount: 2
 Fore
-Refer: 1726 1726 N 1 0 0 1 0 0 2
+Refer: 1247 1726 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAB
-Encoding: 64427 64427 64427
+Encoding: 64427 64427 3508
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 596 1152 basechar 0
@@ -99888,18 +103456,20 @@ SplineSet
  922 464 922 464 877 508 c 1,55,56
 EndSplineSet
 EndChar
+
 StartChar: uniFBAC
-Encoding: 64428 64428 64428
+Encoding: 64428 64428 3509
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 440 1152 basechar 0
 AnchorPoint: "rtl-below" 440 -156 basechar 0
 LayerCount: 2
 Fore
-Refer: 65259 65259 N 1 0 0 1 0 0 2
+Refer: 3639 65259 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAD
-Encoding: 64429 64429 64429
+Encoding: 64429 64429 3510
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 528 1152 basechar 0
@@ -99945,8 +103515,9 @@ SplineSet
  818 464 818 464 773 508 c 1,45,46
 EndSplineSet
 EndChar
+
 StartChar: uniFBE8
-Encoding: 64488 64488 64488
+Encoding: 64488 64488 3511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99965,8 +103536,9 @@ SplineSet
  700 196 700 196 608 86 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBE9
-Encoding: 64489 64489 64489
+Encoding: 64489 64489 3512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99990,75 +103562,83 @@ SplineSet
  686 0 686 0 606 86 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBFC
-Encoding: 64508 64508 64508
+Encoding: 64508 64508 3513
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -400 basechar 0
 AnchorPoint: "rtl-above" 460 806 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFD
-Encoding: 64509 64509 64509
+Encoding: 64509 64509 3514
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 408 -400 basechar 0
 AnchorPoint: "rtl-above" 404 638 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFE
-Encoding: 64510 64510 64510
+Encoding: 64510 64510 3515
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 591 -350 basechar 0
 AnchorPoint: "rtl-above" 591 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 391 -300 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 391 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFF
-Encoding: 64511 64511 64511
+Encoding: 64511 64511 3516
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -350 basechar 0
 AnchorPoint: "rtl-above" 603 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 -300 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE70
-Encoding: 65136 65136 65136
+Encoding: 65136 65136 3517
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1611 1611 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE71
-Encoding: 65137 65137 65137
+Encoding: 65137 65137 3518
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1611 1611 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE72
-Encoding: 65138 65138 65138
+Encoding: 65138 65138 3519
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1612 1612 N 1 0 0 1 0 0 2
+Refer: 1206 1612 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE73
-Encoding: 65139 65139 65139
+Encoding: 65139 65139 3520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -100077,241 +103657,267 @@ SplineSet
  986 332 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFE74
-Encoding: 65140 65140 65140
+Encoding: 65140 65140 3521
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1613 1613 N 1 0 0 1 0 0 2
+Refer: 1207 1613 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE76
-Encoding: 65142 65142 65142
+Encoding: 65142 65142 3522
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1614 1614 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE77
-Encoding: 65143 65143 65143
+Encoding: 65143 65143 3523
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1614 1614 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE78
-Encoding: 65144 65144 65144
+Encoding: 65144 65144 3524
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1615 1615 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE79
-Encoding: 65145 65145 65145
+Encoding: 65145 65145 3525
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1615 1615 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7A
-Encoding: 65146 65146 65146
+Encoding: 65146 65146 3526
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1616 1616 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7B
-Encoding: 65147 65147 65147
+Encoding: 65147 65147 3527
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1616 1616 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7C
-Encoding: 65148 65148 65148
+Encoding: 65148 65148 3528
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1617 1617 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7D
-Encoding: 65149 65149 65149
+Encoding: 65149 65149 3529
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1617 1617 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7E
-Encoding: 65150 65150 65150
+Encoding: 65150 65150 3530
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1618 1618 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7F
-Encoding: 65151 65151 65151
+Encoding: 65151 65151 3531
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1618 1618 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE80
-Encoding: 65152 65152 65152
+Encoding: 65152 65152 3532
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 704 28 basechar 0
 AnchorPoint: "rtl-above" 688 1208 basechar 0
 LayerCount: 2
 Fore
-Refer: 1569 1569 N 1 0 0 1 0 0 2
+Refer: 1168 1569 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE81
-Encoding: 65153 65153 65153
+Encoding: 65153 65153 3533
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 0 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
 EndChar
+
 StartChar: uniFE82
-Encoding: 65154 65154 65154
+Encoding: 65154 65154 3534
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 0 450 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE83
-Encoding: 65155 65155 65155
+Encoding: 65155 65155 3535
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 524 2264 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -10 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -10 450 2
 EndChar
+
 StartChar: uniFE84
-Encoding: 65156 65156 65156
+Encoding: 65156 65156 3536
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 600 2272 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 39 450 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 39 450 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE85
-Encoding: 65157 65157 65157
+Encoding: 65157 65157 3537
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 652 1360 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 96 -450 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 96 -450 2
 EndChar
+
 StartChar: uniFE86
-Encoding: 65158 65158 65158
+Encoding: 65158 65158 3538
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 600 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 50 -450 2
-Refer: 65262 65262 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 50 -450 2
+Refer: 3642 65262 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE87
-Encoding: 65159 65159 65159
+Encoding: 65159 65159 3539
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 -7 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -7 0 2
 EndChar
+
 StartChar: uniFE88
-Encoding: 65160 65160 65160
+Encoding: 65160 65160 3540
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 716 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 86 0 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 86 0 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE89
-Encoding: 65161 65161 65161
+Encoding: 65161 65161 3541
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 384 1240 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -167 -545 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -167 -545 2
 EndChar
+
 StartChar: uniFE8A
-Encoding: 65162 65162 65162
+Encoding: 65162 65162 3542
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 284 1012 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -284 -792 2
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -284 -792 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8B
-Encoding: 65163 65163 65163
+Encoding: 65163 65163 3543
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 536 -128 basechar 0
 AnchorPoint: "rtl-above" 556 1377 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -22 -400 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -22 -400 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8C
-Encoding: 65164 65164 65164
+Encoding: 65164 65164 3544
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -168 basechar 0
 AnchorPoint: "rtl-above" 580 1382 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 0 -400 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 -400 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8D
-Encoding: 65165 65165 65165
+Encoding: 65165 65165 3545
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -136 basechar 0
 AnchorPoint: "rtl-above" 604 1752 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8E
-Encoding: 65166 65166 65166
+Encoding: 65166 65166 3546
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 688 -168 basechar 0
@@ -100332,216 +103938,236 @@ SplineSet
  588 193 588 193 588 371 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFE8F
-Encoding: 65167 65167 65167
+Encoding: 65167 65167 3547
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -408 basechar 0
 AnchorPoint: "rtl-above" 616 828 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 539 -350 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 539 -350 2
 EndChar
+
 StartChar: uniFE90
-Encoding: 65168 65168 65168
+Encoding: 65168 65168 3548
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 540 -408 basechar 0
 AnchorPoint: "rtl-above" 528 744 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 465 -350 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 465 -350 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE91
-Encoding: 65169 65169 65169
+Encoding: 65169 65169 3549
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 580 -372 basechar 0
 AnchorPoint: "rtl-above" 524 968 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 504 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 504 -300 2
 EndChar
+
 StartChar: uniFE92
-Encoding: 65170 65170 65170
+Encoding: 65170 65170 3550
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -372 basechar 0
 AnchorPoint: "rtl-above" 604 924 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 532 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 532 -300 2
 EndChar
+
 StartChar: uniFE93
-Encoding: 65171 65171 65171
+Encoding: 65171 65171 3551
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 556 -180 basechar 0
 AnchorPoint: "rtl-above" 516 1224 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 362 900 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 362 900 2
 EndChar
+
 StartChar: uniFE94
-Encoding: 65172 65172 65172
+Encoding: 65172 65172 3552
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 604 1240 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 454 900 2
-Refer: 65258 65258 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 454 900 2
+Refer: 3638 65258 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE95
-Encoding: 65173 65173 65173
+Encoding: 65173 65173 3553
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 604 1012 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 447 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 447 650 2
 EndChar
+
 StartChar: uniFE96
-Encoding: 65174 65174 65174
+Encoding: 65174 65174 3554
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -144 basechar 0
 AnchorPoint: "rtl-above" 560 1044 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 412 650 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 412 650 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE97
-Encoding: 65175 65175 65175
+Encoding: 65175 65175 3555
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -124 basechar 0
 AnchorPoint: "rtl-above" 556 1220 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 850 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE98
-Encoding: 65176 65176 65176
+Encoding: 65176 65176 3556
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -132 basechar 0
 AnchorPoint: "rtl-above" 560 1248 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 850 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 850 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE99
-Encoding: 65177 65177 65177
+Encoding: 65177 65177 3557
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 576 1264 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 442 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 442 650 2
 EndChar
+
 StartChar: uniFE9A
-Encoding: 65178 65178 65178
+Encoding: 65178 65178 3558
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -128 basechar 0
 AnchorPoint: "rtl-above" 556 1280 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 424 650 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 424 650 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9B
-Encoding: 65179 65179 65179
+Encoding: 65179 65179 3559
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -132 basechar 0
 AnchorPoint: "rtl-above" 544 1380 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 412 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 412 850 2
 EndChar
+
 StartChar: uniFE9C
-Encoding: 65180 65180 65180
+Encoding: 65180 65180 3560
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -140 basechar 0
 AnchorPoint: "rtl-above" 544 1376 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 411 812 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 411 812 2
 EndChar
+
 StartChar: uniFE9D
-Encoding: 65181 65181 65181
+Encoding: 65181 65181 3561
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 504 1152 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 671 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 671 25 2
 EndChar
+
 StartChar: uniFE9E
-Encoding: 65182 65182 65182
+Encoding: 65182 65182 3562
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 468 1148 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 624 -50 2
-Refer: 65186 65186 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 624 -50 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9F
-Encoding: 65183 65183 65183
+Encoding: 65183 65183 3563
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -376 basechar 0
 AnchorPoint: "rtl-above" 372 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 -300 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA0
-Encoding: 65184 65184 65184
+Encoding: 65184 65184 3564
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -404 basechar 0
 AnchorPoint: "rtl-above" 352 1072 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 -300 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA1
-Encoding: 65185 65185 65185
+Encoding: 65185 65185 3565
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 476 1188 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA2
-Encoding: 65186 65186 65186
+Encoding: 65186 65186 3566
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
@@ -100579,8 +104205,9 @@ SplineSet
  1149 184 1149 184 1233 184 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA3
-Encoding: 65187 65187 65187
+Encoding: 65187 65187 3567
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 316 -124 basechar 0
@@ -100609,8 +104236,9 @@ SplineSet
  750 506 750 506 851 541 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA4
-Encoding: 65188 65188 65188
+Encoding: 65188 65188 3568
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 340 -144 basechar 0
@@ -100646,62 +104274,68 @@ SplineSet
  466 815 466 815 638 780 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA5
-Encoding: 65189 65189 65189
+Encoding: 65189 65189 3569
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 476 1344 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 476 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 476 1050 2
 EndChar
+
 StartChar: uniFEA6
-Encoding: 65190 65190 65190
+Encoding: 65190 65190 3570
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 472 1372 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 472 1050 2
-Refer: 65186 65186 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 472 1050 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA7
-Encoding: 65191 65191 65191
+Encoding: 65191 65191 3571
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 380 -128 basechar 0
 AnchorPoint: "rtl-above" 288 1248 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 950 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 950 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA8
-Encoding: 65192 65192 65192
+Encoding: 65192 65192 3572
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 324 -164 basechar 0
 AnchorPoint: "rtl-above" 280 1244 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 950 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 950 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA9
-Encoding: 65193 65193 65193
+Encoding: 65193 65193 3573
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 524 1196 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAA
-Encoding: 65194 65194 65194
+Encoding: 65194 65194 3574
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
@@ -100731,40 +104365,44 @@ SplineSet
  1000 486 1000 486 1000 378 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAB
-Encoding: 65195 65195 65195
+Encoding: 65195 65195 3575
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 520 1364 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 524 1050 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 524 1050 2
 EndChar
+
 StartChar: uniFEAC
-Encoding: 65196 65196 65196
+Encoding: 65196 65196 3576
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 532 1376 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 533 1050 2
-Refer: 65194 65194 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 533 1050 2
+Refer: 3574 65194 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAD
-Encoding: 65197 65197 65197
+Encoding: 65197 65197 3577
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 444 -576 basechar 0
 AnchorPoint: "rtl-above" 576 788 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAE
-Encoding: 65198 65198 65198
+Encoding: 65198 65198 3578
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 396 -579 basechar 0
@@ -100790,40 +104428,44 @@ SplineSet
  803 414 803 414 750 550 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAF
-Encoding: 65199 65199 65199
+Encoding: 65199 65199 3579
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 444 -576 basechar 0
 AnchorPoint: "rtl-above" 404 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 861 800 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 861 800 2
 EndChar
+
 StartChar: uniFEB0
-Encoding: 65200 65200 65200
+Encoding: 65200 65200 3580
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 412 -580 basechar 0
 AnchorPoint: "rtl-above" 312 1160 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 751 800 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 751 800 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB1
-Encoding: 65201 65201 65201
+Encoding: 65201 65201 3581
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 408 -500 basechar 0
 AnchorPoint: "rtl-above" 564 1039 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB2
-Encoding: 65202 65202 65202
+Encoding: 65202 65202 3582
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 344 -496 basechar 0
@@ -100875,8 +104517,9 @@ SplineSet
  895 -29 895 -29 820 -29 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB3
-Encoding: 65203 65203 65203
+Encoding: 65203 65203 3583
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -100917,8 +104560,9 @@ SplineSet
  415 181 415 181 486 181 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB4
-Encoding: 65204 65204 65204
+Encoding: 65204 65204 3584
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 272 -156 basechar 0
@@ -100964,62 +104608,68 @@ SplineSet
  721 594 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB5
-Encoding: 65205 65205 65205
+Encoding: 65205 65205 3585
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 348 -484 basechar 0
 AnchorPoint: "rtl-above" 280 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 310 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 310 800 2
 EndChar
+
 StartChar: uniFEB6
-Encoding: 65206 65206 65206
+Encoding: 65206 65206 3586
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 265 -488 basechar 0
 AnchorPoint: "rtl-above" 180 1336 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 236 800 2
-Refer: 65202 65202 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 236 800 2
+Refer: 3582 65202 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB7
-Encoding: 65207 65207 65207
+Encoding: 65207 65207 3587
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 304 1352 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 406 800 2
-Refer: 65203 65203 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 406 800 2
+Refer: 3583 65203 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB8
-Encoding: 65208 65208 65208
+Encoding: 65208 65208 3588
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 268 1340 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 338 800 2
-Refer: 65204 65204 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 338 800 2
+Refer: 3584 65204 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB9
-Encoding: 65209 65209 65209
+Encoding: 65209 65209 3589
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 376 -492 basechar 0
 AnchorPoint: "rtl-above" 324 908 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBA
-Encoding: 65210 65210 65210
+Encoding: 65210 65210 3590
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 324 -495 basechar 0
@@ -101071,8 +104721,9 @@ SplineSet
  1141 495 1141 495 1141 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBB
-Encoding: 65211 65211 65211
+Encoding: 65211 65211 3591
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -101111,8 +104762,9 @@ SplineSet
  562 0 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBC
-Encoding: 65212 65212 65212
+Encoding: 65212 65212 3592
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -101158,62 +104810,68 @@ SplineSet
  486 0 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBD
-Encoding: 65213 65213 65213
+Encoding: 65213 65213 3593
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 332 -496 basechar 0
 AnchorPoint: "rtl-above" 296 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 335 670 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 335 670 2
 EndChar
+
 StartChar: uniFEBE
-Encoding: 65214 65214 65214
+Encoding: 65214 65214 3594
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 288 -488 basechar 0
 AnchorPoint: "rtl-above" 208 1112 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 260 670 2
-Refer: 65210 65210 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 260 670 2
+Refer: 3590 65210 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBF
-Encoding: 65215 65215 65215
+Encoding: 65215 65215 3595
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 292 1108 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 343 736 2
-Refer: 65211 65211 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 343 736 2
+Refer: 3591 65211 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC0
-Encoding: 65216 65216 65216
+Encoding: 65216 65216 3596
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 260 -148 basechar 0
 AnchorPoint: "rtl-above" 212 1140 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 308 722 2
-Refer: 65212 65212 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 308 722 2
+Refer: 3592 65212 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC1
-Encoding: 65217 65217 65217
+Encoding: 65217 65217 3597
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 240 1752 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC2
-Encoding: 65218 65218 65218
+Encoding: 65218 65218 3598
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 216 -148 basechar 0
@@ -101251,8 +104909,9 @@ SplineSet
  1152 495 1152 495 1152 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC3
-Encoding: 65219 65219 65219
+Encoding: 65219 65219 3599
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
@@ -101284,8 +104943,9 @@ SplineSet
  878 0 878 0 751 0 c 2,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEC4
-Encoding: 65220 65220 65220
+Encoding: 65220 65220 3600
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 208 -144 basechar 0
@@ -101323,62 +104983,68 @@ SplineSet
  1152 495 1152 495 1152 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC5
-Encoding: 65221 65221 65221
+Encoding: 65221 65221 3601
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 236 1780 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
 EndChar
+
 StartChar: uniFEC6
-Encoding: 65222 65222 65222
+Encoding: 65222 65222 3602
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 208 -152 basechar 0
 AnchorPoint: "rtl-above" 208 1764 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65218 65218 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3598 65218 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC7
-Encoding: 65223 65223 65223
+Encoding: 65223 65223 3603
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 240 1768 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65219 65219 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3599 65219 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC8
-Encoding: 65224 65224 65224
+Encoding: 65224 65224 3604
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 220 -148 basechar 0
 AnchorPoint: "rtl-above" 200 1760 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65220 65220 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3600 65220 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC9
-Encoding: 65225 65225 65225
+Encoding: 65225 65225 3605
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 388 1328 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECA
-Encoding: 65226 65226 65226
+Encoding: 65226 65226 3606
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
@@ -101421,8 +105087,9 @@ SplineSet
  573 597 573 597 547 597 c 128,-1,46
 EndSplineSet
 EndChar
+
 StartChar: uniFECB
-Encoding: 65227 65227 65227
+Encoding: 65227 65227 3607
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -109 basechar 0
@@ -101451,8 +105118,9 @@ SplineSet
  61 184 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFECC
-Encoding: 65228 65228 65228
+Encoding: 65228 65228 3608
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -115 basechar 0
@@ -101492,150 +105160,164 @@ SplineSet
  642 597 642 597 616 597 c 128,-1,38
 EndSplineSet
 EndChar
+
 StartChar: uniFECD
-Encoding: 65229 65229 65229
+Encoding: 65229 65229 3609
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 388 1584 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 375 1200 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 1200 2
 EndChar
+
 StartChar: uniFECE
-Encoding: 65230 65230 65230
+Encoding: 65230 65230 3610
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 472 1392 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 470 950 2
-Refer: 65226 65226 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 470 950 2
+Refer: 3606 65226 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECF
-Encoding: 65231 65231 65231
+Encoding: 65231 65231 3611
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 402 -97 basechar 0
 AnchorPoint: "rtl-above" 384 1612 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 375 1200 2
-Refer: 65227 65227 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 1200 2
+Refer: 3607 65227 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED0
-Encoding: 65232 65232 65232
+Encoding: 65232 65232 3612
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -97 basechar 0
 AnchorPoint: "rtl-above" 616 1340 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 539 950 2
-Refer: 65228 65228 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 539 950 2
+Refer: 3608 65228 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED1
-Encoding: 65233 65233 65233
+Encoding: 65233 65233 3613
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -211 basechar 0
 AnchorPoint: "rtl-above" 760 1392 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 752 1066 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 752 1066 2
 EndChar
+
 StartChar: uniFED2
-Encoding: 65234 65234 65234
+Encoding: 65234 65234 3614
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -241 basechar 0
 AnchorPoint: "rtl-above" 760 1272 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 758 950 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 758 950 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED3
-Encoding: 65235 65235 65235
+Encoding: 65235 65235 3615
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -139 basechar 0
 AnchorPoint: "rtl-above" 428 1464 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 425 1150 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 425 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED4
-Encoding: 65236 65236 65236
+Encoding: 65236 65236 3616
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -127 basechar 0
 AnchorPoint: "rtl-above" 620 1316 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 546 1000 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 546 1000 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED5
-Encoding: 65237 65237 65237
+Encoding: 65237 65237 3617
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -487 basechar 0
 AnchorPoint: "rtl-above" 612 1452 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 605 1150 2
+Refer: 3762 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 605 1150 2
 EndChar
+
 StartChar: uniFED6
-Encoding: 65238 65238 65238
+Encoding: 65238 65238 3618
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -583 basechar 0
 AnchorPoint: "rtl-above" 608 1236 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 590 875 2
-Refer: 1114139 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 590 875 2
+Refer: 3752 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED7
-Encoding: 65239 65239 65239
+Encoding: 65239 65239 3619
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 312 -115 basechar 0
 AnchorPoint: "rtl-above" 304 1436 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 300 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 300 1150 2
 EndChar
+
 StartChar: uniFED8
-Encoding: 65240 65240 65240
+Encoding: 65240 65240 3620
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -127 basechar 0
 AnchorPoint: "rtl-above" 616 1336 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 406 1000 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 406 1000 2
 EndChar
+
 StartChar: uniFED9
-Encoding: 65241 65241 65241
+Encoding: 65241 65241 3621
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 570 -181 basechar 0
 AnchorPoint: "rtl-above" 572 1544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1603 1603 N 1 0 0 1 0 0 2
+Refer: 1197 1603 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDA
-Encoding: 65242 65242 65242
+Encoding: 65242 65242 3622
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 474 -175 basechar 0
@@ -101686,8 +105368,9 @@ SplineSet
  1059 1556 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDB
-Encoding: 65243 65243 65243
+Encoding: 65243 65243 3623
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 216 -127 basechar 0
@@ -101718,8 +105401,9 @@ SplineSet
  625 0 625 0 402 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDC
-Encoding: 65244 65244 65244
+Encoding: 65244 65244 3624
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 162 -163 basechar 0
@@ -101757,18 +105441,20 @@ SplineSet
  632 0 632 0 412 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDD
-Encoding: 65245 65245 65245
+Encoding: 65245 65245 3625
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -403 basechar 0
 AnchorPoint: "rtl-above" 592 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 1604 1604 N 1 0 0 1 0 0 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDE
-Encoding: 65246 65246 65246
+Encoding: 65246 65246 3626
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 510 -415 basechar 0
@@ -101801,8 +105487,9 @@ SplineSet
  1042 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDF
-Encoding: 65247 65247 65247
+Encoding: 65247 65247 3627
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -121 basechar 0
@@ -101823,8 +105510,9 @@ SplineSet
  1001 371 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE0
-Encoding: 65248 65248 65248
+Encoding: 65248 65248 3628
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -139 basechar 0
@@ -101850,18 +105538,20 @@ SplineSet
  696 0 696 0 616 86 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE1
-Encoding: 65249 65249 65249
+Encoding: 65249 65249 3629
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 786 -139 basechar 0
 AnchorPoint: "rtl-above" 652 984 basechar 0
 LayerCount: 2
 Fore
-Refer: 1605 1605 N 1 0 0 1 0 0 2
+Refer: 1199 1605 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE2
-Encoding: 65250 65250 65250
+Encoding: 65250 65250 3630
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 684 -349 basechar 0
@@ -101903,8 +105593,9 @@ SplineSet
  994 0 994 0 962 52 c 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uniFEE3
-Encoding: 65251 65251 65251
+Encoding: 65251 65251 3631
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 582 -235 basechar 0
@@ -101939,8 +105630,9 @@ SplineSet
  416 230 416 230 406 199 c 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uniFEE4
-Encoding: 65252 65252 65252
+Encoding: 65252 65252 3632
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -217 basechar 0
@@ -101979,62 +105671,68 @@ SplineSet
  440 230 440 230 430 199 c 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uniFEE5
-Encoding: 65253 65253 65253
+Encoding: 65253 65253 3633
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 510 -427 basechar 0
 AnchorPoint: "rtl-above" 484 1160 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 467 750 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 467 750 2
 EndChar
+
 StartChar: uniFEE6
-Encoding: 65254 65254 65254
+Encoding: 65254 65254 3634
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 391 850 basechar 0
 AnchorPoint: "rtl-below" 450 -571 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 375 537 2
-Refer: 64415 64415 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 537 2
+Refer: 3506 64415 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE7
-Encoding: 65255 65255 65255
+Encoding: 65255 65255 3635
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 544 1133.5 basechar 0
 AnchorPoint: "rtl-below" 576 -127 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 528 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 528 850 2
 EndChar
+
 StartChar: uniFEE8
-Encoding: 65256 65256 65256
+Encoding: 65256 65256 3636
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 548.5 1142.5 basechar 0
 AnchorPoint: "rtl-below" 588 -133 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 533 850 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 533 850 2
 EndChar
+
 StartChar: uniFEE9
-Encoding: 65257 65257 65257
+Encoding: 65257 65257 3637
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 490 904 basechar 0
 AnchorPoint: "rtl-below" 594 -181 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEA
-Encoding: 65258 65258 65258
+Encoding: 65258 65258 3638
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 562 890.5 basechar 0
@@ -102067,8 +105765,9 @@ SplineSet
  555 653 555 653 706 668 c 1,11,12
 EndSplineSet
 EndChar
+
 StartChar: uniFEEB
-Encoding: 65259 65259 65259
+Encoding: 65259 65259 3639
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 431.5 1120 basechar 0
@@ -102114,8 +105813,9 @@ SplineSet
  768 438 768 438 701 508 c 1,46,47
 EndSplineSet
 EndChar
+
 StartChar: uniFEEC
-Encoding: 65260 65260 65260
+Encoding: 65260 65260 3640
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 494.5 796 basechar 0
@@ -102156,18 +105856,20 @@ SplineSet
  484 0 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uniFEED
-Encoding: 65261 65261 65261
+Encoding: 65261 65261 3641
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 643 845.5 basechar 0
 AnchorPoint: "rtl-below" 588 -535 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEE
-Encoding: 65262 65262 65262
+Encoding: 65262 65262 3642
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 571 809.5 basechar 0
@@ -102204,18 +105906,20 @@ SplineSet
  1003 279 1003 279 1007 184 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEEF
-Encoding: 65263 65263 65263
+Encoding: 65263 65263 3643
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 508 850 basechar 0
 AnchorPoint: "rtl-below" 558 -367 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF0
-Encoding: 65264 65264 65264
+Encoding: 65264 65264 3644
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 422.5 580 basechar 0
@@ -102255,52 +105959,57 @@ SplineSet
  770 22 770 22 769 51 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEF1
-Encoding: 65265 65265 65265
+Encoding: 65265 65265 3645
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 517 872.5 basechar 0
 AnchorPoint: "rtl-below" 540 -595 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 345 -500 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 345 -500 2
 EndChar
+
 StartChar: uniFEF2
-Encoding: 65266 65266 65266
+Encoding: 65266 65266 3646
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 368.5 607 basechar 0
 AnchorPoint: "rtl-below" 402 -580 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 192 -500 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 192 -500 2
 EndChar
+
 StartChar: uniFEF3
-Encoding: 65267 65267 65267
+Encoding: 65267 65267 3647
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 553 841 basechar 0
 AnchorPoint: "rtl-below" 570 -373 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 386 -300 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 386 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF4
-Encoding: 65268 65268 65268
+Encoding: 65268 65268 3648
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 544 850 basechar 0
 AnchorPoint: "rtl-below" 594 -379 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 -300 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF5
-Encoding: 65269 65269 65269
+Encoding: 65269 65269 3649
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 147 1845.5 baselig 1
@@ -102309,13 +106018,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 -362 300 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -362 300 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF6
-Encoding: 65270 65270 65270
+Encoding: 65270 65270 3650
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 91 1817.5 baselig 1
@@ -102324,13 +106034,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 816 -32 baselig 0
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 -448 300 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -448 300 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF7
-Encoding: 65271 65271 65271
+Encoding: 65271 65271 3651
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 155 2038.5 baselig 1
@@ -102339,13 +106050,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -362 300 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -362 300 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF8
-Encoding: 65272 65272 65272
+Encoding: 65272 65272 3652
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 43 2042.5 baselig 1
@@ -102354,13 +106066,14 @@ AnchorPoint: "Ligature rtl-above" 852 1644 baselig 0
 AnchorPoint: "Ligature rtl-below" 828 -120 baselig 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -477 300 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -477 300 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF9
-Encoding: 65273 65273 65273
+Encoding: 65273 65273 3653
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
@@ -102369,13 +106082,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 936 44 baselig 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 -312 0 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 0 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFA
-Encoding: 65274 65274 65274
+Encoding: 65274 65274 3654
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 268 -548 baselig 1
@@ -102384,13 +106098,14 @@ AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
 AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 -312 0 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 0 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFB
-Encoding: 65275 65275 65275
+Encoding: 65275 65275 3655
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
@@ -102418,10 +106133,11 @@ SplineSet
  1054 834 l 2,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 6" uniFEDF uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFC
-Encoding: 65276 65276 65276
+Encoding: 65276 65276 3656
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 159 1501.5 baselig 1
@@ -102455,40 +106171,46 @@ SplineSet
  830 284 830 284 831 316 c 9,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 6" uniFEE0 uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFF
-Encoding: 65279 65279 65279
+Encoding: 65279 65279 3657
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFF9
-Encoding: 65529 65529 65529
+Encoding: 65529 65529 3658
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFA
-Encoding: 65530 65530 65530
+Encoding: 65530 65530 3659
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFB
-Encoding: 65531 65531 65531
+Encoding: 65531 65531 3660
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFC
-Encoding: 65532 65532 65532
+Encoding: 65532 65532 3661
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFD
-Encoding: 65533 65533 65533
+Encoding: 65533 65533 3662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102531,8 +106253,9 @@ SplineSet
  514 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: u1D55A
-Encoding: 120154 120154 120154
+Encoding: 120154 120154 3663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102561,504 +106284,567 @@ SplineSet
  542 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: u1D670
-Encoding: 120432 120432 120432
+Encoding: 120432 120432 3664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D671
-Encoding: 120433 120433 120433
+Encoding: 120433 120433 3665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D672
-Encoding: 120434 120434 120434
+Encoding: 120434 120434 3666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D673
-Encoding: 120435 120435 120435
+Encoding: 120435 120435 3667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D674
-Encoding: 120436 120436 120436
+Encoding: 120436 120436 3668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D675
-Encoding: 120437 120437 120437
+Encoding: 120437 120437 3669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D676
-Encoding: 120438 120438 120438
+Encoding: 120438 120438 3670
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D677
-Encoding: 120439 120439 120439
+Encoding: 120439 120439 3671
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D678
-Encoding: 120440 120440 120440
+Encoding: 120440 120440 3672
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D679
-Encoding: 120441 120441 120441
+Encoding: 120441 120441 3673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67A
-Encoding: 120442 120442 120442
+Encoding: 120442 120442 3674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67B
-Encoding: 120443 120443 120443
+Encoding: 120443 120443 3675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67C
-Encoding: 120444 120444 120444
+Encoding: 120444 120444 3676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67D
-Encoding: 120445 120445 120445
+Encoding: 120445 120445 3677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67E
-Encoding: 120446 120446 120446
+Encoding: 120446 120446 3678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67F
-Encoding: 120447 120447 120447
+Encoding: 120447 120447 3679
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D680
-Encoding: 120448 120448 120448
+Encoding: 120448 120448 3680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D681
-Encoding: 120449 120449 120449
+Encoding: 120449 120449 3681
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D682
-Encoding: 120450 120450 120450
+Encoding: 120450 120450 3682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D683
-Encoding: 120451 120451 120451
+Encoding: 120451 120451 3683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D684
-Encoding: 120452 120452 120452
+Encoding: 120452 120452 3684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D685
-Encoding: 120453 120453 120453
+Encoding: 120453 120453 3685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D686
-Encoding: 120454 120454 120454
+Encoding: 120454 120454 3686
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D687
-Encoding: 120455 120455 120455
+Encoding: 120455 120455 3687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D688
-Encoding: 120456 120456 120456
+Encoding: 120456 120456 3688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D689
-Encoding: 120457 120457 120457
+Encoding: 120457 120457 3689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68A
-Encoding: 120458 120458 120458
+Encoding: 120458 120458 3690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68B
-Encoding: 120459 120459 120459
+Encoding: 120459 120459 3691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68C
-Encoding: 120460 120460 120460
+Encoding: 120460 120460 3692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68D
-Encoding: 120461 120461 120461
+Encoding: 120461 120461 3693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68E
-Encoding: 120462 120462 120462
+Encoding: 120462 120462 3694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68F
-Encoding: 120463 120463 120463
+Encoding: 120463 120463 3695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 102 102 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D690
-Encoding: 120464 120464 120464
+Encoding: 120464 120464 3696
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D691
-Encoding: 120465 120465 120465
+Encoding: 120465 120465 3697
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D692
-Encoding: 120466 120466 120466
+Encoding: 120466 120466 3698
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D693
-Encoding: 120467 120467 120467
+Encoding: 120467 120467 3699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D694
-Encoding: 120468 120468 120468
+Encoding: 120468 120468 3700
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D695
-Encoding: 120469 120469 120469
+Encoding: 120469 120469 3701
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D696
-Encoding: 120470 120470 120470
+Encoding: 120470 120470 3702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D697
-Encoding: 120471 120471 120471
+Encoding: 120471 120471 3703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D698
-Encoding: 120472 120472 120472
+Encoding: 120472 120472 3704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D699
-Encoding: 120473 120473 120473
+Encoding: 120473 120473 3705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69A
-Encoding: 120474 120474 120474
+Encoding: 120474 120474 3706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69B
-Encoding: 120475 120475 120475
+Encoding: 120475 120475 3707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69C
-Encoding: 120476 120476 120476
+Encoding: 120476 120476 3708
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69D
-Encoding: 120477 120477 120477
+Encoding: 120477 120477 3709
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69E
-Encoding: 120478 120478 120478
+Encoding: 120478 120478 3710
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69F
-Encoding: 120479 120479 120479
+Encoding: 120479 120479 3711
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A0
-Encoding: 120480 120480 120480
+Encoding: 120480 120480 3712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A1
-Encoding: 120481 120481 120481
+Encoding: 120481 120481 3713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A2
-Encoding: 120482 120482 120482
+Encoding: 120482 120482 3714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A3
-Encoding: 120483 120483 120483
+Encoding: 120483 120483 3715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F6
-Encoding: 120822 120822 120822
+Encoding: 120822 120822 3716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 48 48 N 1 0 0 1 0 0 2
+Refer: 17 48 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F7
-Encoding: 120823 120823 120823
+Encoding: 120823 120823 3717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 49 49 N 1 0 0 1 0 0 2
+Refer: 18 49 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F8
-Encoding: 120824 120824 120824
+Encoding: 120824 120824 3718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 50 50 N 1 0 0 1 0 0 2
+Refer: 19 50 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F9
-Encoding: 120825 120825 120825
+Encoding: 120825 120825 3719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FA
-Encoding: 120826 120826 120826
+Encoding: 120826 120826 3720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 52 52 N 1 0 0 1 0 0 2
+Refer: 21 52 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FB
-Encoding: 120827 120827 120827
+Encoding: 120827 120827 3721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 53 53 N 1 0 0 1 0 0 2
+Refer: 22 53 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FC
-Encoding: 120828 120828 120828
+Encoding: 120828 120828 3722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 54 54 N 1 0 0 1 0 0 2
+Refer: 23 54 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FD
-Encoding: 120829 120829 120829
+Encoding: 120829 120829 3723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 55 55 N 1 0 0 1 0 0 2
+Refer: 24 55 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FE
-Encoding: 120830 120830 120830
+Encoding: 120830 120830 3724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 56 56 N 1 0 0 1 0 0 2
+Refer: 25 56 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FF
-Encoding: 120831 120831 120831
+Encoding: 120831 120831 3725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 57 57 N 1 0 0 1 0 0 2
+Refer: 26 57 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dlLtcaron
-Encoding: 1114113 -1 1114113
+Encoding: 1114113 -1 3726
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103090,8 +106876,9 @@ SplineSet
  544 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Diaeresis
-Encoding: 1114114 -1 1114114
+Encoding: 1114114 -1 3727
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103180,8 +106967,9 @@ SplineSet
  711 1497 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Acute
-Encoding: 1114115 -1 1114115
+Encoding: 1114115 -1 3728
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103291,8 +107079,9 @@ SplineSet
  672 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tilde
-Encoding: 1114116 -1 1114116
+Encoding: 1114116 -1 3729
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103528,8 +107317,9 @@ SplineSet
  664 1310 664 1310 612 1337 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Grave
-Encoding: 1114117 -1 1114117
+Encoding: 1114117 -1 3730
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103631,8 +107421,9 @@ SplineSet
  561 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Circumflex
-Encoding: 1114118 -1 1114118
+Encoding: 1114118 -1 3731
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103731,8 +107522,9 @@ SplineSet
  522 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Caron
-Encoding: 1114119 -1 1114119
+Encoding: 1114119 -1 3732
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103843,8 +107635,9 @@ SplineSet
  522 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: fractionslash
-Encoding: 1114120 -1 1114120
+Encoding: 1114120 -1 3733
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103884,8 +107677,9 @@ SplineSet
  51 504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0311.case
-Encoding: 1114121 -1 1114121
+Encoding: 1114121 -1 3734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -103904,8 +107698,9 @@ SplineSet
  303 1659 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0306.case
-Encoding: 1114122 -1 1114122
+Encoding: 1114122 -1 3735
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103951,13 +107746,14 @@ SplineSet
  796 1845 796 1845 811 1901 c 1,7,-1
  930 1901 l 1,8,9
  919 1782 919 1782 839.5 1720.5 c 128,-1,10
- 760 1659 760 1659 616 1659 c 0,11,12
+ 760 1659 760 1659 616 1659 c 256,11,12
  472 1659 472 1659 393 1720 c 128,-1,13
  314 1781 314 1781 303 1901 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307.case
-Encoding: 1114123 -1 1114123
+Encoding: 1114123 -1 3736
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103990,8 +107786,9 @@ SplineSet
  513 1872 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030B.case
-Encoding: 1114124 -1 1114124
+Encoding: 1114124 -1 3737
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104036,8 +107833,9 @@ SplineSet
  541 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030F.case
-Encoding: 1114125 -1 1114125
+Encoding: 1114125 -1 3738
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104055,8 +107853,9 @@ SplineSet
  692 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: thinquestion
-Encoding: 1114126 -1 1114126
+Encoding: 1114126 -1 3739
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104092,8 +107891,9 @@ SplineSet
  487 254 l 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0304.case
-Encoding: 1114127 -1 1114127
+Encoding: 1114127 -1 3740
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104125,8 +107925,9 @@ SplineSet
  317 1840 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar
-Encoding: 1114128 -1 1114128
+Encoding: 1114128 -1 3741
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104139,8 +107940,9 @@ SplineSet
  1077 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.wide
-Encoding: 1114129 -1 1114129
+Encoding: 1114129 -1 3742
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104153,8 +107955,9 @@ SplineSet
  1227 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.small
-Encoding: 1114130 -1 1114130
+Encoding: 1114130 -1 3743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104167,8 +107970,9 @@ SplineSet
  977 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: jot
-Encoding: 1114131 -1 1114131
+Encoding: 1114131 -1 3744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104195,8 +107999,9 @@ SplineSet
  675.36 876.6 675.36 876.6 615.96 876.6 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: diaeresis.symbols
-Encoding: 1114132 -1 1114132
+Encoding: 1114132 -1 3745
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104214,8 +108019,9 @@ SplineSet
  711 1552 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_dot
-Encoding: 1114133 -1 1114133
+Encoding: 1114133 -1 3746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104228,8 +108034,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots
-Encoding: 1114134 -1 1114134
+Encoding: 1114134 -1 3747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104247,8 +108054,9 @@ SplineSet
  0 150 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots
-Encoding: 1114135 -1 1114135
+Encoding: 1114135 -1 3748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104271,8 +108079,9 @@ SplineSet
  0 150 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E.fina
-Encoding: 1114136 -1 1114136
+Encoding: 1114136 -1 3749
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104303,8 +108112,9 @@ SplineSet
  716 -20 716 -20 543 -20 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.init
-Encoding: 1114137 -1 1114137
+Encoding: 1114137 -1 3750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104340,8 +108150,9 @@ SplineSet
  -20 184 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.medi
-Encoding: 1114138 -1 1114138
+Encoding: 1114138 -1 3751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104381,8 +108192,9 @@ SplineSet
  630 592 630 592 616 592 c 128,-1,34
 EndSplineSet
 EndChar
+
 StartChar: uni066F.fina
-Encoding: 1114139 -1 1114139
+Encoding: 1114139 -1 3752
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104427,8 +108239,9 @@ SplineSet
  937 205 937 205 951 203 c 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.fina
-Encoding: 1114140 -1 1114140
+Encoding: 1114140 -1 3753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104471,8 +108284,9 @@ SplineSet
  800 260 800 260 883 223 c 1,44,45
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots_a
-Encoding: 1114141 -1 1114141
+Encoding: 1114141 -1 3754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104495,8 +108309,9 @@ SplineSet
  0 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots_a
-Encoding: 1114142 -1 1114142
+Encoding: 1114142 -1 3755
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104514,8 +108329,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_4dots
-Encoding: 1114143 -1 1114143
+Encoding: 1114143 -1 3756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104543,8 +108359,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar
-Encoding: 1114144 -1 1114144
+Encoding: 1114144 -1 3757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104557,8 +108374,9 @@ SplineSet
  695 1670 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar_a
-Encoding: 1114145 -1 1114145
+Encoding: 1114145 -1 3758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104571,8 +108389,9 @@ SplineSet
  924 1671 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_ring
-Encoding: 1114146 -1 1114146
+Encoding: 1114146 -1 3759
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104598,8 +108417,9 @@ SplineSet
  438 312 438 312 438 220 c 128,-1,13
 EndSplineSet
 EndChar
+
 StartChar: Eng.alt
-Encoding: 1114147 -1 1114147
+Encoding: 1114147 -1 3760
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104695,8 +108515,9 @@ SplineSet
  149 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E
-Encoding: 1114148 -1 1114148
+Encoding: 1114148 -1 3761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104719,8 +108540,9 @@ SplineSet
  1174 539 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni066F
-Encoding: 1114149 -1 1114149
+Encoding: 1114149 -1 3762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104759,71 +108581,78 @@ SplineSet
  312 -196 312 -196 452 -196 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni067C
-Encoding: 1114150 -1 1114150
+Encoding: 1114150 -1 3763
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 632 -560 basechar 0
 AnchorPoint: "rtl-above" 636 980 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114146 -1 N 1 0 0 1 408 -500 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 440 650 2
+Refer: 3759 -1 N 1 0 0 1 408 -500 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 440 650 2
 EndChar
+
 StartChar: uni067D
-Encoding: 1114151 -1 1114151
+Encoding: 1114151 -1 3764
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 425 800 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 425 800 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0681
-Encoding: 1114152 -1 1114152
+Encoding: 1114152 -1 3765
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 580 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -82 -200 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -82 -200 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0682
-Encoding: 1114153 -1 1114153
+Encoding: 1114153 -1 3766
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -560 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 450 1300 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 450 1300 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0685
-Encoding: 1114154 -1 1114154
+Encoding: 1114154 -1 3767
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 340 1050 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 340 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0692
-Encoding: 1114155 -1 1114155
+Encoding: 1114155 -1 3768
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 623.5 1150.5 basechar 0
 AnchorPoint: "rtl-below" 581 -545 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1626 1626 N 1 0 0 1 318.5 -558 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 318.5 -558 2
 EndChar
+
 StartChar: uni06A1
-Encoding: 1114156 -1 1114156
+Encoding: 1114156 -1 3769
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104863,19 +108692,21 @@ SplineSet
  1164 149 1164 149 1064 70 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni06B5
-Encoding: 1114157 -1 1114157
+Encoding: 1114157 -1 3770
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 1002 2100 basechar 0
 AnchorPoint: "rtl-below" 520 -402 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 388 400 2
-Refer: 1604 1604 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 388 400 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06BA
-Encoding: 1114158 -1 1114158
+Encoding: 1114158 -1 3771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104901,38 +108732,42 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB9F
 EndChar
+
 StartChar: uni06C6
-Encoding: 1114159 -1 1114159
+Encoding: 1114159 -1 3772
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -548 basechar 0
 AnchorPoint: "rtl-above" 724 1220 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 112 -492 2
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 112 -492 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06CE
-Encoding: 1114160 -1 1114160
+Encoding: 1114160 -1 3773
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -400 basechar 0
 AnchorPoint: "rtl-above" 391 1168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 -216 -544 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 -216 -544 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06D5
-Encoding: 1114161 -1 1114161
+Encoding: 1114161 -1 3774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: exclamdown.case
-Encoding: 1114162 -1 1114162
+Encoding: 1114162 -1 3775
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104984,8 +108819,9 @@ SplineSet
  516 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: questiondown.case
-Encoding: 1114163 -1 1114163
+Encoding: 1114163 -1 3776
 Width: 1233
 Flags: W
 TtInstrs:
@@ -105155,13 +108991,1176 @@ SplineSet
  745 1239 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18.case
-Encoding: 1114164 -1 1114164
+Encoding: 1114164 -1 3777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 11800 11800 N 1 0 0 1 0 373 3
+Refer: 3398 11800 N 1 0 0 1 0 373 3
+EndChar
+
+StartChar: uni29FC
+Encoding: 10748 10748 3778
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 290 11<-54.3604 -54.3604>
+VStem: 200.64 151 200.64 159
+LayerCount: 2
+Fore
+SplineSet
+853.740234375 -287.150390625 m 5,0,1
+ 855.352539062 -267.25 855.352539062 -267.25 855.352539062 -233.419921875 c 132,-1,2
+ 855.352539062 -199.590820312 855.352539062 -199.590820312 851.321289062 -102.080078125 c 132,-1,3
+ 847.2890625 -4.5703125 847.2890625 -4.5703125 834.385742188 84.9794921875 c 132,-1,4
+ 821.482421875 174.529296875 821.482421875 174.529296875 790.836914062 282.984375 c 132,-1,5
+ 760.192382812 391.439453125 760.192382812 391.439453125 714.224609375 471.040039062 c 132,-1,6
+ 668.2578125 550.639648438 668.2578125 550.639648438 590.03125 606.359375 c 132,-1,7
+ 511.805664062 662.080078125 511.805664062 662.080078125 411.805664062 664.069335938 c 5,8,-1
+ 411.805664062 670.040039062 l 5,9,10
+ 516.64453125 672.029296875 516.64453125 672.029296875 596.482421875 722.774414062 c 132,-1,11
+ 676.321289062 773.51953125 676.321289062 773.51953125 720.67578125 850.134765625 c 132,-1,12
+ 765.03125 926.75 765.03125 926.75 794.869140625 1020.27929688 c 132,-1,13
+ 824.708007812 1113.80957031 824.708007812 1113.80957031 833.579101562 1206.34472656 c 132,-1,14
+ 842.451171875 1298.87988281 842.451171875 1298.87988281 844.869140625 1375.49414062 c 132,-1,15
+ 847.2890625 1452.109375 847.2890625 1452.109375 844.063476562 1499.86914062 c 6,16,-1
+ 840.836914062 1547.62988281 l 5,17,18
+ 818.255859375 1531.70996094 818.255859375 1531.70996094 745.676757812 1519.76953125 c 132,-1,19
+ 673.095703125 1507.83007812 673.095703125 1507.83007812 628.741210938 1487.9296875 c 132,-1,20
+ 584.38671875 1468.02929688 584.38671875 1468.02929688 597.290039062 1424.25 c 4,21,22
+ 616.643554688 1370.51953125 616.643554688 1370.51953125 610.999023438 1294.89941406 c 132,-1,23
+ 605.353515625 1219.27929688 605.353515625 1219.27929688 587.612304688 1137.68945312 c 132,-1,24
+ 569.869140625 1056.09960938 569.869140625 1056.09960938 529.546875 974.509765625 c 132,-1,25
+ 489.224609375 892.919921875 489.224609375 892.919921875 440.837890625 828.245117188 c 132,-1,26
+ 392.451171875 763.569335938 392.451171875 763.569335938 325.515625 721.779296875 c 132,-1,27
+ 258.581054688 679.989257812 258.581054688 679.989257812 186 678 c 5,28,-1
+ 186 656.109375 l 5,29,30
+ 258.581054688 654.120117188 258.581054688 654.120117188 325.515625 606.359375 c 132,-1,31
+ 392.451171875 558.599609375 392.451171875 558.599609375 440.837890625 483.974609375 c 132,-1,32
+ 489.224609375 409.349609375 489.224609375 409.349609375 529.546875 316.814453125 c 132,-1,33
+ 569.869140625 224.279296875 569.869140625 224.279296875 587.612304688 132.739257812 c 132,-1,34
+ 605.353515625 41.19921875 605.353515625 41.19921875 610.999023438 -40.390625 c 132,-1,35
+ 616.643554688 -121.98046875 616.643554688 -121.98046875 597.290039062 -175.709960938 c 4,36,37
+ 584.38671875 -219.490234375 584.38671875 -219.490234375 631.966796875 -236.405273438 c 132,-1,38
+ 679.546875 -253.3203125 679.546875 -253.3203125 754.546875 -262.275390625 c 132,-1,39
+ 829.546875 -271.23046875 829.546875 -271.23046875 853.740234375 -287.150390625 c 5,0,1
+EndSplineSet
+EndChar
+
+StartChar: uni29FD
+Encoding: 10749 10749 3779
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 290 11<543 543>
+VStem: 129 159 137 151
+LayerCount: 2
+Fore
+SplineSet
+340.259765625 -292.150390625 m 5,0,1
+ 338.647460938 -272.25 338.647460938 -272.25 338.647460938 -238.419921875 c 132,-1,2
+ 338.647460938 -204.590820312 338.647460938 -204.590820312 342.678710938 -107.080078125 c 132,-1,3
+ 346.7109375 -9.5703125 346.7109375 -9.5703125 359.614257812 79.9794921875 c 132,-1,4
+ 372.517578125 169.529296875 372.517578125 169.529296875 403.163085938 277.984375 c 132,-1,5
+ 433.807617188 386.439453125 433.807617188 386.439453125 479.775390625 466.040039062 c 132,-1,6
+ 525.7421875 545.639648438 525.7421875 545.639648438 603.96875 601.359375 c 132,-1,7
+ 682.194335938 657.080078125 682.194335938 657.080078125 782.194335938 659.069335938 c 5,8,-1
+ 782.194335938 665.040039062 l 5,9,10
+ 677.35546875 667.029296875 677.35546875 667.029296875 597.517578125 717.774414062 c 132,-1,11
+ 517.678710938 768.51953125 517.678710938 768.51953125 473.32421875 845.134765625 c 132,-1,12
+ 428.96875 921.75 428.96875 921.75 399.130859375 1015.27929688 c 132,-1,13
+ 369.291992188 1108.80957031 369.291992188 1108.80957031 360.420898438 1201.34472656 c 132,-1,14
+ 351.548828125 1293.87988281 351.548828125 1293.87988281 349.130859375 1370.49414062 c 132,-1,15
+ 346.7109375 1447.109375 346.7109375 1447.109375 349.936523438 1494.86914062 c 6,16,-1
+ 353.163085938 1542.62988281 l 5,17,18
+ 375.744140625 1526.70996094 375.744140625 1526.70996094 448.323242188 1514.76953125 c 132,-1,19
+ 520.904296875 1502.83007812 520.904296875 1502.83007812 565.258789062 1482.9296875 c 132,-1,20
+ 609.61328125 1463.02929688 609.61328125 1463.02929688 596.709960938 1419.25 c 4,21,22
+ 577.356445312 1365.51953125 577.356445312 1365.51953125 583.000976562 1289.89941406 c 132,-1,23
+ 588.646484375 1214.27929688 588.646484375 1214.27929688 606.387695312 1132.68945312 c 132,-1,24
+ 624.130859375 1051.09960938 624.130859375 1051.09960938 664.453125 969.509765625 c 132,-1,25
+ 704.775390625 887.919921875 704.775390625 887.919921875 753.162109375 823.245117188 c 132,-1,26
+ 801.548828125 758.569335938 801.548828125 758.569335938 868.484375 716.779296875 c 132,-1,27
+ 935.418945312 674.989257812 935.418945312 674.989257812 1008 673 c 5,28,-1
+ 1008 651.109375 l 5,29,30
+ 935.418945312 649.120117188 935.418945312 649.120117188 868.484375 601.359375 c 132,-1,31
+ 801.548828125 553.599609375 801.548828125 553.599609375 753.162109375 478.974609375 c 132,-1,32
+ 704.775390625 404.349609375 704.775390625 404.349609375 664.453125 311.814453125 c 132,-1,33
+ 624.130859375 219.279296875 624.130859375 219.279296875 606.387695312 127.739257812 c 132,-1,34
+ 588.646484375 36.19921875 588.646484375 36.19921875 583.000976562 -45.390625 c 132,-1,35
+ 577.356445312 -126.98046875 577.356445312 -126.98046875 596.709960938 -180.709960938 c 4,36,37
+ 609.61328125 -224.490234375 609.61328125 -224.490234375 562.033203125 -241.405273438 c 132,-1,38
+ 514.453125 -258.3203125 514.453125 -258.3203125 439.453125 -267.275390625 c 132,-1,39
+ 364.453125 -276.23046875 364.453125 -276.23046875 340.259765625 -292.150390625 c 5,0,1
+EndSplineSet
+EndChar
+
+StartChar: uni2991
+Encoding: 10641 10641 3780
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 305 128<392 414>
+VStem: 339 128<358 380>
+LayerCount: 2
+Fore
+SplineSet
+660.16015625 652.943359375 m 132,-1,1
+ 660.16015625 690.345703125 660.16015625 690.345703125 706.909179688 742.049804688 c 132,-1,2
+ 753.657226562 793.754882812 753.657226562 793.754882812 787.4765625 793.754882812 c 132,-1,3
+ 821.293945312 793.754882812 821.293945312 793.754882812 868.043945312 742.049804688 c 132,-1,4
+ 914.79296875 690.345703125 914.79296875 690.345703125 914.79296875 652.943359375 c 132,-1,5
+ 914.79296875 615.540039062 914.79296875 615.540039062 868.043945312 563.833984375 c 132,-1,6
+ 821.293945312 512.130859375 821.293945312 512.130859375 787.4765625 512.130859375 c 132,-1,7
+ 753.657226562 512.130859375 753.657226562 512.130859375 706.909179688 563.833984375 c 132,-1,0
+ 660.16015625 615.540039062 660.16015625 615.540039062 660.16015625 652.943359375 c 132,-1,1
+950.6015625 1453.80957031 m 5,8,-1
+ 871.028320312 1546.21679688 l 5,9,-1
+ 180.733398438 683.74609375 l 5,10,-1
+ 180.733398438 630.939453125 l 5,11,-1
+ 876.99609375 -209.529296875 l 5,12,-1
+ 956.568359375 -128.122070312 l 5,13,-1
+ 341.869140625 655.14453125 l 5,14,-1
+ 950.6015625 1453.80957031 l 5,8,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2992
+Encoding: 10642 10642 3781
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 305 128<186 208>
+VStem: 133 128<358 380>
+LayerCount: 2
+Fore
+SplineSet
+548.83984375 652.943359375 m 132,-1,1
+ 548.83984375 690.345703125 548.83984375 690.345703125 502.090820312 742.049804688 c 132,-1,2
+ 455.342773438 793.754882812 455.342773438 793.754882812 421.5234375 793.754882812 c 132,-1,3
+ 387.706054688 793.754882812 387.706054688 793.754882812 340.956054688 742.049804688 c 132,-1,4
+ 294.20703125 690.345703125 294.20703125 690.345703125 294.20703125 652.943359375 c 132,-1,5
+ 294.20703125 615.540039062 294.20703125 615.540039062 340.956054688 563.833984375 c 132,-1,6
+ 387.706054688 512.130859375 387.706054688 512.130859375 421.5234375 512.130859375 c 132,-1,7
+ 455.342773438 512.130859375 455.342773438 512.130859375 502.090820312 563.833984375 c 132,-1,0
+ 548.83984375 615.540039062 548.83984375 615.540039062 548.83984375 652.943359375 c 132,-1,1
+258.3984375 1453.80957031 m 5,8,-1
+ 337.971679688 1546.21679688 l 5,9,-1
+ 1028.26660156 683.74609375 l 5,10,-1
+ 1028.26660156 630.939453125 l 5,11,-1
+ 332.00390625 -209.529296875 l 5,12,-1
+ 252.431640625 -128.122070312 l 5,13,-1
+ 867.130859375 655.14453125 l 5,14,-1
+ 258.3984375 1453.80957031 l 5,8,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2993
+Encoding: 10643 10643 3782
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: -2 21G<544 544> 732.556 4.37598 735.611 2.38867
+VStem: 250.68 80.5938
+LayerCount: 2
+Fore
+SplineSet
+945.69140625 1544.90527344 m 5,0,1
+ 930.228515625 1547.01367188 930.228515625 1547.01367188 929.513671875 1547.01367188 c 4,2,3
+ 921.325195312 1547.01367188 921.325195312 1547.01367188 909.799804688 1539.81738281 c 4,4,5
+ 908.591796875 1539.0625 908.591796875 1539.0625 907.392578125 1538.30566406 c 6,6,-1
+ 945.69140625 1544.90527344 l 5,0,1
+945.69140625 1544.90527344 m 6,7,-1
+ 970.2578125 1549.13964844 l 6,8,9
+ 962.380859375 1544.38671875 962.380859375 1544.38671875 952.719726562 1544.38671875 c 4,10,11
+ 949.502929688 1544.38671875 949.502929688 1544.38671875 945.69140625 1544.90527344 c 6,7,-1
+907.392578125 1538.30566406 m 5,12,13
+ 715.841796875 1417.23144531 715.841796875 1417.23144531 693.357421875 1002.16992188 c 5,14,-1
+ 1086.79296875 1210.83984375 l 5,15,-1
+ 1086.79296875 1047.66015625 l 5,16,-1
+ 690.825195312 850.5625 l 5,17,18
+ 690.966796875 832.25390625 690.966796875 832.25390625 691.286132812 806.840820312 c 132,-1,19
+ 691.60546875 781.427734375 691.60546875 781.427734375 691.879882812 761.607421875 c 132,-1,20
+ 692.15625 741.788085938 692.15625 741.788085938 692.374023438 716.635742188 c 132,-1,21
+ 692.590820312 691.484375 692.590820312 691.484375 692.590820312 670.24609375 c 4,22,23
+ 692.590820312 644.82421875 692.590820312 644.82421875 692.190429688 576.362304688 c 132,-1,24
+ 691.790039062 507.900390625 691.790039062 507.900390625 692.020507812 471.578125 c 5,25,-1
+ 1092.43261719 249.669921875 l 5,26,-1
+ 1092.43261719 76.5400390625 l 5,27,-1
+ 697.739257812 308.514648438 l 5,28,29
+ 731.857421875 -143.591796875 731.857421875 -143.591796875 962.739257812 -285.639648438 c 5,30,-1
+ 876.27734375 -251.809570312 l 5,31,32
+ 781.103515625 -198.918945312 781.103515625 -198.918945312 715.399414062 -126.270507812 c 132,-1,33
+ 649.694335938 -53.623046875 649.694335938 -53.623046875 614.9609375 34.896484375 c 132,-1,34
+ 580.225585938 123.415039062 580.225585938 123.415039062 564.6796875 207.946289062 c 132,-1,35
+ 549.133789062 292.4765625 549.133789062 292.4765625 544.19921875 398.756835938 c 5,36,-1
+ 103.762695312 643.690429688 l 5,37,-1
+ 103.762695312 691.450195312 l 5,38,-1
+ 547.040039062 924.565429688 l 5,39,40
+ 554.15234375 1026.90917969 554.15234375 1026.90917969 572.28515625 1109.96289062 c 132,-1,41
+ 590.41796875 1193.01660156 590.41796875 1193.01660156 627.294921875 1276.50097656 c 132,-1,42
+ 664.171875 1359.984375 664.171875 1359.984375 730.270507812 1425.92480469 c 132,-1,43
+ 796.369140625 1491.86621094 796.369140625 1491.86621094 889.435546875 1535.20996094 c 5,44,-1
+ 907.392578125 1538.30566406 l 5,12,13
+541.130859375 555.203125 m 5,45,46
+ 541.106445312 563.153320312 541.106445312 563.153320312 541.106445312 662.51953125 c 4,47,48
+ 541.106445312 732.552734375 541.106445312 732.552734375 541.67578125 776.3203125 c 5,49,-1
+ 331.193359375 671.549804688 l 5,50,-1
+ 541.130859375 555.203125 l 5,45,46
+EndSplineSet
+EndChar
+
+StartChar: uni2994
+Encoding: 10644 10644 3783
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 732.556 3.31641 735.611 2.38867 735.872 1.05957
+LayerCount: 2
+Fore
+SplineSet
+259.30859375 1544.90527344 m 5,0,1
+ 274.771484375 1547.01367188 274.771484375 1547.01367188 275.486328125 1547.01367188 c 4,2,3
+ 283.674804688 1547.01367188 283.674804688 1547.01367188 295.200195312 1539.81738281 c 4,4,5
+ 296.408203125 1539.0625 296.408203125 1539.0625 297.607421875 1538.30566406 c 6,6,-1
+ 259.30859375 1544.90527344 l 5,0,1
+259.30859375 1544.90527344 m 6,7,-1
+ 234.7421875 1549.13964844 l 6,8,9
+ 242.619140625 1544.38671875 242.619140625 1544.38671875 252.280273438 1544.38671875 c 4,10,11
+ 255.497070312 1544.38671875 255.497070312 1544.38671875 259.30859375 1544.90527344 c 6,7,-1
+297.607421875 1538.30566406 m 5,12,13
+ 489.158203125 1417.23144531 489.158203125 1417.23144531 511.642578125 1002.16992188 c 5,14,-1
+ 118.20703125 1210.83984375 l 5,15,-1
+ 118.20703125 1047.66015625 l 5,16,-1
+ 514.174804688 850.5625 l 5,17,18
+ 514.033203125 832.25390625 514.033203125 832.25390625 513.713867188 806.840820312 c 132,-1,19
+ 513.39453125 781.427734375 513.39453125 781.427734375 513.120117188 761.607421875 c 132,-1,20
+ 512.84375 741.788085938 512.84375 741.788085938 512.625976562 716.635742188 c 132,-1,21
+ 512.409179688 691.484375 512.409179688 691.484375 512.409179688 670.24609375 c 4,22,23
+ 512.409179688 644.82421875 512.409179688 644.82421875 512.809570312 576.362304688 c 132,-1,24
+ 513.209960938 507.900390625 513.209960938 507.900390625 512.979492188 471.578125 c 5,25,-1
+ 112.567382812 249.669921875 l 5,26,-1
+ 112.567382812 76.5400390625 l 5,27,-1
+ 507.260742188 308.514648438 l 5,28,29
+ 473.142578125 -143.591796875 473.142578125 -143.591796875 242.260742188 -285.639648438 c 5,30,-1
+ 328.72265625 -251.809570312 l 5,31,32
+ 423.896484375 -198.918945312 423.896484375 -198.918945312 489.600585938 -126.270507812 c 132,-1,33
+ 555.305664062 -53.623046875 555.305664062 -53.623046875 590.0390625 34.896484375 c 132,-1,34
+ 624.774414062 123.415039062 624.774414062 123.415039062 640.3203125 207.946289062 c 132,-1,35
+ 655.866210938 292.4765625 655.866210938 292.4765625 660.80078125 398.756835938 c 5,36,-1
+ 1101.23730469 643.690429688 l 5,37,-1
+ 1101.23730469 691.450195312 l 5,38,-1
+ 657.959960938 924.565429688 l 5,39,40
+ 650.84765625 1026.90917969 650.84765625 1026.90917969 632.71484375 1109.96289062 c 132,-1,41
+ 614.58203125 1193.01660156 614.58203125 1193.01660156 577.705078125 1276.50097656 c 132,-1,42
+ 540.828125 1359.984375 540.828125 1359.984375 474.729492188 1425.92480469 c 132,-1,43
+ 408.630859375 1491.86621094 408.630859375 1491.86621094 315.564453125 1535.20996094 c 5,44,-1
+ 297.607421875 1538.30566406 l 5,12,13
+663.869140625 555.203125 m 5,45,46
+ 663.893554688 563.153320312 663.893554688 563.153320312 663.893554688 662.51953125 c 4,47,48
+ 663.893554688 732.552734375 663.893554688 732.552734375 663.32421875 776.3203125 c 5,49,-1
+ 873.806640625 671.549804688 l 5,50,-1
+ 663.869140625 555.203125 l 5,45,46
+EndSplineSet
+EndChar
+
+StartChar: uni2983
+Encoding: 10627 10627 3784
+Width: -23560
+VWidth: 1000
+Flags: W
+HStem: 2.84177e+07 4.10481e+06<-12549.6 -6602.78 -12549.6 -6344.22 -12549.6 -3809.51>
+VStem: 20490.3 20967 71018.1 12099.2
+LayerCount: 2
+Fore
+SplineSet
+793.721679688 -144.498046875 m 4,0,1
+ 787.1171875 -159.052734375 787.1171875 -159.052734375 779.100585938 -167.836914062 c 132,-1,2
+ 771.084960938 -176.622070312 771.084960938 -176.622070312 763.689453125 -180.538085938 c 132,-1,3
+ 756.293945312 -184.454101562 756.293945312 -184.454101562 746.005859375 -182.846679688 c 132,-1,4
+ 735.717773438 -181.23828125 735.717773438 -181.23828125 728.211914062 -178.451171875 c 132,-1,5
+ 720.706054688 -175.665039062 720.706054688 -175.665039062 708.583984375 -167.370117188 c 132,-1,6
+ 696.461914062 -159.075195312 696.461914062 -159.075195312 689.283203125 -153.291015625 c 132,-1,7
+ 682.10546875 -147.506835938 682.10546875 -147.506835938 668.5859375 -136.231445312 c 132,-1,8
+ 655.067382812 -124.955078125 655.067382812 -124.955078125 648.411132812 -119.650390625 c 4,9,10
+ 567.032226562 -54.7841796875 567.032226562 -54.7841796875 567.032226562 117.44921875 c 4,11,12
+ 567.032226562 146.69140625 567.032226562 146.69140625 570.189453125 210.005859375 c 132,-1,13
+ 573.346679688 273.3203125 573.346679688 273.3203125 573.346679688 310.24609375 c 4,14,15
+ 573.346679688 379.692382812 573.346679688 379.692382812 562.884765625 437.017578125 c 132,-1,16
+ 552.422851562 494.34375 552.422851562 494.34375 536.075195312 532.221679688 c 132,-1,17
+ 519.727539062 570.099609375 519.727539062 570.099609375 496.708007812 599.051757812 c 132,-1,18
+ 473.689453125 628.002929688 473.689453125 628.002929688 451.752929688 643.715820312 c 132,-1,19
+ 429.817382812 659.4296875 429.817382812 659.4296875 405 669.41015625 c 5,20,21
+ 501.53515625 717.327148438 501.53515625 717.327148438 546.795898438 824.408203125 c 4,22,23
+ 578.470703125 899.357421875 578.470703125 899.357421875 578.470703125 1009.82421875 c 4,24,25
+ 578.470703125 1038.12792969 578.470703125 1038.12792969 575.525390625 1091.26757812 c 132,-1,26
+ 572.580078125 1144.40722656 572.580078125 1144.40722656 572.580078125 1171.87207031 c 4,27,28
+ 572.580078125 1328.65820312 572.580078125 1328.65820312 652.46484375 1386.36621094 c 4,29,30
+ 657.428710938 1389.95214844 657.428710938 1389.95214844 674.815429688 1403.109375 c 132,-1,31
+ 692.201171875 1416.265625 692.201171875 1416.265625 698.583984375 1420.25 c 132,-1,32
+ 704.965820312 1424.234375 704.965820312 1424.234375 719.579101562 1432.58398438 c 132,-1,33
+ 734.192382812 1440.93359375 734.192382812 1440.93359375 742.091796875 1440.4609375 c 132,-1,34
+ 749.9921875 1439.98925781 749.9921875 1439.98925781 761.3671875 1438.30566406 c 132,-1,35
+ 772.741210938 1436.62207031 772.741210938 1436.62207031 781.693359375 1426.46777344 c 132,-1,36
+ 790.645507812 1416.31347656 790.645507812 1416.31347656 798.880859375 1399.7421875 c 4,37,38
+ 814.39453125 1367.98828125 814.39453125 1367.98828125 816.897460938 1330.64355469 c 132,-1,39
+ 819.401367188 1293.29785156 819.401367188 1293.29785156 814.037109375 1267.55761719 c 132,-1,40
+ 808.672851562 1241.81640625 808.672851562 1241.81640625 799.818359375 1209.32617188 c 132,-1,41
+ 790.963867188 1176.83691406 790.963867188 1176.83691406 789.30078125 1165.90527344 c 4,42,43
+ 781.130859375 1112.22851562 781.130859375 1112.22851562 776.306640625 1065.47851562 c 132,-1,44
+ 771.483398438 1018.72949219 771.483398438 1018.72949219 768.798828125 953.052734375 c 132,-1,45
+ 766.115234375 887.375976562 766.115234375 887.375976562 765.169921875 840.556640625 c 132,-1,46
+ 764.224609375 793.73828125 764.224609375 793.73828125 762.76171875 685.33203125 c 4,47,48
+ 761.245117188 587.076171875 761.245117188 587.076171875 763.043945312 460.59375 c 132,-1,49
+ 764.842773438 334.111328125 764.842773438 334.111328125 767.41796875 234.301757812 c 132,-1,50
+ 769.994140625 134.491210938 769.994140625 134.491210938 769.994140625 117.453125 c 4,51,52
+ 769.994140625 92.9111328125 769.994140625 92.9111328125 780.232421875 57.3134765625 c 132,-1,53
+ 790.469726562 21.7158203125 790.469726562 21.7158203125 799.272460938 -5.2255859375 c 132,-1,54
+ 808.075195312 -32.1669921875 808.075195312 -32.1669921875 809.60546875 -71.912109375 c 132,-1,55
+ 811.13671875 -111.658203125 811.13671875 -111.658203125 793.721679688 -144.498046875 c 4,0,1
+964 1547 m 5,56,-1
+ 862.51953125 1547.00390625 l 6,57,58
+ 858.53515625 1547.00390625 858.53515625 1547.00390625 830.508789062 1547.12695312 c 132,-1,59
+ 802.481445312 1547.24902344 802.481445312 1547.24902344 795.592773438 1547.11035156 c 132,-1,60
+ 788.703125 1546.97070312 788.703125 1546.97070312 762.665039062 1546.12207031 c 132,-1,61
+ 736.626953125 1545.2734375 736.626953125 1545.2734375 726.822265625 1543.59667969 c 132,-1,62
+ 717.017578125 1541.91894531 717.017578125 1541.91894531 693.610351562 1538.68261719 c 132,-1,63
+ 670.203125 1535.44628906 670.203125 1535.44628906 658.125976562 1530.81445312 c 132,-1,64
+ 646.048828125 1526.18261719 646.048828125 1526.18261719 625.915039062 1519.14160156 c 132,-1,65
+ 605.78125 1512.09960938 605.78125 1512.09960938 592.073242188 1503.09667969 c 132,-1,66
+ 578.366210938 1494.09277344 578.366210938 1494.09277344 562.1484375 1481.83007812 c 132,-1,67
+ 545.930664062 1469.56835938 545.930664062 1469.56835938 531.888671875 1454.75878906 c 4,68,69
+ 433.548828125 1351.04785156 433.548828125 1351.04785156 433.548828125 1145.86914062 c 4,70,71
+ 433.548828125 1117.14746094 433.548828125 1117.14746094 436.091796875 1062.8359375 c 132,-1,72
+ 438.633789062 1008.52539062 438.633789062 1008.52539062 438.633789062 980.83203125 c 4,73,74
+ 438.633789062 847.737304688 438.633789062 847.737304688 386.998046875 785.075195312 c 4,75,76
+ 344.165039062 733.091796875 344.165039062 733.091796875 253.639648438 733.091796875 c 6,77,-1
+ 214.080078125 733.091796875 l 5,78,-1
+ 214.080078125 603.7421875 l 5,79,-1
+ 255.359375 603.7421875 l 6,80,81
+ 340.83203125 603.7421875 340.83203125 603.7421875 381.295898438 557.865234375 c 4,82,83
+ 433.868164062 498.264648438 433.868164062 498.264648438 433.868164062 346.80078125 c 4,84,85
+ 433.868164062 313.104492188 433.868164062 313.104492188 430.129882812 238.295898438 c 132,-1,86
+ 426.392578125 163.48828125 426.392578125 163.48828125 426.392578125 116.306640625 c 4,87,88
+ 426.392578125 -119.680664062 426.392578125 -119.680664062 537.479492188 -218.314453125 c 4,89,90
+ 550.185546875 -229.595703125 550.185546875 -229.595703125 564.387695312 -238.82421875 c 132,-1,91
+ 578.590820312 -248.052734375 578.590820312 -248.052734375 590.49609375 -254.901367188 c 132,-1,92
+ 602.401367188 -261.750976562 602.401367188 -261.750976562 620.009765625 -267.018554688 c 132,-1,93
+ 637.618164062 -272.28515625 637.618164062 -272.28515625 648.1875 -275.797851562 c 132,-1,94
+ 658.7578125 -279.310546875 658.7578125 -279.310546875 679.83203125 -281.701171875 c 132,-1,95
+ 700.90625 -284.091796875 700.90625 -284.091796875 710.201171875 -285.3515625 c 132,-1,96
+ 719.49609375 -286.612304688 719.49609375 -286.612304688 744.096679688 -287.2109375 c 132,-1,97
+ 768.697265625 -287.809570312 768.697265625 -287.809570312 776.778320312 -287.90234375 c 132,-1,98
+ 784.859375 -287.995117188 784.859375 -287.995117188 813.047851562 -287.88671875 c 132,-1,99
+ 841.236328125 -287.77734375 841.236328125 -287.77734375 848.759765625 -287.77734375 c 6,100,-1
+ 962.279296875 -287.77734375 l 5,101,-1
+ 962.279296875 -142.5078125 l 5,102,103
+ 947.508789062 -130.734375 947.508789062 -130.734375 935.918945312 -116.397460938 c 132,-1,104
+ 924.330078125 -102.060546875 924.330078125 -102.060546875 916.426757812 -83.6611328125 c 132,-1,105
+ 908.524414062 -65.2626953125 908.524414062 -65.2626953125 903.247070312 -50.9013671875 c 132,-1,106
+ 897.970703125 -36.541015625 897.970703125 -36.541015625 894.107421875 -13.1123046875 c 132,-1,107
+ 890.244140625 10.3154296875 890.244140625 10.3154296875 888.565429688 22.330078125 c 132,-1,108
+ 886.885742188 34.3447265625 886.885742188 34.3447265625 884.348632812 60.4326171875 c 132,-1,109
+ 881.810546875 86.51953125 881.810546875 86.51953125 880.900390625 94.591796875 c 4,110,111
+ 871.690429688 176.310546875 871.690429688 176.310546875 860.111328125 358.728515625 c 132,-1,112
+ 848.532226562 541.147460938 848.532226562 541.147460938 850.479492188 685.33203125 c 4,113,114
+ 851.133789062 733.763671875 851.133789062 733.763671875 852.381835938 775.014648438 c 132,-1,115
+ 853.629882812 816.265625 853.629882812 816.265625 856.454101562 857.166992188 c 132,-1,116
+ 859.279296875 898.068359375 859.279296875 898.068359375 860.922851562 922.508789062 c 132,-1,117
+ 862.56640625 946.94921875 862.56640625 946.94921875 867.465820312 988.879882812 c 132,-1,118
+ 872.365234375 1030.81054688 872.365234375 1030.81054688 874.079101562 1045.19042969 c 132,-1,119
+ 875.79296875 1059.57128906 875.79296875 1059.57128906 882.44140625 1109.28222656 c 132,-1,120
+ 889.090820312 1158.99414062 889.090820312 1158.99414062 890.778320312 1171.87402344 c 4,121,122
+ 890.809570312 1172.109375 890.809570312 1172.109375 893.313476562 1192.10742188 c 132,-1,123
+ 895.817382812 1212.10449219 895.817382812 1212.10449219 896.944335938 1219.79296875 c 132,-1,124
+ 898.071289062 1227.48144531 898.071289062 1227.48144531 901.770507812 1249.12597656 c 132,-1,125
+ 905.469726562 1270.77050781 905.469726562 1270.77050781 908.68359375 1282.9609375 c 132,-1,126
+ 911.897460938 1295.15136719 911.897460938 1295.15136719 917.729492188 1314.91308594 c 132,-1,127
+ 923.561523438 1334.67578125 923.561523438 1334.67578125 929.801757812 1347.83984375 c 132,-1,128
+ 936.041992188 1361.00390625 936.041992188 1361.00390625 944.9453125 1375.35644531 c 132,-1,129
+ 953.848632812 1389.70898438 953.848632812 1389.70898438 964 1399.74023438 c 5,130,-1
+ 964 1547 l 5,56,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2984
+Encoding: 10628 10628 3785
+Width: -23560
+VWidth: 1000
+Flags: W
+HStem: 264 65<494.197 528 505 528 505 528>
+VStem: 158 50.7949 319.124 81.0918
+LayerCount: 2
+Fore
+SplineSet
+451.278320312 -144.498046875 m 4,0,1
+ 457.8828125 -159.052734375 457.8828125 -159.052734375 465.899414062 -167.836914062 c 132,-1,2
+ 473.915039062 -176.622070312 473.915039062 -176.622070312 481.310546875 -180.538085938 c 132,-1,3
+ 488.706054688 -184.454101562 488.706054688 -184.454101562 498.994140625 -182.846679688 c 132,-1,4
+ 509.282226562 -181.23828125 509.282226562 -181.23828125 516.788085938 -178.451171875 c 132,-1,5
+ 524.293945312 -175.665039062 524.293945312 -175.665039062 536.416015625 -167.370117188 c 132,-1,6
+ 548.538085938 -159.075195312 548.538085938 -159.075195312 555.716796875 -153.291015625 c 132,-1,7
+ 562.89453125 -147.506835938 562.89453125 -147.506835938 576.4140625 -136.231445312 c 132,-1,8
+ 589.932617188 -124.955078125 589.932617188 -124.955078125 596.588867188 -119.650390625 c 4,9,10
+ 677.967773438 -54.7841796875 677.967773438 -54.7841796875 677.967773438 117.44921875 c 4,11,12
+ 677.967773438 146.69140625 677.967773438 146.69140625 674.810546875 210.005859375 c 132,-1,13
+ 671.653320312 273.3203125 671.653320312 273.3203125 671.653320312 310.24609375 c 4,14,15
+ 671.653320312 379.692382812 671.653320312 379.692382812 682.115234375 437.017578125 c 132,-1,16
+ 692.577148438 494.34375 692.577148438 494.34375 708.924804688 532.221679688 c 132,-1,17
+ 725.272460938 570.099609375 725.272460938 570.099609375 748.291992188 599.051757812 c 132,-1,18
+ 771.310546875 628.002929688 771.310546875 628.002929688 793.247070312 643.715820312 c 132,-1,19
+ 815.182617188 659.4296875 815.182617188 659.4296875 840 669.41015625 c 5,20,21
+ 743.46484375 717.327148438 743.46484375 717.327148438 698.204101562 824.408203125 c 4,22,23
+ 666.529296875 899.357421875 666.529296875 899.357421875 666.529296875 1009.82421875 c 4,24,25
+ 666.529296875 1038.12792969 666.529296875 1038.12792969 669.474609375 1091.26757812 c 132,-1,26
+ 672.419921875 1144.40722656 672.419921875 1144.40722656 672.419921875 1171.87207031 c 4,27,28
+ 672.419921875 1328.65820312 672.419921875 1328.65820312 592.53515625 1386.36621094 c 4,29,30
+ 587.571289062 1389.95214844 587.571289062 1389.95214844 570.184570312 1403.109375 c 132,-1,31
+ 552.798828125 1416.265625 552.798828125 1416.265625 546.416015625 1420.25 c 132,-1,32
+ 540.034179688 1424.234375 540.034179688 1424.234375 525.420898438 1432.58398438 c 132,-1,33
+ 510.807617188 1440.93359375 510.807617188 1440.93359375 502.908203125 1440.4609375 c 132,-1,34
+ 495.0078125 1439.98925781 495.0078125 1439.98925781 483.6328125 1438.30566406 c 132,-1,35
+ 472.258789062 1436.62207031 472.258789062 1436.62207031 463.306640625 1426.46777344 c 132,-1,36
+ 454.354492188 1416.31347656 454.354492188 1416.31347656 446.119140625 1399.7421875 c 4,37,38
+ 430.60546875 1367.98828125 430.60546875 1367.98828125 428.102539062 1330.64355469 c 132,-1,39
+ 425.598632812 1293.29785156 425.598632812 1293.29785156 430.962890625 1267.55761719 c 132,-1,40
+ 436.327148438 1241.81640625 436.327148438 1241.81640625 445.181640625 1209.32617188 c 132,-1,41
+ 454.036132812 1176.83691406 454.036132812 1176.83691406 455.69921875 1165.90527344 c 4,42,43
+ 463.869140625 1112.22851562 463.869140625 1112.22851562 468.693359375 1065.47851562 c 132,-1,44
+ 473.516601562 1018.72949219 473.516601562 1018.72949219 476.201171875 953.052734375 c 132,-1,45
+ 478.884765625 887.375976562 478.884765625 887.375976562 479.830078125 840.556640625 c 132,-1,46
+ 480.775390625 793.73828125 480.775390625 793.73828125 482.23828125 685.33203125 c 4,47,48
+ 483.754882812 587.076171875 483.754882812 587.076171875 481.956054688 460.59375 c 132,-1,49
+ 480.157226562 334.111328125 480.157226562 334.111328125 477.58203125 234.301757812 c 132,-1,50
+ 475.005859375 134.491210938 475.005859375 134.491210938 475.005859375 117.453125 c 4,51,52
+ 475.005859375 92.9111328125 475.005859375 92.9111328125 464.767578125 57.3134765625 c 132,-1,53
+ 454.530273438 21.7158203125 454.530273438 21.7158203125 445.727539062 -5.2255859375 c 132,-1,54
+ 436.924804688 -32.1669921875 436.924804688 -32.1669921875 435.39453125 -71.912109375 c 132,-1,55
+ 433.86328125 -111.658203125 433.86328125 -111.658203125 451.278320312 -144.498046875 c 4,0,1
+281 1547 m 5,56,-1
+ 382.48046875 1547.00390625 l 6,57,58
+ 386.46484375 1547.00390625 386.46484375 1547.00390625 414.491210938 1547.12695312 c 132,-1,59
+ 442.518554688 1547.24902344 442.518554688 1547.24902344 449.407226562 1547.11035156 c 132,-1,60
+ 456.296875 1546.97070312 456.296875 1546.97070312 482.334960938 1546.12207031 c 132,-1,61
+ 508.373046875 1545.2734375 508.373046875 1545.2734375 518.177734375 1543.59667969 c 132,-1,62
+ 527.982421875 1541.91894531 527.982421875 1541.91894531 551.389648438 1538.68261719 c 132,-1,63
+ 574.796875 1535.44628906 574.796875 1535.44628906 586.874023438 1530.81445312 c 132,-1,64
+ 598.951171875 1526.18261719 598.951171875 1526.18261719 619.084960938 1519.14160156 c 132,-1,65
+ 639.21875 1512.09960938 639.21875 1512.09960938 652.926757812 1503.09667969 c 132,-1,66
+ 666.633789062 1494.09277344 666.633789062 1494.09277344 682.8515625 1481.83007812 c 132,-1,67
+ 699.069335938 1469.56835938 699.069335938 1469.56835938 713.111328125 1454.75878906 c 4,68,69
+ 811.451171875 1351.04785156 811.451171875 1351.04785156 811.451171875 1145.86914062 c 4,70,71
+ 811.451171875 1117.14746094 811.451171875 1117.14746094 808.908203125 1062.8359375 c 132,-1,72
+ 806.366210938 1008.52539062 806.366210938 1008.52539062 806.366210938 980.83203125 c 4,73,74
+ 806.366210938 847.737304688 806.366210938 847.737304688 858.001953125 785.075195312 c 4,75,76
+ 900.834960938 733.091796875 900.834960938 733.091796875 991.360351562 733.091796875 c 6,77,-1
+ 1030.91992188 733.091796875 l 5,78,-1
+ 1030.91992188 603.7421875 l 5,79,-1
+ 989.640625 603.7421875 l 6,80,81
+ 904.16796875 603.7421875 904.16796875 603.7421875 863.704101562 557.865234375 c 4,82,83
+ 811.131835938 498.264648438 811.131835938 498.264648438 811.131835938 346.80078125 c 4,84,85
+ 811.131835938 313.104492188 811.131835938 313.104492188 814.870117188 238.295898438 c 132,-1,86
+ 818.607421875 163.48828125 818.607421875 163.48828125 818.607421875 116.306640625 c 4,87,88
+ 818.607421875 -119.680664062 818.607421875 -119.680664062 707.520507812 -218.314453125 c 4,89,90
+ 694.814453125 -229.595703125 694.814453125 -229.595703125 680.612304688 -238.82421875 c 132,-1,91
+ 666.409179688 -248.052734375 666.409179688 -248.052734375 654.50390625 -254.901367188 c 132,-1,92
+ 642.598632812 -261.750976562 642.598632812 -261.750976562 624.990234375 -267.018554688 c 132,-1,93
+ 607.381835938 -272.28515625 607.381835938 -272.28515625 596.8125 -275.797851562 c 132,-1,94
+ 586.2421875 -279.310546875 586.2421875 -279.310546875 565.16796875 -281.701171875 c 132,-1,95
+ 544.09375 -284.091796875 544.09375 -284.091796875 534.798828125 -285.3515625 c 132,-1,96
+ 525.50390625 -286.612304688 525.50390625 -286.612304688 500.903320312 -287.2109375 c 132,-1,97
+ 476.302734375 -287.809570312 476.302734375 -287.809570312 468.221679688 -287.90234375 c 132,-1,98
+ 460.140625 -287.995117188 460.140625 -287.995117188 431.952148438 -287.88671875 c 132,-1,99
+ 403.763671875 -287.77734375 403.763671875 -287.77734375 396.240234375 -287.77734375 c 6,100,-1
+ 282.720703125 -287.77734375 l 5,101,-1
+ 282.720703125 -142.5078125 l 5,102,103
+ 297.491210938 -130.734375 297.491210938 -130.734375 309.081054688 -116.397460938 c 132,-1,104
+ 320.669921875 -102.060546875 320.669921875 -102.060546875 328.573242188 -83.6611328125 c 132,-1,105
+ 336.475585938 -65.2626953125 336.475585938 -65.2626953125 341.752929688 -50.9013671875 c 132,-1,106
+ 347.029296875 -36.541015625 347.029296875 -36.541015625 350.892578125 -13.1123046875 c 132,-1,107
+ 354.755859375 10.3154296875 354.755859375 10.3154296875 356.434570312 22.330078125 c 132,-1,108
+ 358.114257812 34.3447265625 358.114257812 34.3447265625 360.651367188 60.4326171875 c 132,-1,109
+ 363.189453125 86.51953125 363.189453125 86.51953125 364.099609375 94.591796875 c 4,110,111
+ 373.309570312 176.310546875 373.309570312 176.310546875 384.888671875 358.728515625 c 132,-1,112
+ 396.467773438 541.147460938 396.467773438 541.147460938 394.520507812 685.33203125 c 4,113,114
+ 393.866210938 733.763671875 393.866210938 733.763671875 392.618164062 775.014648438 c 132,-1,115
+ 391.370117188 816.265625 391.370117188 816.265625 388.545898438 857.166992188 c 132,-1,116
+ 385.720703125 898.068359375 385.720703125 898.068359375 384.077148438 922.508789062 c 132,-1,117
+ 382.43359375 946.94921875 382.43359375 946.94921875 377.534179688 988.879882812 c 132,-1,118
+ 372.634765625 1030.81054688 372.634765625 1030.81054688 370.920898438 1045.19042969 c 132,-1,119
+ 369.20703125 1059.57128906 369.20703125 1059.57128906 362.55859375 1109.28222656 c 132,-1,120
+ 355.909179688 1158.99414062 355.909179688 1158.99414062 354.221679688 1171.87402344 c 4,121,122
+ 354.190429688 1172.109375 354.190429688 1172.109375 351.686523438 1192.10742188 c 132,-1,123
+ 349.182617188 1212.10449219 349.182617188 1212.10449219 348.055664062 1219.79296875 c 132,-1,124
+ 346.928710938 1227.48144531 346.928710938 1227.48144531 343.229492188 1249.12597656 c 132,-1,125
+ 339.530273438 1270.77050781 339.530273438 1270.77050781 336.31640625 1282.9609375 c 132,-1,126
+ 333.102539062 1295.15136719 333.102539062 1295.15136719 327.270507812 1314.91308594 c 132,-1,127
+ 321.438476562 1334.67578125 321.438476562 1334.67578125 315.198242188 1347.83984375 c 132,-1,128
+ 308.958007812 1361.00390625 308.958007812 1361.00390625 300.0546875 1375.35644531 c 132,-1,129
+ 291.151367188 1389.70898438 291.151367188 1389.70898438 281 1399.74023438 c 5,130,-1
+ 281 1547 l 5,56,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2985
+Encoding: 10629 10629 3786
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 696.611 32
+VStem: 138.68 32 275.273 32
+LayerCount: 2
+Fore
+SplineSet
+819.419921875 1491.60449219 m 5,0,1
+ 612.734375 1384.74511719 612.734375 1384.74511719 501.21484375 1177.50097656 c 132,-1,2
+ 389.696289062 970.255859375 389.696289062 970.255859375 389.696289062 686.326171875 c 4,3,4
+ 389.696289062 402.1640625 389.696289062 402.1640625 500.461914062 182.126953125 c 132,-1,5
+ 611.229492188 -37.9091796875 611.229492188 -37.9091796875 820.947265625 -167.2890625 c 5,6,-1
+ 878.993164062 -154.721679688 l 5,7,8
+ 791.545898438 -94.9951171875 791.545898438 -94.9951171875 725.991210938 0.7705078125 c 132,-1,9
+ 660.4375 96.53515625 660.4375 96.53515625 622.965820312 211.307617188 c 132,-1,10
+ 585.494140625 326.078125 585.494140625 326.078125 567.479492188 446.409179688 c 132,-1,11
+ 549.46484375 566.739257812 549.46484375 566.739257812 549.46484375 693.297851562 c 4,12,13
+ 549.46484375 852.802734375 549.46484375 852.802734375 573.715820312 991.345703125 c 132,-1,14
+ 597.96484375 1129.88867188 597.96484375 1129.88867188 661.633789062 1257.15820312 c 132,-1,15
+ 725.302734375 1384.42773438 725.302734375 1384.42773438 823.75 1452.67285156 c 4,16,17
+ 833.115234375 1459.16503906 833.115234375 1459.16503906 839.771484375 1459.16503906 c 4,18,19
+ 842.780273438 1459.16503906 842.780273438 1459.16503906 848.900390625 1457.97949219 c 132,-1,20
+ 855.018554688 1456.79492188 855.018554688 1456.79492188 858.629882812 1456.79492188 c 4,21,22
+ 866.479492188 1456.79492188 866.479492188 1456.79492188 872.8828125 1461.08398438 c 6,23,-1
+ 819.419921875 1491.60449219 l 5,0,1
+799.73828125 1544.19140625 m 6,24,-1
+ 820.435546875 1554.89257812 l 5,25,-1
+ 840.775390625 1543.28027344 l 5,26,-1
+ 894.23828125 1512.75976562 l 5,27,-1
+ 977.659179688 1465.13769531 l 5,28,-1
+ 897.084960938 1411.16796875 l 6,29,30
+ 879.428710938 1399.34277344 879.428710938 1399.34277344 858.62890625 1399.34277344 c 4,31,32
+ 852.221679688 1399.34277344 852.221679688 1399.34277344 844.857421875 1400.57324219 c 4,33,34
+ 779.9765625 1354.25097656 779.9765625 1354.25097656 731.3515625 1277.89160156 c 132,-1,35
+ 682.724609375 1201.53222656 682.724609375 1201.53222656 654.288085938 1106.859375 c 132,-1,36
+ 625.8515625 1012.18652344 625.8515625 1012.18652344 612.098632812 908.962890625 c 132,-1,37
+ 598.346679688 805.73828125 598.346679688 805.73828125 598.346679688 693.295898438 c 4,38,39
+ 598.346679688 571.38671875 598.346679688 571.38671875 615.755859375 455.905273438 c 132,-1,40
+ 633.165039062 340.423828125 633.165039062 340.423828125 668.563476562 233.131835938 c 132,-1,41
+ 703.961914062 125.83984375 703.961914062 125.83984375 764.1328125 37.458984375 c 132,-1,42
+ 824.301757812 -50.921875 824.301757812 -50.921875 903.553710938 -105.049804688 c 6,43,-1
+ 1017.80664062 -183.084960938 l 5,44,-1
+ 887.84765625 -211.22265625 l 5,45,-1
+ 829.801757812 -223.7890625 l 5,46,-1
+ 813.1875 -227.38671875 l 5,47,-1
+ 798.228515625 -218.157226562 l 6,48,49
+ 576.912109375 -81.6220703125 576.912109375 -81.6220703125 458.86328125 152.888671875 c 132,-1,50
+ 340.814453125 387.400390625 340.814453125 387.400390625 340.814453125 686.326171875 c 4,51,52
+ 340.814453125 885.3984375 340.814453125 885.3984375 394.770507812 1052.76464844 c 132,-1,53
+ 448.727539062 1220.12988281 448.727539062 1220.12988281 551.478515625 1344.54589844 c 132,-1,54
+ 654.229492188 1468.96289062 654.229492188 1468.96289062 799.73828125 1544.19140625 c 6,24,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2986
+Encoding: 10630 10630 3787
+Width: 600
+VWidth: 1000
+Flags: W
+VStem: 294.028 32 432 32<186.197 393.461>
+LayerCount: 2
+Fore
+SplineSet
+380.580078125 1490.60449219 m 5,0,1
+ 587.265625 1383.74511719 587.265625 1383.74511719 698.78515625 1176.50097656 c 132,-1,2
+ 810.303710938 969.255859375 810.303710938 969.255859375 810.303710938 685.326171875 c 4,3,4
+ 810.303710938 401.1640625 810.303710938 401.1640625 699.538085938 181.126953125 c 132,-1,5
+ 588.770507812 -38.9091796875 588.770507812 -38.9091796875 379.052734375 -168.2890625 c 5,6,-1
+ 321.006835938 -155.721679688 l 5,7,8
+ 408.454101562 -95.9951171875 408.454101562 -95.9951171875 474.008789062 -0.2294921875 c 132,-1,9
+ 539.5625 95.53515625 539.5625 95.53515625 577.034179688 210.307617188 c 132,-1,10
+ 614.505859375 325.078125 614.505859375 325.078125 632.520507812 445.409179688 c 132,-1,11
+ 650.53515625 565.739257812 650.53515625 565.739257812 650.53515625 692.297851562 c 4,12,13
+ 650.53515625 851.802734375 650.53515625 851.802734375 626.284179688 990.345703125 c 132,-1,14
+ 602.03515625 1128.88867188 602.03515625 1128.88867188 538.366210938 1256.15820312 c 132,-1,15
+ 474.697265625 1383.42773438 474.697265625 1383.42773438 376.25 1451.67285156 c 4,16,17
+ 366.884765625 1458.16503906 366.884765625 1458.16503906 360.228515625 1458.16503906 c 4,18,19
+ 357.219726562 1458.16503906 357.219726562 1458.16503906 351.099609375 1456.97949219 c 132,-1,20
+ 344.981445312 1455.79492188 344.981445312 1455.79492188 341.370117188 1455.79492188 c 4,21,22
+ 333.520507812 1455.79492188 333.520507812 1455.79492188 327.1171875 1460.08398438 c 6,23,-1
+ 380.580078125 1490.60449219 l 5,0,1
+400.26171875 1543.19140625 m 6,24,-1
+ 379.564453125 1553.89257812 l 5,25,-1
+ 359.224609375 1542.28027344 l 5,26,-1
+ 305.76171875 1511.75976562 l 5,27,-1
+ 222.340820312 1464.13769531 l 5,28,-1
+ 302.915039062 1410.16796875 l 6,29,30
+ 320.571289062 1398.34277344 320.571289062 1398.34277344 341.37109375 1398.34277344 c 4,31,32
+ 347.778320312 1398.34277344 347.778320312 1398.34277344 355.142578125 1399.57324219 c 4,33,34
+ 420.0234375 1353.25097656 420.0234375 1353.25097656 468.6484375 1276.89160156 c 132,-1,35
+ 517.275390625 1200.53222656 517.275390625 1200.53222656 545.711914062 1105.859375 c 132,-1,36
+ 574.1484375 1011.18652344 574.1484375 1011.18652344 587.901367188 907.962890625 c 132,-1,37
+ 601.653320312 804.73828125 601.653320312 804.73828125 601.653320312 692.295898438 c 4,38,39
+ 601.653320312 570.38671875 601.653320312 570.38671875 584.244140625 454.905273438 c 132,-1,40
+ 566.834960938 339.423828125 566.834960938 339.423828125 531.436523438 232.131835938 c 132,-1,41
+ 496.038085938 124.83984375 496.038085938 124.83984375 435.8671875 36.458984375 c 132,-1,42
+ 375.698242188 -51.921875 375.698242188 -51.921875 296.446289062 -106.049804688 c 6,43,-1
+ 182.193359375 -184.084960938 l 5,44,-1
+ 312.15234375 -212.22265625 l 5,45,-1
+ 370.198242188 -224.7890625 l 5,46,-1
+ 386.8125 -228.38671875 l 5,47,-1
+ 401.771484375 -219.157226562 l 6,48,49
+ 623.087890625 -82.6220703125 623.087890625 -82.6220703125 741.13671875 151.888671875 c 132,-1,50
+ 859.185546875 386.400390625 859.185546875 386.400390625 859.185546875 685.326171875 c 4,51,52
+ 859.185546875 884.3984375 859.185546875 884.3984375 805.229492188 1051.76464844 c 132,-1,53
+ 751.272460938 1219.12988281 751.272460938 1219.12988281 648.521484375 1343.54589844 c 132,-1,54
+ 545.770507812 1467.96289062 545.770507812 1467.96289062 400.26171875 1543.19140625 c 6,24,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2E28
+Encoding: 11816 11816 3788
+Width: -4549
+VWidth: 1000
+Flags: W
+VStem: 1.28776e+06 376531 2.08667e+06 376531
+LayerCount: 2
+Fore
+SplineSet
+612.599609375 1511.36035156 m 5,0,-1
+ 681.200195312 1389.24023438 l 5,1,2
+ 672.985351562 1385.13183594 672.985351562 1385.13183594 662.911132812 1385.13183594 c 4,3,4
+ 658.279296875 1385.13183594 658.279296875 1385.13183594 650.426757812 1386.26660156 c 132,-1,5
+ 642.575195312 1387.40234375 642.575195312 1387.40234375 638.713867188 1387.40234375 c 4,6,7
+ 630.172851562 1387.40234375 630.172851562 1387.40234375 618.15625 1381.18261719 c 4,8,9
+ 570.767578125 1356.65527344 570.767578125 1356.65527344 532.994140625 1326.453125 c 132,-1,10
+ 495.221679688 1296.25097656 495.221679688 1296.25097656 468.813476562 1257.13964844 c 132,-1,11
+ 442.40625 1218.02832031 442.40625 1218.02832031 423.096679688 1183.42089844 c 132,-1,12
+ 403.787109375 1148.81347656 403.787109375 1148.81347656 392.23046875 1096.60351562 c 132,-1,13
+ 380.673828125 1044.39453125 380.673828125 1044.39453125 373.771484375 1008.12597656 c 132,-1,14
+ 366.868164062 971.857421875 366.868164062 971.857421875 364.10546875 909.294921875 c 132,-1,15
+ 361.34375 846.733398438 361.34375 846.733398438 360.790039062 811.547851562 c 132,-1,16
+ 360.236328125 776.36328125 360.236328125 776.36328125 360.28515625 707.450195312 c 4,17,18
+ 360.295898438 692.247070312 360.295898438 692.247070312 360.295898438 684.6328125 c 4,19,20
+ 360.295898438 592.69140625 360.295898438 592.69140625 363.318359375 528.65234375 c 132,-1,21
+ 366.341796875 464.612304688 366.341796875 464.612304688 376.319335938 381.150390625 c 132,-1,22
+ 386.297851562 297.689453125 386.297851562 297.689453125 408.493164062 235.568359375 c 132,-1,23
+ 430.688476562 173.447265625 430.688476562 173.447265625 465.625 108.874023438 c 132,-1,24
+ 500.561523438 44.30078125 500.561523438 44.30078125 557.135742188 -7.0625 c 132,-1,25
+ 613.7109375 -58.42578125 613.7109375 -58.42578125 689.040039062 -96.83984375 c 5,26,-1
+ 614.559570312 -201.759765625 l 5,27,28
+ 510.0859375 -153.63671875 510.0859375 -153.63671875 433.849609375 -80.1552734375 c 132,-1,29
+ 357.61328125 -6.6748046875 357.61328125 -6.6748046875 313.741210938 73.9921875 c 132,-1,30
+ 269.870117188 154.658203125 269.870117188 154.658203125 244.1328125 260.866210938 c 132,-1,31
+ 218.396484375 367.07421875 218.396484375 367.07421875 210.364257812 462.125976562 c 132,-1,32
+ 202.33203125 557.177734375 202.33203125 557.177734375 202.33203125 677.954101562 c 4,33,34
+ 202.33203125 797.892578125 202.33203125 797.892578125 210.985351562 892.7734375 c 132,-1,35
+ 219.637695312 987.653320312 219.637695312 987.653320312 245.795898438 1088.76269531 c 132,-1,36
+ 271.954101562 1189.87304688 271.954101562 1189.87304688 316.076171875 1265.53515625 c 132,-1,37
+ 360.198242188 1341.19824219 360.198242188 1341.19824219 435.240234375 1406.53027344 c 132,-1,38
+ 510.283203125 1471.86328125 510.283203125 1471.86328125 612.599609375 1511.36035156 c 5,0,-1
+971.280273438 1470.08007812 m 5,39,-1
+ 1039.87988281 1347.95996094 l 5,40,41
+ 1031.66503906 1343.8515625 1031.66503906 1343.8515625 1021.59082031 1343.8515625 c 4,42,43
+ 1016.95898438 1343.8515625 1016.95898438 1343.8515625 1009.10644531 1344.98730469 c 132,-1,44
+ 1001.25488281 1346.12207031 1001.25488281 1346.12207031 997.393554688 1346.12207031 c 4,45,46
+ 988.853515625 1346.12207031 988.853515625 1346.12207031 976.836914062 1339.90234375 c 4,47,48
+ 921.102539062 1311.05566406 921.102539062 1311.05566406 877.765625 1274.53320312 c 132,-1,49
+ 834.427734375 1238.00976562 834.427734375 1238.00976562 804.9453125 1200.50097656 c 132,-1,50
+ 775.462890625 1162.99121094 775.462890625 1162.99121094 754.754882812 1113.20996094 c 132,-1,51
+ 734.046875 1063.42871094 734.046875 1063.42871094 722.587890625 1019.57910156 c 132,-1,52
+ 711.12890625 975.73046875 711.12890625 975.73046875 704.888671875 914.24609375 c 132,-1,53
+ 698.6484375 852.76171875 698.6484375 852.76171875 697.051757812 804.129882812 c 132,-1,54
+ 695.456054688 755.497070312 695.456054688 755.497070312 695.456054688 684.6328125 c 4,55,56
+ 695.456054688 581.186523438 695.456054688 581.186523438 702.072265625 502.83203125 c 132,-1,57
+ 708.689453125 424.477539062 708.689453125 424.477539062 730.276367188 337.014648438 c 132,-1,58
+ 751.862304688 249.551757812 751.862304688 249.551757812 789.408203125 183.080078125 c 132,-1,59
+ 826.953125 116.609375 826.953125 116.609375 892.108398438 53.5888671875 c 132,-1,60
+ 957.263671875 -9.4306640625 957.263671875 -9.4306640625 1047.71972656 -55.5595703125 c 5,61,-1
+ 973.240234375 -160.48046875 l 5,62,63
+ 842.668945312 -100.3359375 842.668945312 -100.3359375 754.108398438 -12.6826171875 c 132,-1,64
+ 665.548828125 74.9716796875 665.548828125 74.9716796875 619.739257812 187.333007812 c 132,-1,65
+ 573.9296875 299.694335938 573.9296875 299.694335938 555.7109375 415.321289062 c 132,-1,66
+ 537.4921875 530.948242188 537.4921875 530.948242188 537.4921875 677.954101562 c 4,67,68
+ 537.4921875 824.333984375 537.4921875 824.333984375 556.47265625 938.390625 c 132,-1,69
+ 575.453125 1052.44726562 575.453125 1052.44726562 621.958007812 1158.109375 c 132,-1,70
+ 668.462890625 1263.77148438 668.462890625 1263.77148438 755.850585938 1342.21191406 c 132,-1,71
+ 843.23828125 1420.65234375 843.23828125 1420.65234375 971.280273438 1470.08007812 c 5,39,-1
+EndSplineSet
+EndChar
+
+StartChar: uni2E29
+Encoding: 11817 11817 3789
+Width: -4549
+VWidth: 1000
+Flags: W
+VStem: 278.028 81.9717 446.028 81.9717
+LayerCount: 2
+Fore
+SplineSet
+628.384765625 1511.36035156 m 5,0,-1
+ 559.784179688 1389.24023438 l 5,1,2
+ 567.999023438 1385.13183594 567.999023438 1385.13183594 578.073242188 1385.13183594 c 4,3,4
+ 582.705078125 1385.13183594 582.705078125 1385.13183594 590.557617188 1386.26660156 c 132,-1,5
+ 598.409179688 1387.40234375 598.409179688 1387.40234375 602.270507812 1387.40234375 c 4,6,7
+ 610.811523438 1387.40234375 610.811523438 1387.40234375 622.828125 1381.18261719 c 4,8,9
+ 670.216796875 1356.65527344 670.216796875 1356.65527344 707.990234375 1326.453125 c 132,-1,10
+ 745.762695312 1296.25097656 745.762695312 1296.25097656 772.170898438 1257.13964844 c 132,-1,11
+ 798.578125 1218.02832031 798.578125 1218.02832031 817.887695312 1183.42089844 c 132,-1,12
+ 837.197265625 1148.81347656 837.197265625 1148.81347656 848.75390625 1096.60351562 c 132,-1,13
+ 860.310546875 1044.39453125 860.310546875 1044.39453125 867.212890625 1008.12597656 c 132,-1,14
+ 874.116210938 971.857421875 874.116210938 971.857421875 876.87890625 909.294921875 c 132,-1,15
+ 879.640625 846.733398438 879.640625 846.733398438 880.194335938 811.547851562 c 132,-1,16
+ 880.748046875 776.36328125 880.748046875 776.36328125 880.69921875 707.450195312 c 4,17,18
+ 880.688476562 692.247070312 880.688476562 692.247070312 880.688476562 684.6328125 c 4,19,20
+ 880.688476562 592.69140625 880.688476562 592.69140625 877.666015625 528.65234375 c 132,-1,21
+ 874.642578125 464.612304688 874.642578125 464.612304688 864.665039062 381.150390625 c 132,-1,22
+ 854.686523438 297.689453125 854.686523438 297.689453125 832.491210938 235.568359375 c 132,-1,23
+ 810.295898438 173.447265625 810.295898438 173.447265625 775.359375 108.874023438 c 132,-1,24
+ 740.422851562 44.30078125 740.422851562 44.30078125 683.848632812 -7.0625 c 132,-1,25
+ 627.2734375 -58.42578125 627.2734375 -58.42578125 551.944335938 -96.83984375 c 5,26,-1
+ 626.424804688 -201.759765625 l 5,27,28
+ 730.8984375 -153.63671875 730.8984375 -153.63671875 807.134765625 -80.1552734375 c 132,-1,29
+ 883.37109375 -6.6748046875 883.37109375 -6.6748046875 927.243164062 73.9921875 c 132,-1,30
+ 971.114257812 154.658203125 971.114257812 154.658203125 996.8515625 260.866210938 c 132,-1,31
+ 1022.58789062 367.07421875 1022.58789062 367.07421875 1030.62011719 462.125976562 c 132,-1,32
+ 1038.65234375 557.177734375 1038.65234375 557.177734375 1038.65234375 677.954101562 c 4,33,34
+ 1038.65234375 797.892578125 1038.65234375 797.892578125 1029.99902344 892.7734375 c 132,-1,35
+ 1021.34667969 987.653320312 1021.34667969 987.653320312 995.188476562 1088.76269531 c 132,-1,36
+ 969.030273438 1189.87304688 969.030273438 1189.87304688 924.908203125 1265.53515625 c 132,-1,37
+ 880.786132812 1341.19824219 880.786132812 1341.19824219 805.744140625 1406.53027344 c 132,-1,38
+ 730.701171875 1471.86328125 730.701171875 1471.86328125 628.384765625 1511.36035156 c 5,0,-1
+269.704101562 1470.08007812 m 5,39,-1
+ 201.104492188 1347.95996094 l 5,40,41
+ 209.319335938 1343.8515625 209.319335938 1343.8515625 219.393554688 1343.8515625 c 4,42,43
+ 224.025390625 1343.8515625 224.025390625 1343.8515625 231.877929688 1344.98730469 c 132,-1,44
+ 239.729492188 1346.12207031 239.729492188 1346.12207031 243.590820312 1346.12207031 c 4,45,46
+ 252.130859375 1346.12207031 252.130859375 1346.12207031 264.147460938 1339.90234375 c 4,47,48
+ 319.881835938 1311.05566406 319.881835938 1311.05566406 363.21875 1274.53320312 c 132,-1,49
+ 406.556640625 1238.00976562 406.556640625 1238.00976562 436.0390625 1200.50097656 c 132,-1,50
+ 465.521484375 1162.99121094 465.521484375 1162.99121094 486.229492188 1113.20996094 c 132,-1,51
+ 506.9375 1063.42871094 506.9375 1063.42871094 518.396484375 1019.57910156 c 132,-1,52
+ 529.85546875 975.73046875 529.85546875 975.73046875 536.095703125 914.24609375 c 132,-1,53
+ 542.3359375 852.76171875 542.3359375 852.76171875 543.932617188 804.129882812 c 132,-1,54
+ 545.528320312 755.497070312 545.528320312 755.497070312 545.528320312 684.6328125 c 4,55,56
+ 545.528320312 581.186523438 545.528320312 581.186523438 538.912109375 502.83203125 c 132,-1,57
+ 532.294921875 424.477539062 532.294921875 424.477539062 510.708007812 337.014648438 c 132,-1,58
+ 489.122070312 249.551757812 489.122070312 249.551757812 451.576171875 183.080078125 c 132,-1,59
+ 414.03125 116.609375 414.03125 116.609375 348.875976562 53.5888671875 c 132,-1,60
+ 283.720703125 -9.4306640625 283.720703125 -9.4306640625 193.264648438 -55.5595703125 c 5,61,-1
+ 267.744140625 -160.48046875 l 5,62,63
+ 398.315429688 -100.3359375 398.315429688 -100.3359375 486.875976562 -12.6826171875 c 132,-1,64
+ 575.435546875 74.9716796875 575.435546875 74.9716796875 621.245117188 187.333007812 c 132,-1,65
+ 667.0546875 299.694335938 667.0546875 299.694335938 685.2734375 415.321289062 c 132,-1,66
+ 703.4921875 530.948242188 703.4921875 530.948242188 703.4921875 677.954101562 c 4,67,68
+ 703.4921875 824.333984375 703.4921875 824.333984375 684.51171875 938.390625 c 132,-1,69
+ 665.53125 1052.44726562 665.53125 1052.44726562 619.026367188 1158.109375 c 132,-1,70
+ 572.521484375 1263.77148438 572.521484375 1263.77148438 485.133789062 1342.21191406 c 132,-1,71
+ 397.74609375 1420.65234375 397.74609375 1420.65234375 269.704101562 1470.08007812 c 5,39,-1
+EndSplineSet
+EndChar
+
+StartChar: uni3010
+Encoding: 12304 12304 3790
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 727.084 48.916<453.24 457.623> 734.93 41.0703<469.08 471.4>
+VStem: 185.09 42.166<152.436 344.213 152.436 776>
+LayerCount: 2
+Fore
+SplineSet
+881.545898438 -182.6328125 m 5,0,-1
+ 881.545898438 -252.640625 l 5,1,-1
+ 387.354492188 -252.640625 l 5,2,-1
+ 387.354492188 1553.5546875 l 5,3,-1
+ 879.80859375 1553.5546875 l 5,4,-1
+ 879.80859375 1477.36914062 l 6,5,6
+ 875.703125 1477.36914062 875.703125 1477.36914062 865.849609375 1470.09277344 c 132,-1,7
+ 855.997070312 1462.81542969 855.997070312 1462.81542969 852.57421875 1462.81542969 c 4,8,9
+ 845.004882812 1462.81542969 845.004882812 1462.81542969 834.354492188 1455.37011719 c 4,10,11
+ 662.548828125 1335.265625 662.548828125 1335.265625 561.213867188 1090.46191406 c 132,-1,12
+ 459.879882812 845.659179688 459.879882812 845.659179688 459.879882812 582.188476562 c 4,13,14
+ 459.879882812 400.600585938 459.879882812 400.600585938 509.686523438 260.325195312 c 132,-1,15
+ 559.4921875 120.05078125 559.4921875 120.05078125 648.325195312 18.4345703125 c 132,-1,16
+ 737.158203125 -83.181640625 737.158203125 -83.181640625 881.545898438 -182.6328125 c 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: uni3011
+Encoding: 12305 12305 3791
+Width: 600
+VWidth: 1000
+Flags: W
+VStem: 373.727 41.2734<152.436 344.213>
+LayerCount: 2
+Fore
+SplineSet
+318.454101562 -182.6328125 m 5,0,-1
+ 318.454101562 -252.640625 l 5,1,-1
+ 812.645507812 -252.640625 l 5,2,-1
+ 812.645507812 1553.5546875 l 5,3,-1
+ 320.19140625 1553.5546875 l 5,4,-1
+ 320.19140625 1477.36914062 l 6,5,6
+ 324.296875 1477.36914062 324.296875 1477.36914062 334.150390625 1470.09277344 c 132,-1,7
+ 344.002929688 1462.81542969 344.002929688 1462.81542969 347.42578125 1462.81542969 c 4,8,9
+ 354.995117188 1462.81542969 354.995117188 1462.81542969 365.645507812 1455.37011719 c 4,10,11
+ 537.451171875 1335.265625 537.451171875 1335.265625 638.786132812 1090.46191406 c 132,-1,12
+ 740.120117188 845.659179688 740.120117188 845.659179688 740.120117188 582.188476562 c 4,13,14
+ 740.120117188 400.600585938 740.120117188 400.600585938 690.313476562 260.325195312 c 132,-1,15
+ 640.5078125 120.05078125 640.5078125 120.05078125 551.674804688 18.4345703125 c 132,-1,16
+ 462.841796875 -83.181640625 462.841796875 -83.181640625 318.454101562 -182.6328125 c 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: uni3016
+Encoding: 12310 12310 3792
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: -197.69 35.5205 727.084 48.916 740.48 35.5195
+VStem: 162 32<-162.17 740.48 -162.17 776> 219.273 32
+LayerCount: 2
+Fore
+SplineSet
+934.625976562 -279.470703125 m 5,0,-1
+ 934.625976562 -353.397460938 l 5,1,-1
+ 337.192382812 -353.397460938 l 5,2,-1
+ 337.192382812 1553.8671875 l 5,3,-1
+ 932.826171875 1553.8671875 l 5,4,-1
+ 932.826171875 1473.41894531 l 6,5,6
+ 928.573242188 1473.41894531 928.573242188 1473.41894531 918.368164062 1465.73535156 c 132,-1,7
+ 908.161132812 1458.05175781 908.161132812 1458.05175781 904.616210938 1458.05175781 c 4,8,9
+ 896.776367188 1458.05175781 896.776367188 1458.05175781 885.7421875 1450.18847656 c 4,10,11
+ 707.775390625 1323.36425781 707.775390625 1323.36425781 602.807617188 1064.86230469 c 132,-1,12
+ 497.83984375 806.360351562 497.83984375 806.360351562 497.83984375 528.146484375 c 4,13,14
+ 497.83984375 336.397460938 497.83984375 336.397460938 549.430664062 188.2734375 c 132,-1,15
+ 601.0234375 40.150390625 601.0234375 40.150390625 693.041992188 -67.1533203125 c 132,-1,16
+ 785.061523438 -174.456054688 785.061523438 -174.456054688 934.625976562 -279.470703125 c 5,0,-1
+830.297851562 -283.818359375 m 5,17,18
+ 635.455078125 -130.930664062 635.455078125 -130.930664062 537.854492188 61.0634765625 c 132,-1,19
+ 440.255859375 253.059570312 440.255859375 253.059570312 440.255859375 528.146484375 c 4,20,21
+ 440.255859375 809.990234375 440.255859375 809.990234375 541.788085938 1073.8046875 c 132,-1,22
+ 643.3203125 1337.6171875 643.3203125 1337.6171875 822.668945312 1484.29199219 c 5,23,-1
+ 394.776367188 1484.29199219 l 5,24,-1
+ 394.776367188 -283.818359375 l 5,25,-1
+ 830.297851562 -283.818359375 l 5,17,18
+EndSplineSet
+EndChar
+
+StartChar: uni3017
+Encoding: 12311 12311 3793
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: -197.8 35.5195 726.975 48.915 740.37 35.5195
+VStem: 349.727 32 407 32<-162.28 740.37 740.37 740.37>
+LayerCount: 2
+Fore
+SplineSet
+265.374023438 -279.470703125 m 5,0,-1
+ 265.374023438 -353.397460938 l 5,1,-1
+ 862.807617188 -353.397460938 l 5,2,-1
+ 862.807617188 1553.8671875 l 5,3,-1
+ 267.173828125 1553.8671875 l 5,4,-1
+ 267.173828125 1473.41894531 l 6,5,6
+ 271.426757812 1473.41894531 271.426757812 1473.41894531 281.631835938 1465.73535156 c 132,-1,7
+ 291.838867188 1458.05175781 291.838867188 1458.05175781 295.383789062 1458.05175781 c 4,8,9
+ 303.223632812 1458.05175781 303.223632812 1458.05175781 314.2578125 1450.18847656 c 4,10,11
+ 492.224609375 1323.36425781 492.224609375 1323.36425781 597.192382812 1064.86230469 c 132,-1,12
+ 702.16015625 806.360351562 702.16015625 806.360351562 702.16015625 528.146484375 c 4,13,14
+ 702.16015625 336.397460938 702.16015625 336.397460938 650.569335938 188.2734375 c 132,-1,15
+ 598.9765625 40.150390625 598.9765625 40.150390625 506.958007812 -67.1533203125 c 132,-1,16
+ 414.938476562 -174.456054688 414.938476562 -174.456054688 265.374023438 -279.470703125 c 5,0,-1
+369.702148438 -283.818359375 m 5,17,18
+ 564.544921875 -130.930664062 564.544921875 -130.930664062 662.145507812 61.0634765625 c 132,-1,19
+ 759.744140625 253.059570312 759.744140625 253.059570312 759.744140625 528.146484375 c 4,20,21
+ 759.744140625 809.990234375 759.744140625 809.990234375 658.211914062 1073.8046875 c 132,-1,22
+ 556.6796875 1337.6171875 556.6796875 1337.6171875 377.331054688 1484.29199219 c 5,23,-1
+ 805.223632812 1484.29199219 l 5,24,-1
+ 805.223632812 -283.818359375 l 5,25,-1
+ 369.702148438 -283.818359375 l 5,17,18
+EndSplineSet
+EndChar
+
+StartChar: uni301A
+Encoding: 12314 12314 3794
+Width: 596
+VWidth: 1000
+Flags: W
+HStem: -198 66<243 334 375 513 181 334> 707 69<243 334 243 243 375 375 375 512>
+VStem: 181 62<-132 -132 -132 707> 334 41<-132 707>
+LayerCount: 2
+Fore
+SplineSet
+405.05859375 -158.028320312 m 5,0,-1
+ 593.650390625 -158.028320312 l 5,1,-1
+ 593.650390625 1391.55078125 l 5,2,-1
+ 405.05859375 1391.55078125 l 5,3,-1
+ 405.05859375 -158.028320312 l 5,0,-1
+678.619140625 -158.028320312 m 5,4,-1
+ 964.615234375 -158.028320312 l 5,5,-1
+ 964.615234375 -279.926757812 l 5,6,-1
+ 276.567382812 -279.926757812 l 5,7,-1
+ 276.567382812 1518.98925781 l 5,8,-1
+ 962.54296875 1518.98925781 l 5,9,-1
+ 962.54296875 1391.55078125 l 5,10,-1
+ 678.619140625 1391.55078125 l 5,11,-1
+ 678.619140625 -158.028320312 l 5,4,-1
+EndSplineSet
+EndChar
+
+StartChar: uni301B
+Encoding: 12315 12315 3795
+Width: 596
+VWidth: 1000
+Flags: W
+HStem: -198 66<110 248 289 380 110 248> 707 69<111 248 111 442 289 380 289 289>
+VStem: 248 41<-132 707 -132 707> 380 62<-132 707 707 707>
+LayerCount: 2
+Fore
+SplineSet
+782.94140625 -158.028320312 m 5,0,-1
+ 594.349609375 -158.028320312 l 5,1,-1
+ 594.349609375 1391.55078125 l 5,2,-1
+ 782.94140625 1391.55078125 l 5,3,-1
+ 782.94140625 -158.028320312 l 5,0,-1
+509.380859375 -158.028320312 m 5,4,-1
+ 223.384765625 -158.028320312 l 5,5,-1
+ 223.384765625 -279.926757812 l 5,6,-1
+ 911.432617188 -279.926757812 l 5,7,-1
+ 911.432617188 1518.98925781 l 5,8,-1
+ 225.45703125 1518.98925781 l 5,9,-1
+ 225.45703125 1391.55078125 l 5,10,-1
+ 509.380859375 1391.55078125 l 5,11,-1
+ 509.380859375 -158.028320312 l 5,4,-1
+EndSplineSet
+EndChar
+
+StartChar: uni169B
+Encoding: 5787 5787 3796
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 331 78<368.89 522 368.89 522 368.387 522>
+LayerCount: 2
+Fore
+SplineSet
+254.299804688 1459.97949219 m 5,0,-1
+ 345.5 1545.86035156 l 5,1,-1
+ 732.890625 718.700195312 l 5,2,-1
+ 1023.79980469 718.700195312 l 5,3,-1
+ 1023.79980469 542.419921875 l 5,4,-1
+ 731.934570312 542.419921875 l 5,5,-1
+ 332.200195312 -257.620117188 l 5,6,-1
+ 241 -164.959960938 l 5,7,-1
+ 638.099609375 630.559570312 l 5,8,-1
+ 254.299804688 1459.97949219 l 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: uni169C
+Encoding: 5788 5788 3797
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 331 78<78 234.11 78 234.613 78 234.11>
+LayerCount: 2
+Fore
+SplineSet
+944.700195312 1459.97949219 m 5,0,-1
+ 853.5 1545.86035156 l 5,1,-1
+ 466.109375 718.700195312 l 5,2,-1
+ 175.200195312 718.700195312 l 5,3,-1
+ 175.200195312 542.419921875 l 5,4,-1
+ 467.065429688 542.419921875 l 5,5,-1
+ 866.799804688 -257.620117188 l 5,6,-1
+ 958 -164.959960938 l 5,7,-1
+ 560.900390625 630.559570312 l 5,8,-1
+ 944.700195312 1459.97949219 l 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: uni27EC
+Encoding: 10220 10220 3798
+Width: 600
+VWidth: 1000
+Flags: W
+VStem: 138 32<36.0234 47.2783 36.0234 47.2783 47.2783 508.722 508.722 535.978> 253 32<94.0186 462.281 109.719 462.281 109.719 477.981 109.719 477.981> 421 32<-145.091 -102.087 -102.087 -46.7744 -46.7744 -20.2812 -35.9814 -35.9814 -35.9814 -20.2812 607.981 618.774 618.774 674.087 674.087 717.091 717.091 717.091>
+LayerCount: 2
+Fore
+SplineSet
+345.0390625 121.518554688 m 5,0,-1
+ 307.16015625 148.850585938 l 5,1,-1
+ 307.16015625 198.853515625 l 5,2,-1
+ 307.16015625 1034.06640625 l 5,3,-1
+ 307.16015625 1113.02929688 l 5,4,-1
+ 347.708007812 1142.28808594 l 5,5,-1
+ 722.377929688 1412.63769531 l 5,6,-1
+ 877.309570312 1524.43164062 l 5,7,-1
+ 877.309570312 1333.37695312 l 5,8,-1
+ 877.309570312 1233.26171875 l 5,9,-1
+ 877.309570312 1185.30859375 l 5,10,-1
+ 839.384765625 1155.96191406 l 5,11,-1
+ 573.23046875 950.008789062 l 5,12,-1
+ 573.23046875 311.87109375 l 5,13,-1
+ 839.384765625 105.91796875 l 5,14,-1
+ 877.309570312 76.5712890625 l 5,15,-1
+ 877.309570312 28.6181640625 l 5,16,-1
+ 877.309570312 -71.4970703125 l 5,17,-1
+ 877.309570312 -262.551757812 l 5,18,-1
+ 722.377929688 -150.756835938 l 5,19,-1
+ 345.0390625 121.518554688 l 5,0,-1
+378.930664062 168.48828125 m 5,20,-1
+ 756.26953125 -103.787109375 l 5,21,-1
+ 819.389648438 -149.333984375 l 5,22,-1
+ 819.389648438 -71.4970703125 l 5,23,-1
+ 819.389648438 151.698242188 l 5,24,-1
+ 819.389648438 48.1533203125 l 5,25,-1
+ 803.939453125 60.109375 l 5,26,-1
+ 537.78515625 266.064453125 l 5,27,-1
+ 515.309570312 283.453125 l 5,28,-1
+ 515.309570312 311.87109375 l 5,29,-1
+ 515.309570312 950.008789062 l 5,30,-1
+ 515.309570312 978.426757812 l 5,31,-1
+ 537.78515625 995.815429688 l 5,32,-1
+ 803.939453125 1201.77050781 l 5,33,-1
+ 819.389648438 1213.7265625 l 5,34,-1
+ 819.389648438 1233.26171875 l 5,35,-1
+ 819.389648438 1333.37695312 l 5,36,-1
+ 819.389648438 1411.21484375 l 5,37,-1
+ 756.26953125 1365.66699219 l 5,38,-1
+ 381.599609375 1095.31835938 l 5,39,-1
+ 365.080078125 1083.39941406 l 5,40,-1
+ 365.080078125 1034.06640625 l 5,41,-1
+ 365.080078125 198.853515625 l 5,42,-1
+ 365.080078125 178.482421875 l 5,43,-1
+ 378.930664062 168.48828125 l 5,20,-1
+EndSplineSet
+EndChar
+
+StartChar: uni27ED
+Encoding: 10221 10221 3799
+Width: 600
+VWidth: 1000
+Flags: W
+VStem: 172 32<-145.091 -102.087 -145.091 -102.087 -102.087 -46.7744 -46.7744 -35.9814 607.981 618.774 618.774 674.087 674.087 717.091> 340 32<109.719 462.281> 455 32<36.0225 47.2783 47.2783 524.722 524.722 535.978 535.978 535.978>
+LayerCount: 2
+Fore
+SplineSet
+854.9609375 119.518554688 m 5,0,-1
+ 892.83984375 146.850585938 l 5,1,-1
+ 892.83984375 196.853515625 l 5,2,-1
+ 892.83984375 1032.06640625 l 5,3,-1
+ 892.83984375 1111.02929688 l 5,4,-1
+ 852.291992188 1140.28808594 l 5,5,-1
+ 477.622070312 1410.63769531 l 5,6,-1
+ 322.690429688 1522.43164062 l 5,7,-1
+ 322.690429688 1331.37695312 l 5,8,-1
+ 322.690429688 1231.26171875 l 5,9,-1
+ 322.690429688 1183.30859375 l 5,10,-1
+ 360.615234375 1153.96191406 l 5,11,-1
+ 626.76953125 948.008789062 l 5,12,-1
+ 626.76953125 309.87109375 l 5,13,-1
+ 360.615234375 103.91796875 l 5,14,-1
+ 322.690429688 74.5712890625 l 5,15,-1
+ 322.690429688 26.6181640625 l 5,16,-1
+ 322.690429688 -73.4970703125 l 5,17,-1
+ 322.690429688 -264.551757812 l 5,18,-1
+ 477.622070312 -152.756835938 l 5,19,-1
+ 854.9609375 119.518554688 l 5,0,-1
+821.069335938 166.48828125 m 5,20,-1
+ 443.73046875 -105.787109375 l 5,21,-1
+ 380.610351562 -151.333984375 l 5,22,-1
+ 380.610351562 -73.4970703125 l 5,23,-1
+ 380.610351562 149.698242188 l 5,24,-1
+ 380.610351562 46.1533203125 l 5,25,-1
+ 396.060546875 58.109375 l 5,26,-1
+ 662.21484375 264.064453125 l 5,27,-1
+ 684.690429688 281.453125 l 5,28,-1
+ 684.690429688 309.87109375 l 5,29,-1
+ 684.690429688 948.008789062 l 5,30,-1
+ 684.690429688 976.426757812 l 5,31,-1
+ 662.21484375 993.815429688 l 5,32,-1
+ 396.060546875 1199.77050781 l 5,33,-1
+ 380.610351562 1211.7265625 l 5,34,-1
+ 380.610351562 1231.26171875 l 5,35,-1
+ 380.610351562 1331.37695312 l 5,36,-1
+ 380.610351562 1409.21484375 l 5,37,-1
+ 443.73046875 1363.66699219 l 5,38,-1
+ 818.400390625 1093.31835938 l 5,39,-1
+ 834.919921875 1081.39941406 l 5,40,-1
+ 834.919921875 1032.06640625 l 5,41,-1
+ 834.919921875 196.853515625 l 5,42,-1
+ 834.919921875 176.482421875 l 5,43,-1
+ 821.069335938 166.48828125 l 5,20,-1
+EndSplineSet
+EndChar
+
+StartChar: uni27EE
+Encoding: 10222 10222 3800
+Width: 600
+VWidth: 1000
+Flags: W
+VStem: 266 49.2734
+LayerCount: 2
+Fore
+SplineSet
+748.959960938 1497.28027344 m 5,0,-1
+ 809.16015625 1375.16015625 l 5,1,2
+ 801.948242188 1371.04980469 801.948242188 1371.04980469 793.110351562 1371.04980469 c 4,3,4
+ 789.045898438 1371.04980469 789.045898438 1371.04980469 782.155273438 1372.18652344 c 132,-1,5
+ 775.265625 1373.32226562 775.265625 1373.32226562 771.875976562 1373.32226562 c 4,6,7
+ 764.37890625 1373.32226562 764.37890625 1373.32226562 753.8359375 1367.10058594 c 4,8,9
+ 686.063476562 1327.12890625 686.063476562 1327.12890625 637.479492188 1270.24414062 c 132,-1,10
+ 588.896484375 1213.359375 588.896484375 1213.359375 561.30859375 1152.99511719 c 132,-1,11
+ 533.721679688 1092.62988281 533.721679688 1092.62988281 518.020507812 1011.38867188 c 132,-1,12
+ 502.3203125 930.1484375 502.3203125 930.1484375 497.735351562 858.776367188 c 132,-1,13
+ 493.150390625 787.404296875 493.150390625 787.404296875 493.150390625 691.193359375 c 4,14,15
+ 493.150390625 563.208007812 493.150390625 563.208007812 505.931640625 461.591796875 c 132,-1,16
+ 518.712890625 359.974609375 518.712890625 359.974609375 551.810546875 256.364257812 c 132,-1,17
+ 584.908203125 152.752929688 584.908203125 152.752929688 651.306640625 70.12890625 c 132,-1,18
+ 717.705078125 -12.49609375 717.705078125 -12.49609375 816.040039062 -69.6396484375 c 5,19,-1
+ 750.6796875 -174.559570312 l 5,20,21
+ 625.341796875 -108.76953125 625.341796875 -108.76953125 551.255859375 -27.859375 c 132,-1,22
+ 477.169921875 53.0517578125 477.169921875 53.0517578125 408.400390625 187.162109375 c 5,23,-1
+ 408.400390625 1170.31347656 l 5,24,25
+ 476.479492188 1296.97460938 476.479492188 1296.97460938 550.369140625 1369.69921875 c 132,-1,26
+ 624.2578125 1442.42382812 624.2578125 1442.42382812 748.959960938 1497.28027344 c 5,0,-1
+EndSplineSet
+EndChar
+
+StartChar: uni27EF
+Encoding: 10223 10223 3801
+Width: 600
+VWidth: 1000
+Flags: W
+HStem: 751 20G<122 122>
+VStem: 286.028 49.9717
+LayerCount: 2
+Fore
+SplineSet
+451.040039062 1493.28027344 m 5,0,-1
+ 390.83984375 1371.16015625 l 5,1,2
+ 398.051757812 1367.04980469 398.051757812 1367.04980469 406.889648438 1367.04980469 c 4,3,4
+ 410.954101562 1367.04980469 410.954101562 1367.04980469 417.844726562 1368.18652344 c 132,-1,5
+ 424.734375 1369.32226562 424.734375 1369.32226562 428.124023438 1369.32226562 c 4,6,7
+ 435.62109375 1369.32226562 435.62109375 1369.32226562 446.1640625 1363.10058594 c 4,8,9
+ 513.936523438 1323.12890625 513.936523438 1323.12890625 562.520507812 1266.24414062 c 132,-1,10
+ 611.103515625 1209.359375 611.103515625 1209.359375 638.69140625 1148.99511719 c 132,-1,11
+ 666.278320312 1088.62988281 666.278320312 1088.62988281 681.979492188 1007.38867188 c 132,-1,12
+ 697.6796875 926.1484375 697.6796875 926.1484375 702.264648438 854.776367188 c 132,-1,13
+ 706.849609375 783.404296875 706.849609375 783.404296875 706.849609375 687.193359375 c 4,14,15
+ 706.849609375 559.208007812 706.849609375 559.208007812 694.068359375 457.591796875 c 132,-1,16
+ 681.287109375 355.974609375 681.287109375 355.974609375 648.189453125 252.364257812 c 132,-1,17
+ 615.091796875 148.752929688 615.091796875 148.752929688 548.693359375 66.12890625 c 132,-1,18
+ 482.294921875 -16.49609375 482.294921875 -16.49609375 383.959960938 -73.6396484375 c 5,19,-1
+ 449.3203125 -178.559570312 l 5,20,21
+ 574.658203125 -112.76953125 574.658203125 -112.76953125 648.744140625 -31.859375 c 132,-1,22
+ 722.830078125 49.0517578125 722.830078125 49.0517578125 791.599609375 183.162109375 c 5,23,-1
+ 791.599609375 1166.31347656 l 5,24,25
+ 723.520507812 1292.97460938 723.520507812 1292.97460938 649.630859375 1365.69921875 c 132,-1,26
+ 575.7421875 1438.42382812 575.7421875 1438.42382812 451.040039062 1493.28027344 c 5,0,-1
+EndSplineSet
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
made brackets monospaced in codes 5787, 5788, 8261, 8262, 10214, 10215, 10216, 10217, 10218, 10219, 10220, 10221, 10222, 10223, 10627, 10628, 10629, 10630, 10631, 10632, 10641, 10642, 10643, 10644, 10647, 10648, 10748, 10749, 11816, 11817, 12304, 12305, 12310, 12311, 12314, and 12315