### PR TITLE
Updates DejaVu Sans Mono to add Vietnamese support

### DIFF
--- a/src/DejaVuSansMono-Bold.sfd
+++ b/src/DejaVuSansMono-Bold.sfd
@@ -10,13 +10,16 @@ UnderlinePosition: -85
 UnderlineWidth: 90
 Ascent: 1556
 Descent: 492
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 1 "Back"  1
-Layer: 1 1 "Fore"  0
+Layer: 0 1 "Back" 1
+Layer: 1 1 "Fore" 0
 FSType: 0
 OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
+CreationTime: 1470372098
+ModificationTime: 1492785017
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -37,25 +40,25 @@ HheadAOffset: 0
 HheadDescent: -483
 HheadDOffset: 0
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0"  {"'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
-Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0"  {"'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 2"  {"'fina' Terminal Forms in Arabic lookup 2"  } ['fina' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 3"  {"'medi' Medial Forms in Arabic lookup 3"  } ['medi' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 4"  {"'init' Initial Forms in Arabic lookup 4"  } ['init' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 5"  {"'rlig' Required Ligatures in Arabic lookup 5"  } ['rlig' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 6"  {"'liga' Standard Ligatures in Arabic lookup 6"  } ['liga' ('arab' <'dflt' > ) ]
-Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 9"  {"'dlig' Discretionary Ligatures in Latin lookup 9"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "'case' Case-Sensitive Forms"  {"'case' Case-Sensitive Forms" ("case" ) } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0"  {"'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1"  {"'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2"  {"'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3"  {"'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4"  {"'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5"  {"'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark Positioning lookup 6"  {"'mark' Mark Positioning lookup 6"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark Positioning lookup 7"  {"'mark' Mark Positioning lookup 7"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 257 0 0 "'mark' Mark Positioning lookup 8"  {"'mark' Mark Positioning lookup 8"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark positioning in Lao"  {"'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0" { "'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0" { "'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 2" { "'fina' Terminal Forms in Arabic lookup 2"  } ['fina' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 3" { "'medi' Medial Forms in Arabic lookup 3"  } ['medi' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 4" { "'init' Initial Forms in Arabic lookup 4"  } ['init' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 5" { "'rlig' Required Ligatures in Arabic lookup 5"  } ['rlig' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 6" { "'liga' Standard Ligatures in Arabic lookup 6"  } ['liga' ('arab' <'dflt' > ) ]
+Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 9" { "'dlig' Discretionary Ligatures in Latin lookup 9"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "'case' Case-Sensitive Forms" { "'case' Case-Sensitive Forms" ("case") } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0" { "'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1" { "'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2" { "'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3" { "'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4" { "'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5" { "'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark Positioning lookup 6" { "'mark' Mark Positioning lookup 6"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark Positioning lookup 7" { "'mark' Mark Positioning lookup 7"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 257 0 0 "'mark' Mark Positioning lookup 8" { "'mark' Mark Positioning lookup 8"  } ['mark' ('cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark positioning in Lao" { "'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
 DEI: 91125
 TtTable: prep
 PUSHW_1
@@ -1702,12 +1705,14 @@ ShortTable: maxp 16
   3
   1
 EndShort
-LangName: 1033 "" "" "" "DejaVu Sans Mono Bold" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License" 
+LangName: 1033 "" "" "" "DejaVu Sans Mono Bold" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License"
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
+WinInfo: 7776 27 8
 GridOrder2: 1
 Grid
 1 740 m 25,0,-1
@@ -1717,50 +1722,50 @@ Grid
  1 894 l 25,1,-1
  -139 1034 l 25,0,0
 1 1510 m 9,0,-1
- -139 1650 l 17,0,0
+ -139 1650 l 1041,0,0
 1 1202 m 9,1,-1
- -139 1342 l 17,0,0
+ -139 1342 l 1041,0,0
 1 1818 m 9,1,-1
- -139 1958 l 17,0,0
+ -139 1958 l 1041,0,0
 1 1048 m 9,1,-1
- -139 1188 l 17,0,0
+ -139 1188 l 1041,0,0
 1 1664 m 9,1,-1
- -139 1804 l 17,0,0
+ -139 1804 l 1041,0,0
 1 1356 m 9,1,-1
- -139 1496 l 17,0,0
+ -139 1496 l 1041,0,0
 -139 -352 m 9,0,0
  1 -492 l 25,1,-1
- 141 -632 l 17
+ 141 -632 l 1041
 -139 -198 m 25,0,0
  1 -338 l 25,1,-1
  -139 -198 l 25,0,0
 1 278 m 9,0,-1
- -139 418 l 17,0,0
+ -139 418 l 1041,0,0
 1 -30 m 9,1,-1
- -139 110 l 17,0,0
+ -139 110 l 1041,0,0
 1 586 m 9,1,-1
- -139 726 l 17,0,0
+ -139 726 l 1041,0,0
 1 -184 m 9,1,-1
- -139 -44 l 17,0,0
+ -139 -44 l 1041,0,0
 1 432 m 9,1,-1
- -139 572 l 17,0,0
+ -139 572 l 1041,0,0
 1 124 m 9,1,-1
- -139 264 l 17,0,0
+ -139 264 l 1041,0,0
 1232 -409 m 25,0,0
  1372 -549 l 25,1,-1
  1232 -409 l 25,0,0
 1372 67 m 9,0,-1
- 1232 207 l 17,0,0
+ 1232 207 l 1041,0,0
 1372 -241 m 9,1,-1
- 1232 -101 l 17,0,0
+ 1232 -101 l 1041,0,0
 1372 375 m 9,1,-1
- 1232 515 l 17,0,0
+ 1232 515 l 1041,0,0
 1372 -395 m 9,1,-1
- 1232 -255 l 17,0,0
+ 1232 -255 l 1041,0,0
 1372 221 m 9,1,-1
- 1232 361 l 17,0,0
+ 1232 361 l 1041,0,0
 1372 -87 m 9,1,-1
- 1232 53 l 17,0,0
+ 1232 53 l 1041,0,0
 1232 669 m 25,0,0
  1372 529 l 25,1,-1
  1232 669 l 25,0,0
@@ -1768,56 +1773,56 @@ Grid
  1372 683 l 25,1,-1
  1232 823 l 25,0,0
 1372 1299 m 9,0,-1
- 1232 1439 l 17,0,0
+ 1232 1439 l 1041,0,0
 1372 991 m 9,1,-1
- 1232 1131 l 17,0,0
+ 1232 1131 l 1041,0,0
 1372 1607 m 9,1,-1
- 1232 1747 l 17,0,0
+ 1232 1747 l 1041,0,0
 1372 837 m 9,1,-1
- 1232 977 l 17,0,0
+ 1232 977 l 1041,0,0
 1372 1453 m 9,1,-1
- 1232 1593 l 17,0,0
+ 1232 1593 l 1041,0,0
 1372 1145 m 9,1,-1
- 1232 1285 l 17,0,0
+ 1232 1285 l 1041,0,0
 1372 1761 m 9,1,-1
  1232 1901 l 25,0,0
- 1092 2041 l 17,0,0
+ 1092 2041 l 1041,0,0
 1373 -632 m 9,1,-1
- 1233 -492 l 17,0,0
+ 1233 -492 l 1041,0,0
 1079 -492 m 25,0,0
  1219 -632 l 25,1,-1
  1079 -492 l 25,0,0
 603 -632 m 9,0,-1
- 463 -492 l 17,0,0
+ 463 -492 l 1041,0,0
 911 -632 m 9,1,-1
- 771 -492 l 17,0,0
+ 771 -492 l 1041,0,0
 295 -632 m 9,1,-1
- 155 -492 l 17,0,0
+ 155 -492 l 1041,0,0
 1065 -632 m 9,1,-1
- 925 -492 l 17,0,0
+ 925 -492 l 1041,0,0
 449 -632 m 9,1,-1
- 309 -492 l 17,0,0
+ 309 -492 l 1041,0,0
 757 -632 m 9,1,-1
- 617 -492 l 17,0,0
+ 617 -492 l 1041,0,0
 1386 1901 m 9,1,-1
- 1246 2041 l 17,0,0
+ 1246 2041 l 1041,0,0
 938 2041 m 25,0,0
  1078 1901 l 25,1,-1
  938 2041 l 25,0,0
 462 1901 m 9,0,-1
- 322 2041 l 17,0,0
+ 322 2041 l 1041,0,0
 770 1901 m 9,1,-1
- 630 2041 l 17,0,0
+ 630 2041 l 1041,0,0
 154 1901 m 9,1,-1
- 14 2041 l 17,0,0
+ 14 2041 l 1041,0,0
 924 1901 m 9,1,-1
- 784 2041 l 17,0,0
+ 784 2041 l 1041,0,0
 308 1901 m 9,1,-1
- 168 2041 l 17,0,0
+ 168 2041 l 1041,0,0
 616 1901 m 9,1,-1
- 476 2041 l 17,0,0
+ 476 2041 l 1041,0,0
 0 1901 m 9,1,-1
- -140 2041 l 17,0,0
+ -140 2041 l 1041,0,0
 -140 2041 m 1,1,-1
  1373 2041 l 1,2,-1
  1373 -632 l 1,3,-1
@@ -1829,8 +1834,9 @@ Grid
  0 -492 l 1,8,-1
  0 1901 l 1,5,-1
 EndSplineSet
-AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" "above"  "'mark' Mark Positioning lookup 7" "below"  "'mark' Mark Positioning lookup 6" "rtl-above"  "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above"  "'mark' Mark Positioning in Arabic lookup 4" "rtl-below"  "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below"  "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark"  "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark"  "'mkmk' Mark to Mark in Arabic lookup 0" 
-BeginChars: 1114165 0
+AnchorClass2: "lao-below" "'mark' Mark positioning in Lao" "lao-above" "'mark' Mark positioning in Lao" "above" "'mark' Mark Positioning lookup 7" "below" "'mark' Mark Positioning lookup 6" "rtl-above" "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above" "'mark' Mark Positioning in Arabic lookup 4" "rtl-below" "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below" "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark" "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark" "'mkmk' Mark to Mark in Arabic lookup 0"
+BeginChars: 1114165 3763
+
 StartChar: .notdef
 Encoding: 0 -1 0
 Width: 1233
@@ -1878,14 +1884,16 @@ SplineSet
  219 -248 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: space
-Encoding: 32 32 32
+Encoding: 32 32 1
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclam
-Encoding: 33 33 33
+Encoding: 33 33 2
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1936,8 +1944,9 @@ SplineSet
  483 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedbl
-Encoding: 34 34 34
+Encoding: 34 34 3
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1983,8 +1992,9 @@ SplineSet
  487 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: numbersign
-Encoding: 35 35 35
+Encoding: 35 35 4
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2102,8 +2112,9 @@ SplineSet
  762 881 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: dollar
-Encoding: 36 36 36
+Encoding: 36 36 5
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2232,8 +2243,9 @@ SplineSet
  694 -301 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: percent
-Encoding: 37 37 37
+Encoding: 37 37 6
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2327,30 +2339,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-33 1112 m 0,0,1
+33 1112 m 256,0,1
  33 1246 33 1246 126 1339 c 128,-1,2
- 219 1432 219 1432 352 1432 c 0,3,4
+ 219 1432 219 1432 352 1432 c 256,3,4
  485 1432 485 1432 578.5 1338.5 c 128,-1,5
- 672 1245 672 1245 672 1112 c 0,6,7
+ 672 1245 672 1245 672 1112 c 256,6,7
  672 979 672 979 578.5 886 c 128,-1,8
- 485 793 485 793 352 793 c 0,9,10
+ 485 793 485 793 352 793 c 256,9,10
  219 793 219 793 126 885.5 c 128,-1,11
- 33 978 33 978 33 1112 c 0,0,1
-352 1249 m 0,12,13
+ 33 978 33 978 33 1112 c 256,0,1
+352 1249 m 256,12,13
  295 1249 295 1249 255 1209.5 c 128,-1,14
- 215 1170 215 1170 215 1112 c 0,15,16
+ 215 1170 215 1170 215 1112 c 256,15,16
  215 1054 215 1054 255 1014.5 c 128,-1,17
  295 975 295 975 352 975 c 0,18,19
  410 975 410 975 449.5 1014.5 c 128,-1,20
  489 1054 489 1054 489 1112 c 0,21,22
  489 1169 489 1169 449 1209 c 128,-1,23
- 409 1249 409 1249 352 1249 c 0,12,13
+ 409 1249 409 1249 352 1249 c 256,12,13
 86 561 m 1,24,-1
  1128 979 l 1,25,-1
  1169 883 l 1,26,-1
  121 465 l 1,27,-1
  86 561 l 1,24,-1
-580 319 m 0,28,29
+580 319 m 256,28,29
  580 453 580 453 672.5 546 c 128,-1,30
  765 639 765 639 899 639 c 0,31,32
  1031 639 1031 639 1125 545.5 c 128,-1,33
@@ -2358,20 +2370,21 @@ SplineSet
  1219 187 1219 187 1125 93.5 c 128,-1,36
  1031 0 1031 0 899 0 c 0,37,38
  765 0 765 0 672.5 92.5 c 128,-1,39
- 580 185 580 185 580 319 c 0,28,29
+ 580 185 580 185 580 319 c 256,28,29
 897 457 m 0,40,41
  841 457 841 457 801.5 417 c 128,-1,42
- 762 377 762 377 762 319 c 0,43,44
+ 762 377 762 377 762 319 c 256,43,44
  762 261 762 261 801 221.5 c 128,-1,45
  840 182 840 182 897 182 c 0,46,47
  955 182 955 182 995.5 222 c 128,-1,48
- 1036 262 1036 262 1036 319 c 0,49,50
+ 1036 262 1036 262 1036 319 c 256,49,50
  1036 376 1036 376 995 416.5 c 128,-1,51
  954 457 954 457 897 457 c 0,40,41
 EndSplineSet
 EndChar
+
 StartChar: ampersand
-Encoding: 38 38 38
+Encoding: 38 38 7
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2592,8 +2605,9 @@ SplineSet
  440 731 l 1,43,44
 EndSplineSet
 EndChar
+
 StartChar: quotesingle
-Encoding: 39 39 39
+Encoding: 39 39 8
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2625,8 +2639,9 @@ SplineSet
  743 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: parenleft
-Encoding: 40 40 40
+Encoding: 40 40 9
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2677,8 +2692,9 @@ SplineSet
  924 1554 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: parenright
-Encoding: 41 41 41
+Encoding: 41 41 10
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2729,8 +2745,9 @@ SplineSet
  441 1315 441 1315 309 1554 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asterisk
-Encoding: 42 42 42
+Encoding: 42 42 11
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2833,8 +2850,9 @@ SplineSet
  1108 1217 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: plus
-Encoding: 43 43 43
+Encoding: 43 43 12
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2892,8 +2910,9 @@ SplineSet
  735 1192 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: comma
-Encoding: 44 44 44
+Encoding: 44 44 13
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2933,8 +2952,9 @@ SplineSet
  461 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: hyphen
-Encoding: 45 45 45
+Encoding: 45 45 14
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2965,8 +2985,9 @@ SplineSet
  301 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: period
-Encoding: 46 46 46
+Encoding: 46 46 15
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2997,8 +3018,9 @@ SplineSet
  449 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: slash
-Encoding: 47 47 47
+Encoding: 47 47 16
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3035,8 +3057,9 @@ SplineSet
  899 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zero
-Encoding: 48 48 48
+Encoding: 48 48 17
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3336,7 +3359,7 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-492 745 m 0,0,1
+492 745 m 256,0,1
  492 798 492 798 528 834 c 128,-1,2
  564 870 564 870 616 870 c 0,3,4
  669 870 669 870 705 834 c 128,-1,5
@@ -3344,7 +3367,7 @@ SplineSet
  741 693 741 693 705 657 c 128,-1,8
  669 621 669 621 616 621 c 0,9,10
  564 621 564 621 528 656.5 c 128,-1,11
- 492 692 492 692 492 745 c 0,0,1
+ 492 692 492 692 492 745 c 256,0,1
 616 1270 m 0,12,13
  514 1270 514 1270 467 1145 c 128,-1,14
  420 1020 420 1020 420 745 c 0,15,16
@@ -3365,8 +3388,9 @@ SplineSet
  123 358 123 358 123 745 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: one
-Encoding: 49 49 49
+Encoding: 49 49 18
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3424,8 +3448,9 @@ SplineSet
  188 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: two
-Encoding: 50 50 50
+Encoding: 50 50 19
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3548,8 +3573,9 @@ SplineSet
  510 337 510 337 434 260 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: three
-Encoding: 51 51 51
+Encoding: 51 51 20
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3653,15 +3679,16 @@ SplineSet
  225 9 225 9 125 45 c 1,31,-1
  125 319 l 1,32,33
  219 272 219 272 328 247.5 c 128,-1,34
- 437 223 437 223 557 223 c 0,35,36
+ 437 223 437 223 557 223 c 256,35,36
  677 223 677 223 747 278.5 c 128,-1,37
  817 334 817 334 817 428 c 0,38,39
  817 543 817 543 747 605.5 c 128,-1,40
  677 668 677 668 549 668 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: four
-Encoding: 52 52 52
+Encoding: 52 52 21
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3753,8 +3780,9 @@ SplineSet
  668 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: five
-Encoding: 53 53 53
+Encoding: 53 53 22
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3847,8 +3875,9 @@ SplineSet
  193 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: six
-Encoding: 54 54 54
+Encoding: 54 54 23
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3909,15 +3938,15 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-643 748 m 0,0,1
+643 748 m 256,0,1
  547 748 547 748 496.5 678.5 c 128,-1,2
  446 609 446 609 446 477 c 0,3,4
  446 346 446 346 496.5 276.5 c 128,-1,5
- 547 207 547 207 643 207 c 0,6,7
+ 547 207 547 207 643 207 c 256,6,7
  739 207 739 207 790.5 276.5 c 128,-1,8
- 842 346 842 346 842 477 c 0,9,10
+ 842 346 842 346 842 477 c 256,9,10
  842 608 842 608 790.5 678 c 128,-1,11
- 739 748 739 748 643 748 c 0,0,1
+ 739 748 739 748 643 748 c 256,0,1
 1030 1458 m 1,12,-1
  1030 1190 l 1,13,14
  951 1235 951 1235 878.5 1257.5 c 128,-1,15
@@ -3938,8 +3967,9 @@ SplineSet
  954 1488 954 1488 1030 1458 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: seven
-Encoding: 55 55 55
+Encoding: 55 55 24
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4010,8 +4040,9 @@ SplineSet
  135 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: eight
-Encoding: 56 56 56
+Encoding: 56 56 25
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4089,9 +4120,9 @@ Fore
 SplineSet
 616 666 m 0,0,1
  517 666 517 666 456 603.5 c 128,-1,2
- 395 541 395 541 395 438 c 0,3,4
+ 395 541 395 541 395 438 c 256,3,4
  395 335 395 335 456 272 c 128,-1,5
- 517 209 517 209 616 209 c 0,6,7
+ 517 209 517 209 616 209 c 256,6,7
  715 209 715 209 776.5 273 c 128,-1,8
  838 337 838 337 838 438 c 0,9,10
  838 541 838 541 777 603.5 c 128,-1,11
@@ -4124,8 +4155,9 @@ SplineSet
  428 1180 428 1180 428 1094 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: nine
-Encoding: 57 57 57
+Encoding: 57 57 26
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4212,13 +4244,14 @@ SplineSet
  786 1143 786 1143 735.5 1212.5 c 128,-1,30
  685 1282 685 1282 590 1282 c 0,31,32
  494 1282 494 1282 442.5 1212.5 c 128,-1,33
- 391 1143 391 1143 391 1012 c 0,34,35
+ 391 1143 391 1143 391 1012 c 256,34,35
  391 881 391 881 442.5 811 c 128,-1,36
  494 741 494 741 590 741 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: colon
-Encoding: 58 58 58
+Encoding: 58 58 27
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4264,8 +4297,9 @@ SplineSet
  449 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: semicolon
-Encoding: 59 59 59
+Encoding: 59 59 28
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4321,8 +4355,9 @@ SplineSet
  449 1063 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: less
-Encoding: 60 60 60
+Encoding: 60 60 29
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4371,8 +4406,9 @@ SplineSet
  1145 926 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equal
-Encoding: 61 61 61
+Encoding: 61 61 30
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4421,8 +4457,9 @@ SplineSet
  88 987 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: greater
-Encoding: 62 62 62
+Encoding: 62 62 31
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4471,8 +4508,9 @@ SplineSet
  88 926 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: question
-Encoding: 63 63 63
+Encoding: 63 63 32
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4625,8 +4663,9 @@ SplineSet
  707 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: at
-Encoding: 64 64 64
+Encoding: 64 64 33
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4729,11 +4768,11 @@ Fore
 SplineSet
 973 545 m 0,0,1
  973 658 973 658 922 722 c 128,-1,2
- 871 786 871 786 782 786 c 0,3,4
+ 871 786 871 786 782 786 c 256,3,4
  693 786 693 786 642.5 722 c 128,-1,5
  592 658 592 658 592 545 c 0,6,7
  592 431 592 431 642.5 367 c 128,-1,8
- 693 303 693 303 782 303 c 0,9,10
+ 693 303 693 303 782 303 c 256,9,10
  871 303 871 303 922 367 c 128,-1,11
  973 431 973 431 973 545 c 0,0,1
 1159 135 m 1,12,-1
@@ -4768,8 +4807,9 @@ SplineSet
  1159 135 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: A
-Encoding: 65 65 65
+Encoding: 65 65 34
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4969,8 +5009,9 @@ SplineSet
  436 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: B
-Encoding: 66 66 66
+Encoding: 66 66 35
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5054,7 +5095,7 @@ SplineSet
  410 913 l 1,10,-1
  606 913 l 2,11,12
  718 913 718 913 765.5 953 c 128,-1,13
- 813 993 813 993 813 1085 c 0,14,15
+ 813 993 813 993 813 1085 c 256,14,15
  813 1177 813 1177 764.5 1218.5 c 128,-1,16
  716 1260 716 1260 606 1260 c 2,17,-1
  410 1260 l 1,9,-1
@@ -5072,8 +5113,9 @@ SplineSet
  125 1495 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: C
-Encoding: 67 67 67
+Encoding: 67 67 36
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5150,8 +5192,9 @@ SplineSet
  1081 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: D
-Encoding: 68 68 68
+Encoding: 68 68 37
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5219,8 +5262,9 @@ SplineSet
  137 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: E
-Encoding: 69 69 69
+Encoding: 69 69 38
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5287,8 +5331,9 @@ SplineSet
  1098 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: F
-Encoding: 70 70 70
+Encoding: 70 70 39
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5348,8 +5393,9 @@ SplineSet
  1112 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: G
-Encoding: 71 71 71
+Encoding: 71 71 40
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5467,8 +5513,9 @@ SplineSet
  851 253 851 253 872 270 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: H
-Encoding: 72 72 72
+Encoding: 72 72 41
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5531,8 +5578,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: I
-Encoding: 73 73 73
+Encoding: 73 73 42
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5592,8 +5640,9 @@ SplineSet
  172 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: J
-Encoding: 74 74 74
+Encoding: 74 74 43
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5666,8 +5715,9 @@ SplineSet
  214 23 214 23 109 74 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: K
-Encoding: 75 75 75
+Encoding: 75 75 44
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5789,8 +5839,9 @@ SplineSet
  117 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: L
-Encoding: 76 76 76
+Encoding: 76 76 45
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5833,8 +5884,9 @@ SplineSet
  225 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: M
-Encoding: 77 77 77
+Encoding: 77 77 46
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6056,8 +6108,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: N
-Encoding: 78 78 78
+Encoding: 78 78 47
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6163,8 +6216,9 @@ SplineSet
  119 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: O
-Encoding: 79 79 79
+Encoding: 79 79 48
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6229,8 +6283,9 @@ SplineSet
  92 363 92 363 92 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: P
-Encoding: 80 80 80
+Encoding: 80 80 49
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6288,14 +6343,14 @@ SplineSet
  457 807 l 1,1,-1
  578 807 l 2,2,3
  723 807 723 807 781.5 856 c 128,-1,4
- 840 905 840 905 840 1026 c 0,5,6
+ 840 905 840 905 840 1026 c 256,5,6
  840 1147 840 1147 781.5 1196 c 128,-1,7
  723 1245 723 1245 578 1245 c 2,8,-1
  457 1245 l 1,0,-1
 162 1493 m 1,9,-1
  567 1493 l 2,10,11
  876 1493 876 1493 1011.5 1383 c 128,-1,12
- 1147 1273 1147 1273 1147 1026 c 0,13,14
+ 1147 1273 1147 1273 1147 1026 c 256,13,14
  1147 779 1147 779 1011.5 669 c 128,-1,15
  876 559 876 559 567 559 c 2,16,-1
  457 559 l 1,17,-1
@@ -6304,8 +6359,9 @@ SplineSet
  162 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Q
-Encoding: 81 81 81
+Encoding: 81 81 50
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6400,8 +6456,9 @@ SplineSet
  730 1255 730 1255 616 1255 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: R
-Encoding: 82 82 82
+Encoding: 82 82 51
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6534,14 +6591,15 @@ SplineSet
  428 838 l 1,22,-1
  567 838 l 2,23,24
  688 838 688 838 740.5 885.5 c 128,-1,25
- 793 933 793 933 793 1042 c 0,26,27
+ 793 933 793 933 793 1042 c 256,26,27
  793 1151 793 1151 741 1198 c 128,-1,28
  689 1245 689 1245 567 1245 c 2,29,-1
  428 1245 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: S
-Encoding: 83 83 83
+Encoding: 83 83 52
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6694,8 +6752,9 @@ SplineSet
  510 655 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: T
-Encoding: 84 84 84
+Encoding: 84 84 53
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6742,8 +6801,9 @@ SplineSet
  764 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: U
-Encoding: 85 85 85
+Encoding: 85 85 54
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6800,7 +6860,7 @@ SplineSet
  401 1493 l 1,2,-1
  401 477 l 2,3,4
  401 365 401 365 458 301.5 c 128,-1,5
- 515 238 515 238 616 238 c 0,6,7
+ 515 238 515 238 616 238 c 256,6,7
  717 238 717 238 774 301.5 c 128,-1,8
  831 365 831 365 831 477 c 2,9,-1
  831 1493 l 1,10,-1
@@ -6812,8 +6872,9 @@ SplineSet
  106 247 106 247 106 551 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: V
-Encoding: 86 86 86
+Encoding: 86 86 55
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6940,8 +7001,9 @@ SplineSet
  616 246 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: W
-Encoding: 87 87 87
+Encoding: 87 87 56
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7148,8 +7210,9 @@ SplineSet
  0 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: X
-Encoding: 88 88 88
+Encoding: 88 88 57
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7336,8 +7399,9 @@ SplineSet
  1206 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Y
-Encoding: 89 89 89
+Encoding: 89 89 58
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7442,8 +7506,9 @@ SplineSet
  8 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Z
-Encoding: 90 90 90
+Encoding: 90 90 59
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7522,8 +7587,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketleft
-Encoding: 91 91 91
+Encoding: 91 91 60
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7578,8 +7644,9 @@ SplineSet
  422 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: backslash
-Encoding: 92 92 92
+Encoding: 92 92 61
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7616,8 +7683,9 @@ SplineSet
  334 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketright
-Encoding: 93 93 93
+Encoding: 93 93 62
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7668,8 +7736,9 @@ SplineSet
  811 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciicircum
-Encoding: 94 94 94
+Encoding: 94 94 63
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7711,8 +7780,9 @@ SplineSet
  739 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underscore
-Encoding: 95 95 95
+Encoding: 95 95 64
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7742,8 +7812,9 @@ SplineSet
  1233 -293 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: grave
-Encoding: 96 96 96
+Encoding: 96 96 65
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7790,8 +7861,9 @@ SplineSet
  481 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: a
-Encoding: 97 97 97
+Encoding: 97 97 66
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7966,8 +8038,9 @@ SplineSet
  1108 925 1108 925 1108 639 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: b
-Encoding: 98 98 98
+Encoding: 98 98 67
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8031,15 +8104,15 @@ AnchorPoint: "above" 616 1556 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-850 557 m 0,0,1
+850 557 m 256,0,1
  850 719 850 719 796 811 c 128,-1,2
- 742 903 742 903 647 903 c 0,3,4
+ 742 903 742 903 647 903 c 256,3,4
  552 903 552 903 497 811 c 128,-1,5
- 442 719 442 719 442 557 c 0,6,7
+ 442 719 442 719 442 557 c 256,6,7
  442 395 442 395 497 303 c 128,-1,8
- 552 211 552 211 647 211 c 0,9,10
+ 552 211 552 211 647 211 c 256,9,10
  742 211 742 211 796 303 c 128,-1,11
- 850 395 850 395 850 557 c 0,0,1
+ 850 395 850 395 850 557 c 256,0,1
 442 961 m 1,12,13
  496 1054 496 1054 567.5 1100.5 c 128,-1,14
  639 1147 639 1147 729 1147 c 0,15,16
@@ -8056,8 +8129,9 @@ SplineSet
  442 961 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: c
-Encoding: 99 99 99
+Encoding: 99 99 68
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8126,7 +8200,7 @@ SplineSet
  997 850 997 850 920.5 879.5 c 128,-1,15
  844 909 844 909 762 909 c 0,16,17
  619 909 619 909 542 818 c 128,-1,18
- 465 727 465 727 465 559 c 0,19,20
+ 465 727 465 727 465 559 c 256,19,20
  465 391 465 391 542 301 c 128,-1,21
  619 211 619 211 762 211 c 0,22,23
  847 211 847 211 921 239.5 c 128,-1,24
@@ -8134,8 +8208,9 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: d
-Encoding: 100 100 100
+Encoding: 100 100 69
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8213,19 +8288,20 @@ SplineSet
  305 1147 305 1147 504 1147 c 0,14,15
  594 1147 594 1147 665.5 1100.5 c 128,-1,16
  737 1054 737 1054 791 961 c 1,0,-1
-383 557 m 0,17,18
+383 557 m 256,17,18
  383 395 383 395 437 303 c 128,-1,19
- 491 211 491 211 586 211 c 0,20,21
+ 491 211 491 211 586 211 c 256,20,21
  681 211 681 211 736 303 c 128,-1,22
- 791 395 791 395 791 557 c 0,23,24
+ 791 395 791 395 791 557 c 256,23,24
  791 719 791 719 736 811 c 128,-1,25
- 681 903 681 903 586 903 c 0,26,27
+ 681 903 681 903 586 903 c 256,26,27
  491 903 491 903 437 811 c 128,-1,28
- 383 719 383 719 383 557 c 0,17,18
+ 383 719 383 719 383 557 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: e
-Encoding: 101 101 101
+Encoding: 101 101 70
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8335,8 +8411,9 @@ SplineSet
  854 685 l 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: f
-Encoding: 102 102 102
+Encoding: 102 102 71
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8419,8 +8496,9 @@ SplineSet
  741 1283 741 1283 739 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: g
-Encoding: 103 103 103
+Encoding: 103 103 72
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8537,8 +8615,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 0" uniF6C5
 EndChar
+
 StartChar: h
-Encoding: 104 104 104
+Encoding: 104 104 73
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8613,8 +8692,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: i
-Encoding: 105 105 105
+Encoding: 105 105 74
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8683,8 +8763,9 @@ SplineSet
  508 1665 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: j
-Encoding: 106 106 106
+Encoding: 106 106 75
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8768,8 +8849,9 @@ SplineSet
  850 1323 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: k
-Encoding: 107 107 107
+Encoding: 107 107 76
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8858,8 +8940,9 @@ SplineSet
  174 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: l
-Encoding: 108 108 108
+Encoding: 108 108 77
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8921,8 +9004,9 @@ SplineSet
  387 216 387 216 387 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: m
-Encoding: 109 109 109
+Encoding: 109 109 78
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9087,14 +9171,14 @@ SplineSet
  915 0 l 1,8,-1
  915 719 l 2,9,10
  915 844 915 844 896 886 c 128,-1,11
- 877 928 877 928 827 928 c 0,12,13
+ 877 928 877 928 827 928 c 256,12,13
  777 928 777 928 757 885 c 128,-1,14
  737 842 737 842 737 719 c 2,15,-1
  737 0 l 1,16,-1
  500 0 l 1,17,-1
  500 719 l 2,18,19
  500 842 500 842 480 885 c 128,-1,20
- 460 928 460 928 410 928 c 0,21,22
+ 460 928 460 928 410 928 c 256,21,22
  360 928 360 928 341 886 c 128,-1,23
  322 844 322 844 322 719 c 2,24,-1
  322 0 l 1,25,-1
@@ -9103,13 +9187,14 @@ SplineSet
  295 1120 l 1,28,-1
  295 1004 l 1,29,30
  320 1070 320 1070 375 1108.5 c 128,-1,31
- 430 1147 430 1147 498 1147 c 0,32,33
+ 430 1147 430 1147 498 1147 c 256,32,33
  566 1147 566 1147 622 1106.5 c 128,-1,34
  678 1066 678 1066 690 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: n
-Encoding: 110 110 110
+Encoding: 110 110 79
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9186,8 +9271,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: o
-Encoding: 111 111 111
+Encoding: 111 111 80
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9234,26 +9320,27 @@ Fore
 SplineSet
 616 909 m 0,0,1
  511 909 511 909 451 816.5 c 128,-1,2
- 391 724 391 724 391 559 c 0,3,4
+ 391 724 391 724 391 559 c 256,3,4
  391 394 391 394 451 301.5 c 128,-1,5
  511 209 511 209 616 209 c 0,6,7
  722 209 722 209 782 301.5 c 128,-1,8
- 842 394 842 394 842 559 c 0,9,10
+ 842 394 842 394 842 559 c 256,9,10
  842 724 842 724 782 816.5 c 128,-1,11
  722 909 722 909 616 909 c 0,0,1
-98 559 m 0,12,13
+98 559 m 256,12,13
  98 830 98 830 238.5 988.5 c 128,-1,14
  379 1147 379 1147 616 1147 c 0,15,16
  854 1147 854 1147 994.5 988.5 c 128,-1,17
- 1135 830 1135 830 1135 559 c 0,18,19
+ 1135 830 1135 830 1135 559 c 256,18,19
  1135 288 1135 288 994.5 129.5 c 128,-1,20
  854 -29 854 -29 616 -29 c 0,21,22
  379 -29 379 -29 238.5 129.5 c 128,-1,23
- 98 288 98 288 98 559 c 0,12,13
+ 98 288 98 288 98 559 c 256,12,13
 EndSplineSet
 EndChar
+
 StartChar: p
-Encoding: 112 112 112
+Encoding: 112 112 81
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9334,19 +9421,20 @@ SplineSet
  928 -29 928 -29 729 -29 c 0,14,15
  639 -29 639 -29 567.5 17.5 c 128,-1,16
  496 64 496 64 442 158 c 1,0,-1
-850 561 m 0,17,18
+850 561 m 256,17,18
  850 723 850 723 796 815 c 128,-1,19
- 742 907 742 907 647 907 c 0,20,21
+ 742 907 742 907 647 907 c 256,20,21
  552 907 552 907 497 815 c 128,-1,22
- 442 723 442 723 442 561 c 0,23,24
+ 442 723 442 723 442 561 c 256,23,24
  442 399 442 399 497 307 c 128,-1,25
- 552 215 552 215 647 215 c 0,26,27
+ 552 215 552 215 647 215 c 256,26,27
  742 215 742 215 796 307 c 128,-1,28
- 850 399 850 399 850 561 c 0,17,18
+ 850 399 850 399 850 561 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: q
-Encoding: 113 113 113
+Encoding: 113 113 82
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9409,15 +9497,15 @@ AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-383 561 m 0,0,1
+383 561 m 256,0,1
  383 399 383 399 437 307 c 128,-1,2
- 491 215 491 215 586 215 c 0,3,4
+ 491 215 491 215 586 215 c 256,3,4
  681 215 681 215 736 307 c 128,-1,5
- 791 399 791 399 791 561 c 0,6,7
+ 791 399 791 399 791 561 c 256,6,7
  791 723 791 723 736 815 c 128,-1,8
- 681 907 681 907 586 907 c 0,9,10
+ 681 907 681 907 586 907 c 256,9,10
  491 907 491 907 437 815 c 128,-1,11
- 383 723 383 723 383 561 c 0,0,1
+ 383 723 383 723 383 561 c 256,0,1
 791 158 m 1,12,13
  737 64 737 64 665.5 17.5 c 128,-1,14
  594 -29 594 -29 504 -29 c 0,15,16
@@ -9434,8 +9522,9 @@ SplineSet
  791 158 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: r
-Encoding: 114 114 114
+Encoding: 114 114 83
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9505,8 +9594,9 @@ SplineSet
  1151 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: s
-Encoding: 115 115 115
+Encoding: 115 115 84
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9712,8 +9802,9 @@ SplineSet
  902 1116 902 1116 991 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: t
-Encoding: 116 116 116
+Encoding: 116 116 85
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9793,8 +9884,9 @@ SplineSet
  690 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: u
-Encoding: 117 117 117
+Encoding: 117 117 86
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9857,7 +9949,7 @@ SplineSet
  453 1120 l 1,2,-1
  453 436 l 2,3,4
  453 315 453 315 487 263 c 128,-1,5
- 521 211 521 211 600 211 c 0,6,7
+ 521 211 521 211 600 211 c 256,6,7
  679 211 679 211 723.5 281 c 128,-1,8
  768 351 768 351 768 477 c 2,9,-1
  768 1120 l 1,10,-1
@@ -9871,8 +9963,9 @@ SplineSet
  160 183 160 183 160 391 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: v
-Encoding: 118 118 118
+Encoding: 118 118 87
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9997,8 +10090,9 @@ SplineSet
  1153 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: w
-Encoding: 119 119 119
+Encoding: 119 119 88
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10215,8 +10309,9 @@ SplineSet
  0 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: x
-Encoding: 120 120 120
+Encoding: 120 120 89
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10392,8 +10487,9 @@ SplineSet
  1145 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: y
-Encoding: 121 121 121
+Encoding: 121 121 90
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10539,8 +10635,9 @@ SplineSet
  711 -121 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: z
-Encoding: 122 122 122
+Encoding: 122 122 91
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10619,8 +10716,9 @@ SplineSet
  186 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceleft
-Encoding: 123 123 123
+Encoding: 123 123 92
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10754,8 +10852,9 @@ SplineSet
  1053 -143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bar
-Encoding: 124 124 124
+Encoding: 124 124 93
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10787,8 +10886,9 @@ SplineSet
  729 1565 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceright
-Encoding: 125 125 125
+Encoding: 125 125 94
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10924,8 +11024,9 @@ SplineSet
  180 -143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciitilde
-Encoding: 126 126 126
+Encoding: 126 126 95
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10997,14 +11098,16 @@ SplineSet
  1072 747 1072 747 1145 811 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: nonbreakingspace
-Encoding: 160 160 160
+Encoding: 160 160 96
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclamdown
-Encoding: 161 161 161
+Encoding: 161 161 97
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11059,8 +11162,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" exclamdown.case
 EndChar
+
 StartChar: cent
-Encoding: 162 162 162
+Encoding: 162 162 98
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11168,8 +11272,9 @@ SplineSet
  544 221 544 221 655 215 c 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: sterling
-Encoding: 163 163 163
+Encoding: 163 163 99
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11266,8 +11371,9 @@ SplineSet
  1036 1491 1036 1491 1102 1462 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: currency
-Encoding: 164 164 164
+Encoding: 164 164 100
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11414,8 +11520,9 @@ SplineSet
  773 961 773 961 819 938 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: yen
-Encoding: 165 165 165
+Encoding: 165 165 101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11566,8 +11673,9 @@ SplineSet
  8 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: brokenbar
-Encoding: 166 166 166
+Encoding: 166 166 102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11612,8 +11720,9 @@ SplineSet
  729 1432 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: section
-Encoding: 167 167 167
+Encoding: 167 167 103
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11788,8 +11897,9 @@ SplineSet
  847 1490 847 1490 930 1460 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: dieresis
-Encoding: 168 168 168
+Encoding: 168 168 104
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11833,10 +11943,11 @@ SplineSet
  301 1339 l 1,7,-1
  301 1585 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: copyright
-Encoding: 169 169 169
+Encoding: 169 169 105
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11917,7 +12028,7 @@ SplineSet
  796 912 796 912 750.5 926 c 128,-1,3
  705 940 705 940 657 940 c 0,4,5
  560 940 560 940 506.5 888 c 128,-1,6
- 453 836 453 836 453 741 c 0,7,8
+ 453 836 453 836 453 741 c 256,7,8
  453 646 453 646 506 594.5 c 128,-1,9
  559 543 559 543 657 543 c 0,10,11
  710 543 710 543 758 557.5 c 128,-1,12
@@ -11937,11 +12048,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,31
  1233 867 1233 867 1233 741 c 0,32,33
  1233 616 1233 616 1187.5 507 c 128,-1,34
- 1142 398 1142 398 1051 307 c 0,35,36
+ 1142 398 1142 398 1051 307 c 256,35,36
  960 216 960 216 851 170.5 c 128,-1,37
  742 125 742 125 616 125 c 0,38,39
  491 125 491 125 382 170.5 c 128,-1,40
- 273 216 273 216 182 307 c 0,41,42
+ 273 216 273 216 182 307 c 256,41,42
  91 398 91 398 45.5 507 c 128,-1,43
  0 616 0 616 0 741 c 0,44,45
  0 867 0 867 46 977 c 128,-1,46
@@ -11954,7 +12065,7 @@ SplineSet
  203 1014 203 1014 167 928 c 128,-1,55
  131 842 131 842 131 741 c 0,56,57
  131 643 131 643 167 558 c 128,-1,58
- 203 473 203 473 274 401 c 0,59,60
+ 203 473 203 473 274 401 c 256,59,60
  345 329 345 329 431 292.5 c 128,-1,61
  517 256 517 256 616 256 c 0,62,63
  716 256 716 256 802 292.5 c 128,-1,64
@@ -11967,8 +12078,9 @@ SplineSet
  717 1229 717 1229 616 1229 c 0,50,51
 EndSplineSet
 EndChar
+
 StartChar: ordfeminine
-Encoding: 170 170 170
+Encoding: 170 170 106
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12113,8 +12225,9 @@ SplineSet
  293 598 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotleft
-Encoding: 171 171 171
+Encoding: 171 171 107
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12185,8 +12298,9 @@ SplineSet
  588 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalnot
-Encoding: 172 172 172
+Encoding: 172 172 108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12228,8 +12342,9 @@ SplineSet
  88 899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: sfthyphen
-Encoding: 173 173 173
+Encoding: 173 173 109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12260,8 +12375,9 @@ SplineSet
  301 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: registered
-Encoding: 174 174 174
+Encoding: 174 174 110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12367,11 +12483,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,5
  1233 867 1233 867 1233 741 c 0,6,7
  1233 616 1233 616 1187.5 507 c 128,-1,8
- 1142 398 1142 398 1051 307 c 0,9,10
+ 1142 398 1142 398 1051 307 c 256,9,10
  960 216 960 216 851 170.5 c 128,-1,11
  742 125 742 125 616 125 c 0,12,13
  491 125 491 125 382 170.5 c 128,-1,14
- 273 216 273 216 182 307 c 0,15,16
+ 273 216 273 216 182 307 c 256,15,16
  91 398 91 398 45.5 507 c 128,-1,17
  0 616 0 616 0 741 c 0,18,19
  0 867 0 867 46 977 c 128,-1,20
@@ -12411,7 +12527,7 @@ SplineSet
  131 643 131 643 167 558 c 128,-1,61
  203 473 203 473 274 399 c 1,62,63
  346 328 346 328 431.5 292 c 128,-1,64
- 517 256 517 256 616 256 c 0,65,66
+ 517 256 517 256 616 256 c 256,65,66
  715 256 715 256 801 292 c 128,-1,67
  887 328 887 328 958 399 c 0,68,69
  1030 473 1030 473 1066 558 c 128,-1,70
@@ -12422,8 +12538,9 @@ SplineSet
  717 1229 717 1229 616 1229 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: macron
-Encoding: 175 175 175
+Encoding: 175 175 111
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12453,10 +12570,11 @@ SplineSet
  301 1368 l 1,3,-1
  301 1556 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: degree
-Encoding: 176 176 176
+Encoding: 176 176 112
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12509,17 +12627,18 @@ SplineSet
  475 1520 475 1520 616 1520 c 0,0,1
 616 1358 m 0,18,19
  544 1358 544 1358 494 1308 c 128,-1,20
- 444 1258 444 1258 444 1186 c 0,21,22
+ 444 1258 444 1258 444 1186 c 256,21,22
  444 1114 444 1114 493 1065 c 128,-1,23
- 542 1016 542 1016 614 1016 c 0,24,25
+ 542 1016 542 1016 614 1016 c 256,24,25
  686 1016 686 1016 736 1065.5 c 128,-1,26
  786 1115 786 1115 786 1186 c 0,27,28
  786 1258 786 1258 736.5 1308 c 128,-1,29
  687 1358 687 1358 616 1358 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: plusminus
-Encoding: 177 177 177
+Encoding: 177 177 113
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12589,8 +12708,9 @@ SplineSet
  88 238 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: twosuperior
-Encoding: 178 178 178
+Encoding: 178 178 114
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12668,8 +12788,9 @@ SplineSet
  529 836 529 836 500 813 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: threesuperior
-Encoding: 179 179 179
+Encoding: 179 179 115
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12777,8 +12898,9 @@ SplineSet
  668 1042 668 1042 582 1042 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: acute
-Encoding: 180 180 180
+Encoding: 180 180 116
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12824,10 +12946,11 @@ SplineSet
  469 1262 l 1,3,-1
  752 1638 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: mu
-Encoding: 181 181 181
+Encoding: 181 181 117
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12934,8 +13057,9 @@ SplineSet
  174 -428 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: paragraph
-Encoding: 182 182 182
+Encoding: 182 182 118
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12992,8 +13116,9 @@ SplineSet
  330 1493 330 1493 545 1493 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: periodcentered
-Encoding: 183 183 183
+Encoding: 183 183 119
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13026,17 +13151,19 @@ SplineSet
  449 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: cedilla
-Encoding: 184 184 184
+Encoding: 184 184 120
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: onesuperior
-Encoding: 185 185 185
+Encoding: 185 185 121
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13099,8 +13226,9 @@ SplineSet
  313 813 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ordmasculine
-Encoding: 186 186 186
+Encoding: 186 186 122
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13161,28 +13289,29 @@ SplineSet
  981 428 l 1,2,-1
  293 428 l 1,3,-1
  293 598 l 1,0,-1
-274 1108 m 0,4,5
+274 1108 m 256,4,5
  274 1297 274 1297 372.5 1408.5 c 128,-1,6
- 471 1520 471 1520 637 1520 c 0,7,8
+ 471 1520 471 1520 637 1520 c 256,7,8
  803 1520 803 1520 901 1409 c 128,-1,9
  999 1298 999 1298 999 1108 c 0,10,11
  999 919 999 919 901.5 808.5 c 128,-1,12
  804 698 804 698 637 698 c 0,13,14
  471 698 471 698 372.5 808.5 c 128,-1,15
- 274 919 274 919 274 1108 c 0,4,5
-637 1343 m 0,16,17
+ 274 919 274 919 274 1108 c 256,4,5
+637 1343 m 256,16,17
  564 1343 564 1343 521.5 1280 c 128,-1,18
- 479 1217 479 1217 479 1108 c 0,19,20
+ 479 1217 479 1217 479 1108 c 256,19,20
  479 999 479 999 521.5 936.5 c 128,-1,21
- 564 874 564 874 637 874 c 0,22,23
+ 564 874 564 874 637 874 c 256,22,23
  710 874 710 874 752.5 936.5 c 128,-1,24
- 795 999 795 999 795 1108 c 0,25,26
+ 795 999 795 999 795 1108 c 256,25,26
  795 1217 795 1217 752.5 1280 c 128,-1,27
- 710 1343 710 1343 637 1343 c 0,16,17
+ 710 1343 710 1343 637 1343 c 256,16,17
 EndSplineSet
 EndChar
+
 StartChar: guillemotright
-Encoding: 187 187 187
+Encoding: 187 187 123
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13253,40 +13382,44 @@ SplineSet
  647 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: onequarter
-Encoding: 188 188 188
+Encoding: 188 188 124
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: onehalf
-Encoding: 189 189 189
+Encoding: 189 189 125
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: threequarters
-Encoding: 190 190 190
+Encoding: 190 190 126
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 179 179 N 1 0 0 1 -227 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 115 179 N 1 0 0 1 -227 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: questiondown
-Encoding: 191 191 191
+Encoding: 191 191 127
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13447,8 +13580,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" questiondown.case
 EndChar
+
 StartChar: Agrave
-Encoding: 192 192 192
+Encoding: 192 192 128
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13462,12 +13596,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aacute
-Encoding: 193 193 193
+Encoding: 193 193 129
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13481,12 +13616,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Acircumflex
-Encoding: 194 194 194
+Encoding: 194 194 130
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13509,12 +13645,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Atilde
-Encoding: 195 195 195
+Encoding: 195 195 131
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13537,12 +13674,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Adieresis
-Encoding: 196 196 196
+Encoding: 196 196 132
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13581,12 +13719,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aring
-Encoding: 197 197 197
+Encoding: 197 197 133
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13863,24 +14002,25 @@ SplineSet
  901 1733 901 1733 901 1616 c 0,16,17
  901 1554 901 1554 880 1506.5 c 128,-1,18
  859 1459 859 1459 815 1421 c 1,0,-1
-485 1616 m 0,19,20
+485 1616 m 256,19,20
  485 1562 485 1562 524 1523.5 c 128,-1,21
  563 1485 563 1485 616 1485 c 0,22,23
  671 1485 671 1485 709.5 1523.5 c 128,-1,24
- 748 1562 748 1562 748 1616 c 0,25,26
+ 748 1562 748 1562 748 1616 c 256,25,26
  748 1670 748 1670 709 1708.5 c 128,-1,27
  670 1747 670 1747 616 1747 c 0,28,29
  563 1747 563 1747 524 1708.5 c 128,-1,30
- 485 1670 485 1670 485 1616 c 0,19,20
+ 485 1670 485 1670 485 1616 c 256,19,20
 616 1223 m 1,31,-1
  477 612 l 1,32,-1
  756 612 l 1,33,-1
  616 1223 l 1,31,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: AE
-Encoding: 198 198 198
+Encoding: 198 198 134
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14013,78 +14153,86 @@ SplineSet
  537 1233 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: Ccedilla
-Encoding: 199 199 199
+Encoding: 199 199 135
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 117 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 117 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Egrave
-Encoding: 200 200 200
+Encoding: 200 200 136
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 31 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 31 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eacute
-Encoding: 201 201 201
+Encoding: 201 201 137
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 31 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ecircumflex
-Encoding: 202 202 202
+Encoding: 202 202 138
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 31 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 31 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Edieresis
-Encoding: 203 203 203
+Encoding: 203 203 139
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 31 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 31 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Igrave
-Encoding: 204 204 204
+Encoding: 204 204 140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Iacute
-Encoding: 205 205 205
+Encoding: 205 205 141
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Icircumflex
-Encoding: 206 206 206
+Encoding: 206 206 142
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14099,12 +14247,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Idieresis
-Encoding: 207 207 207
+Encoding: 207 207 143
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14137,12 +14286,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eth
-Encoding: 208 208 208
+Encoding: 208 208 144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14233,8 +14383,9 @@ SplineSet
  137 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: Ntilde
-Encoding: 209 209 209
+Encoding: 209 209 145
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14257,12 +14408,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ograve
-Encoding: 210 210 210
+Encoding: 210 210 146
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14276,12 +14428,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Oacute
-Encoding: 211 211 211
+Encoding: 211 211 147
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14295,12 +14448,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ocircumflex
-Encoding: 212 212 212
+Encoding: 212 212 148
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14323,12 +14477,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Otilde
-Encoding: 213 213 213
+Encoding: 213 213 149
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14351,12 +14506,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Odieresis
-Encoding: 214 214 214
+Encoding: 214 214 150
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14371,12 +14527,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: multiply
-Encoding: 215 215 215
+Encoding: 215 215 151
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14447,8 +14604,9 @@ SplineSet
  1112 971 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Oslash
-Encoding: 216 216 216
+Encoding: 216 216 152
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14607,8 +14765,9 @@ SplineSet
  162 289 l 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: Ugrave
-Encoding: 217 217 217
+Encoding: 217 217 153
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14622,12 +14781,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uacute
-Encoding: 218 218 218
+Encoding: 218 218 154
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14641,12 +14801,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ucircumflex
-Encoding: 219 219 219
+Encoding: 219 219 155
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14669,12 +14830,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Udieresis
-Encoding: 220 220 220
+Encoding: 220 220 156
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14689,22 +14851,24 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Yacute
-Encoding: 221 221 221
+Encoding: 221 221 157
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Thorn
-Encoding: 222 222 222
+Encoding: 222 222 158
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14782,8 +14946,9 @@ SplineSet
  162 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: germandbls
-Encoding: 223 223 223
+Encoding: 223 223 159
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14917,28 +15082,31 @@ SplineSet
  1034 1059 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: agrave
-Encoding: 224 224 224
+Encoding: 224 224 160
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aacute
-Encoding: 225 225 225
+Encoding: 225 225 161
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: acircumflex
-Encoding: 226 226 226
+Encoding: 226 226 162
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14954,42 +15122,46 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: atilde
-Encoding: 227 227 227
+Encoding: 227 227 163
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: adieresis
-Encoding: 228 228 228
+Encoding: 228 228 164
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aring
-Encoding: 229 229 229
+Encoding: 229 229 165
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ae
-Encoding: 230 230 230
+Encoding: 230 230 166
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15193,7 +15365,7 @@ SplineSet
 963 690 m 1,12,-1
  963 713 l 2,13,14
  963 838 963 838 938 885 c 128,-1,15
- 913 932 913 932 850 932 c 0,16,17
+ 913 932 913 932 850 932 c 256,16,17
  787 932 787 932 762 885 c 128,-1,18
  737 838 737 838 737 713 c 2,19,-1
  737 690 l 1,20,-1
@@ -15233,38 +15405,42 @@ SplineSet
  1188 479 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: ccedilla
-Encoding: 231 231 231
+Encoding: 231 231 167
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 72 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 72 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: egrave
-Encoding: 232 232 232
+Encoding: 232 232 168
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 39 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 39 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eacute
-Encoding: 233 233 233
+Encoding: 233 233 169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 39 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 39 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecircumflex
-Encoding: 234 234 234
+Encoding: 234 234 170
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15280,62 +15456,68 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 39 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 39 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: edieresis
-Encoding: 235 235 235
+Encoding: 235 235 171
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 39 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 39 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: igrave
-Encoding: 236 236 236
+Encoding: 236 236 172
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: iacute
-Encoding: 237 237 237
+Encoding: 237 237 173
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: icircumflex
-Encoding: 238 238 238
+Encoding: 238 238 174
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: idieresis
-Encoding: 239 239 239
+Encoding: 239 239 175
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eth
-Encoding: 240 240 240
+Encoding: 240 240 176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15517,38 +15699,42 @@ SplineSet
  940 1100 l 2,15,16
 EndSplineSet
 EndChar
+
 StartChar: ntilde
-Encoding: 241 241 241
+Encoding: 241 241 177
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ograve
-Encoding: 242 242 242
+Encoding: 242 242 178
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 -4 2 2
-Refer: 111 111 N 1 0 0 1 0 0 3
-LCarets2: 1 0 
+Refer: 655 768 N 1 0 0 1 -4 2 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+LCarets2: 1 0
 EndChar
+
 StartChar: oacute
-Encoding: 243 243 243
+Encoding: 243 243 179
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 2 1 2
-Refer: 111 111 N 1 0 0 1 0 0 3
-LCarets2: 1 0 
+Refer: 656 769 N 1 0 0 1 2 1 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+LCarets2: 1 0
 EndChar
+
 StartChar: ocircumflex
-Encoding: 244 244 244
+Encoding: 244 244 180
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15571,12 +15757,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 1 2
-Refer: 111 111 N 1 0 0 1 0 0 3
-LCarets2: 1 0 
+Refer: 622 710 N 1 0 0 1 0 1 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+LCarets2: 1 0
 EndChar
+
 StartChar: otilde
-Encoding: 245 245 245
+Encoding: 245 245 181
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15591,12 +15778,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 -33 2
-Refer: 111 111 N 1 0 0 1 0 0 3
-LCarets2: 1 0 
+Refer: 640 732 N 1 0 0 1 0 -33 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+LCarets2: 1 0
 EndChar
+
 StartChar: odieresis
-Encoding: 246 246 246
+Encoding: 246 246 182
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15611,12 +15799,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 111 111 N 1 0 0 1 0 0 3
-LCarets2: 1 0 
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+LCarets2: 1 0
 EndChar
+
 StartChar: divide
-Encoding: 247 247 247
+Encoding: 247 247 183
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15677,8 +15866,9 @@ SplineSet
  66 762 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: oslash
-Encoding: 248 248 248
+Encoding: 248 248 184
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15838,28 +16028,31 @@ SplineSet
  188 199 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: ugrave
-Encoding: 249 249 249
+Encoding: 249 249 185
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uacute
-Encoding: 250 250 250
+Encoding: 250 250 186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ucircumflex
-Encoding: 251 251 251
+Encoding: 251 251 187
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15882,12 +16075,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: udieresis
-Encoding: 252 252 252
+Encoding: 252 252 188
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15902,22 +16096,24 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: yacute
-Encoding: 253 253 253
+Encoding: 253 253 189
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: thorn
-Encoding: 254 254 254
+Encoding: 254 254 190
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15996,19 +16192,20 @@ SplineSet
  928 -29 928 -29 729 -29 c 0,14,15
  639 -29 639 -29 567.5 17.5 c 128,-1,16
  496 64 496 64 442 158 c 1,0,-1
-850 561 m 0,17,18
+850 561 m 256,17,18
  850 723 850 723 796 815 c 128,-1,19
- 742 907 742 907 647 907 c 0,20,21
+ 742 907 742 907 647 907 c 256,20,21
  552 907 552 907 497 815 c 128,-1,22
- 442 723 442 723 442 561 c 0,23,24
+ 442 723 442 723 442 561 c 256,23,24
  442 399 442 399 497 307 c 128,-1,25
- 552 215 552 215 647 215 c 0,26,27
+ 552 215 552 215 647 215 c 256,26,27
  742 215 742 215 796 307 c 128,-1,28
- 850 399 850 399 850 561 c 0,17,18
+ 850 399 850 399 850 561 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: ydieresis
-Encoding: 255 255 255
+Encoding: 255 255 191
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16059,12 +16256,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Amacron
-Encoding: 256 256 256
+Encoding: 256 256 192
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -16098,139 +16296,154 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: amacron
-Encoding: 257 257 257
+Encoding: 257 257 193
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Abreve
-Encoding: 258 258 258
+Encoding: 258 258 194
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: abreve
-Encoding: 259 259 259
+Encoding: 259 259 195
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Aogonek
-Encoding: 260 260 260
+Encoding: 260 260 196
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 355 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 355 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aogonek
-Encoding: 261 261 261
+Encoding: 261 261 197
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 258 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 258 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cacute
-Encoding: 262 262 262
+Encoding: 262 262 198
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 137 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 137 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: cacute
-Encoding: 263 263 263
+Encoding: 263 263 199
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 102 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 102 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ccircumflex
-Encoding: 264 264 264
+Encoding: 264 264 200
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 156 373 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 156 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ccircumflex
-Encoding: 265 265 265
+Encoding: 265 265 201
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 105 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 105 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cdotaccent
-Encoding: 266 266 266
+Encoding: 266 266 202
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: cdotaccent
-Encoding: 267 267 267
+Encoding: 267 267 203
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 75 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 75 0 2
 EndChar
+
 StartChar: Ccaron
-Encoding: 268 268 268
+Encoding: 268 268 204
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 137 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 137 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ccaron
-Encoding: 269 269 269
+Encoding: 269 269 205
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 102 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 102 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcaron
-Encoding: 270 270 270
+Encoding: 270 270 206
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -13 391 2
-LCarets2: 1 0 
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 -13 391 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dcaron
-Encoding: 271 271 271
+Encoding: 271 271 207
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16250,20 +16463,22 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1.02235 0 0 1.01863 610.518 -112.514 2
-Refer: 100 100 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3665 -1 N 1.02235 0 0 1.01863 610.518 -112.514 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcroat
-Encoding: 272 272 272
+Encoding: 272 272 208
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dcroat
-Encoding: 273 273 273
+Encoding: 273 273 209
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16363,19 +16578,20 @@ SplineSet
  305 1147 305 1147 504 1147 c 0,22,23
  594 1147 594 1147 665.5 1100.5 c 128,-1,24
  737 1054 737 1054 791 961 c 1,0,-1
-383 557 m 0,25,26
+383 557 m 256,25,26
  383 395 383 395 437 303 c 128,-1,27
- 491 211 491 211 586 211 c 0,28,29
+ 491 211 491 211 586 211 c 256,28,29
  681 211 681 211 736 303 c 128,-1,30
- 791 395 791 395 791 557 c 0,31,32
+ 791 395 791 395 791 557 c 256,31,32
  791 719 791 719 736 811 c 128,-1,33
- 681 903 681 903 586 903 c 0,34,35
+ 681 903 681 903 586 903 c 256,34,35
  491 903 491 903 437 811 c 128,-1,36
- 383 719 383 719 383 557 c 0,25,26
+ 383 719 383 719 383 557 c 256,25,26
 EndSplineSet
 EndChar
+
 StartChar: Emacron
-Encoding: 274 274 274
+Encoding: 274 274 210
 Width: 1233
 TtInstrs:
 SVTCA[y-axis]
@@ -16389,83 +16605,92 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: emacron
-Encoding: 275 275 275
+Encoding: 275 275 211
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ebreve
-Encoding: 276 276 276
+Encoding: 276 276 212
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: ebreve
-Encoding: 277 277 277
+Encoding: 277 277 213
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: Edotaccent
-Encoding: 278 278 278
+Encoding: 278 278 214
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: edotaccent
-Encoding: 279 279 279
+Encoding: 279 279 215
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: Eogonek
-Encoding: 280 280 280
+Encoding: 280 280 216
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 225 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 225 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eogonek
-Encoding: 281 281 281
+Encoding: 281 281 217
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 231 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 231 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ecaron
-Encoding: 282 282 282
+Encoding: 282 282 218
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 53 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 53 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecaron
-Encoding: 283 283 283
+Encoding: 283 283 219
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16481,75 +16706,83 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 17 5 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 17 5 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gcircumflex
-Encoding: 284 284 284
+Encoding: 284 284 220
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 121 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 121 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcircumflex
-Encoding: 285 285 285
+Encoding: 285 285 221
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -20 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 -20 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gbreve
-Encoding: 286 286 286
+Encoding: 286 286 222
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 50 0 2
-LCarets2: 1 0 
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 50 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: gbreve
-Encoding: 287 287 287
+Encoding: 287 287 223
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gdotaccent
-Encoding: 288 288 288
+Encoding: 288 288 224
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: gdotaccent
-Encoding: 289 289 289
+Encoding: 289 289 225
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcommaaccent
-Encoding: 290 290 290
+Encoding: 290 290 226
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 165.5 11 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 165.5 11 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcommaaccent
-Encoding: 291 291 291
+Encoding: 291 291 227
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16564,11 +16797,12 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 786 786 N 1 0 0 1 8 356 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 673 786 N 1 0 0 1 8 356 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hcircumflex
-Encoding: 292 292 292
+Encoding: 292 292 228
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -16582,11 +16816,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hcircumflex
-Encoding: 293 293 293
+Encoding: 293 293 229
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -16622,11 +16857,12 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 -301 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 -301 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hbar
-Encoding: 294 294 294
+Encoding: 294 294 230
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16726,8 +16962,9 @@ SplineSet
  432 1105 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: hbar
-Encoding: 295 295 295
+Encoding: 295 295 231
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16828,8 +17065,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Itilde
-Encoding: 296 296 296
+Encoding: 296 296 232
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -16843,11 +17081,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: itilde
-Encoding: 297 297 297
+Encoding: 297 297 233
 Width: 1233
 TtInstrs:
 NPUSHB
@@ -16860,11 +17099,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Imacron
-Encoding: 298 298 298
+Encoding: 298 298 234
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -16894,65 +17134,72 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: imacron
-Encoding: 299 299 299
+Encoding: 299 299 235
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ibreve
-Encoding: 300 300 300
+Encoding: 300 300 236
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ibreve
-Encoding: 301 301 301
+Encoding: 301 301 237
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iogonek
-Encoding: 302 302 302
+Encoding: 302 302 238
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 66 0.000455856 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 66 0.000455856 2
 EndChar
+
 StartChar: iogonek
-Encoding: 303 303 303
+Encoding: 303 303 239
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 103 0.000455856 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 103 0.000455856 2
 EndChar
+
 StartChar: Idotaccent
-Encoding: 304 304 304
+Encoding: 304 304 240
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotlessi
-Encoding: 305 305 305
+Encoding: 305 305 241
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17006,8 +17253,9 @@ SplineSet
  221 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: IJ
-Encoding: 306 306 306
+Encoding: 306 306 242
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17087,14 +17335,14 @@ SplineSet
  573.98 419 l 1,1,2
  636.76 331 636.76 331 707.935 285 c 128,-1,3
  779.11 239 779.11 239 851.38 239 c 0,4,5
- 936.06 239 936.06 239 975.48 297 c 0,6,7
+ 936.06 239 936.06 239 975.48 297 c 256,6,7
  1014.9 355 1014.9 355 1014.9 482 c 2,8,-1
  1014.9 1236 l 1,9,-1
  751.37 1236 l 1,10,-1
  751.37 1496 l 1,11,-1
  1230.25 1496 l 1,12,-1
  1230.25 482 l 2,13,14
- 1230.25 209 1230.25 209 1146.67 91.5 c 0,15,16
+ 1230.25 209 1230.25 209 1146.67 91.5 c 256,15,16
  1063.08 -26 1063.08 -26 871.09 -26 c 0,17,18
  801.74 -26 801.74 -26 726.185 0 c 128,-1,19
  650.63 26 650.63 26 573.98 77 c 1,0,-1
@@ -17112,10 +17360,11 @@ SplineSet
  181.44 1233 l 1,31,-1
  -8.63965 1233 l 1,20,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ij
-Encoding: 307 307 307
+Encoding: 307 307 243
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17229,10 +17478,11 @@ SplineSet
  264.673 1323 l 1,31,-1
  264.673 1665 l 1,28,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: Jcircumflex
-Encoding: 308 308 308
+Encoding: 308 308 244
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17247,37 +17497,41 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 64 373 2
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 64 373 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: jcircumflex
-Encoding: 309 309 309
+Encoding: 309 309 245
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 493 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kcommaaccent
-Encoding: 310 310 310
+Encoding: 310 310 246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 113.5 40 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 113.5 40 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kcommaaccent
-Encoding: 311 311 311
+Encoding: 311 311 247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 128.5 40 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 128.5 40 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kgreenlandic
-Encoding: 312 312 312
+Encoding: 312 312 248
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17363,18 +17617,20 @@ SplineSet
  174 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Lacute
-Encoding: 313 313 313
+Encoding: 313 313 249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 1 374 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3667 -1 N 1 0 0 1 1 374 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lacute
-Encoding: 314 314 314
+Encoding: 314 314 250
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17403,59 +17659,65 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 1 374 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3667 -1 N 1 0 0 1 1 374 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lcommaaccent
-Encoding: 315 315 315
+Encoding: 315 315 251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 130.5 40 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 130.5 40 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lcommaaccent
-Encoding: 316 316 316
+Encoding: 316 316 252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 3.5 40 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 3.5 40 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lcaron
-Encoding: 317 317 317
+Encoding: 317 317 253
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 324 -145 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3665 -1 N 1 0 0 1 324 -145 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lcaron
-Encoding: 318 318 318
+Encoding: 318 318 254
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 363 -82 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3665 -1 N 1 0 0 1 363 -82 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ldot
-Encoding: 319 319 319
+Encoding: 319 319 255
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 387.5 172.5 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 387.5 172.5 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ldot
-Encoding: 320 320 320
+Encoding: 320 320 256
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17471,12 +17733,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 441 172 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 441 172 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lslash
-Encoding: 321 321 321
+Encoding: 321 321 257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17556,8 +17819,9 @@ SplineSet
  225 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lslash
-Encoding: 322 322 322
+Encoding: 322 322 258
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17656,74 +17920,82 @@ SplineSet
  410 216 410 216 410 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Nacute
-Encoding: 323 323 323
+Encoding: 323 323 259
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 31 374 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 374 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nacute
-Encoding: 324 324 324
+Encoding: 324 324 260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -1.5 7 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -1.5 7 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncommaaccent
-Encoding: 325 325 325
+Encoding: 325 325 261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 58 40 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 58 40 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ncommaaccent
-Encoding: 326 326 326
+Encoding: 326 326 262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 64 40 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 64 40 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncaron
-Encoding: 327 327 327
+Encoding: 327 327 263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 41 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 41 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ncaron
-Encoding: 328 328 328
+Encoding: 328 328 264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 36 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 36 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: napostrophe
-Encoding: 329 329 329
+Encoding: 329 329 265
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 159 0 2
-Refer: 700 700 N 1 0 0 1 -542 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 159 0 2
+Refer: 616 700 N 1 0 0 1 -542 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eng
-Encoding: 330 330 330
+Encoding: 330 330 266
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17809,8 +18081,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Latin lookup 0-1" Eng.alt
 EndChar
+
 StartChar: eng
-Encoding: 331 331 331
+Encoding: 331 331 267
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17898,8 +18171,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omacron
-Encoding: 332 332 332
+Encoding: 332 332 268
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17933,11 +18207,12 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omacron
-Encoding: 333 333 333
+Encoding: 333 333 269
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17959,47 +18234,52 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Obreve
-Encoding: 334 334 334
+Encoding: 334 334 270
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: obreve
-Encoding: 335 335 335
+Encoding: 335 335 271
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ohungarumlaut
-Encoding: 336 336 336
+Encoding: 336 336 272
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3676 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ohungarumlaut
-Encoding: 337 337 337
+Encoding: 337 337 273
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: OE
-Encoding: 338 338 338
+Encoding: 338 338 274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18097,8 +18377,9 @@ SplineSet
  569 1233 l 2,17,18
 EndSplineSet
 EndChar
+
 StartChar: oe
-Encoding: 339 339 339
+Encoding: 339 339 275
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18246,7 +18527,7 @@ SplineSet
 985 690 m 1,33,-1
  985 725 l 2,34,35
  985 841 985 841 959.5 887.5 c 128,-1,36
- 934 934 934 934 872 934 c 0,37,38
+ 934 934 934 934 872 934 c 256,37,38
  810 934 810 934 785 886.5 c 128,-1,39
  760 839 760 839 760 713 c 2,40,-1
  760 690 l 1,41,-1
@@ -18255,163 +18536,180 @@ SplineSet
  520 801 520 801 491 867.5 c 128,-1,44
  462 934 462 934 385 934 c 0,45,46
  307 934 307 934 277.5 867.5 c 128,-1,47
- 248 801 248 801 248 559 c 0,48,49
+ 248 801 248 801 248 559 c 256,48,49
  248 317 248 317 277.5 250.5 c 128,-1,50
  307 184 307 184 385 184 c 0,51,52
  462 184 462 184 491 251 c 128,-1,53
  520 318 520 318 520 559 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: Racute
-Encoding: 340 340 340
+Encoding: 340 340 276
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 1 374 2
-Refer: 82 82 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3667 -1 N 1 0 0 1 1 374 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: racute
-Encoding: 341 341 341
+Encoding: 341 341 277
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 153.5 7 2
-Refer: 114 114 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 116 180 N 1 0 0 1 153.5 7 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Rcommaaccent
-Encoding: 342 342 342
+Encoding: 342 342 278
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 125.5 40 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 125.5 40 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: rcommaaccent
-Encoding: 343 343 343
+Encoding: 343 343 279
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -120 40 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 -120 40 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rcaron
-Encoding: 344 344 344
+Encoding: 344 344 280
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -31 373 2
-LCarets2: 1 0 
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 -31 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: rcaron
-Encoding: 345 345 345
+Encoding: 345 345 281
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 102 0 2
-LCarets2: 1 0 
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 102 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Sacute
-Encoding: 346 346 346
+Encoding: 346 346 282
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 31 374 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 374 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: sacute
-Encoding: 347 347 347
+Encoding: 347 347 283
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -1.5 7 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -1.5 7 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scircumflex
-Encoding: 348 348 348
+Encoding: 348 348 284
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scircumflex
-Encoding: 349 349 349
+Encoding: 349 349 285
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scedilla
-Encoding: 350 350 350
+Encoding: 350 350 286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scedilla
-Encoding: 351 351 351
+Encoding: 351 351 287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Scaron
-Encoding: 352 352 352
+Encoding: 352 352 288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scaron
-Encoding: 353 353 353
+Encoding: 353 353 289
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tcommaaccent
-Encoding: 354 354 354
+Encoding: 354 354 290
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tcommaaccent
-Encoding: 355 355 355
+Encoding: 355 355 291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 181 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 181 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Tcaron
-Encoding: 356 356 356
+Encoding: 356 356 292
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18426,12 +18724,13 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -7 385 2
-LCarets2: 1 0 
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 -7 385 2
+LCarets2: 1 0
 EndChar
+
 StartChar: tcaron
-Encoding: 357 357 357
+Encoding: 357 357 293
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18462,12 +18761,13 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114113 -1 N 1 0 0 1 364 49.0001 2
-LCarets2: 1 0 
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3665 -1 N 1 0 0 1 364 49.0001 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tbar
-Encoding: 358 358 358
+Encoding: 358 358 294
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18536,8 +18836,9 @@ SplineSet
  764 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tbar
-Encoding: 359 359 359
+Encoding: 359 359 295
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18639,8 +18940,9 @@ SplineSet
  690 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Utilde
-Encoding: 360 360 360
+Encoding: 360 360 296
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18662,11 +18964,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: utilde
-Encoding: 361 361 361
+Encoding: 361 361 297
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18680,11 +18983,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Umacron
-Encoding: 362 362 362
+Encoding: 362 362 298
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18718,11 +19022,12 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: umacron
-Encoding: 363 363 363
+Encoding: 363 363 299
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18744,29 +19049,32 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ubreve
-Encoding: 364 364 364
+Encoding: 364 364 300
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ubreve
-Encoding: 365 365 365
+Encoding: 365 365 301
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uring
-Encoding: 366 366 366
+Encoding: 366 366 302
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18783,58 +19091,64 @@ IUP[y]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 5 82 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 5 82 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uring
-Encoding: 367 367 367
+Encoding: 367 367 303
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uhungarumlaut
-Encoding: 368 368 368
+Encoding: 368 368 304
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3676 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uhungarumlaut
-Encoding: 369 369 369
+Encoding: 369 369 305
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uogonek
-Encoding: 370 370 370
+Encoding: 370 370 306
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 -11.5 -15.6333 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 -11.5 -15.6333 2
 EndChar
+
 StartChar: uogonek
-Encoding: 371 371 371
+Encoding: 371 371 307
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 354 0.366699 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 354 0.366699 2
 EndChar
+
 StartChar: Wcircumflex
-Encoding: 372 372 372
+Encoding: 372 372 308
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18848,11 +19162,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wcircumflex
-Encoding: 373 373 373
+Encoding: 373 373 309
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18866,11 +19181,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ycircumflex
-Encoding: 374 374 374
+Encoding: 374 374 310
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18884,11 +19200,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3670 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ycircumflex
-Encoding: 375 375 375
+Encoding: 375 375 311
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18910,11 +19227,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 1 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 1 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ydieresis
-Encoding: 376 376 376
+Encoding: 376 376 312
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18961,68 +19279,75 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Zacute
-Encoding: 377 377 377
+Encoding: 377 377 313
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 31 374 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 374 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zacute
-Encoding: 378 378 378
+Encoding: 378 378 314
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -1.5 7 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -1.5 7 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zdotaccent
-Encoding: 379 379 379
+Encoding: 379 379 315
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: zdotaccent
-Encoding: 380 380 380
+Encoding: 380 380 316
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zcaron
-Encoding: 381 381 381
+Encoding: 381 381 317
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: zcaron
-Encoding: 382 382 382
+Encoding: 382 382 318
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: longs
-Encoding: 383 383 383
+Encoding: 383 383 319
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19089,8 +19414,9 @@ SplineSet
  739 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0180
-Encoding: 384 384 384
+Encoding: 384 384 320
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -19131,8 +19457,9 @@ SplineSet
  850 395 850 395 850 557 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0181
-Encoding: 385 385 385
+Encoding: 385 385 321
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19240,16 +19567,18 @@ SplineSet
  168 1495 168 1495 396 1495 c 2,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0182
-Encoding: 386 386 386
+Encoding: 386 386 322
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1041 1041 N 1 0 0 1 0 0 2
+Refer: 855 1041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0183
-Encoding: 387 387 387
+Encoding: 387 387 323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19280,8 +19609,9 @@ SplineSet
  850 395 850 395 850 557 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni0184
-Encoding: 388 388 388
+Encoding: 388 388 324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19308,8 +19638,9 @@ SplineSet
  205 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0185
-Encoding: 389 389 389
+Encoding: 389 389 325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19341,8 +19672,9 @@ SplineSet
  487 961 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0186
-Encoding: 390 390 390
+Encoding: 390 390 326
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19420,8 +19752,9 @@ SplineSet
  152 1448 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0187
-Encoding: 391 391 391
+Encoding: 391 391 327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19450,8 +19783,9 @@ SplineSet
  766.65 236 766.65 236 786 236 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0188
-Encoding: 392 392 392
+Encoding: 392 392 328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19482,16 +19816,18 @@ SplineSet
  701.699 211 701.699 211 762 211 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0189
-Encoding: 393 393 393
+Encoding: 393 393 329
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni018A
-Encoding: 394 394 394
+Encoding: 394 394 330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19510,7 +19846,7 @@ SplineSet
  884 1493 884 1493 1045 1318.5 c 0,17,18
  1206 1144 1206 1144 1206 748 c 0,19,20
  1206 351 1206 351 1045 175.5 c 0,21,22
- 884 4.57764e-05 884 4.57764e-05 518 0 c 2,23,-1
+ 884 4.57764e-005 884 4.57764e-005 518 0 c 2,23,-1
  282 0 l 1,24,-1
  282 1206 l 1,0,1
 577 1227 m 1,25,-1
@@ -19521,8 +19857,9 @@ SplineSet
  751 1227 751 1227 577 1227 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018B
-Encoding: 395 395 395
+Encoding: 395 395 331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19553,8 +19890,9 @@ SplineSet
  207 1494 l 25,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018C
-Encoding: 396 396 396
+Encoding: 396 396 332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19585,8 +19923,9 @@ SplineSet
  443 719 443 719 443 557 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni018D
-Encoding: 397 397 397
+Encoding: 397 397 333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19626,8 +19965,9 @@ SplineSet
  510 209 510 209 616 209 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni018E
-Encoding: 398 398 398
+Encoding: 398 398 334
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19693,8 +20033,9 @@ SplineSet
  1098 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018F
-Encoding: 399 399 399
+Encoding: 399 399 335
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19788,8 +20129,9 @@ SplineSet
  405.335 580 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0190
-Encoding: 400 400 400
+Encoding: 400 400 336
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19879,7 +20221,7 @@ SplineSet
  548 668 548 668 478 605.5 c 128,-1,24
  408 543 408 543 408 428 c 0,25,26
  408 334 408 334 478 278.5 c 128,-1,27
- 548 223 548 223 668 223 c 0,28,29
+ 548 223 548 223 668 223 c 256,28,29
  788 223 788 223 897 247.5 c 128,-1,30
  1006 272 1006 272 1100 319 c 1,31,-1
  1100 45 l 1,32,33
@@ -19891,8 +20233,9 @@ SplineSet
  293 777 293 777 453 805 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0191
-Encoding: 401 401 401
+Encoding: 401 401 337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19919,8 +20262,9 @@ SplineSet
  1124.75 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: florin
-Encoding: 402 402 402
+Encoding: 402 402 338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19952,8 +20296,9 @@ SplineSet
  801.682 1332.36 801.682 1332.36 798 1218 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0193
-Encoding: 403 403 403
+Encoding: 403 403 339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -19988,14 +20333,15 @@ SplineSet
  603.034 236 603.034 236 658 236 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0194
-Encoding: 404 404 404
+Encoding: 404 404 340
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-616 510 m 1,3,-1
+616 510 m 1025,3,-1
 431.3 762 m 1,0,0
  32.9004 1493 l 1,7,-1
  354.5 1493 l 1,8,-1
@@ -20014,8 +20360,9 @@ SplineSet
  749.7 278.899 749.7 278.899 616.1 510 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0195
-Encoding: 405 405 405
+Encoding: 405 405 341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20052,8 +20399,9 @@ SplineSet
  1221 569 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0196
-Encoding: 406 406 406
+Encoding: 406 406 342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20076,8 +20424,9 @@ SplineSet
  470 238 470 238 470 462 c 10,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0197
-Encoding: 407 407 407
+Encoding: 407 407 343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20106,8 +20455,9 @@ SplineSet
  172 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0198
-Encoding: 408 408 408
+Encoding: 408 408 344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20133,8 +20483,9 @@ SplineSet
  873.53 1197.05 873.53 1197.05 763.75 1060 c 2,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0199
-Encoding: 409 409 409
+Encoding: 409 409 345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20163,8 +20514,9 @@ SplineSet
  174 1089 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019A
-Encoding: 410 410 410
+Encoding: 410 410 346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20195,8 +20547,9 @@ SplineSet
  690 753 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019B
-Encoding: 411 411 411
+Encoding: 411 411 347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20221,8 +20574,9 @@ SplineSet
  768 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019C
-Encoding: 412 412 412
+Encoding: 412 412 348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20258,14 +20612,15 @@ SplineSet
  559 54 559 54 547 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019D
-Encoding: 413 413 413
+Encoding: 413 413 349
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-468.857 -6.61675e-07 m 1,0,1
+468.857 -6.61675e-007 m 1,0,1
  459.718 -284.361 459.718 -284.361 312.49 -374.341 c 0,2,3
  227.966 -426 227.966 -426 78.5 -426 c 2,4,-1
  30.5 -426 l 1,5,-1
@@ -20282,11 +20637,12 @@ SplineSet
  887.5 0 l 1,18,-1
  469.5 1085 l 1,19,-1
  469.5 0 l 1,20,-1
- 468.857 -6.61675e-07 l 1,0,1
+ 468.857 -6.61675e-007 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019E
-Encoding: 414 414 414
+Encoding: 414 414 350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20311,8 +20667,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019F
-Encoding: 415 415 415
+Encoding: 415 415 351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20341,26 +20698,29 @@ SplineSet
  822.087 449.395 822.087 449.395 832 651 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: Ohorn
-Encoding: 416 416 416
+Encoding: 416 416 352
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 412 388 2
-Refer: 79 79 N 1 0 0 1 -88 0 2
+Refer: 682 795 N 1 0 0 1 412 388 2
+Refer: 48 79 N 1 0 0 1 -88 0 2
 EndChar
+
 StartChar: ohorn
-Encoding: 417 417 417
+Encoding: 417 417 353
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 407 0 2
-Refer: 111 111 N 1 0 0 1 -89 0 2
+Refer: 682 795 N 1 0 0 1 407 0 2
+Refer: 80 111 N 1 0 0 1 -89 0 2
 EndChar
+
 StartChar: uni01A2
-Encoding: 418 418 418
+Encoding: 418 418 354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20390,8 +20750,9 @@ SplineSet
  306 906.926 306 906.926 306 745 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni01A3
-Encoding: 419 419 419
+Encoding: 419 419 355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20421,8 +20782,9 @@ SplineSet
  579.5 909 579.5 909 536 909 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni01A4
-Encoding: 420 420 420
+Encoding: 420 420 356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20456,8 +20818,9 @@ SplineSet
  330 1206 l 1,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni01A5
-Encoding: 421 421 421
+Encoding: 421 421 357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20495,8 +20858,9 @@ SplineSet
  830.782 -29 830.782 -29 729 -29 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni01A6
-Encoding: 422 422 422
+Encoding: 422 422 358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20531,8 +20895,9 @@ SplineSet
  428 1007 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A7
-Encoding: 423 423 423
+Encoding: 423 423 359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20569,8 +20934,9 @@ SplineSet
  952 740 952 740 729 655 c 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A8
-Encoding: 424 424 424
+Encoding: 424 424 360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20607,16 +20973,18 @@ SplineSet
  248 1085 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A9
-Encoding: 425 425 425
+Encoding: 425 425 361
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 931 931 N 1 0 0 1 0 0 2
+Refer: 760 931 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01AA
-Encoding: 426 426 426
+Encoding: 426 426 362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20655,8 +21023,9 @@ SplineSet
  327.88 1331 l 2,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni01AB
-Encoding: 427 427 427
+Encoding: 427 427 363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20673,7 +21042,7 @@ SplineSet
  1073 225 l 1,10,-1
  1073 43 l 1,11,-1
  1073 0 l 1,12,-1
- 1072.26 4.2487e-07 l 1,13,14
+ 1072.26 4.2487e-007 l 1,13,14
  1064.72 -214.342 1064.72 -214.342 980 -316 c 0,15,16
  890 -424 890 -424 680 -424 c 2,17,-1
  559 -424 l 1,18,-1
@@ -20691,8 +21060,9 @@ SplineSet
  690 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AC
-Encoding: 428 428 428
+Encoding: 428 428 364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20718,8 +21088,9 @@ SplineSet
  390 1237 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AD
-Encoding: 429 429 429
+Encoding: 429 429 365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20751,8 +21122,9 @@ SplineSet
  399 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AE
-Encoding: 430 430 430
+Encoding: 430 430 366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20775,26 +21147,29 @@ SplineSet
  476.006 -217.982 476.006 -217.982 469 0 c 2,1,-1
 EndSplineSet
 EndChar
+
 StartChar: Uhorn
-Encoding: 431 431 431
+Encoding: 431 431 367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 411 388 2
-Refer: 85 85 N 1 0 0 1 -101 0 2
+Refer: 682 795 N 1 0 0 1 411 388 2
+Refer: 54 85 N 1 0 0 1 -101 0 2
 EndChar
+
 StartChar: uhorn
-Encoding: 432 432 432
+Encoding: 432 432 368
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 408.5 0 2
-Refer: 117 117 N 1 0 0 1 -152.5 0 2
+Refer: 682 795 N 1 0 0 1 408.5 0 2
+Refer: 86 117 N 1 0 0 1 -152.5 0 2
 EndChar
+
 StartChar: uni01B1
-Encoding: 433 433 433
+Encoding: 433 433 369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20827,8 +21202,9 @@ SplineSet
  1143 1249 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B2
-Encoding: 434 434 434
+Encoding: 434 434 370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20854,8 +21230,9 @@ SplineSet
  805 597.435 805 597.435 805 707 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B3
-Encoding: 435 435 435
+Encoding: 435 435 371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20878,8 +21255,9 @@ SplineSet
  1033.8 1239.31 1033.8 1239.31 933.256 1026 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B4
-Encoding: 436 436 436
+Encoding: 436 436 372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20906,8 +21284,9 @@ SplineSet
  968.989 779.428 968.989 779.428 928.15 664 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B5
-Encoding: 437 437 437
+Encoding: 437 437 373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20934,8 +21313,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B6
-Encoding: 438 438 438
+Encoding: 438 438 374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20962,8 +21342,9 @@ SplineSet
  181 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B7
-Encoding: 439 439 439
+Encoding: 439 439 375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20994,8 +21375,9 @@ SplineSet
  1223 574.886 1223 574.886 1223 425 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B8
-Encoding: 440 440 440
+Encoding: 440 440 376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21025,8 +21407,9 @@ SplineSet
  555.369 234 555.369 234 641 234 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B9
-Encoding: 441 441 441
+Encoding: 441 441 377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21057,8 +21440,9 @@ SplineSet
  922 452 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BA
-Encoding: 442 442 442
+Encoding: 442 442 378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21097,8 +21481,9 @@ SplineSet
  792 546 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BB
-Encoding: 443 443 443
+Encoding: 443 443 379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21137,8 +21522,9 @@ SplineSet
  434 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BC
-Encoding: 444 444 444
+Encoding: 444 444 380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21170,8 +21556,9 @@ SplineSet
  324 646 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BD
-Encoding: 445 445 445
+Encoding: 445 445 381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21202,8 +21589,9 @@ SplineSet
  620 452 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BE
-Encoding: 446 446 446
+Encoding: 446 446 382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21238,8 +21626,9 @@ SplineSet
  686 1078 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BF
-Encoding: 447 447 447
+Encoding: 447 447 383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21264,8 +21653,9 @@ SplineSet
  396 145 l 17,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni01C0
-Encoding: 448 448 448
+Encoding: 448 448 384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21278,17 +21668,19 @@ SplineSet
  483 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C1
-Encoding: 449 449 449
+Encoding: 449 449 385
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 448 448 N 1 0 0 1 229 0 2
-Refer: 448 448 N 1 0 0 1 -229 0 2
+Refer: 384 448 N 1 0 0 1 229 0 2
+Refer: 384 448 N 1 0 0 1 -229 0 2
 EndChar
+
 StartChar: uni01C2
-Encoding: 450 450 450
+Encoding: 450 450 386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21317,393 +21709,440 @@ SplineSet
  483 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C3
-Encoding: 451 451 451
+Encoding: 451 451 387
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 0 0 2
+Refer: 2 33 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01C4
-Encoding: 452 452 452
+Encoding: 452 452 388
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C5
-Encoding: 453 453 453
+Encoding: 453 453 389
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C6
-Encoding: 454 454 454
+Encoding: 454 454 390
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C7
-Encoding: 455 455 455
+Encoding: 455 455 391
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C8
-Encoding: 456 456 456
+Encoding: 456 456 392
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C9
-Encoding: 457 457 457
+Encoding: 457 457 393
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CA
-Encoding: 458 458 458
+Encoding: 458 458 394
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CB
-Encoding: 459 459 459
+Encoding: 459 459 395
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CC
-Encoding: 460 460 460
+Encoding: 460 460 396
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CD
-Encoding: 461 461 461
+Encoding: 461 461 397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CE
-Encoding: 462 462 462
+Encoding: 462 462 398
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CF
-Encoding: 463 463 463
+Encoding: 463 463 399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D0
-Encoding: 464 464 464
+Encoding: 464 464 400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D1
-Encoding: 465 465 465
+Encoding: 465 465 401
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D2
-Encoding: 466 466 466
+Encoding: 466 466 402
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D3
-Encoding: 467 467 467
+Encoding: 467 467 403
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D4
-Encoding: 468 468 468
+Encoding: 468 468 404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D5
-Encoding: 469 469 469
+Encoding: 469 469 405
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 245 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 713 713 N 1 0 0 1 0 461 2
+Refer: 3666 -1 N 1 0 0 1 0 245 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 461 2
 EndChar
+
 StartChar: uni01D6
-Encoding: 470 470 470
+Encoding: 470 470 406
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 315 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 315 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01D7
-Encoding: 471 471 471
+Encoding: 471 471 407
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 245 2
-Refer: 1114115 -1 N 1 0 0 1 0 538 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 245 2
+Refer: 3667 -1 N 1 0 0 1 0 538 2
 EndChar
+
 StartChar: uni01D8
-Encoding: 472 472 472
+Encoding: 472 472 408
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 415 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01D9
-Encoding: 473 473 473
+Encoding: 473 473 409
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 245 2
-Refer: 1114119 -1 N 1 0 0 1 0 538 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 245 2
+Refer: 3671 -1 N 1 0 0 1 0 538 2
 EndChar
+
 StartChar: uni01DA
-Encoding: 474 474 474
+Encoding: 474 474 410
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 780 780 N 1 0 0 1 0 415 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 667 780 N 1 0 0 1 0 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DB
-Encoding: 475 475 475
+Encoding: 475 475 411
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 245 2
-Refer: 1114117 -1 N 1 0 0 1 0 538 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 245 2
+Refer: 3669 -1 N 1 0 0 1 0 538 2
 EndChar
+
 StartChar: uni01DC
-Encoding: 476 476 476
+Encoding: 476 476 412
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 0 415 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 655 768 N 1 0 0 1 0 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DD
-Encoding: 477 477 477
+Encoding: 477 477 413
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01DE
-Encoding: 478 478 478
+Encoding: 478 478 414
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 277 2
-Refer: 713 713 N 1 0 0 1 0 461 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 277 2
+Refer: 625 713 N 1 0 0 1 0 461 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DF
-Encoding: 479 479 479
+Encoding: 479 479 415
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 315 2
-Refer: 228 228 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 315 2
+Refer: 164 228 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E0
-Encoding: 480 480 480
+Encoding: 480 480 416
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 -96 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 713 713 N 1 0 0 1 0 461 2
+Refer: 3675 -1 N 1 0 0 1 0 -96 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 461 2
 EndChar
+
 StartChar: uni01E1
-Encoding: 481 481 481
+Encoding: 481 481 417
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 0 315 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 315 2
 EndChar
+
 StartChar: uni01E2
-Encoding: 482 482 482
+Encoding: 482 482 418
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 143 0 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 143 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E3
-Encoding: 483 483 483
+Encoding: 483 483 419
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcaron
-Encoding: 486 486 486
+Encoding: 486 486 420
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 121 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 121 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcaron
-Encoding: 487 487 487
+Encoding: 487 487 421
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 -20 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 -20 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E8
-Encoding: 488 488 488
+Encoding: 488 488 422
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E9
-Encoding: 489 489 489
+Encoding: 489 489 423
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EA
-Encoding: 490 490 490
+Encoding: 490 490 424
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 -11.5 -15.6333 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 -11.5 -15.6333 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EB
-Encoding: 491 491 491
+Encoding: 491 491 425
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 -11.5 -15.6333 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 -11.5 -15.6333 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EC
-Encoding: 492 492 492
+Encoding: 492 492 426
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 490 490 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 424 490 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01ED
-Encoding: 493 493 493
+Encoding: 493 493 427
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 491 491 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 425 491 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EE
-Encoding: 494 494 494
+Encoding: 494 494 428
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EF
-Encoding: 495 495 495
+Encoding: 495 495 429
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F0
-Encoding: 496 496 496
+Encoding: 496 496 430
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 17 5 2
-Refer: 567 567 N 1 0 0 1 0 0 3
+Refer: 623 711 N 1 0 0 1 17 5 2
+Refer: 493 567 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01F4
-Encoding: 500 500 500
+Encoding: 500 500 431
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 121 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 121 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F5
-Encoding: 501 501 501
+Encoding: 501 501 432
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -20 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -20 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F6
-Encoding: 502 502 502
+Encoding: 502 502 433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21735,312 +22174,347 @@ SplineSet
  25 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01F8
-Encoding: 504 504 504
+Encoding: 504 504 434
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F9
-Encoding: 505 505 505
+Encoding: 505 505 435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 -4 2 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 655 768 N 1 0 0 1 -4 2 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: AEacute
-Encoding: 508 508 508
+Encoding: 508 508 436
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 220 373 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 220 373 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aeacute
-Encoding: 509 509 509
+Encoding: 509 509 437
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Oslashacute
-Encoding: 510 510 510
+Encoding: 510 510 438
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 216 216 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
+Refer: 152 216 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: oslashacute
-Encoding: 511 511 511
+Encoding: 511 511 439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 248 248 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 2 1 2
+Refer: 184 248 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 2 1 2
 EndChar
+
 StartChar: uni0200
-Encoding: 512 512 512
+Encoding: 512 512 440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0201
-Encoding: 513 513 513
+Encoding: 513 513 441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0202
-Encoding: 514 514 514
+Encoding: 514 514 442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0203
-Encoding: 515 515 515
+Encoding: 515 515 443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0204
-Encoding: 516 516 516
+Encoding: 516 516 444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0205
-Encoding: 517 517 517
+Encoding: 517 517 445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni0206
-Encoding: 518 518 518
+Encoding: 518 518 446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0207
-Encoding: 519 519 519
+Encoding: 519 519 447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni0208
-Encoding: 520 520 520
+Encoding: 520 520 448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0209
-Encoding: 521 521 521
+Encoding: 521 521 449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020A
-Encoding: 522 522 522
+Encoding: 522 522 450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020B
-Encoding: 523 523 523
+Encoding: 523 523 451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020C
-Encoding: 524 524 524
+Encoding: 524 524 452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020D
-Encoding: 525 525 525
+Encoding: 525 525 453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020E
-Encoding: 526 526 526
+Encoding: 526 526 454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020F
-Encoding: 527 527 527
+Encoding: 527 527 455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0210
-Encoding: 528 528 528
+Encoding: 528 528 456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni0211
-Encoding: 529 529 529
+Encoding: 529 529 457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 100 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni0212
-Encoding: 530 530 530
+Encoding: 530 530 458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni0213
-Encoding: 531 531 531
+Encoding: 531 531 459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 100 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni0214
-Encoding: 532 532 532
+Encoding: 532 532 460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3677 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0215
-Encoding: 533 533 533
+Encoding: 533 533 461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0216
-Encoding: 534 534 534
+Encoding: 534 534 462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3673 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0217
-Encoding: 535 535 535
+Encoding: 535 535 463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scommaaccent
-Encoding: 536 536 536
+Encoding: 536 536 464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scommaaccent
-Encoding: 537 537 537
+Encoding: 537 537 465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021A
-Encoding: 538 538 538
+Encoding: 538 538 466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021B
-Encoding: 539 539 539
+Encoding: 539 539 467
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 103 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 103 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021C
-Encoding: 540 540 540
+Encoding: 540 540 468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22089,8 +22563,9 @@ SplineSet
  1144 821 1144 821 861 674 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021D
-Encoding: 541 541 541
+Encoding: 541 541 469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22137,26 +22612,29 @@ SplineSet
  945 513 945 513 837 461 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021E
-Encoding: 542 542 542
+Encoding: 542 542 470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021F
-Encoding: 543 543 543
+Encoding: 543 543 471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3671 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0220
-Encoding: 544 544 544
+Encoding: 544 544 472
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22183,8 +22661,9 @@ SplineSet
  1125 1231 1125 1231 1125 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0221
-Encoding: 545 545 545
+Encoding: 545 545 473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22226,8 +22705,9 @@ SplineSet
  301.145 719 301.145 719 301.145 557 c 128,-1,39
 EndSplineSet
 EndChar
+
 StartChar: uni0224
-Encoding: 548 548 548
+Encoding: 548 548 474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22239,14 +22719,14 @@ SplineSet
  455 260 l 1,3,-1
  1161 260 l 1,4,-1
  1161 0 l 1,5,-1
- 1160.29 3.04071e-07 l 1,6,7
+ 1160.29 3.04071e-007 l 1,6,7
  1152.97 -216.441 1152.97 -216.441 1070 -316 c 0,8,9
  979.997 -424 979.997 -424 770 -424 c 2,10,-1
  649 -424 l 1,11,-1
  649 -199 l 1,12,-1
  688 -199 l 2,13,14
  786.142 -199 786.142 -199 829 -144 c 0,15,16
- 863.086 -100.257 863.086 -100.257 868.834 -3.05994e-07 c 1,17,-1
+ 863.086 -100.257 863.086 -100.257 868.834 -3.05994e-007 c 1,17,-1
  115 0 l 1,18,-1
  115 244 l 1,19,-1
  786 1233 l 1,20,-1
@@ -22254,8 +22734,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0225
-Encoding: 549 549 549
+Encoding: 549 549 475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22267,14 +22748,14 @@ SplineSet
  492 219 l 1,3,-1
  1081 219 l 1,4,-1
  1081 0 l 1,5,-1
- 1080.29 -5.80299e-07 l 1,6,7
+ 1080.29 -5.80299e-007 l 1,6,7
  1072.97 -216.441 1072.97 -216.441 990 -316 c 0,8,9
  899.997 -424 899.997 -424 690 -424 c 2,10,-1
  569 -424 l 1,11,-1
  569 -199 l 1,12,-1
  608 -199 l 2,13,14
  706.142 -199 706.142 -199 749 -144 c 0,15,16
- 783.086 -100.257 783.086 -100.257 788.834 3.89115e-07 c 1,17,-1
+ 783.086 -100.257 783.086 -100.257 788.834 3.89115e-007 c 1,17,-1
  162 0 l 1,18,-1
  162 229 l 1,19,-1
  752 901 l 1,20,-1
@@ -22282,131 +22763,146 @@ SplineSet
  186 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0226
-Encoding: 550 550 550
+Encoding: 550 550 476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0227
-Encoding: 551 551 551
+Encoding: 551 551 477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0228
-Encoding: 552 552 552
+Encoding: 552 552 478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni0229
-Encoding: 553 553 553
+Encoding: 553 553 479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni022A
-Encoding: 554 554 554
+Encoding: 554 554 480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 277 2
-Refer: 713 713 N 1 0 0 1 0 461 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 277 2
+Refer: 625 713 N 1 0 0 1 0 461 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022B
-Encoding: 555 555 555
+Encoding: 555 555 481
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 315 2
-Refer: 246 246 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 315 2
+Refer: 182 246 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022C
-Encoding: 556 556 556
+Encoding: 556 556 482
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 277 2
-Refer: 713 713 N 1 0 0 1 0 461 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 277 2
+Refer: 625 713 N 1 0 0 1 0 461 2
 EndChar
+
 StartChar: uni022D
-Encoding: 557 557 557
+Encoding: 557 557 483
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 -0.5 315 2
-Refer: 245 245 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 -0.5 315 2
+Refer: 181 245 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022E
-Encoding: 558 558 558
+Encoding: 558 558 484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022F
-Encoding: 559 559 559
+Encoding: 559 559 485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0230
-Encoding: 560 560 560
+Encoding: 560 560 486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 -96 2
-Refer: 713 713 N 1 0 0 1 0 461 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 -96 2
+Refer: 625 713 N 1 0 0 1 0 461 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0231
-Encoding: 561 561 561
+Encoding: 561 561 487
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 -0.5 315 2
-Refer: 559 559 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 -0.5 315 2
+Refer: 485 559 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0232
-Encoding: 562 562 562
+Encoding: 562 562 488
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0233
-Encoding: 563 563 563
+Encoding: 563 563 489
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0234
-Encoding: 564 564 564
+Encoding: 564 564 490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22437,8 +22933,9 @@ SplineSet
  708.623 212.699 708.623 212.699 750.739 200.316 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0235
-Encoding: 565 565 565
+Encoding: 565 565 491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22478,8 +22975,9 @@ SplineSet
  816.356 270 816.356 270 865.591 248 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0236
-Encoding: 566 566 566
+Encoding: 566 566 492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22515,8 +23013,9 @@ SplineSet
  688 438 l 2,5,6
 EndSplineSet
 EndChar
+
 StartChar: dotlessj
-Encoding: 567 567 567
+Encoding: 567 567 493
 Width: 1233
 Flags: W
 TtInstrs:
@@ -22585,8 +23084,9 @@ SplineSet
  850 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0238
-Encoding: 568 568 568
+Encoding: 568 568 494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22635,8 +23135,9 @@ SplineSet
  718.7 961 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0239
-Encoding: 569 569 569
+Encoding: 569 569 495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22685,8 +23186,9 @@ SplineSet
  514.3 157 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni023A
-Encoding: 570 570 570
+Encoding: 570 570 496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22704,9 +23206,9 @@ SplineSet
  461.295 369 l 1,9,-1
  395.183 275.449 l 1,10,-1
  328 0 l 1,11,-1
- 200.522 1.4766e-14 l 1,12,-1
+ 200.522 1.4766e-014 l 1,12,-1
  156 -63 l 1,13,-1
- 66.4737 2.9976e-15 l 1,14,-1
+ 66.4737 2.9976e-015 l 1,14,-1
  33 0 l 1,15,-1
  38.3433 19.7954 l 1,16,-1
  -6 51 l 1,17,-1
@@ -22722,8 +23224,9 @@ SplineSet
  633.024 612 l 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023B
-Encoding: 571 571 571
+Encoding: 571 571 497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22761,8 +23264,9 @@ SplineSet
  1081 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023C
-Encoding: 572 572 572
+Encoding: 572 572 498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22799,8 +23303,9 @@ SplineSet
  465 541.899 465 541.899 465.798 525.607 c 1,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023D
-Encoding: 573 573 573
+Encoding: 573 573 499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22823,8 +23328,9 @@ SplineSet
  278.5 730 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023E
-Encoding: 574 574 574
+Encoding: 574 574 500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22853,8 +23359,9 @@ SplineSet
  764 1115.8 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023F
-Encoding: 575 575 575
+Encoding: 575 575 501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22898,8 +23405,9 @@ SplineSet
  902 1116 902 1116 991 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0240
-Encoding: 576 576 576
+Encoding: 576 576 502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22917,15 +23425,16 @@ SplineSet
  918 -492 l 2,11,12
  638.027 -492 638.027 -492 507.546 -319.186 c 2,13,-1
  331.596 -86.1494 l 2,14,15
- 266.55 1.52588e-05 266.55 1.52588e-05 162 0 c 1,16,-1
+ 266.55 1.52588e-005 266.55 1.52588e-005 162 0 c 1,16,-1
  162 229 l 1,17,-1
  752 901 l 1,18,-1
  186 901 l 1,19,-1
  186 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0241
-Encoding: 577 577 577
+Encoding: 577 577 503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22958,8 +23467,9 @@ SplineSet
  457.869 1213.45 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0243
-Encoding: 579 579 579
+Encoding: 579 579 504
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -23005,8 +23515,9 @@ SplineSet
  410 338 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0244
-Encoding: 580 580 580
+Encoding: 580 580 505
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -23042,8 +23553,9 @@ SplineSet
  831 538 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0245
-Encoding: 581 581 581
+Encoding: 581 581 506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23059,8 +23571,9 @@ SplineSet
  617 1247 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024C
-Encoding: 588 588 588
+Encoding: 588 588 507
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -23099,8 +23612,9 @@ SplineSet
  491 1245 l 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024D
-Encoding: 589 589 589
+Encoding: 589 589 508
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -23134,8 +23648,9 @@ SplineSet
  1151 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0250
-Encoding: 592 592 592
+Encoding: 592 592 509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23173,8 +23688,9 @@ SplineSet
  110 193 110 193 110 479 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0251
-Encoding: 593 593 593
+Encoding: 593 593 510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23205,8 +23721,9 @@ SplineSet
  413 719 413 719 413 557 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0252
-Encoding: 594 594 594
+Encoding: 594 594 511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23237,8 +23754,9 @@ SplineSet
  820 399 820 399 820 561 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0253
-Encoding: 595 595 595
+Encoding: 595 595 512
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23303,15 +23821,15 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-850 557 m 0,0,1
+850 557 m 256,0,1
  850 719 850 719 796 811 c 128,-1,2
- 742 903 742 903 647 903 c 0,3,4
+ 742 903 742 903 647 903 c 256,3,4
  552 903 552 903 497 811 c 128,-1,5
- 442 719 442 719 442 557 c 0,6,7
+ 442 719 442 719 442 557 c 256,6,7
  442 395 442 395 497 303 c 128,-1,8
- 552 211 552 211 647 211 c 0,9,10
+ 552 211 552 211 647 211 c 256,9,10
  742 211 742 211 796 303 c 128,-1,11
- 850 395 850 395 850 557 c 0,0,1
+ 850 395 850 395 850 557 c 256,0,1
 442 961 m 1,12,13
  496 1054 496 1054 567.5 1100.5 c 128,-1,14
  639 1147 639 1147 729 1147 c 0,15,16
@@ -23334,8 +23852,9 @@ SplineSet
  442 961 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0254
-Encoding: 596 596 596
+Encoding: 596 596 513
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23405,7 +23924,7 @@ SplineSet
  236 270 236 270 312.5 240.5 c 128,-1,15
  389 211 389 211 471 211 c 0,16,17
  614 211 614 211 691 302 c 128,-1,18
- 768 393 768 393 768 561 c 0,19,20
+ 768 393 768 393 768 561 c 256,19,20
  768 729 768 729 691 819 c 128,-1,21
  614 909 614 909 471 909 c 0,22,23
  386 909 386 909 312 880.5 c 128,-1,24
@@ -23413,8 +23932,9 @@ SplineSet
  172 1063 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0255
-Encoding: 597 597 597
+Encoding: 597 597 514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23450,8 +23970,9 @@ SplineSet
  459 405.349 459 405.349 506.807 333.653 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0256
-Encoding: 598 598 598
+Encoding: 598 598 515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23488,8 +24009,9 @@ SplineSet
  649 1054 649 1054 692 961 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0257
-Encoding: 599 599 599
+Encoding: 599 599 516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23526,8 +24048,9 @@ SplineSet
  988.6 1221.66 988.6 1221.66 988.6 1088 c 2,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0258
-Encoding: 600 600 600
+Encoding: 600 600 517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23557,8 +24080,9 @@ SplineSet
  385 801 385 801 383 685 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni0259
-Encoding: 601 601 601
+Encoding: 601 601 518
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23654,8 +24178,9 @@ SplineSet
  387 433 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni025A
-Encoding: 602 602 602
+Encoding: 602 602 519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23697,8 +24222,9 @@ SplineSet
  869 736 l 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni025B
-Encoding: 603 603 603
+Encoding: 603 603 520
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23800,8 +24326,9 @@ SplineSet
  149 150 149 150 149 312 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025C
-Encoding: 604 604 604
+Encoding: 604 604 521
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23927,8 +24454,9 @@ SplineSet
  949 599 949 599 809 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025D
-Encoding: 605 605 605
+Encoding: 605 605 522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23977,8 +24505,9 @@ SplineSet
  650 590 650 590 579 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025E
-Encoding: 606 606 606
+Encoding: 606 606 523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24013,8 +24542,9 @@ SplineSet
  108 948 108 948 409 1099 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni025F
-Encoding: 607 607 607
+Encoding: 607 607 524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24043,8 +24573,9 @@ SplineSet
  850 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0260
-Encoding: 608 608 608
+Encoding: 608 608 525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24090,8 +24621,9 @@ SplineSet
  691 190 l 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0261
-Encoding: 609 609 609
+Encoding: 609 609 526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24128,8 +24660,9 @@ SplineSet
  621 887 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0262
-Encoding: 610 610 610
+Encoding: 610 610 527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24160,8 +24693,9 @@ SplineSet
  1079 101 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0263
-Encoding: 611 611 611
+Encoding: 611 611 528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24185,8 +24719,9 @@ SplineSet
  784 95 784 95 615 369 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0264
-Encoding: 612 612 612
+Encoding: 612 612 529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24210,8 +24745,9 @@ SplineSet
  280 344 280 344 437 586 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0265
-Encoding: 613 613 613
+Encoding: 613 613 530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24236,8 +24772,9 @@ SplineSet
  167 182 167 182 167 391 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0266
-Encoding: 614 614 614
+Encoding: 614 614 531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24268,8 +24805,9 @@ SplineSet
  1066 936 1066 936 1066 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0267
-Encoding: 615 615 615
+Encoding: 615 615 532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24296,7 +24834,7 @@ SplineSet
  639 1147 639 1147 745 1147 c 0,28,29
  904 1147 904 1147 985 1042 c 0,30,31
  1066 936 1066 936 1066 727 c 2,32,-1
- 1065.37 8.693e-09 l 2,33,34
+ 1065.37 8.693e-009 l 2,33,34
  1058.42 -219.918 1058.42 -219.918 975 -318 c 0,35,36
  885 -426 885 -426 675 -426 c 2,37,-1
  554 -426 l 1,38,-1
@@ -24306,8 +24844,9 @@ SplineSet
  775 -91 775 -91 775 41 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0268
-Encoding: 616 616 616
+Encoding: 616 616 533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24339,8 +24878,9 @@ SplineSet
  184 1120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0269
-Encoding: 617 617 617
+Encoding: 617 617 534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24361,8 +24901,9 @@ SplineSet
  430 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026A
-Encoding: 618 618 618
+Encoding: 618 618 535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24383,8 +24924,9 @@ SplineSet
  764 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026B
-Encoding: 619 619 619
+Encoding: 619 619 536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24421,8 +24963,9 @@ SplineSet
  1072 747 1072 747 1144 811 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026C
-Encoding: 620 620 620
+Encoding: 620 620 537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24458,8 +25001,9 @@ SplineSet
  711 579.043 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026D
-Encoding: 621 621 621
+Encoding: 621 621 538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24480,8 +25024,9 @@ SplineSet
  412 -228 412 -228 412 23 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026E
-Encoding: 622 622 622
+Encoding: 622 622 539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24524,8 +25069,9 @@ SplineSet
  597.75 452 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026F
-Encoding: 623 623 623
+Encoding: 623 623 540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24561,8 +25107,9 @@ SplineSet
  557 54 557 54 545 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0270
-Encoding: 624 624 624
+Encoding: 624 624 541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24598,8 +25145,9 @@ SplineSet
  557 54 557 54 545 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0271
-Encoding: 625 625 625
+Encoding: 625 625 542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24641,8 +25189,9 @@ SplineSet
  676.329 1064.89 676.329 1064.89 688 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0272
-Encoding: 626 626 626
+Encoding: 626 626 543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24679,8 +25228,9 @@ SplineSet
  1169 909 1169 909 1169 682 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0273
-Encoding: 627 627 627
+Encoding: 627 627 544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24712,8 +25262,9 @@ SplineSet
  695 722 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0274
-Encoding: 628 628 628
+Encoding: 628 628 545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24732,8 +25283,9 @@ SplineSet
  120 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0275
-Encoding: 629 629 629
+Encoding: 629 629 546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24764,8 +25316,9 @@ SplineSet
  817.782 357.163 817.782 357.163 832.23 438 c 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0276
-Encoding: 630 630 630
+Encoding: 630 630 547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24801,8 +25354,9 @@ SplineSet
  569 1120 569 1120 575 1120 c 2,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0277
-Encoding: 631 631 631
+Encoding: 631 631 548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24837,8 +25391,9 @@ SplineSet
  973 1176 973 1176 1109 828 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0278
-Encoding: 632 632 632
+Encoding: 632 632 549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24885,8 +25440,9 @@ SplineSet
  798.395 849.886 798.395 849.886 763 871.425 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0279
-Encoding: 633 633 633
+Encoding: 633 633 550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24911,8 +25467,9 @@ SplineSet
  186 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027A
-Encoding: 634 634 634
+Encoding: 634 634 551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24937,8 +25494,9 @@ SplineSet
  186 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027B
-Encoding: 635 635 635
+Encoding: 635 635 552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24953,14 +25511,14 @@ SplineSet
  644 494 644 494 644 604 c 2,12,-1
  644 1120 l 1,13,-1
  937 1120 l 1,14,-1
- 936.09 -1.28079e-08 l 2,15,16
+ 936.09 -1.28079e-008 l 2,15,16
  936.015 -92.3621 936.015 -92.3621 976 -146 c 0,17,18
  1017 -201 1017 -201 1117 -201 c 2,19,-1
  1156 -201 l 1,20,-1
  1156 -426 l 1,21,-1
  1035 -426 l 2,22,23
  825 -426 825 -426 735 -318 c 0,24,25
- 651.585 -219.918 651.585 -219.918 644.632 6.79007e-07 c 1,26,-1
+ 651.585 -219.918 651.585 -219.918 644.632 6.79007e-007 c 1,26,-1
  644 0 l 1,27,-1
  644 41 l 1,28,-1
  644 174 l 1,29,30
@@ -24971,8 +25529,9 @@ SplineSet
  77 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027C
-Encoding: 636 636 636
+Encoding: 636 636 553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24997,8 +25556,9 @@ SplineSet
  1046 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027D
-Encoding: 637 637 637
+Encoding: 637 637 554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25029,8 +25589,9 @@ SplineSet
  1046 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027E
-Encoding: 638 638 638
+Encoding: 638 638 555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25053,8 +25614,9 @@ SplineSet
  136 0 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni027F
-Encoding: 639 639 639
+Encoding: 639 639 556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25077,8 +25639,9 @@ SplineSet
  136 0 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0280
-Encoding: 640 640 640
+Encoding: 640 640 557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25116,8 +25679,9 @@ SplineSet
  414 894 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0281
-Encoding: 641 641 641
+Encoding: 641 641 558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25150,8 +25714,9 @@ SplineSet
  423 711 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0282
-Encoding: 642 642 642
+Encoding: 642 642 559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25194,8 +25759,9 @@ SplineSet
  899 1116 899 1116 988 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0283
-Encoding: 643 643 643
+Encoding: 643 643 560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25220,8 +25786,9 @@ SplineSet
  798 0 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0284
-Encoding: 644 644 644
+Encoding: 644 644 561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25229,7 +25796,7 @@ Fore
 SplineSet
 798 438 m 1,0,-1
  798 0 l 1,1,-1
- 797.307 -5.70987e-08 l 1,2,3
+ 797.307 -5.70987e-008 l 1,2,3
  790.08 -218.408 790.08 -218.408 707.5 -316.5 c 0,4,5
  617 -424 617 -424 407 -424 c 2,6,-1
  91 -424 l 1,7,-1
@@ -25259,8 +25826,9 @@ SplineSet
  798 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0285
-Encoding: 645 645 645
+Encoding: 645 645 562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25285,8 +25853,9 @@ SplineSet
  440.936 -216.651 440.936 -216.651 435 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0286
-Encoding: 646 646 646
+Encoding: 646 646 563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25325,8 +25894,9 @@ SplineSet
  327.88 -199 l 2,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0287
-Encoding: 647 647 647
+Encoding: 647 647 564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25353,8 +25923,9 @@ SplineSet
  518 -318 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0288
-Encoding: 648 648 648
+Encoding: 648 648 565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25381,8 +25952,9 @@ SplineSet
  714 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0289
-Encoding: 649 649 649
+Encoding: 649 649 566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25419,8 +25991,9 @@ SplineSet
  770.939 339.766 770.939 339.766 776.867 438 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028A
-Encoding: 650 650 650
+Encoding: 650 650 567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25453,8 +26026,9 @@ SplineSet
  550 837 l 1,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni028B
-Encoding: 651 651 651
+Encoding: 651 651 568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25487,8 +26061,9 @@ SplineSet
  880.511 1115.01 880.511 1115.01 977 1027 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028C
-Encoding: 652 652 652
+Encoding: 652 652 569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25504,8 +26079,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028D
-Encoding: 653 653 653
+Encoding: 653 653 570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25527,8 +26103,9 @@ SplineSet
  1233 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028E
-Encoding: 654 654 654
+Encoding: 654 654 571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25551,8 +26128,9 @@ SplineSet
  523 1241 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028F
-Encoding: 655 655 655
+Encoding: 655 655 572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25570,8 +26148,9 @@ SplineSet
  68 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0290
-Encoding: 656 656 656
+Encoding: 656 656 573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25589,7 +26168,7 @@ SplineSet
  1186 -426 l 1,11,-1
  1066 -426 l 2,12,13
  856 -426 856 -426 766 -318 c 0,14,15
- 681.668 -219.918 681.668 -219.918 674.639 -6.61621e-07 c 1,16,-1
+ 681.668 -219.918 681.668 -219.918 674.639 -6.61621e-007 c 1,16,-1
  46 0 l 1,17,-1
  46 229 l 1,18,-1
  636 901 l 1,19,-1
@@ -25597,8 +26176,9 @@ SplineSet
  70 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0291
-Encoding: 657 657 657
+Encoding: 657 657 574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25629,8 +26209,9 @@ SplineSet
  142 1120 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0292
-Encoding: 658 658 658
+Encoding: 658 658 575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25661,8 +26242,9 @@ SplineSet
  311 452 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0293
-Encoding: 659 659 659
+Encoding: 659 659 576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25702,8 +26284,9 @@ SplineSet
  321 452 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0294
-Encoding: 660 660 660
+Encoding: 660 660 577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25729,8 +26312,9 @@ SplineSet
  344 736 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0295
-Encoding: 661 661 661
+Encoding: 661 661 578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25756,8 +26340,9 @@ SplineSet
  889 736 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0296
-Encoding: 662 662 662
+Encoding: 662 662 579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25783,8 +26368,9 @@ SplineSet
  344 819 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0297
-Encoding: 663 663 663
+Encoding: 663 663 580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25813,8 +26399,9 @@ SplineSet
  481 132 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0298
-Encoding: 664 664 664
+Encoding: 664 664 581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25849,8 +26436,9 @@ SplineSet
  499 513 499 513 499 567 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0299
-Encoding: 665 665 665
+Encoding: 665 665 582
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25906,7 +26494,7 @@ SplineSet
  447 262 l 1,1,-1
  614 262 l 2,2,3
  708 262 708 262 755 287.5 c 128,-1,4
- 802 313 802 313 802 364 c 0,5,6
+ 802 313 802 313 802 364 c 256,5,6
  802 415 802 415 755 440 c 128,-1,7
  708 465 708 465 614 465 c 2,8,-1
  447 465 l 1,0,-1
@@ -25932,8 +26520,9 @@ SplineSet
  119 1120 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029A
-Encoding: 666 666 666
+Encoding: 666 666 583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25968,8 +26557,9 @@ SplineSet
  1125 155 1125 155 824 4 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni029B
-Encoding: 667 667 667
+Encoding: 667 667 584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26006,8 +26596,9 @@ SplineSet
  987 101 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni029C
-Encoding: 668 668 668
+Encoding: 668 668 585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26028,8 +26619,9 @@ SplineSet
  120 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029D
-Encoding: 669 669 669
+Encoding: 669 669 586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26067,8 +26659,9 @@ SplineSet
  659.106 -115.687 659.106 -115.687 669.347 -66.9674 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni029E
-Encoding: 670 670 670
+Encoding: 670 670 587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26089,8 +26682,9 @@ SplineSet
  1128 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029F
-Encoding: 671 671 671
+Encoding: 671 671 588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26105,8 +26699,9 @@ SplineSet
  236 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A0
-Encoding: 672 672 672
+Encoding: 672 672 589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26144,8 +26739,9 @@ SplineSet
  366 723 366 723 366 561 c 128,-1,33
 EndSplineSet
 EndChar
+
 StartChar: uni02A1
-Encoding: 673 673 673
+Encoding: 673 673 590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26181,8 +26777,9 @@ SplineSet
  364 736 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A2
-Encoding: 674 674 674
+Encoding: 674 674 591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26218,8 +26815,9 @@ SplineSet
  547 384 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A3
-Encoding: 675 675 675
+Encoding: 675 675 592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26261,8 +26859,9 @@ SplineSet
  647 901 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A4
-Encoding: 676 676 676
+Encoding: 676 676 593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26315,8 +26914,9 @@ SplineSet
  199 711 199 711 199 549 c 0,56,57
 EndSplineSet
 EndChar
+
 StartChar: uni02A5
-Encoding: 677 677 677
+Encoding: 677 677 594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26370,8 +26970,9 @@ SplineSet
  623 901 l 1,64,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A6
-Encoding: 678 678 678
+Encoding: 678 678 595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26428,8 +27029,9 @@ SplineSet
  641 225 l 1,48,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A7
-Encoding: 679 679 679
+Encoding: 679 679 596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26456,7 +27058,7 @@ SplineSet
  466 -199 l 1,24,-1
  606 -199 l 2,25,26
  665 -199 665 -199 689 -144 c 0,27,28
- 709.714 -98.4299 709.714 -98.4299 713.265 2.80656e-07 c 1,29,-1
+ 709.714 -98.4299 709.714 -98.4299 713.265 2.80656e-007 c 1,29,-1
  566 0 l 2,30,31
  415.167 0 415.167 0 362 80 c 0,32,33
  308 161.254 308 161.254 308 379 c 2,34,-1
@@ -26475,8 +27077,9 @@ SplineSet
  714 225 l 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A8
-Encoding: 680 680 680
+Encoding: 680 680 597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26533,8 +27136,9 @@ SplineSet
  606 758.115 606 758.115 651.739 895 c 1,62,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A9
-Encoding: 681 681 681
+Encoding: 681 681 598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26582,8 +27186,9 @@ SplineSet
  414 1283 414 1283 413 1218 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AA
-Encoding: 682 682 682
+Encoding: 682 682 599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26632,8 +27237,9 @@ SplineSet
  1082 1116 1082 1116 1135 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AB
-Encoding: 683 683 683
+Encoding: 683 683 600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26663,8 +27269,9 @@ SplineSet
  224.5 216 224.5 216 224.5 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AC
-Encoding: 684 684 684
+Encoding: 684 684 601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26700,8 +27307,9 @@ SplineSet
  57 1312 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AD
-Encoding: 685 685 685
+Encoding: 685 685 602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26727,8 +27335,9 @@ SplineSet
  429 862 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AE
-Encoding: 686 686 686
+Encoding: 686 686 603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26760,8 +27369,9 @@ SplineSet
  561.955 1347.71 561.955 1347.71 568 1118 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AF
-Encoding: 687 687 687
+Encoding: 687 687 604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26799,8 +27409,9 @@ SplineSet
  486.578 1346.48 486.578 1346.48 490.732 1118 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B0
-Encoding: 688 688 688
+Encoding: 688 688 605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26825,8 +27436,9 @@ SplineSet
  904 1192 904 1192 904 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B1
-Encoding: 689 689 689
+Encoding: 689 689 606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26857,8 +27469,9 @@ SplineSet
  904 1192 904 1192 904 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B2
-Encoding: 690 690 690
+Encoding: 690 690 607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26884,8 +27497,9 @@ SplineSet
  843 1340 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B3
-Encoding: 691 691 691
+Encoding: 691 691 608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26910,8 +27524,9 @@ SplineSet
  892 1122 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B4
-Encoding: 692 692 692
+Encoding: 692 692 609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26936,8 +27551,9 @@ SplineSet
  341 842 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B5
-Encoding: 693 693 693
+Encoding: 693 693 610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26970,8 +27586,9 @@ SplineSet
  271 841 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B6
-Encoding: 694 694 694
+Encoding: 694 694 611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27004,8 +27621,9 @@ SplineSet
  493 1067 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B7
-Encoding: 695 695 695
+Encoding: 695 695 612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27027,8 +27645,9 @@ SplineSet
  222 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B8
-Encoding: 696 696 696
+Encoding: 696 696 613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27051,39 +27670,44 @@ SplineSet
  676 601 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B9
-Encoding: 697 697 697
+Encoding: 697 697 614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 884 884 N 1 0 0 1 0 0 2
+Refer: 722 884 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BB
-Encoding: 699 699 699
+Encoding: 699 699 615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8216 8216 N 1 0 0 1 0 0 2
+Refer: 1970 8216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BC
-Encoding: 700 700 700
+Encoding: 700 700 616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8217 8217 N 1 0 0 1 0 0 2
+Refer: 1971 8217 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BD
-Encoding: 701 701 701
+Encoding: 701 701 617
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 788 788 N 1 0 0 1 0 0 2
+Refer: 675 788 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BE
-Encoding: 702 702 702
+Encoding: 702 702 618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27102,8 +27726,9 @@ SplineSet
  474 1140 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02BF
-Encoding: 703 703 703
+Encoding: 703 703 619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27122,8 +27747,9 @@ SplineSet
  704 1140 704 1140 759 1140 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02C0
-Encoding: 704 704 704
+Encoding: 704 704 620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27131,26 +27757,27 @@ Fore
 SplineSet
 442 1080 m 9,0,0
  496 1080 l 1,10,11
- 621 1080 621 1080 670 1144 c 128,-1,9
+ 621 1080 621 1080 670 1144 c 0
  703 1187 703 1187 703 1226 c 0,7,8
- 703 1280 703 1280 670 1317 c 128,-1,6
+ 703 1280 703 1280 670 1317 c 0
  613 1381 613 1381 510 1381 c 0,4,5
- 464 1381 464 1381 418 1369 c 128,-1,3
+ 464 1381 464 1381 418 1369 c 0
  373 1357 373 1357 328 1333 c 1,1,2
  328 1500 l 1,0,-1
- 372 1519 372 1519 419 1529 c 128,-1,25
+ 372 1519 372 1519 419 1529 c 0
  465 1539 465 1539 570 1539 c 0,23,24
- 708 1539 708 1539 829 1421 c 128,-1,22
+ 708 1539 708 1539 829 1421 c 0
  905 1347 905 1347 905 1226 c 0,20,21
- 905 1097 905 1097 816 1016 c 128,-1,19
+ 905 1097 905 1097 816 1016 c 0
  757 963 757 963 648 946 c 1,0,0
  648 668 l 1,0,-1
  442 668 l 1,1,-1
  442 1080 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02C1
-Encoding: 705 705 705
+Encoding: 705 705 621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27176,8 +27803,9 @@ SplineSet
  791 1080 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: circumflex
-Encoding: 710 710 710
+Encoding: 710 710 622
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27242,8 +27870,9 @@ SplineSet
  496 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: caron
-Encoding: 711 711 711
+Encoding: 711 711 623
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27308,8 +27937,9 @@ SplineSet
  496 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C8
-Encoding: 712 712 712
+Encoding: 712 712 624
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27343,16 +27973,18 @@ SplineSet
  711.3 1554 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C9
-Encoding: 713 713 713
+Encoding: 713 713 625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CC
-Encoding: 716 716 716
+Encoding: 716 716 626
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27386,32 +28018,36 @@ SplineSet
  711.3 390 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02CD
-Encoding: 717 717 717
+Encoding: 717 717 627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CE
-Encoding: 718 718 718
+Encoding: 718 718 628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni02CF
-Encoding: 719 719 719
+Encoding: 719 719 629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni02D0
-Encoding: 720 720 720
+Encoding: 720 720 630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27427,8 +28063,9 @@ SplineSet
  617 380 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D1
-Encoding: 721 721 721
+Encoding: 721 721 631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27440,24 +28077,27 @@ SplineSet
  616 740 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D2
-Encoding: 722 722 722
+Encoding: 722 722 632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 702 702 N 1 0 0 1 0 -436 2
+Refer: 618 702 N 1 0 0 1 0 -436 2
 EndChar
+
 StartChar: uni02D3
-Encoding: 723 723 723
+Encoding: 723 723 633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 -436 2
+Refer: 619 703 N 1 0 0 1 0 -436 2
 EndChar
+
 StartChar: uni02D6
-Encoding: 726 726 726
+Encoding: 726 726 634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27478,8 +28118,9 @@ SplineSet
  526 649 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D7
-Encoding: 727 727 727
+Encoding: 727 727 635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27492,26 +28133,29 @@ SplineSet
  842 469 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: breve
-Encoding: 728 728 728
+Encoding: 728 728 636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 661 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotaccent
-Encoding: 729 729 729
+Encoding: 729 729 637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 662 775 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ring
-Encoding: 730 730 730
+Encoding: 730 730 638
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27589,29 +28233,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-332 1534 m 0,0,1
+332 1534 m 256,0,1
  332 1652 332 1652 415 1735.5 c 128,-1,2
  498 1819 498 1819 616 1819 c 0,3,4
  735 1819 735 1819 818 1735.5 c 128,-1,5
- 901 1652 901 1652 901 1534 c 0,6,7
+ 901 1652 901 1652 901 1534 c 256,6,7
  901 1416 901 1416 818 1332.5 c 128,-1,8
  735 1249 735 1249 616 1249 c 0,9,10
  498 1249 498 1249 415 1332.5 c 128,-1,11
- 332 1416 332 1416 332 1534 c 0,0,1
+ 332 1416 332 1416 332 1534 c 256,0,1
 485 1534 m 0,12,13
  485 1479 485 1479 523.5 1441 c 128,-1,14
  562 1403 562 1403 616 1403 c 0,15,16
  671 1403 671 1403 709.5 1441.5 c 128,-1,17
- 748 1480 748 1480 748 1534 c 0,18,19
+ 748 1480 748 1480 748 1534 c 256,18,19
  748 1588 748 1588 709 1626.5 c 128,-1,20
- 670 1665 670 1665 616 1665 c 0,21,22
+ 670 1665 670 1665 616 1665 c 256,21,22
  562 1665 562 1665 523.5 1626.5 c 128,-1,23
  485 1588 485 1588 485 1534 c 0,12,13
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ogonek
-Encoding: 731 731 731
+Encoding: 731 731 639
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27667,8 +28312,9 @@ SplineSet
  501 -61 501 -61 557 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tilde
-Encoding: 732 732 732
+Encoding: 732 732 640
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27897,19 +28543,21 @@ SplineSet
  732 1307 732 1307 699 1319 c 128,-1,30
  666 1331 666 1331 618 1364 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: hungarumlaut
-Encoding: 733 733 733
+Encoding: 733 733 641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 666 779 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni02DE
-Encoding: 734 734 734
+Encoding: 734 734 642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27930,8 +28578,9 @@ SplineSet
  -311.999 883.291 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E0
-Encoding: 736 736 736
+Encoding: 736 736 643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27955,8 +28604,9 @@ SplineSet
  723 729 723 729 616 882 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02E1
-Encoding: 737 737 737
+Encoding: 737 737 644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27977,8 +28627,9 @@ SplineSet
  485 789 485 789 485 930 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E2
-Encoding: 738 738 738
+Encoding: 738 738 645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28015,8 +28666,9 @@ SplineSet
  797 1294 797 1294 854 1277 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E3
-Encoding: 739 739 739
+Encoding: 739 739 646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28037,8 +28689,9 @@ SplineSet
  955 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E4
-Encoding: 740 740 740
+Encoding: 740 740 647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28064,8 +28717,9 @@ SplineSet
  791 1080 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02E5
-Encoding: 741 741 741
+Encoding: 741 741 648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28080,8 +28734,9 @@ SplineSet
  959 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E6
-Encoding: 742 742 742
+Encoding: 742 742 649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28098,8 +28753,9 @@ SplineSet
  959 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E7
-Encoding: 743 743 743
+Encoding: 743 743 650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28116,8 +28772,9 @@ SplineSet
  959 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E8
-Encoding: 744 744 744
+Encoding: 744 744 651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28134,8 +28791,9 @@ SplineSet
  959 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E9
-Encoding: 745 745 745
+Encoding: 745 745 652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28150,64 +28808,71 @@ SplineSet
  959 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02EE
-Encoding: 750 750 750
+Encoding: 750 750 653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8221 8221 N 1 0 0 1 0 0 3
+Refer: 1975 8221 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni02F3
-Encoding: 755 755 755
+Encoding: 755 755 654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gravecomb
-Encoding: 768 768 768
+Encoding: 768 768 655
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: acutecomb
-Encoding: 769 769 769
+Encoding: 769 769 656
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0302
-Encoding: 770 770 770
+Encoding: 770 770 657
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: tildecomb
-Encoding: 771 771 771
+Encoding: 771 771 658
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0304
-Encoding: 772 772 772
+Encoding: 772 772 659
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28240,18 +28905,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0305
-Encoding: 773 773 773
+Encoding: 773 773 660
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0306
-Encoding: 774 774 774
+Encoding: 774 774 661
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28291,7 +28958,7 @@ SplineSet
 281 1606 m 1,0,-1
  422 1606 l 1,1,2
  433 1537 433 1537 483 1499.5 c 128,-1,3
- 533 1462 533 1462 616 1462 c 0,4,5
+ 533 1462 533 1462 616 1462 c 256,4,5
  699 1462 699 1462 748.5 1499 c 128,-1,6
  798 1536 798 1536 809 1606 c 1,7,-1
  952 1606 l 1,8,9
@@ -28302,8 +28969,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0307
-Encoding: 775 775 775
+Encoding: 775 775 662
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28345,18 +29013,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0308
-Encoding: 776 776 776
+Encoding: 776 776 663
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: hookabovecomb
-Encoding: 777 777 777
+Encoding: 777 777 664
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28381,18 +29051,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030A
-Encoding: 778 778 778
+Encoding: 778 778 665
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030B
-Encoding: 779 779 779
+Encoding: 779 779 666
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28466,18 +29138,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030C
-Encoding: 780 780 780
+Encoding: 780 780 667
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030D
-Encoding: 781 781 781
+Encoding: 781 781 668
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28492,19 +29166,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030E
-Encoding: 782 782 782
+Encoding: 782 782 669
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 781 781 N 1 0 0 1 285 0 2
-Refer: 781 781 N 1 0 0 1 -285 0 2
+Refer: 668 781 N 1 0 0 1 285 0 2
+Refer: 668 781 N 1 0 0 1 -285 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030F
-Encoding: 783 783 783
+Encoding: 783 783 670
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28524,19 +29200,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0310
-Encoding: 784 784 784
+Encoding: 784 784 671
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 0 216 2
-Refer: 728 728 N 1 0 0 1 0 0 2
+Refer: 637 729 N 1 0 0 1 0 216 2
+Refer: 636 728 N 1 0 0 1 0 0 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0311
-Encoding: 785 785 785
+Encoding: 785 785 672
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28557,8 +29235,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0312
-Encoding: 786 786 786
+Encoding: 786 786 673
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28590,8 +29269,9 @@ SplineSet
  729 903 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0313
-Encoding: 787 787 787
+Encoding: 787 787 674
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28609,8 +29289,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0314
-Encoding: 788 788 788
+Encoding: 788 788 675
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28628,8 +29309,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0315
-Encoding: 789 789 789
+Encoding: 789 789 676
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -28644,26 +29326,29 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0316
-Encoding: 790 790 790
+Encoding: 790 790 677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 135 -1855 2
+Refer: 65 96 N 1 0 0 1 135 -1855 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0317
-Encoding: 791 791 791
+Encoding: 791 791 678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -135 -1855 2
+Refer: 116 180 N 1 0 0 1 -135 -1855 2
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0318
-Encoding: 792 792 792
+Encoding: 792 792 679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28681,8 +29366,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0319
-Encoding: 793 793 793
+Encoding: 793 793 680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28700,8 +29386,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Mark Positioning lookup 8" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031A
-Encoding: 794 794 794
+Encoding: 794 794 681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28716,8 +29403,9 @@ SplineSet
  705 1713 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031B
-Encoding: 795 795 795
+Encoding: 795 795 682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28740,8 +29428,9 @@ SplineSet
  477 793 477 793 416 850 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031C
-Encoding: 796 796 796
+Encoding: 796 796 683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28760,8 +29449,9 @@ SplineSet
  726 -502 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni031D
-Encoding: 797 797 797
+Encoding: 797 797 684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28778,8 +29468,9 @@ SplineSet
  342.7 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031E
-Encoding: 798 798 798
+Encoding: 798 798 685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28796,8 +29487,9 @@ SplineSet
  497.7 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031F
-Encoding: 799 799 799
+Encoding: 799 799 686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28818,8 +29510,9 @@ SplineSet
  535.4 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0320
-Encoding: 800 800 800
+Encoding: 800 800 687
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28832,8 +29525,9 @@ SplineSet
  339 -441 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0321
-Encoding: 801 801 801
+Encoding: 801 801 688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28852,8 +29546,9 @@ SplineSet
  1071 43 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0322
-Encoding: 802 802 802
+Encoding: 802 802 689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28872,8 +29567,9 @@ SplineSet
  167 -208.808 167 -208.808 167 41 c 10,0,0
 EndSplineSet
 EndChar
+
 StartChar: dotbelowcomb
-Encoding: 803 803 803
+Encoding: 803 803 690
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28913,8 +29609,9 @@ SplineSet
  479 -216 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0324
-Encoding: 804 804 804
+Encoding: 804 804 691
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28959,8 +29656,9 @@ SplineSet
  301 -216 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0325
-Encoding: 805 805 805
+Encoding: 805 805 692
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28997,28 +29695,29 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-836 -282 m 0,0,1
+836 -282 m 256,0,1
  836 -374 836 -374 772.5 -438 c 128,-1,2
  709 -502 709 -502 616 -502 c 0,3,4
  524 -502 524 -502 460.5 -438 c 128,-1,5
- 397 -374 397 -374 397 -282 c 0,6,7
+ 397 -374 397 -374 397 -282 c 256,6,7
  397 -190 397 -190 460.5 -126.5 c 128,-1,8
  524 -63 524 -63 616 -63 c 0,9,10
  709 -63 709 -63 772.5 -126.5 c 128,-1,11
- 836 -190 836 -190 836 -282 c 0,0,1
+ 836 -190 836 -190 836 -282 c 256,0,1
 704 -282 m 0,12,13
  704 -246 704 -246 678.5 -220.5 c 128,-1,14
- 653 -195 653 -195 616 -195 c 0,15,16
+ 653 -195 653 -195 616 -195 c 256,15,16
  579 -195 579 -195 554 -220 c 128,-1,17
  529 -245 529 -245 529 -282 c 0,18,19
  529 -320 529 -320 554 -345 c 128,-1,20
- 579 -370 579 -370 616 -370 c 0,21,22
+ 579 -370 579 -370 616 -370 c 256,21,22
  653 -370 653 -370 678.5 -344.5 c 128,-1,23
  704 -319 704 -319 704 -282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0326
-Encoding: 806 806 806
+Encoding: 806 806 693
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29050,8 +29749,9 @@ SplineSet
  461 -198 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0327
-Encoding: 807 807 807
+Encoding: 807 807 694
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29109,16 +29809,18 @@ SplineSet
  707 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0328
-Encoding: 808 808 808
+Encoding: 808 808 695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 -43.5 0 2
+Refer: 639 731 N 1 0 0 1 -43.5 0 2
 EndChar
+
 StartChar: uni0329
-Encoding: 809 809 809
+Encoding: 809 809 696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29131,8 +29833,9 @@ SplineSet
  711 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032A
-Encoding: 810 810 810
+Encoding: 810 810 697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29149,8 +29852,9 @@ SplineSet
  931.5 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032B
-Encoding: 811 811 811
+Encoding: 811 811 698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29174,8 +29878,9 @@ SplineSet
  1024.14 -192 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni032C
-Encoding: 812 812 812
+Encoding: 812 812 699
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29216,8 +29921,9 @@ SplineSet
  496 -485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032D
-Encoding: 813 813 813
+Encoding: 813 813 700
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29258,8 +29964,9 @@ SplineSet
  496 -109 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032E
-Encoding: 814 814 814
+Encoding: 814 814 701
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29298,7 +30005,7 @@ SplineSet
 281 -194 m 1,0,-1
  422 -194 l 1,1,2
  433 -263 433 -263 483 -300.5 c 128,-1,3
- 533 -338 533 -338 616 -338 c 0,4,5
+ 533 -338 533 -338 616 -338 c 256,4,5
  699 -338 699 -338 748.5 -301 c 128,-1,6
  798 -264 798 -264 809 -194 c 1,7,-1
  952 -194 l 1,8,9
@@ -29308,8 +30015,9 @@ SplineSet
  287 -338 287 -338 281 -194 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032F
-Encoding: 815 815 815
+Encoding: 815 815 702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29328,8 +30036,9 @@ SplineSet
  946 -345 946 -345 952 -489 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0330
-Encoding: 816 816 816
+Encoding: 816 816 703
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29514,8 +30223,9 @@ SplineSet
  666 -463 666 -463 618 -430 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0331
-Encoding: 817 817 817
+Encoding: 817 817 704
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29546,32 +30256,36 @@ SplineSet
  301 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0332
-Encoding: 818 818 818
+Encoding: 818 818 705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0333
-Encoding: 819 819 819
+Encoding: 819 819 706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8215 8215 N 1 0 0 1 0 0 2
+Refer: 1969 8215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0334
-Encoding: 820 820 820
+Encoding: 820 820 707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0335
-Encoding: 821 821 821
+Encoding: 821 821 708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29584,8 +30298,9 @@ SplineSet
  192 438 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0336
-Encoding: 822 822 822
+Encoding: 822 822 709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29598,8 +30313,9 @@ SplineSet
  0 438 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0337
-Encoding: 823 823 823
+Encoding: 823 823 710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29612,8 +30328,9 @@ SplineSet
  164 -117 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0338
-Encoding: 824 824 824
+Encoding: 824 824 711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29626,8 +30343,9 @@ SplineSet
  156 -63 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni0339
-Encoding: 825 825 825
+Encoding: 825 825 712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29646,8 +30364,9 @@ SplineSet
  599 -502 599 -502 507 -502 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033A
-Encoding: 826 826 826
+Encoding: 826 826 713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29664,8 +30383,9 @@ SplineSet
  301.5 -520 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033B
-Encoding: 827 827 827
+Encoding: 827 827 714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29683,8 +30403,9 @@ SplineSet
  732 -620 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033C
-Encoding: 828 828 828
+Encoding: 828 828 715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29708,8 +30429,9 @@ SplineSet
  208.864 -489 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033D
-Encoding: 829 829 829
+Encoding: 829 829 716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29730,8 +30452,9 @@ SplineSet
  616.5 1321.07 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033E
-Encoding: 830 830 830
+Encoding: 830 830 717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29762,33 +30485,37 @@ SplineSet
  702 1495 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033F
-Encoding: 831 831 831
+Encoding: 831 831 718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
-Refer: 8254 8254 N 1 0 0 1 0 -275 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 -275 2
 EndChar
+
 StartChar: uni0343
-Encoding: 835 835 835
+Encoding: 835 835 719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 787 787 N 1 0 0 1 0 0 2
+Refer: 674 787 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0358
-Encoding: 856 856 856
+Encoding: 856 856 720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 474 0 2
+Refer: 637 729 N 1 0 0 1 474 0 2
 EndChar
+
 StartChar: uni0361
-Encoding: 865 865 865
+Encoding: 865 865 721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29807,8 +30534,9 @@ SplineSet
  302.667 1796.91 302.667 1796.91 616.51 1803 c 24,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni0374
-Encoding: 884 884 884
+Encoding: 884 884 722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29821,8 +30549,9 @@ SplineSet
  500 1140 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0375
-Encoding: 885 885 885
+Encoding: 885 885 723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29835,24 +30564,27 @@ SplineSet
  733 72 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0376
-Encoding: 886 886 886
+Encoding: 886 886 724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 3
+Refer: 862 1048 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0377
-Encoding: 887 887 887
+Encoding: 887 887 725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 3
+Refer: 894 1080 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037A
-Encoding: 890 890 890
+Encoding: 890 890 726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29869,173 +30601,193 @@ SplineSet
  785 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni037B
-Encoding: 891 891 891
+Encoding: 891 891 727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 513 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037C
-Encoding: 892 892 892
+Encoding: 892 892 728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 165 -124 2
+Refer: 68 99 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 165 -124 2
 EndChar
+
 StartChar: uni037D
-Encoding: 893 893 893
+Encoding: 893 893 729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 -148 -124 2
+Refer: 513 596 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 -148 -124 2
 EndChar
+
 StartChar: uni037E
-Encoding: 894 894 894
+Encoding: 894 894 730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 59 59 N 1 0 0 1 0 0 2
+Refer: 28 59 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni037F
-Encoding: 895 895 895
+Encoding: 895 895 731
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 3
+Refer: 43 74 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: tonos
-Encoding: 900 900 900
+Encoding: 900 900 732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dieresistonos
-Encoding: 901 901 901
+Encoding: 901 901 733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 408 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 408 2
 EndChar
+
 StartChar: Alphatonos
-Encoding: 902 902 902
+Encoding: 902 902 734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -550 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -550 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: anoteleia
-Encoding: 903 903 903
+Encoding: 903 903 735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Epsilontonos
-Encoding: 904 904 904
+Encoding: 904 904 736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -820 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -820 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Etatonos
-Encoding: 905 905 905
+Encoding: 905 905 737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -860 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -860 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iotatonos
-Encoding: 906 906 906
+Encoding: 906 906 738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -800 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -800 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Omicrontonos
-Encoding: 908 908 908
+Encoding: 908 908 739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -640 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -640 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilontonos
-Encoding: 910 910 910
+Encoding: 910 910 740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -965 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -965 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Omegatonos
-Encoding: 911 911 911
+Encoding: 911 911 741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -595 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -595 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotadieresistonos
-Encoding: 912 912 912
+Encoding: 912 912 742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alpha
-Encoding: 913 913 913
+Encoding: 913 913 743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Beta
-Encoding: 914 914 914
+Encoding: 914 914 744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gamma
-Encoding: 915 915 915
+Encoding: 915 915 745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0394
-Encoding: 916 916 916
+Encoding: 916 916 746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30052,32 +30804,36 @@ SplineSet
  845 260 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: Epsilon
-Encoding: 917 917 917
+Encoding: 917 917 747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zeta
-Encoding: 918 918 918
+Encoding: 918 918 748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eta
-Encoding: 919 919 919
+Encoding: 919 919 749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Theta
-Encoding: 920 920 920
+Encoding: 920 920 750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30108,24 +30864,27 @@ SplineSet
  92 363 92 363 92 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: Iota
-Encoding: 921 921 921
+Encoding: 921 921 751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kappa
-Encoding: 922 922 922
+Encoding: 922 922 752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lambda
-Encoding: 923 923 923
+Encoding: 923 923 753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30141,24 +30900,27 @@ SplineSet
  328 0 l 17,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Mu
-Encoding: 924 924 924
+Encoding: 924 924 754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Nu
-Encoding: 925 925 925
+Encoding: 925 925 755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Xi
-Encoding: 926 926 926
+Encoding: 926 926 756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30181,32 +30943,36 @@ SplineSet
  856.35 664 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: Omicron
-Encoding: 927 927 927
+Encoding: 927 927 757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Pi
-Encoding: 928 928 928
+Encoding: 928 928 758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1055 1055 N 1 0 0 1 0 0 2
+Refer: 869 1055 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rho
-Encoding: 929 929 929
+Encoding: 929 929 759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Sigma
-Encoding: 931 931 931
+Encoding: 931 931 760
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30227,24 +30993,27 @@ SplineSet
  499 747 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tau
-Encoding: 932 932 932
+Encoding: 932 932 761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilon
-Encoding: 933 933 933
+Encoding: 933 933 762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Phi
-Encoding: 934 934 934
+Encoding: 934 934 763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30287,16 +31056,18 @@ SplineSet
  447.697 537.729 447.697 537.729 469 526.395 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: Chi
-Encoding: 935 935 935
+Encoding: 935 935 764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Psi
-Encoding: 936 936 936
+Encoding: 936 936 765
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30329,8 +31100,9 @@ SplineSet
  764 260 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: Omega
-Encoding: 937 937 937
+Encoding: 937 937 766
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30435,71 +31207,79 @@ SplineSet
  90 211 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Iotadieresis
-Encoding: 938 938 938
+Encoding: 938 938 767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilondieresis
-Encoding: 939 939 939
+Encoding: 939 939 768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alphatonos
-Encoding: 940 940 940
+Encoding: 940 940 769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: epsilontonos
-Encoding: 941 941 941
+Encoding: 941 941 770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: etatonos
-Encoding: 942 942 942
+Encoding: 942 942 771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotatonos
-Encoding: 943 943 943
+Encoding: 943 943 772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresistonos
-Encoding: 944 944 944
+Encoding: 944 944 773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alpha
-Encoding: 945 945 945
+Encoding: 945 945 774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30534,8 +31314,9 @@ SplineSet
  695 589 l 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: beta
-Encoding: 946 946 946
+Encoding: 946 946 775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30562,8 +31343,9 @@ SplineSet
  422.3 402 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: gamma
-Encoding: 947 947 947
+Encoding: 947 947 776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30587,8 +31369,9 @@ SplineSet
  449.58 957.353 449.58 957.353 494.5 808 c 2,3,-1
 EndSplineSet
 EndChar
+
 StartChar: delta
-Encoding: 948 948 948
+Encoding: 948 948 777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30628,18 +31411,20 @@ SplineSet
  722 909 722 909 616 909 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: epsilon
-Encoding: 949 949 949
+Encoding: 949 949 778
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 603 603 N 1 0 0 1 0 0 3
+Refer: 520 603 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: zeta
-Encoding: 950 950 950
+Encoding: 950 950 779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30665,8 +31450,9 @@ SplineSet
  435 952.546 435 952.546 435 534 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: eta
-Encoding: 951 951 951
+Encoding: 951 951 780
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30691,8 +31477,9 @@ SplineSet
  1071 936 1071 936 1071 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: theta
-Encoding: 952 952 952
+Encoding: 952 952 781
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30721,8 +31508,9 @@ SplineSet
  854 -24.3203 854 -24.3203 616 -24.3203 c 24,21,22
 EndSplineSet
 EndChar
+
 StartChar: iota
-Encoding: 953 953 953
+Encoding: 953 953 782
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30743,16 +31531,18 @@ SplineSet
  763 1120 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: kappa
-Encoding: 954 954 954
+Encoding: 954 954 783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
+Refer: 896 1082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lambda
-Encoding: 955 955 955
+Encoding: 955 955 784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30775,16 +31565,18 @@ SplineSet
  678.931 1393.65 678.931 1393.65 738 1220 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03BC
-Encoding: 956 956 956
+Encoding: 956 956 785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 181 181 N 1 0 0 1 0 0 2
+Refer: 117 181 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nu
-Encoding: 957 957 957
+Encoding: 957 957 786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30806,8 +31598,9 @@ SplineSet
  576 295 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: xi
-Encoding: 958 958 958
+Encoding: 958 958 787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30838,16 +31631,18 @@ SplineSet
  801.254 -0.000976562 801.254 -0.000976562 742 0 c 0,5,-1
 EndSplineSet
 EndChar
+
 StartChar: omicron
-Encoding: 959 959 959
+Encoding: 959 959 788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: pi
-Encoding: 960 960 960
+Encoding: 960 960 789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30879,8 +31674,9 @@ SplineSet
  1182 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rho
-Encoding: 961 961 961
+Encoding: 961 961 790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30908,8 +31704,9 @@ SplineSet
  850 399 850 399 850 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: sigma1
-Encoding: 962 962 962
+Encoding: 962 962 791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30940,8 +31737,9 @@ SplineSet
  604.987 231.78 604.987 231.78 749 225 c 24,22,23
 EndSplineSet
 EndChar
+
 StartChar: sigma
-Encoding: 963 963 963
+Encoding: 963 963 792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30969,8 +31767,9 @@ SplineSet
  599.374 866.814 599.374 866.814 554 887.362 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: tau
-Encoding: 964 964 964
+Encoding: 964 964 793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30993,8 +31792,9 @@ SplineSet
  136 1120 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: upsilon
-Encoding: 965 965 965
+Encoding: 965 965 794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31021,8 +31821,9 @@ SplineSet
  899 0 899 0 671 0 c 16,0,1
 EndSplineSet
 EndChar
+
 StartChar: phi
-Encoding: 966 966 966
+Encoding: 966 966 795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31052,8 +31853,9 @@ SplineSet
  854.87 867.855 854.87 867.855 817 864 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: chi
-Encoding: 967 967 967
+Encoding: 967 967 796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31086,8 +31888,9 @@ SplineSet
  757.04 -289.717 757.04 -289.717 677.5 -114 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: psi
-Encoding: 968 968 968
+Encoding: 968 968 797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31112,8 +31915,9 @@ SplineSet
  763 225 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: omega
-Encoding: 969 969 969
+Encoding: 969 969 798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31141,53 +31945,59 @@ SplineSet
  743 665 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: iotadieresis
-Encoding: 970 970 970
+Encoding: 970 970 799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresis
-Encoding: 971 971 971
+Encoding: 971 971 800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omicrontonos
-Encoding: 972 972 972
+Encoding: 972 972 801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilontonos
-Encoding: 973 973 973
+Encoding: 973 973 802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omegatonos
-Encoding: 974 974 974
+Encoding: 974 974 803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D0
-Encoding: 976 976 976
+Encoding: 976 976 804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31216,8 +32026,9 @@ SplineSet
  885 590 885 590 700 685 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: theta1
-Encoding: 977 977 977
+Encoding: 977 977 805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31246,8 +32057,9 @@ SplineSet
  860.018 572.934 860.018 572.934 860.758 668 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: Upsilon1
-Encoding: 978 978 978
+Encoding: 978 978 806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31272,26 +32084,29 @@ SplineSet
  954.966 1087.53 954.966 1087.53 941.079 1202.95 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D3
-Encoding: 979 979 979
+Encoding: 979 979 807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -945 0 2
-Refer: 978 978 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -945 0 2
+Refer: 806 978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D4
-Encoding: 980 980 980
+Encoding: 980 980 808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 806 978 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: phi1
-Encoding: 981 981 981
+Encoding: 981 981 809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31326,8 +32141,9 @@ SplineSet
  815.145 848.707 815.145 848.707 763 874 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: omega1
-Encoding: 982 982 982
+Encoding: 982 982 810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31356,8 +32172,9 @@ SplineSet
  382.936 895 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D7
-Encoding: 983 983 983
+Encoding: 983 983 811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31392,8 +32209,9 @@ SplineSet
  1089 195 1089 195 1145 261 c 25,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03D8
-Encoding: 984 984 984
+Encoding: 984 984 812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31422,8 +32240,9 @@ SplineSet
  918.601 32.4316 918.601 32.4316 763 -10 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D9
-Encoding: 985 985 985
+Encoding: 985 985 813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31452,8 +32271,9 @@ SplineSet
  903.352 24.8633 903.352 24.8633 763 -11 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DA
-Encoding: 986 986 986
+Encoding: 986 986 814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31482,8 +32302,9 @@ SplineSet
  568 236 568 236 680 236 c 136,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni03DB
-Encoding: 987 987 987
+Encoding: 987 987 815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31512,16 +32333,18 @@ SplineSet
  684 895 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DC
-Encoding: 988 988 988
+Encoding: 988 988 816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 3
+Refer: 39 70 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03DD
-Encoding: 989 989 989
+Encoding: 989 989 817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31554,8 +32377,9 @@ SplineSet
  378 -54 378 -54 377 55 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DE
-Encoding: 990 990 990
+Encoding: 990 990 818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31580,8 +32404,9 @@ SplineSet
  618.779 1368.79 618.779 1368.79 612 1159 c 26,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DF
-Encoding: 991 991 991
+Encoding: 991 991 819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31598,8 +32423,9 @@ SplineSet
  1117 924 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E0
-Encoding: 992 992 992
+Encoding: 992 992 820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31629,8 +32455,9 @@ SplineSet
  490 1273 490 1273 415 1240 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E1
-Encoding: 993 993 993
+Encoding: 993 993 821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31655,8 +32482,9 @@ SplineSet
  828 48 828 48 795 180 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03F0
-Encoding: 1008 1008 1008
+Encoding: 1008 1008 822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31689,8 +32517,9 @@ SplineSet
  147 417 147 417 285 507 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03F1
-Encoding: 1009 1009 1009
+Encoding: 1009 1009 823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31722,24 +32551,27 @@ SplineSet
  850 399 850 399 850 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03F2
-Encoding: 1010 1010 1010
+Encoding: 1010 1010 824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F3
-Encoding: 1011 1011 1011
+Encoding: 1011 1011 825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 3
+Refer: 75 106 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F4
-Encoding: 1012 1012 1012
+Encoding: 1012 1012 826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31768,8 +32600,9 @@ SplineSet
  92 363 92 363 92 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni03F5
-Encoding: 1013 1013 1013
+Encoding: 1013 1013 827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31799,8 +32632,9 @@ SplineSet
  1053 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F6
-Encoding: 1014 1014 1014
+Encoding: 1014 1014 828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31830,32 +32664,36 @@ SplineSet
  238.458 15.3007 238.458 15.3007 168 57 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F7
-Encoding: 1015 1015 1015
+Encoding: 1015 1015 829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 222 222 N 1 0 0 1 0 0 3
+Refer: 158 222 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F8
-Encoding: 1016 1016 1016
+Encoding: 1016 1016 830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 254 254 N 1 0 0 1 0 0 3
+Refer: 190 254 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F9
-Encoding: 1017 1017 1017
+Encoding: 1017 1017 831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 3
+Refer: 36 67 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FA
-Encoding: 1018 1018 1018
+Encoding: 1018 1018 832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31877,8 +32715,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FB
-Encoding: 1019 1019 1019
+Encoding: 1019 1019 833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31900,8 +32739,9 @@ SplineSet
  86 1020 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FC
-Encoding: 1020 1020 1020
+Encoding: 1020 1020 834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31937,8 +32777,9 @@ SplineSet
  850 399 850 399 850 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03FD
-Encoding: 1021 1021 1021
+Encoding: 1021 1021 835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31965,44 +32806,49 @@ SplineSet
  222 7 222 7 152 43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03FE
-Encoding: 1022 1022 1022
+Encoding: 1022 1022 836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 166 0 2
-Refer: 1017 1017 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 166 0 2
+Refer: 831 1017 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FF
-Encoding: 1023 1023 1023
+Encoding: 1023 1023 837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1021 1021 N 1 0 0 1 0 0 2
-Refer: 183 183 N 1 0 0 1 -187 0 2
+Refer: 835 1021 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 -187 0 2
 EndChar
+
 StartChar: uni0400
-Encoding: 1024 1024 1024
+Encoding: 1024 1024 838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 31 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 31 373 2
 EndChar
+
 StartChar: uni0401
-Encoding: 1025 1025 1025
+Encoding: 1025 1025 839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 31 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 31 373 2
 EndChar
+
 StartChar: uni0402
-Encoding: 1026 1026 1026
+Encoding: 1026 1026 840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32043,17 +32889,19 @@ SplineSet
  1182 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0403
-Encoding: 1027 1027 1027
+Encoding: 1027 1027 841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 31 373 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 373 2
 EndChar
+
 StartChar: uni0404
-Encoding: 1028 1028 1028
+Encoding: 1028 1028 842
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32143,24 +32991,27 @@ SplineSet
  1081 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0405
-Encoding: 1029 1029 1029
+Encoding: 1029 1029 843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0406
-Encoding: 1030 1030 1030
+Encoding: 1030 1030 844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0407
-Encoding: 1031 1031 1031
+Encoding: 1031 1031 845
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32193,19 +33044,21 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1030 1030 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 844 1030 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni0408
-Encoding: 1032 1032 1032
+Encoding: 1032 1032 846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0409
-Encoding: 1033 1033 1033
+Encoding: 1033 1033 847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32243,8 +33096,9 @@ SplineSet
  582 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040A
-Encoding: 1034 1034 1034
+Encoding: 1034 1034 848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32278,8 +33132,9 @@ SplineSet
  582 0 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040B
-Encoding: 1035 1035 1035
+Encoding: 1035 1035 849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32314,35 +33169,39 @@ SplineSet
  -34 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040C
-Encoding: 1036 1036 1036
+Encoding: 1036 1036 850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1050 1050 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 31 373 2
+Refer: 864 1050 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 31 373 2
 EndChar
+
 StartChar: uni040D
-Encoding: 1037 1037 1037
+Encoding: 1037 1037 851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 31 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 31 373 2
 EndChar
+
 StartChar: uni040E
-Encoding: 1038 1038 1038
+Encoding: 1038 1038 852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040F
-Encoding: 1039 1039 1039
+Encoding: 1039 1039 853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32363,16 +33222,18 @@ SplineSet
  137 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0410
-Encoding: 1040 1040 1040
+Encoding: 1040 1040 854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0411
-Encoding: 1041 1041 1041
+Encoding: 1041 1041 855
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32434,7 +33295,7 @@ SplineSet
 457 248 m 1,0,-1
  578 248 l 2,1,2
  723 248 723 248 781.5 297 c 128,-1,3
- 840 346 840 346 840 467 c 0,4,5
+ 840 346 840 346 840 467 c 256,4,5
  840 588 840 588 781.5 637 c 128,-1,6
  723 686 723 686 578 686 c 2,7,-1
  457 686 l 1,8,-1
@@ -32446,23 +33307,25 @@ SplineSet
  457 934 l 1,13,-1
  567 934 l 2,14,15
  876 934 876 934 1011.5 824 c 128,-1,16
- 1147 714 1147 714 1147 467 c 0,17,18
+ 1147 714 1147 714 1147 467 c 256,17,18
  1147 220 1147 220 1011.5 110 c 128,-1,19
  876 0 876 0 567 0 c 2,20,-1
  162 0 l 1,21,-1
  162 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0412
-Encoding: 1042 1042 1042
+Encoding: 1042 1042 856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0413
-Encoding: 1043 1043 1043
+Encoding: 1043 1043 857
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32503,8 +33366,9 @@ SplineSet
  477 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0414
-Encoding: 1044 1044 1044
+Encoding: 1044 1044 858
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32637,16 +33501,18 @@ SplineSet
  40 260 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0415
-Encoding: 1045 1045 1045
+Encoding: 1045 1045 859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0416
-Encoding: 1046 1046 1046
+Encoding: 1046 1046 860
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32794,16 +33660,18 @@ SplineSet
  497 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0417
-Encoding: 1047 1047 1047
+Encoding: 1047 1047 861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0418
-Encoding: 1048 1048 1048
+Encoding: 1048 1048 862
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32901,25 +33769,28 @@ SplineSet
  1112 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0419
-Encoding: 1049 1049 1049
+Encoding: 1049 1049 863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041A
-Encoding: 1050 1050 1050
+Encoding: 1050 1050 864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041B
-Encoding: 1051 1051 1051
+Encoding: 1051 1051 865
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32995,32 +33866,36 @@ SplineSet
  521 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni041C
-Encoding: 1052 1052 1052
+Encoding: 1052 1052 866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041D
-Encoding: 1053 1053 1053
+Encoding: 1053 1053 867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041E
-Encoding: 1054 1054 1054
+Encoding: 1054 1054 868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041F
-Encoding: 1055 1055 1055
+Encoding: 1055 1055 869
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33068,32 +33943,36 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0420
-Encoding: 1056 1056 1056
+Encoding: 1056 1056 870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0421
-Encoding: 1057 1057 1057
+Encoding: 1057 1057 871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0422
-Encoding: 1058 1058 1058
+Encoding: 1058 1058 872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0423
-Encoding: 1059 1059 1059
+Encoding: 1059 1059 873
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33116,8 +33995,9 @@ SplineSet
  727 303 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0424
-Encoding: 1060 1060 1060
+Encoding: 1060 1060 874
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33270,16 +34150,18 @@ SplineSet
  749 387 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0425
-Encoding: 1061 1061 1061
+Encoding: 1061 1061 875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0426
-Encoding: 1062 1062 1062
+Encoding: 1062 1062 876
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33365,8 +34247,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0427
-Encoding: 1063 1063 1063
+Encoding: 1063 1063 877
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33427,8 +34310,9 @@ SplineSet
  1127 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0428
-Encoding: 1064 1064 1064
+Encoding: 1064 1064 878
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33573,8 +34457,9 @@ SplineSet
  1154 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0429
-Encoding: 1065 1065 1065
+Encoding: 1065 1065 879
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33712,8 +34597,9 @@ SplineSet
  980 0 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042A
-Encoding: 1066 1066 1066
+Encoding: 1066 1066 880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33741,8 +34627,9 @@ SplineSet
  270 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042B
-Encoding: 1067 1067 1067
+Encoding: 1067 1067 881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33773,8 +34660,9 @@ SplineSet
  938 0 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042C
-Encoding: 1068 1068 1068
+Encoding: 1068 1068 882
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33846,8 +34734,9 @@ SplineSet
  124 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042D
-Encoding: 1069 1069 1069
+Encoding: 1069 1069 883
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33871,8 +34760,9 @@ SplineSet
  767 875 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni042E
-Encoding: 1070 1070 1070
+Encoding: 1070 1070 884
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33964,8 +34854,9 @@ SplineSet
  0 0 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042F
-Encoding: 1071 1071 1071
+Encoding: 1071 1071 885
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34038,14 +34929,14 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-450 1042 m 0,0,1
+450 1042 m 256,0,1
  450 933 450 933 508 885.5 c 128,-1,2
  566 838 566 838 676 838 c 2,3,-1
  865 838 l 1,4,-1
  865 1245 l 1,5,-1
  676 1245 l 2,6,7
  566 1245 566 1245 508 1198 c 128,-1,8
- 450 1151 450 1151 450 1042 c 0,0,1
+ 450 1151 450 1151 450 1042 c 256,0,1
 83 0 m 1,9,-1
  409 644 l 1,10,11
  334 679 334 679 239.5 780.5 c 128,-1,12
@@ -34061,17 +34952,19 @@ SplineSet
  83 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0430
-Encoding: 1072 1072 1072
+Encoding: 1072 1072 886
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0431
-Encoding: 1073 1073 1073
+Encoding: 1073 1073 887
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34141,9 +35034,9 @@ SplineSet
  328 1201 328 1201 298 1045 c 1,8,9
  426 1147 426 1147 616 1147 c 0,10,11
  854 1147 854 1147 994.5 988.5 c 128,-1,12
- 1135 830 1135 830 1135 559 c 0,13,14
+ 1135 830 1135 830 1135 559 c 256,13,14
  1135 288 1135 288 994.5 129.5 c 128,-1,15
- 854 -29 854 -29 616.5 -29 c 0,16,17
+ 854 -29 854 -29 616.5 -29 c 256,16,17
  379 -29 379 -29 238.5 129.5 c 128,-1,18
  98 288 98 288 98 559 c 0,19,20
  98 611 98 611 97 621 c 2,21,-1
@@ -34154,20 +35047,21 @@ SplineSet
  213 1428 213 1428 381 1516 c 0,29,30
  502 1580 502 1580 843 1593 c 0,31,32
  894 1595 894 1595 929 1611 c 1,0,-1
-616.5 909 m 0,33,34
+616.5 909 m 256,33,34
  511 909 511 909 451 816.5 c 128,-1,35
- 391 724 391 724 391 559 c 0,36,37
+ 391 724 391 724 391 559 c 256,36,37
  391 394 391 394 451 301.5 c 128,-1,38
- 511 209 511 209 616.5 209 c 0,39,40
+ 511 209 511 209 616.5 209 c 256,39,40
  722 209 722 209 782 301.5 c 128,-1,41
- 842 394 842 394 842 559 c 0,42,43
+ 842 394 842 394 842 559 c 256,42,43
  842 724 842 724 782 816.5 c 128,-1,44
- 722 909 722 909 616.5 909 c 0,33,34
+ 722 909 722 909 616.5 909 c 256,33,34
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 0" uniF6C5
 EndChar
+
 StartChar: uni0432
-Encoding: 1074 1074 1074
+Encoding: 1074 1074 888
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34224,7 +35118,7 @@ SplineSet
  411 219 l 1,1,-1
  578 219 l 2,2,3
  703 219 703 219 762 249.5 c 128,-1,4
- 821 280 821 280 821 350 c 0,5,6
+ 821 280 821 280 821 350 c 256,5,6
  821 420 821 420 762 449.5 c 128,-1,7
  703 479 703 479 578 479 c 2,8,-1
  411 479 l 1,0,-1
@@ -34232,7 +35126,7 @@ SplineSet
  411 698 l 1,10,-1
  567 698 l 2,11,12
  705 698 705 698 744 722 c 128,-1,13
- 783 746 783 746 783 795 c 0,14,15
+ 783 746 783 746 783 795 c 256,14,15
  783 844 783 844 744 872.5 c 128,-1,16
  705 901 705 901 567 901 c 2,17,-1
  411 901 l 1,9,-1
@@ -34250,8 +35144,9 @@ SplineSet
  119 1120 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0433
-Encoding: 1075 1075 1075
+Encoding: 1075 1075 889
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34291,8 +35186,9 @@ SplineSet
  513 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0434
-Encoding: 1076 1076 1076
+Encoding: 1076 1076 890
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34424,17 +35320,19 @@ SplineSet
  139 219 l 2,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0435
-Encoding: 1077 1077 1077
+Encoding: 1077 1077 891
 Width: 1233
 Flags: W
 AnchorPoint: "above" 615 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0436
-Encoding: 1078 1078 1078
+Encoding: 1078 1078 892
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34583,8 +35481,9 @@ SplineSet
  497 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0437
-Encoding: 1079 1079 1079
+Encoding: 1079 1079 893
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34666,7 +35565,7 @@ SplineSet
  252 231 252 231 331.5 216 c 128,-1,12
  411 201 411 201 534 201 c 0,13,14
  648 201 648 201 717 221 c 128,-1,15
- 786 241 786 241 786 325 c 0,16,17
+ 786 241 786 241 786 325 c 256,16,17
  786 409 786 409 706 435.5 c 128,-1,18
  626 462 626 462 556 462 c 2,19,-1
  393 462 l 1,20,-1
@@ -34685,8 +35584,9 @@ SplineSet
  927 598 927 598 857 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0438
-Encoding: 1080 1080 1080
+Encoding: 1080 1080 894
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34791,26 +35691,29 @@ SplineSet
  1091 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0439
-Encoding: 1081 1081 1081
+Encoding: 1081 1081 895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043A
-Encoding: 1082 1082 1082
+Encoding: 1082 1082 896
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 2
+Refer: 248 312 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043B
-Encoding: 1083 1083 1083
+Encoding: 1083 1083 897
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34885,8 +35788,9 @@ SplineSet
  571 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043C
-Encoding: 1084 1084 1084
+Encoding: 1084 1084 898
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35031,8 +35935,9 @@ SplineSet
  86 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043D
-Encoding: 1085 1085 1085
+Encoding: 1085 1085 899
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35093,17 +35998,19 @@ SplineSet
  1071 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043E
-Encoding: 1086 1086 1086
+Encoding: 1086 1086 900
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043F
-Encoding: 1087 1087 1087
+Encoding: 1087 1087 901
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35152,26 +36059,29 @@ SplineSet
  1071 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0440
-Encoding: 1088 1088 1088
+Encoding: 1088 1088 902
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0441
-Encoding: 1089 1089 1089
+Encoding: 1089 1089 903
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0442
-Encoding: 1090 1090 1090
+Encoding: 1090 1090 904
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35217,17 +36127,19 @@ SplineSet
  1071 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0443
-Encoding: 1091 1091 1091
+Encoding: 1091 1091 905
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0444
-Encoding: 1092 1092 1092
+Encoding: 1092 1092 906
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35301,43 +36213,45 @@ SplineSet
 496.5 -426 m 1,0,-1
  496.5 -29 l 1,1,2
  347.5 -14 347.5 -14 213.5 137 c 128,-1,3
- 79.5 288 79.5 288 79.5 559 c 0,4,5
+ 79.5 288 79.5 288 79.5 559 c 256,4,5
  79.5 830 79.5 830 213.5 981 c 128,-1,6
  347.5 1132 347.5 1132 496.5 1147 c 1,7,-1
  496.5 1556 l 1,8,-1
  736.5 1556 l 1,9,-1
  736.5 1147 l 1,10,11
  885.5 1132 885.5 1132 1019.5 981 c 128,-1,12
- 1153.5 830 1153.5 830 1153.5 559 c 0,13,14
+ 1153.5 830 1153.5 830 1153.5 559 c 256,13,14
  1153.5 288 1153.5 288 1019.5 137 c 128,-1,15
  885.5 -14 885.5 -14 736.5 -29 c 1,16,-1
  736.5 -426 l 1,17,-1
  496.5 -426 l 1,0,-1
 496.5 909 m 1,18,19
  425.5 892 425.5 892 372.5 810.5 c 128,-1,20
- 319.5 729 319.5 729 319.5 559 c 0,21,22
+ 319.5 729 319.5 729 319.5 559 c 256,21,22
  319.5 389 319.5 389 372.5 307.5 c 128,-1,23
  425.5 226 425.5 226 496.5 209 c 1,24,-1
  496.5 909 l 1,18,19
 736.5 209 m 1,25,26
  807.5 226 807.5 226 860.5 307.5 c 128,-1,27
- 913.5 389 913.5 389 913.5 559 c 0,28,29
+ 913.5 389 913.5 389 913.5 559 c 256,28,29
  913.5 729 913.5 729 860.5 810.5 c 128,-1,30
  807.5 892 807.5 892 736.5 909 c 1,31,-1
  736.5 209 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0445
-Encoding: 1093 1093 1093
+Encoding: 1093 1093 907
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0446
-Encoding: 1094 1094 1094
+Encoding: 1094 1094 908
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35398,8 +36312,9 @@ SplineSet
  1152 219 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0447
-Encoding: 1095 1095 1095
+Encoding: 1095 1095 909
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35458,8 +36373,9 @@ SplineSet
  437 783 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0448
-Encoding: 1096 1096 1096
+Encoding: 1096 1096 910
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35605,8 +36521,9 @@ SplineSet
  1154 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0449
-Encoding: 1097 1097 1097
+Encoding: 1097 1097 911
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35745,8 +36662,9 @@ SplineSet
  1001 0 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044A
-Encoding: 1098 1098 1098
+Encoding: 1098 1098 912
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -35775,8 +36693,9 @@ SplineSet
  582 698 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044B
-Encoding: 1099 1099 1099
+Encoding: 1099 1099 913
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -35808,8 +36727,9 @@ SplineSet
  908 0 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044C
-Encoding: 1100 1100 1100
+Encoding: 1100 1100 914
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35858,7 +36778,7 @@ SplineSet
  428 219 l 1,1,-1
  551 219 l 2,2,3
  661 219 661 219 714 249.5 c 128,-1,4
- 767 280 767 280 767 350 c 0,5,6
+ 767 280 767 280 767 350 c 256,5,6
  767 420 767 420 714 449.5 c 128,-1,7
  661 479 661 479 551 479 c 2,8,-1
  428 479 l 1,0,-1
@@ -35866,7 +36786,7 @@ SplineSet
  428 698 l 1,10,-1
  605 698 l 2,11,12
  817 698 817 698 938.5 612 c 128,-1,13
- 1060 526 1060 526 1060 350 c 0,14,15
+ 1060 526 1060 526 1060 350 c 256,14,15
  1060 174 1060 174 938.5 87 c 128,-1,16
  817 0 817 0 605 0 c 2,17,-1
  137 0 l 1,18,-1
@@ -35874,8 +36794,9 @@ SplineSet
  428 1120 l 17,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044D
-Encoding: 1101 1101 1101
+Encoding: 1101 1101 915
 Width: 1233
 Flags: W
 AnchorPoint: "above" 538 1120 basechar 0
@@ -35900,8 +36821,9 @@ SplineSet
  770 -29 770 -29 510 -29 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni044E
-Encoding: 1102 1102 1102
+Encoding: 1102 1102 916
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35987,8 +36909,9 @@ SplineSet
  56.5 0 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044F
-Encoding: 1103 1103 1103
+Encoding: 1103 1103 917
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36061,14 +36984,14 @@ AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-454 779 m 0,0,1
+454 779 m 256,0,1
  454 709 454 709 509 678.5 c 128,-1,2
  564 648 564 648 644 648 c 2,3,-1
  817 648 l 1,4,-1
  817 909 l 1,5,-1
  644 909 l 2,6,7
  564 909 564 909 509 879 c 128,-1,8
- 454 849 454 849 454 779 c 0,0,1
+ 454 849 454 849 454 779 c 256,0,1
 96 0 m 1,9,-1
  393 488 l 1,10,11
  350 510 350 510 261 579 c 128,-1,12
@@ -36084,26 +37007,29 @@ SplineSet
  96 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0450
-Encoding: 1104 1104 1104
+Encoding: 1104 1104 918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 39 0 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni0451
-Encoding: 1105 1105 1105
+Encoding: 1105 1105 919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 39 0 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni0452
-Encoding: 1106 1106 1106
+Encoding: 1106 1106 920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36138,17 +37064,19 @@ SplineSet
  20 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0453
-Encoding: 1107 1107 1107
+Encoding: 1107 1107 921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1075 1075 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 889 1075 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0454
-Encoding: 1108 1108 1108
+Encoding: 1108 1108 922
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36241,42 +37169,47 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0455
-Encoding: 1109 1109 1109
+Encoding: 1109 1109 923
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0456
-Encoding: 1110 1110 1110
+Encoding: 1110 1110 924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0457
-Encoding: 1111 1111 1111
+Encoding: 1111 1111 925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0458
-Encoding: 1112 1112 1112
+Encoding: 1112 1112 926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0459
-Encoding: 1113 1113 1113
+Encoding: 1113 1113 927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36314,8 +37247,9 @@ SplineSet
  574 901 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045A
-Encoding: 1114 1114 1114
+Encoding: 1114 1114 928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36349,8 +37283,9 @@ SplineSet
  574 0 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045B
-Encoding: 1115 1115 1115
+Encoding: 1115 1115 929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36383,35 +37318,39 @@ SplineSet
  20 895 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045C
-Encoding: 1116 1116 1116
+Encoding: 1116 1116 930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 896 1082 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045D
-Encoding: 1117 1117 1117
+Encoding: 1117 1117 931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 39 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni045E
-Encoding: 1118 1118 1118
+Encoding: 1118 1118 932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045F
-Encoding: 1119 1119 1119
+Encoding: 1119 1119 933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36432,8 +37371,9 @@ SplineSet
  171 1120 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0462
-Encoding: 1122 1122 1122
+Encoding: 1122 1122 934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36461,14 +37401,15 @@ SplineSet
  904 913 904 913 1039.5 803 c 128,-1,21
  1175 693 1175 693 1175 451 c 0,22,23
  1175 220 1175 220 1039.5 110 c 128,-1,24
- 904 2.28882e-05 904 2.28882e-05 595 0 c 2,25,-1
+ 904 2.28882e-005 904 2.28882e-005 595 0 c 2,25,-1
  270 0 l 1,26,-1
  270 1124 l 1,27,-1
  20 1124 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0463
-Encoding: 1123 1123 1123
+Encoding: 1123 1123 935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36502,76 +37443,87 @@ SplineSet
  582 479 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni046A
-Encoding: 1130 1130 1130
+Encoding: 1130 1130 936
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni046B
-Encoding: 1131 1131 1131
+Encoding: 1131 1131 937
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0472
-Encoding: 1138 1138 1138
+Encoding: 1138 1138 938
 Width: 1233
 Flags: W
 AnchorPoint: "above" 807 1520 basechar 0
 AnchorPoint: "below" 807 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 415 415 N 1 0 0 1 0 0 3
+Refer: 351 415 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0473
-Encoding: 1139 1139 1139
+Encoding: 1139 1139 939
 Width: 1233
 Flags: W
 AnchorPoint: "below" 637 0 basechar 0
 AnchorPoint: "above" 637 1147 basechar 0
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 3
+Refer: 546 629 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni048A
-Encoding: 1162 1162 1162
+Encoding: 1162 1162 940
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048B
-Encoding: 1163 1163 1163
+Encoding: 1163 1163 941
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048C
-Encoding: 1164 1164 1164
+Encoding: 1164 1164 942
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048D
-Encoding: 1165 1165 1165
+Encoding: 1165 1165 943
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048E
-Encoding: 1166 1166 1166
+Encoding: 1166 1166 944
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048F
-Encoding: 1167 1167 1167
+Encoding: 1167 1167 945
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0490
-Encoding: 1168 1168 1168
+Encoding: 1168 1168 946
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36618,8 +37570,9 @@ SplineSet
  477 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0491
-Encoding: 1169 1169 1169
+Encoding: 1169 1169 947
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36664,8 +37617,9 @@ SplineSet
  513 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0492
-Encoding: 1170 1170 1170
+Encoding: 1170 1170 948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36688,8 +37642,9 @@ SplineSet
  477 664 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0493
-Encoding: 1171 1171 1171
+Encoding: 1171 1171 949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36712,8 +37667,9 @@ SplineSet
  513 458 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0494
-Encoding: 1172 1172 1172
+Encoding: 1172 1172 950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36745,8 +37701,9 @@ SplineSet
  477 952 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0495
-Encoding: 1173 1173 1173
+Encoding: 1173 1173 951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36777,8 +37734,9 @@ SplineSet
  513 645 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0496
-Encoding: 1174 1174 1174
+Encoding: 1174 1174 952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36811,8 +37769,9 @@ SplineSet
  13 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0497
-Encoding: 1175 1175 1175
+Encoding: 1175 1175 953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36845,26 +37804,29 @@ SplineSet
  14 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0498
-Encoding: 1176 1176 1176
+Encoding: 1176 1176 954
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -54 0 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -54 0 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0499
-Encoding: 1177 1177 1177
+Encoding: 1177 1177 955
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -70 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -70 0 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni049A
-Encoding: 1178 1178 1178
+Encoding: 1178 1178 956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36889,8 +37851,9 @@ SplineSet
  1085 260 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049B
-Encoding: 1179 1179 1179
+Encoding: 1179 1179 957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36915,44 +37878,51 @@ SplineSet
  1065 209 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049C
-Encoding: 1180 1180 1180
+Encoding: 1180 1180 958
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049D
-Encoding: 1181 1181 1181
+Encoding: 1181 1181 959
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049E
-Encoding: 1182 1182 1182
+Encoding: 1182 1182 960
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049F
-Encoding: 1183 1183 1183
+Encoding: 1183 1183 961
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A0
-Encoding: 1184 1184 1184
+Encoding: 1184 1184 962
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A1
-Encoding: 1185 1185 1185
+Encoding: 1185 1185 963
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A2
-Encoding: 1186 1186 1186
+Encoding: 1186 1186 964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36977,8 +37947,9 @@ SplineSet
  940 0 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A3
-Encoding: 1187 1187 1187
+Encoding: 1187 1187 965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37003,8 +37974,9 @@ SplineSet
  927 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A4
-Encoding: 1188 1188 1188
+Encoding: 1188 1188 966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37027,8 +37999,9 @@ SplineSet
  78 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A5
-Encoding: 1189 1189 1189
+Encoding: 1189 1189 967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37051,50 +38024,57 @@ SplineSet
  78 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A6
-Encoding: 1190 1190 1190
+Encoding: 1190 1190 968
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A7
-Encoding: 1191 1191 1191
+Encoding: 1191 1191 969
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A8
-Encoding: 1192 1192 1192
+Encoding: 1192 1192 970
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A9
-Encoding: 1193 1193 1193
+Encoding: 1193 1193 971
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04AA
-Encoding: 1194 1194 1194
+Encoding: 1194 1194 972
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 117 0 2
-Refer: 1057 1057 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 117 0 2
+Refer: 871 1057 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AB
-Encoding: 1195 1195 1195
+Encoding: 1195 1195 973
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 72 0 2
-Refer: 1089 1089 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 72 0 2
+Refer: 903 1089 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AC
-Encoding: 1196 1196 1196
+Encoding: 1196 1196 974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37115,8 +38095,9 @@ SplineSet
  764 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AD
-Encoding: 1197 1197 1197
+Encoding: 1197 1197 975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37137,16 +38118,18 @@ SplineSet
  763 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AE
-Encoding: 1198 1198 1198
+Encoding: 1198 1198 976
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AF
-Encoding: 1199 1199 1199
+Encoding: 1199 1199 977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37164,8 +38147,9 @@ SplineSet
  57 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B0
-Encoding: 1200 1200 1200
+Encoding: 1200 1200 978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37191,8 +38175,9 @@ SplineSet
  8 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B1
-Encoding: 1201 1201 1201
+Encoding: 1201 1201 979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37218,8 +38203,9 @@ SplineSet
  57 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B2
-Encoding: 1202 1202 1202
+Encoding: 1202 1202 980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37244,8 +38230,9 @@ SplineSet
  1206 260 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B3
-Encoding: 1203 1203 1203
+Encoding: 1203 1203 981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37270,44 +38257,51 @@ SplineSet
  1031 209 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B4
-Encoding: 1204 1204 1204
+Encoding: 1204 1204 982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B5
-Encoding: 1205 1205 1205
+Encoding: 1205 1205 983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B6
-Encoding: 1206 1206 1206
+Encoding: 1206 1206 984
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B7
-Encoding: 1207 1207 1207
+Encoding: 1207 1207 985
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B8
-Encoding: 1208 1208 1208
+Encoding: 1208 1208 986
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B9
-Encoding: 1209 1209 1209
+Encoding: 1209 1209 987
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BA
-Encoding: 1210 1210 1210
+Encoding: 1210 1210 988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37337,66 +38331,75 @@ SplineSet
  101 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04BB
-Encoding: 1211 1211 1211
+Encoding: 1211 1211 989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04BC
-Encoding: 1212 1212 1212
+Encoding: 1212 1212 990
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BD
-Encoding: 1213 1213 1213
+Encoding: 1213 1213 991
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BE
-Encoding: 1214 1214 1214
+Encoding: 1214 1214 992
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BF
-Encoding: 1215 1215 1215
+Encoding: 1215 1215 993
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C0
-Encoding: 1216 1216 1216
+Encoding: 1216 1216 994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C1
-Encoding: 1217 1217 1217
+Encoding: 1217 1217 995
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1046 1046 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C2
-Encoding: 1218 1218 1218
+Encoding: 1218 1218 996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1078 1078 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C3
-Encoding: 1219 1219 1219
+Encoding: 1219 1219 997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37429,8 +38432,9 @@ SplineSet
  558.531 686.11 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C4
-Encoding: 1220 1220 1220
+Encoding: 1220 1220 998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37462,20 +38466,23 @@ SplineSet
  467 405 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C5
-Encoding: 1221 1221 1221
+Encoding: 1221 1221 999
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C6
-Encoding: 1222 1222 1222
+Encoding: 1222 1222 1000
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C7
-Encoding: 1223 1223 1223
+Encoding: 1223 1223 1001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37502,8 +38509,9 @@ SplineSet
  1096 43 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C8
-Encoding: 1224 1224 1224
+Encoding: 1224 1224 1002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37530,20 +38538,23 @@ SplineSet
  1071 43 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C9
-Encoding: 1225 1225 1225
+Encoding: 1225 1225 1003
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CA
-Encoding: 1226 1226 1226
+Encoding: 1226 1226 1004
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CB
-Encoding: 1227 1227 1227
+Encoding: 1227 1227 1005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37577,8 +38588,9 @@ SplineSet
  836 260 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CC
-Encoding: 1228 1228 1228
+Encoding: 1228 1228 1006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37607,20 +38619,23 @@ SplineSet
  770 209 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CD
-Encoding: 1229 1229 1229
+Encoding: 1229 1229 1007
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CE
-Encoding: 1230 1230 1230
+Encoding: 1230 1230 1008
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CF
-Encoding: 1231 1231 1231
+Encoding: 1231 1231 1009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37633,26 +38648,29 @@ SplineSet
  680 1556 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04D0
-Encoding: 1232 1232 1232
+Encoding: 1232 1232 1010
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1040 1040 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D1
-Encoding: 1233 1233 1233
+Encoding: 1233 1233 1011
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1072 1072 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D2
-Encoding: 1234 1234 1234
+Encoding: 1234 1234 1012
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37691,176 +38709,196 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1040 1040 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04D3
-Encoding: 1235 1235 1235
+Encoding: 1235 1235 1013
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D4
-Encoding: 1236 1236 1236
+Encoding: 1236 1236 1014
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D5
-Encoding: 1237 1237 1237
+Encoding: 1237 1237 1015
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D6
-Encoding: 1238 1238 1238
+Encoding: 1238 1238 1016
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni04D7
-Encoding: 1239 1239 1239
+Encoding: 1239 1239 1017
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 14 0 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni04D8
-Encoding: 1240 1240 1240
+Encoding: 1240 1240 1018
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 399 399 N 1 0 0 1 0 0 3
+Refer: 335 399 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04D9
-Encoding: 1241 1241 1241
+Encoding: 1241 1241 1019
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04DA
-Encoding: 1242 1242 1242
+Encoding: 1242 1242 1020
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1240 1240 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 1018 1240 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DB
-Encoding: 1243 1243 1243
+Encoding: 1243 1243 1021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1241 1241 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 1019 1241 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DC
-Encoding: 1244 1244 1244
+Encoding: 1244 1244 1022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -8 373 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 -8 373 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DD
-Encoding: 1245 1245 1245
+Encoding: 1245 1245 1023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -1 -24 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -1 -24 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DE
-Encoding: 1246 1246 1246
+Encoding: 1246 1246 1024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -20 373 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 -20 373 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DF
-Encoding: 1247 1247 1247
+Encoding: 1247 1247 1025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -11.5 -24 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -11.5 -24 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E0
-Encoding: 1248 1248 1248
+Encoding: 1248 1248 1026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E1
-Encoding: 1249 1249 1249
+Encoding: 1249 1249 1027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E2
-Encoding: 1250 1250 1250
+Encoding: 1250 1250 1028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E3
-Encoding: 1251 1251 1251
+Encoding: 1251 1251 1029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E4
-Encoding: 1252 1252 1252
+Encoding: 1252 1252 1030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E5
-Encoding: 1253 1253 1253
+Encoding: 1253 1253 1031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 -24 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
 EndChar
+
 StartChar: uni04E6
-Encoding: 1254 1254 1254
+Encoding: 1254 1254 1032
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37875,11 +38913,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1054 1054 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 868 1054 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04E7
-Encoding: 1255 1255 1255
+Encoding: 1255 1255 1033
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37894,135 +38933,150 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1086 1086 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 900 1086 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E8
-Encoding: 1256 1256 1256
+Encoding: 1256 1256 1034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1012 1012 N 1 0 0 1 0 0 2
+Refer: 826 1012 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E9
-Encoding: 1257 1257 1257
+Encoding: 1257 1257 1035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 2
+Refer: 546 629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EA
-Encoding: 1258 1258 1258
+Encoding: 1258 1258 1036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1256 1256 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 1034 1256 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EB
-Encoding: 1259 1259 1259
+Encoding: 1259 1259 1037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1257 1257 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 1035 1257 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EC
-Encoding: 1260 1260 1260
+Encoding: 1260 1260 1038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -50 373 2
-Refer: 1069 1069 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 -50 373 2
+Refer: 883 1069 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04ED
-Encoding: 1261 1261 1261
+Encoding: 1261 1261 1039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -52 -24 2
-Refer: 1101 1101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -52 -24 2
+Refer: 915 1101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EE
-Encoding: 1262 1262 1262
+Encoding: 1262 1262 1040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EF
-Encoding: 1263 1263 1263
+Encoding: 1263 1263 1041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F0
-Encoding: 1264 1264 1264
+Encoding: 1264 1264 1042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F1
-Encoding: 1265 1265 1265
+Encoding: 1265 1265 1043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F2
-Encoding: 1266 1266 1266
+Encoding: 1266 1266 1044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
+Refer: 3676 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F3
-Encoding: 1267 1267 1267
+Encoding: 1267 1267 1045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F4
-Encoding: 1268 1268 1268
+Encoding: 1268 1268 1046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1063 1063 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 877 1063 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F5
-Encoding: 1269 1269 1269
+Encoding: 1269 1269 1047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1095 1095 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 909 1095 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F6
-Encoding: 1270 1270 1270
+Encoding: 1270 1270 1048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38041,8 +39095,9 @@ SplineSet
  477 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F7
-Encoding: 1271 1271 1271
+Encoding: 1271 1271 1049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38061,170 +39116,195 @@ SplineSet
  513 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F8
-Encoding: 1272 1272 1272
+Encoding: 1272 1272 1050
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 40 373 2
-Refer: 1067 1067 N 1 0 0 1 0 0 2
+Refer: 3666 -1 N 1 0 0 1 40 373 2
+Refer: 881 1067 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F9
-Encoding: 1273 1273 1273
+Encoding: 1273 1273 1051
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1099 1099 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 913 1099 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0500
-Encoding: 1280 1280 1280
+Encoding: 1280 1280 1052
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0501
-Encoding: 1281 1281 1281
+Encoding: 1281 1281 1053
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0502
-Encoding: 1282 1282 1282
+Encoding: 1282 1282 1054
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0503
-Encoding: 1283 1283 1283
+Encoding: 1283 1283 1055
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0504
-Encoding: 1284 1284 1284
+Encoding: 1284 1284 1056
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0505
-Encoding: 1285 1285 1285
+Encoding: 1285 1285 1057
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0506
-Encoding: 1286 1286 1286
+Encoding: 1286 1286 1058
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0507
-Encoding: 1287 1287 1287
+Encoding: 1287 1287 1059
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0508
-Encoding: 1288 1288 1288
+Encoding: 1288 1288 1060
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0509
-Encoding: 1289 1289 1289
+Encoding: 1289 1289 1061
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050A
-Encoding: 1290 1290 1290
+Encoding: 1290 1290 1062
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050B
-Encoding: 1291 1291 1291
+Encoding: 1291 1291 1063
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050C
-Encoding: 1292 1292 1292
+Encoding: 1292 1292 1064
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050D
-Encoding: 1293 1293 1293
+Encoding: 1293 1293 1065
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050E
-Encoding: 1294 1294 1294
+Encoding: 1294 1294 1066
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050F
-Encoding: 1295 1295 1295
+Encoding: 1295 1295 1067
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0510
-Encoding: 1296 1296 1296
+Encoding: 1296 1296 1068
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 400 400 N 1 0 0 1 0 0 3
+Refer: 336 400 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0511
-Encoding: 1297 1297 1297
+Encoding: 1297 1297 1069
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 3
+Refer: 778 949 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni051A
-Encoding: 1306 1306 1306
+Encoding: 1306 1306 1070
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051B
-Encoding: 1307 1307 1307
+Encoding: 1307 1307 1071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051C
-Encoding: 1308 1308 1308
+Encoding: 1308 1308 1072
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051D
-Encoding: 1309 1309 1309
+Encoding: 1309 1309 1073
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0531
-Encoding: 1329 1329 1329
+Encoding: 1329 1329 1074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38261,8 +39341,9 @@ SplineSet
  71 398 71 398 71 551 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0532
-Encoding: 1330 1330 1330
+Encoding: 1330 1330 1075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38293,8 +39374,9 @@ SplineSet
  1118 1095 1118 1095 1118 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0533
-Encoding: 1331 1331 1331
+Encoding: 1331 1331 1076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38335,8 +39417,9 @@ SplineSet
  758 1016 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0534
-Encoding: 1332 1332 1332
+Encoding: 1332 1332 1077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38367,8 +39450,9 @@ SplineSet
  33 942 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0535
-Encoding: 1333 1333 1333
+Encoding: 1333 1333 1078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38399,8 +39483,9 @@ SplineSet
  1118 551 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0536
-Encoding: 1334 1334 1334
+Encoding: 1334 1334 1079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38438,8 +39523,9 @@ SplineSet
  107 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0537
-Encoding: 1335 1335 1335
+Encoding: 1335 1335 1080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38458,8 +39544,9 @@ SplineSet
  112 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0538
-Encoding: 1336 1336 1336
+Encoding: 1336 1336 1081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38488,8 +39575,9 @@ SplineSet
  1118 1095 1118 1095 1118 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0539
-Encoding: 1337 1337 1337
+Encoding: 1337 1337 1082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38547,8 +39635,9 @@ SplineSet
  619 519 619 519 619 413 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni053A
-Encoding: 1338 1338 1338
+Encoding: 1338 1338 1083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38589,8 +39678,9 @@ SplineSet
  543 819 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni053B
-Encoding: 1339 1339 1339
+Encoding: 1339 1339 1084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38617,8 +39707,9 @@ SplineSet
  1126 714 1126 714 1126 561 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053C
-Encoding: 1340 1340 1340
+Encoding: 1340 1340 1085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38633,8 +39724,9 @@ SplineSet
  153 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053D
-Encoding: 1341 1341 1341
+Encoding: 1341 1341 1086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38671,8 +39763,9 @@ SplineSet
  715 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053E
-Encoding: 1342 1342 1342
+Encoding: 1342 1342 1087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38732,8 +39825,9 @@ SplineSet
  393 715 393 715 393 597 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni053F
-Encoding: 1343 1343 1343
+Encoding: 1343 1343 1088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38760,8 +39854,9 @@ SplineSet
  1126 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0540
-Encoding: 1344 1344 1344
+Encoding: 1344 1344 1089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38794,8 +39889,9 @@ SplineSet
  1146 236 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0541
-Encoding: 1345 1345 1345
+Encoding: 1345 1345 1090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38853,8 +39949,9 @@ SplineSet
  1149 1062 1149 1062 1149 885 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0542
-Encoding: 1346 1346 1346
+Encoding: 1346 1346 1091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38883,8 +39980,9 @@ SplineSet
  33 942 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0543
-Encoding: 1347 1347 1347
+Encoding: 1347 1347 1092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38925,8 +40023,9 @@ SplineSet
  502 628 502 628 486 602 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni0544
-Encoding: 1348 1348 1348
+Encoding: 1348 1348 1093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38955,8 +40054,9 @@ SplineSet
  758 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0545
-Encoding: 1349 1349 1349
+Encoding: 1349 1349 1094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39012,8 +40112,9 @@ SplineSet
  1182 513 1182 513 1182 454 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0546
-Encoding: 1350 1350 1350
+Encoding: 1350 1350 1095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39042,8 +40143,9 @@ SplineSet
  1199 551 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0547
-Encoding: 1351 1351 1351
+Encoding: 1351 1351 1096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39097,8 +40199,9 @@ SplineSet
  383 701 383 701 383 606 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0548
-Encoding: 1352 1352 1352
+Encoding: 1352 1352 1097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39125,8 +40228,9 @@ SplineSet
  1126 1095 1126 1095 1126 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0549
-Encoding: 1353 1353 1353
+Encoding: 1353 1353 1098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39165,8 +40269,9 @@ SplineSet
  852 830 852 830 852 935 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054A
-Encoding: 1354 1354 1354
+Encoding: 1354 1354 1099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39196,8 +40301,9 @@ SplineSet
  743 442 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054B
-Encoding: 1355 1355 1355
+Encoding: 1355 1355 1100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39261,8 +40367,9 @@ SplineSet
  407 261 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni054C
-Encoding: 1356 1356 1356
+Encoding: 1356 1356 1101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39293,8 +40400,9 @@ SplineSet
  1053 1095 1053 1095 1053 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054D
-Encoding: 1357 1357 1357
+Encoding: 1357 1357 1102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39321,8 +40429,9 @@ SplineSet
  106 398 106 398 106 551 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054E
-Encoding: 1358 1358 1358
+Encoding: 1358 1358 1103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39351,8 +40460,9 @@ SplineSet
  1053 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054F
-Encoding: 1359 1359 1359
+Encoding: 1359 1359 1104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39414,8 +40524,9 @@ SplineSet
  412 447 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0550
-Encoding: 1360 1360 1360
+Encoding: 1360 1360 1105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39442,8 +40553,9 @@ SplineSet
  1126 1095 1126 1095 1126 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0551
-Encoding: 1361 1361 1361
+Encoding: 1361 1361 1106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39511,8 +40623,9 @@ SplineSet
  543 1518 543 1518 654 1518 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0552
-Encoding: 1362 1362 1362
+Encoding: 1362 1362 1107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39529,8 +40642,9 @@ SplineSet
  112 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0553
-Encoding: 1363 1363 1363
+Encoding: 1363 1363 1108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39581,8 +40695,9 @@ SplineSet
  487 138 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0554
-Encoding: 1364 1364 1364
+Encoding: 1364 1364 1109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39633,16 +40748,18 @@ SplineSet
  744 1263 744 1263 686 1263 c 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0555
-Encoding: 1365 1365 1365
+Encoding: 1365 1365 1110
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 3
+Refer: 48 79 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0556
-Encoding: 1366 1366 1366
+Encoding: 1366 1366 1111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39701,16 +40818,18 @@ SplineSet
  487 1263 l 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni0559
-Encoding: 1369 1369 1369
+Encoding: 1369 1369 1112
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 0 3
+Refer: 619 703 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni055A
-Encoding: 1370 1370 1370
+Encoding: 1370 1370 1113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39725,8 +40844,9 @@ SplineSet
  509 1495 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055B
-Encoding: 1371 1371 1371
+Encoding: 1371 1371 1114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39739,8 +40859,9 @@ SplineSet
  959 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055C
-Encoding: 1372 1372 1372
+Encoding: 1372 1372 1115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39767,8 +40888,9 @@ SplineSet
  893 1450 893 1450 809 1433 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni055D
-Encoding: 1373 1373 1373
+Encoding: 1373 1373 1116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39781,8 +40903,9 @@ SplineSet
  676 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055E
-Encoding: 1374 1374 1374
+Encoding: 1374 1374 1117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39825,8 +40948,9 @@ SplineSet
  270 1342 270 1342 261 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055F
-Encoding: 1375 1375 1375
+Encoding: 1375 1375 1118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39841,8 +40965,9 @@ SplineSet
  188 1265 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0561
-Encoding: 1377 1377 1377
+Encoding: 1377 1377 1119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39888,8 +41013,9 @@ SplineSet
  551 83 551 83 545 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0562
-Encoding: 1378 1378 1378
+Encoding: 1378 1378 1120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39918,8 +41044,9 @@ SplineSet
  1084 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0563
-Encoding: 1379 1379 1379
+Encoding: 1379 1379 1121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39964,8 +41091,9 @@ SplineSet
  358 642 358 642 358 561 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0564
-Encoding: 1380 1380 1380
+Encoding: 1380 1380 1122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39994,8 +41122,9 @@ SplineSet
  1130 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0565
-Encoding: 1381 1381 1381
+Encoding: 1381 1381 1123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40024,8 +41153,9 @@ SplineSet
  1090 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0566
-Encoding: 1382 1382 1382
+Encoding: 1382 1382 1124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40068,8 +41198,9 @@ SplineSet
  358 642 358 642 358 561 c 0,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni0567
-Encoding: 1383 1383 1383
+Encoding: 1383 1383 1125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40088,8 +41219,9 @@ SplineSet
  967 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0568
-Encoding: 1384 1384 1384
+Encoding: 1384 1384 1126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40116,8 +41248,9 @@ SplineSet
  1084 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0569
-Encoding: 1385 1385 1385
+Encoding: 1385 1385 1127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40178,8 +41311,9 @@ SplineSet
  565 294 565 294 565 254 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni056A
-Encoding: 1386 1386 1386
+Encoding: 1386 1386 1128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40225,8 +41359,9 @@ SplineSet
  1058 895 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056B
-Encoding: 1387 1387 1387
+Encoding: 1387 1387 1129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40251,8 +41386,9 @@ SplineSet
  1066 938 1066 938 1066 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056C
-Encoding: 1388 1388 1388
+Encoding: 1388 1388 1130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40267,8 +41403,9 @@ SplineSet
  905 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056D
-Encoding: 1389 1389 1389
+Encoding: 1389 1389 1131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40323,8 +41460,9 @@ SplineSet
  316 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056E
-Encoding: 1390 1390 1390
+Encoding: 1390 1390 1132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40372,8 +41510,9 @@ SplineSet
  391 720 391 720 391 559 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni056F
-Encoding: 1391 1391 1391
+Encoding: 1391 1391 1133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40398,16 +41537,18 @@ SplineSet
  166 182 166 182 166 391 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0570
-Encoding: 1392 1392 1392
+Encoding: 1392 1392 1134
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 -4 0 3
+Refer: 73 104 N 1 0 0 1 -4 0 3
 EndChar
+
 StartChar: uni0571
-Encoding: 1393 1393 1393
+Encoding: 1393 1393 1135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40469,8 +41610,9 @@ SplineSet
  444 578 444 578 444 435 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni0572
-Encoding: 1394 1394 1394
+Encoding: 1394 1394 1136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40497,8 +41639,9 @@ SplineSet
  1130 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0573
-Encoding: 1395 1395 1395
+Encoding: 1395 1395 1137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40558,8 +41701,9 @@ SplineSet
  464 578 464 578 464 491 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni0574
-Encoding: 1396 1396 1396
+Encoding: 1396 1396 1138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40586,8 +41730,9 @@ SplineSet
  1067 1331 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0575
-Encoding: 1397 1397 1397
+Encoding: 1397 1397 1139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40610,8 +41755,9 @@ SplineSet
  970 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0576
-Encoding: 1398 1398 1398
+Encoding: 1398 1398 1140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40638,8 +41784,9 @@ SplineSet
  231 182 231 182 231 393 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0577
-Encoding: 1399 1399 1399
+Encoding: 1399 1399 1141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40690,16 +41837,18 @@ SplineSet
  532 1145 532 1145 597 1145 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0578
-Encoding: 1400 1400 1400
+Encoding: 1400 1400 1142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 -4 0 3
+Refer: 79 110 N 1 0 0 1 -4 0 3
 EndChar
+
 StartChar: uni0579
-Encoding: 1401 1401 1401
+Encoding: 1401 1401 1143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40745,8 +41894,9 @@ SplineSet
  1007 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057A
-Encoding: 1402 1402 1402
+Encoding: 1402 1402 1144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40792,8 +41942,9 @@ SplineSet
  913 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057B
-Encoding: 1403 1403 1403
+Encoding: 1403 1403 1145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40858,8 +42009,9 @@ SplineSet
  658 917 658 917 610 917 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni057C
-Encoding: 1404 1404 1404
+Encoding: 1404 1404 1146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40901,16 +42053,18 @@ SplineSet
  630 909 630 909 578 909 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057D
-Encoding: 1405 1405 1405
+Encoding: 1405 1405 1147
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 6 0 3
+Refer: 86 117 N 1 0 0 1 6 0 3
 EndChar
+
 StartChar: uni057E
-Encoding: 1406 1406 1406
+Encoding: 1406 1406 1148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40937,8 +42091,9 @@ SplineSet
  1136 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057F
-Encoding: 1407 1407 1407
+Encoding: 1407 1407 1149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40983,8 +42138,9 @@ SplineSet
  1151 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0580
-Encoding: 1408 1408 1408
+Encoding: 1408 1408 1150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41009,16 +42165,18 @@ SplineSet
  1066 938 1066 938 1066 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0581
-Encoding: 1409 1409 1409
+Encoding: 1409 1409 1151
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 19 0 3
+Refer: 72 103 N 1 0 0 1 19 0 3
 EndChar
+
 StartChar: uni0582
-Encoding: 1410 1410 1410
+Encoding: 1410 1410 1152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41033,8 +42191,9 @@ SplineSet
  1044 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0583
-Encoding: 1411 1411 1411
+Encoding: 1411 1411 1153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41079,8 +42238,9 @@ SplineSet
  1151 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0584
-Encoding: 1412 1412 1412
+Encoding: 1412 1412 1154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41129,16 +42289,18 @@ SplineSet
  875 480 875 480 875 561 c 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni0585
-Encoding: 1413 1413 1413
+Encoding: 1413 1413 1155
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 3
+Refer: 80 111 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0586
-Encoding: 1414 1414 1414
+Encoding: 1414 1414 1156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41194,8 +42356,9 @@ SplineSet
  945 507 945 507 945 575 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni0587
-Encoding: 1415 1415 1415
+Encoding: 1415 1415 1157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41222,8 +42385,9 @@ SplineSet
  1187 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0589
-Encoding: 1417 1417 1417
+Encoding: 1417 1417 1158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41241,8 +42405,9 @@ SplineSet
  450 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni058A
-Encoding: 1418 1418 1418
+Encoding: 1418 1418 1159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41256,8 +42421,9 @@ SplineSet
  301 735 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0606
-Encoding: 1542 1542 1542
+Encoding: 1542 1542 1160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41299,8 +42465,9 @@ SplineSet
  1120 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0607
-Encoding: 1543 1543 1543
+Encoding: 1543 1543 1161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41344,8 +42511,9 @@ SplineSet
  1120 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0609
-Encoding: 1545 1545 1545
+Encoding: 1545 1545 1162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41373,8 +42541,9 @@ SplineSet
  584 1300 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060A
-Encoding: 1546 1546 1546
+Encoding: 1546 1546 1163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41407,8 +42576,9 @@ SplineSet
  434 1300 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060C
-Encoding: 1548 1548 1548
+Encoding: 1548 1548 1164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41423,8 +42593,9 @@ SplineSet
  708 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0615
-Encoding: 1557 1557 1557
+Encoding: 1557 1557 1165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41453,8 +42624,9 @@ SplineSet
  734 1276 734 1276 678 1276 c 2,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni061B
-Encoding: 1563 1563 1563
+Encoding: 1563 1563 1166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41474,8 +42646,9 @@ SplineSet
  686 0 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni061F
-Encoding: 1567 1567 1567
+Encoding: 1567 1567 1167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41513,8 +42686,9 @@ SplineSet
  526 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0621
-Encoding: 1569 1569 1569
+Encoding: 1569 1569 1168
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 700 -12 basechar 0
@@ -41543,66 +42717,72 @@ SplineSet
  543 42 543 42 434 27 c 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0622
-Encoding: 1570 1570 1570
+Encoding: 1570 1570 1169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 0 470 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 470 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE82
 EndChar
+
 StartChar: uni0623
-Encoding: 1571 1571 1571
+Encoding: 1571 1571 1170
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 610 2223 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 0 453 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 453 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE84
 EndChar
+
 StartChar: uni0624
-Encoding: 1572 1572 1572
+Encoding: 1572 1572 1171
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 634 1419 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 99 -382 2
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 99 -382 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE86
 EndChar
+
 StartChar: uni0625
-Encoding: 1573 1573 1573
+Encoding: 1573 1573 1172
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -620 basechar 0
 AnchorPoint: "rtl-above" 610 1695 basechar 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 0 -72 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 0 -72 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE88
 EndChar
+
 StartChar: uni0626
-Encoding: 1574 1574 1574
+Encoding: 1574 1574 1173
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -436 basechar 0
 AnchorPoint: "rtl-above" 306 1375 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -250 -432 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -250 -432 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFE8B
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFE8C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE8A
 EndChar
+
 StartChar: uni0627
-Encoding: 1575 1575 1575
+Encoding: 1575 1575 1174
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -76 basechar 0
@@ -41618,76 +42798,82 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE8E
 EndChar
+
 StartChar: uni0628
-Encoding: 1576 1576 1576
+Encoding: 1576 1576 1175
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -408 basechar 0
 AnchorPoint: "rtl-above" 598 851 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 500 -352 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 500 -352 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFE91
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFE92
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE90
 EndChar
+
 StartChar: uni0629
-Encoding: 1577 1577 1577
+Encoding: 1577 1577 1176
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -168 basechar 0
 AnchorPoint: "rtl-above" 462 1291 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 245 900 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 245 900 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE94
 EndChar
+
 StartChar: uni062A
-Encoding: 1578 1578 1578
+Encoding: 1578 1578 1177
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -136 basechar 0
 AnchorPoint: "rtl-above" 538 1083 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 320 650 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 320 650 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFE97
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFE98
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE96
 EndChar
+
 StartChar: uni062B
-Encoding: 1579 1579 1579
+Encoding: 1579 1579 1178
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -136 basechar 0
 AnchorPoint: "rtl-above" 498 1347 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 320 650 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 320 650 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFE9B
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFE9C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE9A
 EndChar
+
 StartChar: uni062C
-Encoding: 1580 1580 1580
+Encoding: 1580 1580 1179
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -600 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 663 13 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 663 13 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFE9F
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEA0
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFE9E
 EndChar
+
 StartChar: uni062D
-Encoding: 1581 1581 1581
+Encoding: 1581 1581 1180
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -588 basechar 0
@@ -41718,22 +42904,24 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEA3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEA4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEA2
 EndChar
+
 StartChar: uni062E
-Encoding: 1582 1582 1582
+Encoding: 1582 1582 1181
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -592 basechar 0
 AnchorPoint: "rtl-above" 466 1419 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 458 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 458 1050 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEA7
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEA8
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEA6
 EndChar
+
 StartChar: uni062F
-Encoding: 1583 1583 1583
+Encoding: 1583 1583 1182
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -136 basechar 0
@@ -41759,20 +42947,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEAA
 EndChar
+
 StartChar: uni0630
-Encoding: 1584 1584 1584
+Encoding: 1584 1584 1183
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -136 basechar 0
 AnchorPoint: "rtl-above" 538 1479 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 540 1122 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 540 1122 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEAC
 EndChar
+
 StartChar: uni0631
-Encoding: 1585 1585 1585
+Encoding: 1585 1585 1184
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 558 -548 basechar 0
@@ -41794,20 +42984,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEAE
 EndChar
+
 StartChar: uni0632
-Encoding: 1586 1586 1586
+Encoding: 1586 1586 1185
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 556 -527 basechar 0
 AnchorPoint: "rtl-above" 486 1167 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 849 760 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 849 760 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEB0
 EndChar
+
 StartChar: uni0633
-Encoding: 1587 1587 1587
+Encoding: 1587 1587 1186
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -492 basechar 0
@@ -41857,22 +43049,24 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEB3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEB4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEB2
 EndChar
+
 StartChar: uni0634
-Encoding: 1588 1588 1588
+Encoding: 1588 1588 1187
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -488 basechar 0
 AnchorPoint: "rtl-above" 446 1543 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 265 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 265 800 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEB7
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEB8
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEB6
 EndChar
+
 StartChar: uni0635
-Encoding: 1589 1589 1589
+Encoding: 1589 1589 1188
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -484 basechar 0
@@ -41920,22 +43114,24 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEBB
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEBC
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEBA
 EndChar
+
 StartChar: uni0636
-Encoding: 1590 1590 1590
+Encoding: 1590 1590 1189
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -488 basechar 0
 AnchorPoint: "rtl-above" 378 1135 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 232 695 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 232 695 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEBF
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEC0
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEBE
 EndChar
+
 StartChar: uni0637
-Encoding: 1591 1591 1591
+Encoding: 1591 1591 1190
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 384 -104 basechar 0
@@ -41969,22 +43165,24 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEC3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEC4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEC2
 EndChar
+
 StartChar: uni0638
-Encoding: 1592 1592 1592
+Encoding: 1592 1592 1191
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 384 -104 basechar 0
 AnchorPoint: "rtl-above" 306 1719 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 662 844 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 662 844 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEC7
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEC8
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEC6
 EndChar
+
 StartChar: uni0639
-Encoding: 1593 1593 1593
+Encoding: 1593 1593 1192
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 544 -585 basechar 0
@@ -42021,22 +43219,24 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFECC
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFECB
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFECA
 EndChar
+
 StartChar: uni063A
-Encoding: 1594 1594 1594
+Encoding: 1594 1594 1193
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 544 -585 basechar 0
 AnchorPoint: "rtl-above" 370 1547 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 311 1210 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 311 1210 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFECE
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFED0
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFECF
 EndChar
+
 StartChar: uni0640
-Encoding: 1600 1600 1600
+Encoding: 1600 1600 1194
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
@@ -42051,36 +43251,39 @@ SplineSet
  -32 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0641
-Encoding: 1601 1601 1601
+Encoding: 1601 1601 1195
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 504 -225 basechar 0
 AnchorPoint: "rtl-above" 626 1399 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 736 1042 2
+Refer: 3708 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 736 1042 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFED3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFED4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFED2
 EndChar
+
 StartChar: uni0642
-Encoding: 1602 1602 1602
+Encoding: 1602 1602 1196
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 580 -497 basechar 0
 AnchorPoint: "rtl-above" 518 1555 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 515 1200 2
+Refer: 3701 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 515 1200 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFED7
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFED8
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFED6
 EndChar
+
 StartChar: uni0643
-Encoding: 1603 1603 1603
+Encoding: 1603 1603 1197
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -193 basechar 0
@@ -42129,8 +43332,9 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEDB
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEDC
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEDA
 EndChar
+
 StartChar: uni0644
-Encoding: 1604 1604 1604
+Encoding: 1604 1604 1198
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 476 -425 basechar 0
@@ -42160,8 +43364,9 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEDF
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEE0
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEDE
 EndChar
+
 StartChar: uni0645
-Encoding: 1605 1605 1605
+Encoding: 1605 1605 1199
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 780 -141 basechar 0
@@ -42201,22 +43406,24 @@ Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEE3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEE4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEE2
 EndChar
+
 StartChar: uni0646
-Encoding: 1606 1606 1606
+Encoding: 1606 1606 1200
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -397 basechar 0
 AnchorPoint: "rtl-above" 466 1147 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 454 726 2
+Refer: 3710 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 454 726 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEE7
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEE8
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEE6
 EndChar
+
 StartChar: uni0647
-Encoding: 1607 1607 1607
+Encoding: 1607 1607 1201
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
@@ -42247,8 +43454,9 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEEC
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEEB
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEEA
 EndChar
+
 StartChar: uni0648
-Encoding: 1608 1608 1608
+Encoding: 1608 1608 1202
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -541 basechar 0
@@ -42281,8 +43489,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEEE
 EndChar
+
 StartChar: uni0649
-Encoding: 1609 1609 1609
+Encoding: 1609 1609 1203
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 552 -421 basechar 0
@@ -42324,22 +43533,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEF0
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFBE9
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFBE8
 EndChar
+
 StartChar: uni064A
-Encoding: 1610 1610 1610
+Encoding: 1610 1610 1204
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 516 -741 basechar 0
 AnchorPoint: "rtl-above" 506 1059 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 279 -661 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 279 -661 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFEF3
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFEF4
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFEF2
 EndChar
+
 StartChar: uni064B
-Encoding: 1611 1611 1611
+Encoding: 1611 1611 1205
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 618 1056 mark 0
@@ -42359,8 +43570,9 @@ SplineSet
  304 1152 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064C
-Encoding: 1612 1612 1612
+Encoding: 1612 1612 1206
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 616 1023 mark 0
@@ -42396,8 +43608,9 @@ SplineSet
  658 1375 658 1375 678 1435 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni064D
-Encoding: 1613 1613 1613
+Encoding: 1613 1613 1207
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 126 mark 0
@@ -42417,8 +43630,9 @@ SplineSet
  304 -604 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064E
-Encoding: 1614 1614 1614
+Encoding: 1614 1614 1208
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 618 1105.5 mark 0
@@ -42434,8 +43648,9 @@ SplineSet
  304 1152 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064F
-Encoding: 1615 1615 1615
+Encoding: 1615 1615 1209
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 605 1130 mark 0
@@ -42468,8 +43683,9 @@ SplineSet
  570 1415 570 1415 621 1452 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0650
-Encoding: 1616 1616 1616
+Encoding: 1616 1616 1210
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 618 -6 mark 0
@@ -42485,8 +43701,9 @@ SplineSet
  304 -350 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0651
-Encoding: 1617 1617 1617
+Encoding: 1617 1617 1211
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 618 1850 basemark 0
@@ -42520,8 +43737,9 @@ SplineSet
  636 1347 636 1347 632 1374 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0652
-Encoding: 1618 1618 1618
+Encoding: 1618 1618 1212
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 618 1128 mark 0
@@ -42550,8 +43768,9 @@ SplineSet
  917 1651 917 1651 917 1524.5 c 128,-1,11
 EndSplineSet
 EndChar
+
 StartChar: uni0653
-Encoding: 1619 1619 1619
+Encoding: 1619 1619 1213
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 618 1056 mark 0
@@ -42574,8 +43793,9 @@ SplineSet
  224 1388 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0654
-Encoding: 1620 1620 1620
+Encoding: 1620 1620 1214
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 618 1750 basemark 0
@@ -42583,10 +43803,11 @@ AnchorPoint: "rtl-above" 618 1098 mark 0
 AnchorPoint: "Ligature rtl-above" 618 1098 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -115 2
+Refer: 1231 1652 N 1 0 0 1 0 -115 2
 EndChar
+
 StartChar: uni0655
-Encoding: 1621 1621 1621
+Encoding: 1621 1621 1215
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 618 -620 basemark 0
@@ -42594,10 +43815,11 @@ AnchorPoint: "rtl-below" 618 0 mark 0
 AnchorPoint: "Ligature rtl-below" 618 0 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -1890 2
+Refer: 1231 1652 N 1 0 0 1 0 -1890 2
 EndChar
+
 StartChar: uni065A
-Encoding: 1626 1626 1626
+Encoding: 1626 1626 1216
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 616.5 1200 mark 0
@@ -42615,8 +43837,9 @@ SplineSet
  507 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0660
-Encoding: 1632 1632 1632
+Encoding: 1632 1632 1217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42629,8 +43852,9 @@ SplineSet
  452 763 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0661
-Encoding: 1633 1633 1633
+Encoding: 1633 1633 1218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42645,8 +43869,9 @@ SplineSet
  868 474 868 474 868 0 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0662
-Encoding: 1634 1634 1634
+Encoding: 1634 1634 1219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42669,8 +43894,9 @@ SplineSet
  576 886 576 886 554 902 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0663
-Encoding: 1635 1635 1635
+Encoding: 1635 1635 1220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42700,8 +43926,9 @@ SplineSet
  543 882 543 882 486 889 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0664
-Encoding: 1636 1636 1636
+Encoding: 1636 1636 1221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42733,8 +43960,9 @@ SplineSet
  644 1396 644 1396 864 1400 c 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0665
-Encoding: 1637 1637 1637
+Encoding: 1637 1637 1222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42760,8 +43988,9 @@ SplineSet
  342 1401 342 1401 616 1400 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0666
-Encoding: 1638 1638 1638
+Encoding: 1638 1638 1223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42780,8 +44009,9 @@ SplineSet
  803 1350 803 1350 1009 1400 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0667
-Encoding: 1639 1639 1639
+Encoding: 1639 1639 1224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42801,8 +44031,9 @@ SplineSet
  490 0 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0668
-Encoding: 1640 1640 1640
+Encoding: 1640 1640 1225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42822,8 +44053,9 @@ SplineSet
  746 1400 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0669
-Encoding: 1641 1641 1641
+Encoding: 1641 1641 1226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42850,8 +44082,9 @@ SplineSet
  596 885 596 885 692 884 c 1,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni066A
-Encoding: 1642 1642 1642
+Encoding: 1642 1642 1227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42874,8 +44107,9 @@ SplineSet
  810 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066B
-Encoding: 1643 1643 1643
+Encoding: 1643 1643 1228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42894,8 +44128,9 @@ SplineSet
  270 -30 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni066C
-Encoding: 1644 1644 1644
+Encoding: 1644 1644 1229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42910,8 +44145,9 @@ SplineSet
  526 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066D
-Encoding: 1645 1645 1645
+Encoding: 1645 1645 1230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42930,8 +44166,9 @@ SplineSet
  146 759 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0674
-Encoding: 1652 1652 1652
+Encoding: 1652 1652 1231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42956,186 +44193,200 @@ SplineSet
  443 1289 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0679
-Encoding: 1657 1657 1657
+Encoding: 1657 1657 1232
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
 AnchorPoint: "rtl-above" 490 1375 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 42 -600 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 42 -600 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB68
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB69
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB67
 EndChar
+
 StartChar: uni067A
-Encoding: 1658 1658 1658
+Encoding: 1658 1658 1233
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
 AnchorPoint: "rtl-above" 538 1267 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 534 900 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 534 900 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB60
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB61
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB5F
 EndChar
+
 StartChar: uni067B
-Encoding: 1659 1659 1659
+Encoding: 1659 1659 1234
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -793 basechar 0
 AnchorPoint: "rtl-above" 578 835 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 488 -382 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 488 -382 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB54
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB55
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB53
 EndChar
+
 StartChar: uni067E
-Encoding: 1662 1662 1662
+Encoding: 1662 1662 1235
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 163 -497 basechar 0
 AnchorPoint: "rtl-above" 610 847 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 330 -378 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 330 -378 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB58
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB59
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB57
 EndChar
+
 StartChar: uni067F
-Encoding: 1663 1663 1663
+Encoding: 1663 1663 1236
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
 AnchorPoint: "rtl-above" 550 1379 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 336 1004 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 336 1004 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB64
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB65
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB63
 EndChar
+
 StartChar: uni0680
-Encoding: 1664 1664 1664
+Encoding: 1664 1664 1237
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" -8 -497 basechar 0
 AnchorPoint: "rtl-above" 622 707 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 330 -346 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 330 -346 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB5C
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB5D
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB5B
 EndChar
+
 StartChar: uni0683
-Encoding: 1667 1667 1667
+Encoding: 1667 1667 1238
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 492 -561 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 582 49 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 582 49 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB77
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB79
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB78
 EndChar
+
 StartChar: uni0684
-Encoding: 1668 1668 1668
+Encoding: 1668 1668 1239
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 484 -553 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 759 227 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 759 227 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB73
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB75
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB74
 EndChar
+
 StartChar: uni0686
-Encoding: 1670 1670 1670
+Encoding: 1670 1670 1240
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 484 -553 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 626 230 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 626 230 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB7B
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB7D
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB7C
 EndChar
+
 StartChar: uni0687
-Encoding: 1671 1671 1671
+Encoding: 1671 1671 1241
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 484 -553 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 626 235 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 626 235 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB7F
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB81
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB80
 EndChar
+
 StartChar: uni0691
-Encoding: 1681 1681 1681
+Encoding: 1681 1681 1242
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 558.5 -540.5 basechar 0
 AnchorPoint: "rtl-above" 637 1305.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 354.5 -585 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 354.5 -585 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB8D
 EndChar
+
 StartChar: uni0698
-Encoding: 1688 1688 1688
+Encoding: 1688 1688 1243
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 484 -553 basechar 0
 AnchorPoint: "rtl-above" 572 1441 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 650 767 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 650 767 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB8B
 EndChar
+
 StartChar: uni06A4
-Encoding: 1700 1700 1700
+Encoding: 1700 1700 1244
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 396 -193 basechar 0
 AnchorPoint: "rtl-above" 518 1555 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 538.5 1033 2
+Refer: 3708 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 538.5 1033 2
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB6C
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB6D
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB6B
 EndChar
+
 StartChar: uni06A9
-Encoding: 1705 1705 1705
+Encoding: 1705 1705 1245
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 565 -182.5 basechar 0
@@ -43175,22 +44426,24 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB91
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB90
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB8F
 EndChar
+
 StartChar: uni06AF
-Encoding: 1711 1711 1711
+Encoding: 1711 1711 1246
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596.5 -150 basechar 0
 AnchorPoint: "rtl-above" 430 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 679.5 0 2
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 3696 -1 N 1 0 0 1 679.5 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFB95
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFB94
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB93
 EndChar
+
 StartChar: uni06BE
-Encoding: 1726 1726 1726
+Encoding: 1726 1726 1247
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 519 -141 basechar 0
@@ -43243,53 +44496,59 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFBAD
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFBAC
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFBAB
 EndChar
+
 StartChar: uni06CC
-Encoding: 1740 1740 1740
+Encoding: 1740 1740 1248
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 590 -400 basechar 0
 AnchorPoint: "rtl-above" 385 805 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 3" uniFBFF
 Substitution2: "'init' Initial Forms in Arabic lookup 4" uniFBFE
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFBFD
 EndChar
+
 StartChar: uni06F0
-Encoding: 1776 1776 1776
+Encoding: 1776 1776 1249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1632 1632 N 1 0 0 1 0 0 2
+Refer: 1217 1632 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F1
-Encoding: 1777 1777 1777
+Encoding: 1777 1777 1250
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1633 1633 N 1 0 0 1 0 0 2
+Refer: 1218 1633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F2
-Encoding: 1778 1778 1778
+Encoding: 1778 1778 1251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1634 1634 N 1 0 0 1 0 0 2
+Refer: 1219 1634 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F3
-Encoding: 1779 1779 1779
+Encoding: 1779 1779 1252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1635 1635 N 1 0 0 1 0 0 2
+Refer: 1220 1635 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F4
-Encoding: 1780 1780 1780
+Encoding: 1780 1780 1253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43321,8 +44580,9 @@ SplineSet
  494 1084 494 1084 524 1080 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F5
-Encoding: 1781 1781 1781
+Encoding: 1781 1781 1254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43353,8 +44613,9 @@ SplineSet
  696 -27 696 -27 616 80 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F6
-Encoding: 1782 1782 1782
+Encoding: 1782 1782 1255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43381,32 +44642,36 @@ SplineSet
  214 0 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni06F7
-Encoding: 1783 1783 1783
+Encoding: 1783 1783 1256
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1639 1639 N 1 0 0 1 0 0 2
+Refer: 1224 1639 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F8
-Encoding: 1784 1784 1784
+Encoding: 1784 1784 1257
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1640 1640 N 1 0 0 1 0 0 2
+Refer: 1225 1640 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F9
-Encoding: 1785 1785 1785
+Encoding: 1785 1785 1258
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1641 1641 N 1 0 0 1 0 0 2
+Refer: 1226 1641 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0E3F
-Encoding: 3647 3647 3647
+Encoding: 3647 3647 1259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43454,8 +44719,9 @@ SplineSet
  679 803 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0E81
-Encoding: 3713 3713 3713
+Encoding: 3713 3713 1260
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -43481,8 +44747,9 @@ SplineSet
  539 184 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E82
-Encoding: 3714 3714 3714
+Encoding: 3714 3714 1261
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43520,8 +44787,9 @@ SplineSet
  518.354 684.769 518.354 684.769 336 688 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E84
-Encoding: 3716 3716 3716
+Encoding: 3716 3716 1262
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43551,8 +44819,9 @@ SplineSet
  121 -47.9075 121 -47.9075 121 349 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E87
-Encoding: 3719 3719 3719
+Encoding: 3719 3719 1263
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1228.5 -492 basechar 0
@@ -43583,8 +44852,9 @@ SplineSet
  419.808 1004.77 419.808 1004.77 356.5 1006 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0E88
-Encoding: 3720 3720 3720
+Encoding: 3720 3720 1264
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43622,8 +44892,9 @@ SplineSet
  312 1178 312 1178 612.25 1178 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8A
-Encoding: 3722 3722 3722
+Encoding: 3722 3722 1265
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1228.5 -492 basechar 0
@@ -43666,8 +44937,9 @@ SplineSet
  504 630 504 630 281 630 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8D
-Encoding: 3725 3725 3725
+Encoding: 3725 3725 1266
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43698,8 +44970,9 @@ SplineSet
  617.5 434.12 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E94
-Encoding: 3732 3732 3732
+Encoding: 3732 3732 1267
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43729,8 +45002,9 @@ SplineSet
  817 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E95
-Encoding: 3733 3733 3733
+Encoding: 3733 3733 1268
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43770,8 +45044,9 @@ SplineSet
  724.991 747 724.991 747 618.5 747 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E96
-Encoding: 3734 3734 3734
+Encoding: 3734 3734 1269
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1228.5 -492 basechar 0
@@ -43803,8 +45078,9 @@ SplineSet
  490.5 351 l 1,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E97
-Encoding: 3735 3735 3735
+Encoding: 3735 3735 1270
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43843,8 +45119,9 @@ SplineSet
  85.25 808 85.25 808 85.25 992 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E99
-Encoding: 3737 3737 3737
+Encoding: 3737 3737 1271
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43876,8 +45153,9 @@ SplineSet
  428 -29 428 -29 75 -29 c 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9A
-Encoding: 3738 3738 3738
+Encoding: 3738 3738 1272
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43906,8 +45184,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9B
-Encoding: 3739 3739 3739
+Encoding: 3739 3739 1273
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43936,8 +45215,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9C
-Encoding: 3740 3740 3740
+Encoding: 3740 3740 1274
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -43993,8 +45273,9 @@ SplineSet
  1016 -17 1016 -17 872 -17 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni0E9D
-Encoding: 3741 3741 3741
+Encoding: 3741 3741 1275
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1238 1560 basechar 0
@@ -44035,8 +45316,9 @@ SplineSet
  1149 300 l 18,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9E
-Encoding: 3742 3742 3742
+Encoding: 3742 3742 1276
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44076,8 +45358,9 @@ SplineSet
  310 216 310 216 432 216 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9F
-Encoding: 3743 3743 3743
+Encoding: 3743 3743 1277
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1238 1560 basechar 0
@@ -44117,8 +45400,9 @@ SplineSet
  310 216 310 216 432 216 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA1
-Encoding: 3745 3745 3745
+Encoding: 3745 3745 1278
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44144,8 +45428,9 @@ SplineSet
  285 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA2
-Encoding: 3746 3746 3746
+Encoding: 3746 3746 1279
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1238 1560 basechar 0
@@ -44176,8 +45461,9 @@ SplineSet
  617.5 434.12 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA3
-Encoding: 3747 3747 3747
+Encoding: 3747 3747 1280
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44213,8 +45499,9 @@ SplineSet
  891 199.999 891 199.999 891 328 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA5
-Encoding: 3749 3749 3749
+Encoding: 3749 3749 1281
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44254,8 +45541,9 @@ SplineSet
  210.033 1165 210.033 1165 629.002 1164 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA7
-Encoding: 3751 3751 3751
+Encoding: 3751 3751 1282
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44285,8 +45573,9 @@ SplineSet
  104 802 l 1,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0EAA
-Encoding: 3754 3754 3754
+Encoding: 3754 3754 1283
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1312 basechar 0
@@ -44332,8 +45621,9 @@ SplineSet
  344 894.77 344 894.77 598 894 c 0,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni0EAB
-Encoding: 3755 3755 3755
+Encoding: 3755 3755 1284
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44376,8 +45666,9 @@ SplineSet
  832.058 -24.8564 832.058 -24.8564 440.002 -24 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0EAD
-Encoding: 3757 3757 3757
+Encoding: 3757 3757 1285
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44415,8 +45706,9 @@ SplineSet
  871 753 871 753 871 857 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: uni0EAE
-Encoding: 3758 3758 3758
+Encoding: 3758 3758 1286
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 basechar 0
@@ -44457,8 +45749,9 @@ SplineSet
  531.367 188.561 531.367 188.561 594 189 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAF
-Encoding: 3759 3759 3759
+Encoding: 3759 3759 1287
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44486,17 +45779,19 @@ SplineSet
  391.001 -259 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB0
-Encoding: 3760 3760 3760
+Encoding: 3760 3760 1288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3761 3761 N 1 0 0 1 0 -674 2
-Refer: 3761 3761 N 1 0 0 1 0 -1282 2
+Refer: 1289 3761 N 1 0 0 1 0 -674 2
+Refer: 1289 3761 N 1 0 0 1 0 -1282 2
 EndChar
+
 StartChar: uni0EB1
-Encoding: 3761 3761 3761
+Encoding: 3761 3761 1289
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -44516,8 +45811,9 @@ SplineSet
  1171.95 1268 1171.95 1268 690 1270 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB2
-Encoding: 3762 3762 3762
+Encoding: 3762 3762 1290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44536,17 +45832,19 @@ SplineSet
  1126 1204 1126 1204 1126 758 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB3
-Encoding: 3763 3763 3763
+Encoding: 3763 3763 1291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3762 3762 N 1 0 0 1 0 0 2
-Refer: 3789 3789 N 1 0 0 1 -1233 0 2
+Refer: 1290 3762 N 1 0 0 1 0 0 2
+Refer: 1305 3789 N 1 0 0 1 -1233 0 2
 EndChar
+
 StartChar: uni0EB4
-Encoding: 3764 3764 3764
+Encoding: 3764 3764 1292
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44566,8 +45864,9 @@ SplineSet
  259.004 1752 259.004 1752 259.004 1584 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB5
-Encoding: 3765 3765 3765
+Encoding: 3765 3765 1293
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44590,8 +45889,9 @@ SplineSet
  143 1781 143 1781 143 1607 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB6
-Encoding: 3766 3766 3766
+Encoding: 3766 3766 1294
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44620,8 +45920,9 @@ SplineSet
  728 1736 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB7
-Encoding: 3767 3767 3767
+Encoding: 3767 3767 1295
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44653,8 +45954,9 @@ SplineSet
  728.5 1764 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB8
-Encoding: 3768 3768 3768
+Encoding: 3768 3768 1296
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -44677,8 +45979,9 @@ SplineSet
  677 -557 677 -557 682 -481 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0EB9
-Encoding: 3769 3769 3769
+Encoding: 3769 3769 1297
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -44707,8 +46010,9 @@ SplineSet
  278 -648 278 -648 278 -480 c 0,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni0EBB
-Encoding: 3771 3771 3771
+Encoding: 3771 3771 1298
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44728,8 +46032,9 @@ SplineSet
  345.527 1836 345.527 1836 587.527 1836 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EBC
-Encoding: 3772 3772 3772
+Encoding: 3772 3772 1299
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -44755,8 +46060,9 @@ SplineSet
  196 -454 196 -454 222 -454 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0EC8
-Encoding: 3784 3784 3784
+Encoding: 3784 3784 1300
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44770,8 +46076,9 @@ SplineSet
  734 1729 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EC9
-Encoding: 3785 3785 3785
+Encoding: 3785 3785 1301
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44792,8 +46099,9 @@ SplineSet
  1236.5 1274 1236.5 1274 524.503 1274 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECA
-Encoding: 3786 3786 3786
+Encoding: 3786 3786 1302
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44831,8 +46139,9 @@ SplineSet
  51 1979 51 1979 401 1972 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECB
-Encoding: 3787 3787 3787
+Encoding: 3787 3787 1303
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44854,17 +46163,19 @@ SplineSet
  273.5 1658 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECC
-Encoding: 3788 3788 3788
+Encoding: 3788 3788 1304
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
 LayerCount: 2
 Fore
-Refer: 3772 3772 N 1 0 0 1 0 1872 2
+Refer: 1299 3772 N 1 0 0 1 0 1872 2
 EndChar
+
 StartChar: uni0ECD
-Encoding: 3789 3789 3789
+Encoding: 3789 3789 1305
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1200 mark 0
@@ -44883,8 +46194,9 @@ SplineSet
  553.498 1583 553.498 1583 555.498 1530 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni10D0
-Encoding: 4304 4304 4304
+Encoding: 4304 4304 1306
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44916,8 +46228,9 @@ SplineSet
  1137 819 1137 819 1137 505 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D1
-Encoding: 4305 4305 4305
+Encoding: 4305 4305 1307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44955,8 +46268,9 @@ SplineSet
  1134 733 1134 733 1134 534 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni10D2
-Encoding: 4306 4306 4306
+Encoding: 4306 4306 1308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44997,8 +46311,9 @@ SplineSet
  1152 386 1152 386 1151 79 c 0,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni10D3
-Encoding: 4307 4307 4307
+Encoding: 4307 4307 1309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45079,8 +46394,9 @@ SplineSet
  123 -229 l 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni10D4
-Encoding: 4308 4308 4308
+Encoding: 4308 4308 1310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45117,8 +46433,9 @@ SplineSet
  1136 8 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D5
-Encoding: 4309 4309 4309
+Encoding: 4309 4309 1311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45171,8 +46488,9 @@ SplineSet
  1136 -4 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D6
-Encoding: 4310 4310 4310
+Encoding: 4310 4310 1312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45219,8 +46537,9 @@ SplineSet
  1136 715 1136 715 1136 520 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni10D7
-Encoding: 4311 4311 4311
+Encoding: 4311 4311 1313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45273,8 +46592,9 @@ SplineSet
  1206 527 l 2,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni10D8
-Encoding: 4312 4312 4312
+Encoding: 4312 4312 1314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45315,8 +46635,9 @@ SplineSet
  1136 670 1136 670 1136 545 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D9
-Encoding: 4313 4313 4313
+Encoding: 4313 4313 1315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45363,8 +46684,9 @@ SplineSet
  1135 0 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DA
-Encoding: 4314 4314 4314
+Encoding: 4314 4314 1316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45411,8 +46733,9 @@ SplineSet
  657 853 657 853 606 853 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DB
-Encoding: 4315 4315 4315
+Encoding: 4315 4315 1317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45458,8 +46781,9 @@ SplineSet
  1136 471 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni10DC
-Encoding: 4316 4316 4316
+Encoding: 4316 4316 1318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45492,8 +46816,9 @@ SplineSet
  1136 1065 1136 1065 1136 538 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10DD
-Encoding: 4317 4317 4317
+Encoding: 4317 4317 1319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45545,8 +46870,9 @@ SplineSet
  1206 468 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DE
-Encoding: 4318 4318 4318
+Encoding: 4318 4318 1320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45588,8 +46914,9 @@ SplineSet
  1136 611 1136 611 1136 486 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DF
-Encoding: 4319 4319 4319
+Encoding: 4319 4319 1321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45630,8 +46957,9 @@ SplineSet
  1137 20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E0
-Encoding: 4320 4320 4320
+Encoding: 4320 4320 1322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45692,8 +47020,9 @@ SplineSet
  1206 468 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E1
-Encoding: 4321 4321 4321
+Encoding: 4321 4321 1323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45730,8 +47059,9 @@ SplineSet
  1137 637 1137 637 1137 525 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E2
-Encoding: 4322 4322 4322
+Encoding: 4322 4322 1324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45765,8 +47095,9 @@ SplineSet
  18 -34 18 -34 18 332 c 0,13,14
 EndSplineSet
 EndChar
+
 StartChar: uni10E3
-Encoding: 4323 4323 4323
+Encoding: 4323 4323 1325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45828,8 +47159,9 @@ SplineSet
  1135 47 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E4
-Encoding: 4324 4324 4324
+Encoding: 4324 4324 1326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45906,8 +47238,9 @@ SplineSet
  1206 -22 l 2,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni10E5
-Encoding: 4325 4325 4325
+Encoding: 4325 4325 1327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45959,8 +47292,9 @@ SplineSet
  1135 102 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E6
-Encoding: 4326 4326 4326
+Encoding: 4326 4326 1328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46023,8 +47357,9 @@ SplineSet
  194 -152 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E7
-Encoding: 4327 4327 4327
+Encoding: 4327 4327 1329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46068,8 +47403,9 @@ SplineSet
  1136 -7 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E8
-Encoding: 4328 4328 4328
+Encoding: 4328 4328 1330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46128,8 +47464,9 @@ SplineSet
  1142 490 l 2,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10E9
-Encoding: 4329 4329 4329
+Encoding: 4329 4329 1331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46176,8 +47513,9 @@ SplineSet
  1136 625 1136 625 1136 546 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni10EA
-Encoding: 4330 4330 4330
+Encoding: 4330 4330 1332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46225,8 +47563,9 @@ SplineSet
  1147 732 1147 732 1147 649 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10EB
-Encoding: 4331 4331 4331
+Encoding: 4331 4331 1333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46257,8 +47596,9 @@ SplineSet
  1136 506 l 2,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni10EC
-Encoding: 4332 4332 4332
+Encoding: 4332 4332 1334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46329,8 +47669,9 @@ SplineSet
  94 1248 l 2,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10ED
-Encoding: 4333 4333 4333
+Encoding: 4333 4333 1335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46393,8 +47734,9 @@ SplineSet
  1133 122 1133 122 1134 18 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10EE
-Encoding: 4334 4334 4334
+Encoding: 4334 4334 1336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46424,8 +47766,9 @@ SplineSet
  1135 1065 1135 1065 1135 537 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EF
-Encoding: 4335 4335 4335
+Encoding: 4335 4335 1337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46465,8 +47808,9 @@ SplineSet
  1135 142 1135 142 1136 18 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F0
-Encoding: 4336 4336 4336
+Encoding: 4336 4336 1338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46525,8 +47869,9 @@ SplineSet
  1136 506 1136 506 1136 381 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F1
-Encoding: 4337 4337 4337
+Encoding: 4337 4337 1339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46593,8 +47938,9 @@ SplineSet
  1134 97 1134 97 1136 -79 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F2
-Encoding: 4338 4338 4338
+Encoding: 4338 4338 1340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46628,8 +47974,9 @@ SplineSet
  136 22 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10F3
-Encoding: 4339 4339 4339
+Encoding: 4339 4339 1341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46665,8 +48012,9 @@ SplineSet
  1136 16 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F4
-Encoding: 4340 4340 4340
+Encoding: 4340 4340 1342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46718,8 +48066,9 @@ SplineSet
  1136 20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F5
-Encoding: 4341 4341 4341
+Encoding: 4341 4341 1343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46758,8 +48107,9 @@ SplineSet
  1071 489 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F6
-Encoding: 4342 4342 4342
+Encoding: 4342 4342 1344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46806,8 +48156,9 @@ SplineSet
  1206 422 l 2,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni10F7
-Encoding: 4343 4343 4343
+Encoding: 4343 4343 1345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46844,8 +48195,9 @@ SplineSet
  1155 210 1155 210 1156 38 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F8
-Encoding: 4344 4344 4344
+Encoding: 4344 4344 1346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46880,8 +48232,9 @@ SplineSet
  99 1044 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F9
-Encoding: 4345 4345 4345
+Encoding: 4345 4345 1347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46909,8 +48262,9 @@ SplineSet
  80 473 80 473 80 625 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni10FA
-Encoding: 4346 4346 4346
+Encoding: 4346 4346 1348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46946,8 +48300,9 @@ SplineSet
  686 -195 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10FB
-Encoding: 4347 4347 4347
+Encoding: 4347 4347 1349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46970,8 +48325,9 @@ SplineSet
  271 1007 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FC
-Encoding: 4348 4348 4348
+Encoding: 4348 4348 1350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46996,524 +48352,611 @@ SplineSet
  609 1319 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni13A0
-Encoding: 5024 5024 5024
+Encoding: 5024 5024 1351
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A1
-Encoding: 5025 5025 5025
+Encoding: 5025 5025 1352
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A2
-Encoding: 5026 5026 5026
+Encoding: 5026 5026 1353
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A3
-Encoding: 5027 5027 5027
+Encoding: 5027 5027 1354
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A4
-Encoding: 5028 5028 5028
+Encoding: 5028 5028 1355
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A5
-Encoding: 5029 5029 5029
+Encoding: 5029 5029 1356
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A6
-Encoding: 5030 5030 5030
+Encoding: 5030 5030 1357
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A7
-Encoding: 5031 5031 5031
+Encoding: 5031 5031 1358
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A8
-Encoding: 5032 5032 5032
+Encoding: 5032 5032 1359
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A9
-Encoding: 5033 5033 5033
+Encoding: 5033 5033 1360
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AA
-Encoding: 5034 5034 5034
+Encoding: 5034 5034 1361
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AB
-Encoding: 5035 5035 5035
+Encoding: 5035 5035 1362
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AC
-Encoding: 5036 5036 5036
+Encoding: 5036 5036 1363
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AD
-Encoding: 5037 5037 5037
+Encoding: 5037 5037 1364
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AE
-Encoding: 5038 5038 5038
+Encoding: 5038 5038 1365
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AF
-Encoding: 5039 5039 5039
+Encoding: 5039 5039 1366
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B0
-Encoding: 5040 5040 5040
+Encoding: 5040 5040 1367
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B1
-Encoding: 5041 5041 5041
+Encoding: 5041 5041 1368
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B2
-Encoding: 5042 5042 5042
+Encoding: 5042 5042 1369
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B3
-Encoding: 5043 5043 5043
+Encoding: 5043 5043 1370
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B4
-Encoding: 5044 5044 5044
+Encoding: 5044 5044 1371
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B5
-Encoding: 5045 5045 5045
+Encoding: 5045 5045 1372
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B6
-Encoding: 5046 5046 5046
+Encoding: 5046 5046 1373
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B7
-Encoding: 5047 5047 5047
+Encoding: 5047 5047 1374
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B8
-Encoding: 5048 5048 5048
+Encoding: 5048 5048 1375
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B9
-Encoding: 5049 5049 5049
+Encoding: 5049 5049 1376
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BA
-Encoding: 5050 5050 5050
+Encoding: 5050 5050 1377
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BB
-Encoding: 5051 5051 5051
+Encoding: 5051 5051 1378
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BC
-Encoding: 5052 5052 5052
+Encoding: 5052 5052 1379
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BD
-Encoding: 5053 5053 5053
+Encoding: 5053 5053 1380
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BE
-Encoding: 5054 5054 5054
+Encoding: 5054 5054 1381
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BF
-Encoding: 5055 5055 5055
+Encoding: 5055 5055 1382
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C0
-Encoding: 5056 5056 5056
+Encoding: 5056 5056 1383
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C1
-Encoding: 5057 5057 5057
+Encoding: 5057 5057 1384
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C2
-Encoding: 5058 5058 5058
+Encoding: 5058 5058 1385
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C3
-Encoding: 5059 5059 5059
+Encoding: 5059 5059 1386
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C4
-Encoding: 5060 5060 5060
+Encoding: 5060 5060 1387
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C5
-Encoding: 5061 5061 5061
+Encoding: 5061 5061 1388
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C6
-Encoding: 5062 5062 5062
+Encoding: 5062 5062 1389
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C7
-Encoding: 5063 5063 5063
+Encoding: 5063 5063 1390
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C8
-Encoding: 5064 5064 5064
+Encoding: 5064 5064 1391
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C9
-Encoding: 5065 5065 5065
+Encoding: 5065 5065 1392
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CA
-Encoding: 5066 5066 5066
+Encoding: 5066 5066 1393
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CB
-Encoding: 5067 5067 5067
+Encoding: 5067 5067 1394
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CC
-Encoding: 5068 5068 5068
+Encoding: 5068 5068 1395
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CD
-Encoding: 5069 5069 5069
+Encoding: 5069 5069 1396
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CE
-Encoding: 5070 5070 5070
+Encoding: 5070 5070 1397
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CF
-Encoding: 5071 5071 5071
+Encoding: 5071 5071 1398
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D0
-Encoding: 5072 5072 5072
+Encoding: 5072 5072 1399
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D1
-Encoding: 5073 5073 5073
+Encoding: 5073 5073 1400
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D2
-Encoding: 5074 5074 5074
+Encoding: 5074 5074 1401
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D3
-Encoding: 5075 5075 5075
+Encoding: 5075 5075 1402
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D4
-Encoding: 5076 5076 5076
+Encoding: 5076 5076 1403
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D5
-Encoding: 5077 5077 5077
+Encoding: 5077 5077 1404
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D6
-Encoding: 5078 5078 5078
+Encoding: 5078 5078 1405
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D7
-Encoding: 5079 5079 5079
+Encoding: 5079 5079 1406
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D8
-Encoding: 5080 5080 5080
+Encoding: 5080 5080 1407
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D9
-Encoding: 5081 5081 5081
+Encoding: 5081 5081 1408
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DA
-Encoding: 5082 5082 5082
+Encoding: 5082 5082 1409
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DB
-Encoding: 5083 5083 5083
+Encoding: 5083 5083 1410
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DC
-Encoding: 5084 5084 5084
+Encoding: 5084 5084 1411
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DD
-Encoding: 5085 5085 5085
+Encoding: 5085 5085 1412
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DE
-Encoding: 5086 5086 5086
+Encoding: 5086 5086 1413
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DF
-Encoding: 5087 5087 5087
+Encoding: 5087 5087 1414
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E0
-Encoding: 5088 5088 5088
+Encoding: 5088 5088 1415
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E1
-Encoding: 5089 5089 5089
+Encoding: 5089 5089 1416
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E2
-Encoding: 5090 5090 5090
+Encoding: 5090 5090 1417
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E3
-Encoding: 5091 5091 5091
+Encoding: 5091 5091 1418
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E4
-Encoding: 5092 5092 5092
+Encoding: 5092 5092 1419
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E5
-Encoding: 5093 5093 5093
+Encoding: 5093 5093 1420
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E6
-Encoding: 5094 5094 5094
+Encoding: 5094 5094 1421
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E7
-Encoding: 5095 5095 5095
+Encoding: 5095 5095 1422
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E8
-Encoding: 5096 5096 5096
+Encoding: 5096 5096 1423
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E9
-Encoding: 5097 5097 5097
+Encoding: 5097 5097 1424
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EA
-Encoding: 5098 5098 5098
+Encoding: 5098 5098 1425
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EB
-Encoding: 5099 5099 5099
+Encoding: 5099 5099 1426
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EC
-Encoding: 5100 5100 5100
+Encoding: 5100 5100 1427
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13ED
-Encoding: 5101 5101 5101
+Encoding: 5101 5101 1428
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EE
-Encoding: 5102 5102 5102
+Encoding: 5102 5102 1429
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EF
-Encoding: 5103 5103 5103
+Encoding: 5103 5103 1430
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F0
-Encoding: 5104 5104 5104
+Encoding: 5104 5104 1431
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F1
-Encoding: 5105 5105 5105
+Encoding: 5105 5105 1432
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F2
-Encoding: 5106 5106 5106
+Encoding: 5106 5106 1433
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F3
-Encoding: 5107 5107 5107
+Encoding: 5107 5107 1434
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F4
-Encoding: 5108 5108 5108
+Encoding: 5108 5108 1435
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F5
-Encoding: 5109 5109 5109
+Encoding: 5109 5109 1436
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni1D02
-Encoding: 7426 7426 7426
+Encoding: 7426 7426 1437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47572,8 +49015,9 @@ SplineSet
  53 639 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D08
-Encoding: 7432 7432 7432
+Encoding: 7432 7432 1438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47611,8 +49055,9 @@ SplineSet
  961 575 961 575 809 552 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D09
-Encoding: 7433 7433 7433
+Encoding: 7433 7433 1439
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47636,8 +49081,9 @@ SplineSet
  762 -541 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D14
-Encoding: 7444 7444 7444
+Encoding: 7444 7444 1440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47686,8 +49132,9 @@ SplineSet
  704 800 704 800 704 559 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni1D16
-Encoding: 7446 7446 7446
+Encoding: 7446 7446 1441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47706,8 +49153,9 @@ SplineSet
  98 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D17
-Encoding: 7447 7447 7447
+Encoding: 7447 7447 1442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47726,8 +49174,9 @@ SplineSet
  1134 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D1D
-Encoding: 7453 7453 7453
+Encoding: 7453 7453 1443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47752,8 +49201,9 @@ SplineSet
  978 0.5 978 0.5 770 0.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1E
-Encoding: 7454 7454 7454
+Encoding: 7454 7454 1444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47788,8 +49238,9 @@ SplineSet
  1021.45 -3.5 1021.45 -3.5 875.85 -3.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1F
-Encoding: 7455 7455 7455
+Encoding: 7455 7455 1445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47825,8 +49276,9 @@ SplineSet
  1109 476 1109 476 1051 464 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2C
-Encoding: 7468 7468 7468
+Encoding: 7468 7468 1446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47847,8 +49299,9 @@ SplineSet
  502 1504 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2D
-Encoding: 7469 7469 7469
+Encoding: 7469 7469 1447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47878,8 +49331,9 @@ SplineSet
  582 1358 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2E
-Encoding: 7470 7470 7470
+Encoding: 7470 7470 1448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47915,8 +49369,9 @@ SplineSet
  290 1505 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D30
-Encoding: 7472 7472 7472
+Encoding: 7472 7472 1449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47940,8 +49395,9 @@ SplineSet
  300 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D31
-Encoding: 7473 7473 7473
+Encoding: 7473 7473 1450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47962,8 +49418,9 @@ SplineSet
  910 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D32
-Encoding: 7474 7474 7474
+Encoding: 7474 7474 1451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47984,8 +49441,9 @@ SplineSet
  324 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D33
-Encoding: 7475 7475 7475
+Encoding: 7475 7475 1452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48016,8 +49474,9 @@ SplineSet
  760 810 760 810 772 819 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D34
-Encoding: 7476 7476 7476
+Encoding: 7476 7476 1453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48038,8 +49497,9 @@ SplineSet
  314 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D35
-Encoding: 7477 7477 7477
+Encoding: 7477 7477 1454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48060,8 +49520,9 @@ SplineSet
  336 1358 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D36
-Encoding: 7478 7478 7478
+Encoding: 7478 7478 1455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48084,8 +49545,9 @@ SplineSet
  400 681 400 681 334 709 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D37
-Encoding: 7479 7479 7479
+Encoding: 7479 7479 1456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48106,8 +49568,9 @@ SplineSet
  268 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D38
-Encoding: 7480 7480 7480
+Encoding: 7480 7480 1457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48122,8 +49585,9 @@ SplineSet
  324 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D39
-Encoding: 7481 7481 7481
+Encoding: 7481 7481 1458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48145,8 +49609,9 @@ SplineSet
  282 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3A
-Encoding: 7482 7482 7482
+Encoding: 7482 7482 1459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48165,8 +49630,9 @@ SplineSet
  304 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3B
-Encoding: 7483 7483 7483
+Encoding: 7483 7483 1460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48185,8 +49651,9 @@ SplineSet
  930 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3C
-Encoding: 7484 7484 7484
+Encoding: 7484 7484 1461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48212,8 +49679,9 @@ SplineSet
  286 871 286 871 286 1085 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D3E
-Encoding: 7486 7486 7486
+Encoding: 7486 7486 1462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48239,8 +49707,9 @@ SplineSet
  306 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3F
-Encoding: 7487 7487 7487
+Encoding: 7487 7487 1463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48273,8 +49742,9 @@ SplineSet
  456 1365 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D40
-Encoding: 7488 7488 7488
+Encoding: 7488 7488 1464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48291,8 +49761,9 @@ SplineSet
  708 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D41
-Encoding: 7489 7489 7489
+Encoding: 7489 7489 1465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48315,8 +49786,9 @@ SplineSet
  296 806 296 806 296 977 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D42
-Encoding: 7490 7490 7490
+Encoding: 7490 7490 1466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48338,8 +49810,9 @@ SplineSet
  228 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D43
-Encoding: 7491 7491 7491
+Encoding: 7491 7491 1467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48377,8 +49850,9 @@ SplineSet
  936 1186 936 1186 936 1026 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D44
-Encoding: 7492 7492 7492
+Encoding: 7492 7492 1468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48416,8 +49890,9 @@ SplineSet
  297 776 297 776 297 936 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D45
-Encoding: 7493 7493 7493
+Encoding: 7493 7493 1469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48448,8 +49923,9 @@ SplineSet
  488 1071 488 1071 488 980 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D46
-Encoding: 7494 7494 7494
+Encoding: 7494 7494 1470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48508,8 +49984,9 @@ SplineSet
  247 1026 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D47
-Encoding: 7495 7495 7495
+Encoding: 7495 7495 1471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48540,8 +50017,9 @@ SplineSet
  488 1206 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D48
-Encoding: 7496 7496 7496
+Encoding: 7496 7496 1472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48572,8 +50050,9 @@ SplineSet
  488 1071 488 1071 488 980 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D49
-Encoding: 7497 7497 7497
+Encoding: 7497 7497 1473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48603,8 +50082,9 @@ SplineSet
  764 1052 l 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1D4A
-Encoding: 7498 7498 7498
+Encoding: 7498 7498 1474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48634,8 +50114,9 @@ SplineSet
  469 910 l 1,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni1D4B
-Encoding: 7499 7499 7499
+Encoding: 7499 7499 1475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48673,8 +50154,9 @@ SplineSet
  399 976 399 976 495 989 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4C
-Encoding: 7500 7500 7500
+Encoding: 7500 7500 1476
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48712,8 +50194,9 @@ SplineSet
  834 990 834 990 738 977 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4D
-Encoding: 7501 7501 7501
+Encoding: 7501 7501 1477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48752,8 +50235,9 @@ SplineSet
  931 715 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D4E
-Encoding: 7502 7502 7502
+Encoding: 7502 7502 1478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48777,8 +50261,9 @@ SplineSet
  708 365 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4F
-Encoding: 7503 7503 7503
+Encoding: 7503 7503 1479
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48799,8 +50284,9 @@ SplineSet
  294 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D50
-Encoding: 7504 7504 7504
+Encoding: 7504 7504 1480
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48836,8 +50322,9 @@ SplineSet
  654 1265 654 1265 662 1232 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D51
-Encoding: 7505 7505 7505
+Encoding: 7505 7505 1481
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48868,8 +50355,9 @@ SplineSet
  900 1192 900 1192 900 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D52
-Encoding: 7506 7506 7506
+Encoding: 7506 7506 1482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48895,8 +50383,9 @@ SplineSet
  290 829 290 829 290 981 c 128,-1,11
 EndSplineSet
 EndChar
+
 StartChar: uni1D53
-Encoding: 7507 7507 7507
+Encoding: 7507 7507 1483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48923,8 +50412,9 @@ SplineSet
  382 676 382 676 335 700 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D54
-Encoding: 7508 7508 7508
+Encoding: 7508 7508 1484
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48943,8 +50433,9 @@ SplineSet
  290 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D55
-Encoding: 7509 7509 7509
+Encoding: 7509 7509 1485
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48963,8 +50454,9 @@ SplineSet
  943 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D56
-Encoding: 7510 7510 7510
+Encoding: 7510 7510 1486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48995,8 +50487,9 @@ SplineSet
  745 891 745 891 745 982 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D57
-Encoding: 7511 7511 7511
+Encoding: 7511 7511 1487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49023,8 +50516,9 @@ SplineSet
  678 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D58
-Encoding: 7512 7512 7512
+Encoding: 7512 7512 1488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49049,8 +50543,9 @@ SplineSet
  333 770 333 770 333 887 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D59
-Encoding: 7513 7513 7513
+Encoding: 7513 7513 1489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49075,8 +50570,9 @@ SplineSet
  845 668 845 668 714 668 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5A
-Encoding: 7514 7514 7514
+Encoding: 7514 7514 1490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49112,8 +50608,9 @@ SplineSet
  579 698 579 698 571 731 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5B
-Encoding: 7515 7515 7515
+Encoding: 7515 7515 1491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49129,40 +50626,45 @@ SplineSet
  954 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D62
-Encoding: 7522 7522 7522
+Encoding: 7522 7522 1492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8305 8305 N 1 0 0 1 0 -668 3
+Refer: 2008 8305 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D63
-Encoding: 7523 7523 7523
+Encoding: 7523 7523 1493
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 691 691 N 1 0 0 1 0 -668 3
+Refer: 608 691 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D64
-Encoding: 7524 7524 7524
+Encoding: 7524 7524 1494
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7512 7512 N 1 0 0 1 0 -668 3
+Refer: 1488 7512 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D65
-Encoding: 7525 7525 7525
+Encoding: 7525 7525 1495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7515 7515 N 1 0 0 1 0 -668 3
+Refer: 1491 7515 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D77
-Encoding: 7543 7543 7543
+Encoding: 7543 7543 1496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49201,16 +50703,18 @@ SplineSet
  98 641 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D78
-Encoding: 7544 7544 7544
+Encoding: 7544 7544 1497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7476 7476 N 1 0 0 1 0 0 2
+Refer: 1453 7476 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1D7B
-Encoding: 7547 7547 7547
+Encoding: 7547 7547 1498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49239,8 +50743,9 @@ SplineSet
  230 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D85
-Encoding: 7557 7557 7557
+Encoding: 7557 7557 1499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49258,21 +50763,22 @@ SplineSet
  1094 168 l 1,11,-1
  1094 43 l 1,12,-1
  1094 0 l 1,13,-1
- 1093.29 8.29784e-08 l 1,14,15
+ 1093.29 8.29784e-008 l 1,14,15
  1085.97 -216.441 1085.97 -216.441 1003 -316 c 0,16,17
  912.997 -424 912.997 -424 703 -424 c 2,18,-1
  582 -424 l 1,19,-1
  582 -199 l 1,20,-1
  621 -199 l 2,21,22
  719.142 -199 719.142 -199 762 -144 c 0,23,24
- 796.086 -100.257 796.086 -100.257 801.834 -2.96828e-06 c 1,25,-1
+ 796.086 -100.257 796.086 -100.257 801.834 -2.96828e-006 c 1,25,-1
  778 0 l 2,26,27
  569 0 569 0 478 108 c 0,28,29
  387 216 387 216 387 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9B
-Encoding: 7579 7579 7579
+Encoding: 7579 7579 1500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49303,8 +50809,9 @@ SplineSet
  745 891 745 891 745 982 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D9C
-Encoding: 7580 7580 7580
+Encoding: 7580 7580 1501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49331,8 +50838,9 @@ SplineSet
  898 700 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9D
-Encoding: 7581 7581 7581
+Encoding: 7581 7581 1502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49368,8 +50876,9 @@ SplineSet
  517 895 517 895 547 855 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9E
-Encoding: 7582 7582 7582
+Encoding: 7582 7582 1503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49410,8 +50919,9 @@ SplineSet
  823 1284 l 2,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni1D9F
-Encoding: 7583 7583 7583
+Encoding: 7583 7583 1504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49449,8 +50959,9 @@ SplineSet
  826 1003 826 1003 738 989 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA0
-Encoding: 7584 7584 7584
+Encoding: 7584 7584 1505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49477,8 +50988,9 @@ SplineSet
  687 1386 687 1386 686 1350 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA1
-Encoding: 7585 7585 7585
+Encoding: 7585 7585 1506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49503,8 +51015,9 @@ SplineSet
  523 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA2
-Encoding: 7586 7586 7586
+Encoding: 7586 7586 1507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49541,8 +51054,9 @@ SplineSet
  619 1165 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni1DA3
-Encoding: 7587 7587 7587
+Encoding: 7587 7587 1508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49567,8 +51081,9 @@ SplineSet
  333 770 333 770 333 887 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA4
-Encoding: 7588 7588 7588
+Encoding: 7588 7588 1509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49600,8 +51115,9 @@ SplineSet
  344 1295 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA5
-Encoding: 7589 7589 7589
+Encoding: 7589 7589 1510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49622,8 +51138,9 @@ SplineSet
  499 1169 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA6
-Encoding: 7590 7590 7590
+Encoding: 7590 7590 1511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49644,8 +51161,9 @@ SplineSet
  709 1169 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA7
-Encoding: 7591 7591 7591
+Encoding: 7591 7591 1512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49674,8 +51192,9 @@ SplineSet
  373 913 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA8
-Encoding: 7592 7592 7592
+Encoding: 7592 7592 1513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49712,8 +51231,9 @@ SplineSet
  643 603 643 603 649 630 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni1DA9
-Encoding: 7593 7593 7593
+Encoding: 7593 7593 1514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49734,8 +51254,9 @@ SplineSet
  488 540 488 540 488 681 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAA
-Encoding: 7594 7594 7594
+Encoding: 7594 7594 1515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49763,8 +51284,9 @@ SplineSet
  487 789 487 789 487 930 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAB
-Encoding: 7595 7595 7595
+Encoding: 7595 7595 1516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49779,8 +51301,9 @@ SplineSet
  377 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAC
-Encoding: 7596 7596 7596
+Encoding: 7596 7596 1517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49822,8 +51345,9 @@ SplineSet
  654 1264 654 1264 662 1232 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAD
-Encoding: 7597 7597 7597
+Encoding: 7597 7597 1518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49859,8 +51383,9 @@ SplineSet
  579 698 579 698 571 731 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAE
-Encoding: 7598 7598 7598
+Encoding: 7598 7598 1519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49897,8 +51422,9 @@ SplineSet
  965 1177 965 1177 965 1050 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAF
-Encoding: 7599 7599 7599
+Encoding: 7599 7599 1520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49930,8 +51456,9 @@ SplineSet
  666 1072 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB0
-Encoding: 7600 7600 7600
+Encoding: 7600 7600 1521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49950,8 +51477,9 @@ SplineSet
  304 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB1
-Encoding: 7601 7601 7601
+Encoding: 7601 7601 1522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49982,8 +51510,9 @@ SplineSet
  743 868 743 868 752 913 c 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB2
-Encoding: 7602 7602 7602
+Encoding: 7602 7602 1523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50026,8 +51555,9 @@ SplineSet
  731 1144 731 1144 709 1156 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB3
-Encoding: 7603 7603 7603
+Encoding: 7603 7603 1524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50070,8 +51600,9 @@ SplineSet
  794 1293 794 1293 851 1276 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB4
-Encoding: 7604 7604 7604
+Encoding: 7604 7604 1525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50096,8 +51627,9 @@ SplineSet
  731 668 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB5
-Encoding: 7605 7605 7605
+Encoding: 7605 7605 1526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50130,8 +51662,9 @@ SplineSet
  678 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB6
-Encoding: 7606 7606 7606
+Encoding: 7606 7606 1527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50168,8 +51701,9 @@ SplineSet
  714 858 714 858 718 913 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB7
-Encoding: 7607 7607 7607
+Encoding: 7607 7607 1528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50202,8 +51736,9 @@ SplineSet
  575 1137 l 1,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni1DB9
-Encoding: 7609 7609 7609
+Encoding: 7609 7609 1529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50236,8 +51771,9 @@ SplineSet
  783 1292 783 1292 844 1243 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBA
-Encoding: 7610 7610 7610
+Encoding: 7610 7610 1530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50253,8 +51789,9 @@ SplineSet
  279 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBB
-Encoding: 7611 7611 7611
+Encoding: 7611 7611 1531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50273,8 +51810,9 @@ SplineSet
  342 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBC
-Encoding: 7612 7612 7612
+Encoding: 7612 7612 1532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50300,8 +51838,9 @@ SplineSet
  273 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBD
-Encoding: 7613 7613 7613
+Encoding: 7613 7613 1533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50332,8 +51871,9 @@ SplineSet
  318 1295 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBE
-Encoding: 7614 7614 7614
+Encoding: 7614 7614 1534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50364,8 +51904,9 @@ SplineSet
  424 921 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBF
-Encoding: 7615 7615 7615
+Encoding: 7615 7615 1535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50394,3223 +51935,3581 @@ SplineSet
  766 654 766 654 616 654 c 24,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1E00
-Encoding: 7680 7680 7680
+Encoding: 7680 7680 1536
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E01
-Encoding: 7681 7681 7681
+Encoding: 7681 7681 1537
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E02
-Encoding: 7682 7682 7682
+Encoding: 7682 7682 1538
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E03
-Encoding: 7683 7683 7683
+Encoding: 7683 7683 1539
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 100 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1E04
-Encoding: 7684 7684 7684
+Encoding: 7684 7684 1540
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E05
-Encoding: 7685 7685 7685
+Encoding: 7685 7685 1541
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E06
-Encoding: 7686 7686 7686
+Encoding: 7686 7686 1542
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E07
-Encoding: 7687 7687 7687
+Encoding: 7687 7687 1543
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E08
-Encoding: 7688 7688 7688
+Encoding: 7688 7688 1544
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 137 373 2
-Refer: 807 807 N 1 0 0 1 117 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 137 373 2
+Refer: 694 807 N 1 0 0 1 117 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E09
-Encoding: 7689 7689 7689
+Encoding: 7689 7689 1545
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 102 0 2
-Refer: 807 807 N 1 0 0 1 72 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 102 0 2
+Refer: 694 807 N 1 0 0 1 72 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0A
-Encoding: 7690 7690 7690
+Encoding: 7690 7690 1546
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0B
-Encoding: 7691 7691 7691
+Encoding: 7691 7691 1547
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 -100 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1E0C
-Encoding: 7692 7692 7692
+Encoding: 7692 7692 1548
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0D
-Encoding: 7693 7693 7693
+Encoding: 7693 7693 1549
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0E
-Encoding: 7694 7694 7694
+Encoding: 7694 7694 1550
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0F
-Encoding: 7695 7695 7695
+Encoding: 7695 7695 1551
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E10
-Encoding: 7696 7696 7696
+Encoding: 7696 7696 1552
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -184.5 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -184.5 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E11
-Encoding: 7697 7697 7697
+Encoding: 7697 7697 1553
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -121.5 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -121.5 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E12
-Encoding: 7698 7698 7698
+Encoding: 7698 7698 1554
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E13
-Encoding: 7699 7699 7699
+Encoding: 7699 7699 1555
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E18
-Encoding: 7704 7704 7704
+Encoding: 7704 7704 1556
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: uni1E19
-Encoding: 7705 7705 7705
+Encoding: 7705 7705 1557
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni1E1A
-Encoding: 7706 7706 7706
+Encoding: 7706 7706 1558
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: uni1E1B
-Encoding: 7707 7707 7707
+Encoding: 7707 7707 1559
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni1E1C
-Encoding: 7708 7708 7708
+Encoding: 7708 7708 1560
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 31 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: uni1E1D
-Encoding: 7709 7709 7709
+Encoding: 7709 7709 1561
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 39 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni1E1E
-Encoding: 7710 7710 7710
+Encoding: 7710 7710 1562
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 14 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1E1F
-Encoding: 7711 7711 7711
+Encoding: 7711 7711 1563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 102 102 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E20
-Encoding: 7712 7712 7712
+Encoding: 7712 7712 1564
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E21
-Encoding: 7713 7713 7713
+Encoding: 7713 7713 1565
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E22
-Encoding: 7714 7714 7714
+Encoding: 7714 7714 1566
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E23
-Encoding: 7715 7715 7715
+Encoding: 7715 7715 1567
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E24
-Encoding: 7716 7716 7716
+Encoding: 7716 7716 1568
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E25
-Encoding: 7717 7717 7717
+Encoding: 7717 7717 1569
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E26
-Encoding: 7718 7718 7718
+Encoding: 7718 7718 1570
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 3
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E27
-Encoding: 7719 7719 7719
+Encoding: 7719 7719 1571
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 7 328 2
+Refer: 73 104 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 7 328 2
 EndChar
+
 StartChar: uni1E28
-Encoding: 7720 7720 7720
+Encoding: 7720 7720 1572
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -335 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -335 0 2
 EndChar
+
 StartChar: uni1E29
-Encoding: 7721 7721 7721
+Encoding: 7721 7721 1573
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -300 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -300 0 2
 EndChar
+
 StartChar: uni1E2A
-Encoding: 7722 7722 7722
+Encoding: 7722 7722 1574
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 814 814 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2B
-Encoding: 7723 7723 7723
+Encoding: 7723 7723 1575
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 814 814 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2C
-Encoding: 7724 7724 7724
+Encoding: 7724 7724 1576
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2D
-Encoding: 7725 7725 7725
+Encoding: 7725 7725 1577
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E30
-Encoding: 7728 7728 7728
+Encoding: 7728 7728 1578
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E31
-Encoding: 7729 7729 7729
+Encoding: 7729 7729 1579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -240 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 -240 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E32
-Encoding: 7730 7730 7730
+Encoding: 7730 7730 1580
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E33
-Encoding: 7731 7731 7731
+Encoding: 7731 7731 1581
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E34
-Encoding: 7732 7732 7732
+Encoding: 7732 7732 1582
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E35
-Encoding: 7733 7733 7733
+Encoding: 7733 7733 1583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E36
-Encoding: 7734 7734 7734
+Encoding: 7734 7734 1584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E37
-Encoding: 7735 7735 7735
+Encoding: 7735 7735 1585
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E38
-Encoding: 7736 7736 7736
+Encoding: 7736 7736 1586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7734 7734 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 1584 7734 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E39
-Encoding: 7737 7737 7737
+Encoding: 7737 7737 1587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7735 7735 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 1585 7735 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3A
-Encoding: 7738 7738 7738
+Encoding: 7738 7738 1588
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E3B
-Encoding: 7739 7739 7739
+Encoding: 7739 7739 1589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3C
-Encoding: 7740 7740 7740
+Encoding: 7740 7740 1590
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E3D
-Encoding: 7741 7741 7741
+Encoding: 7741 7741 1591
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3E
-Encoding: 7742 7742 7742
+Encoding: 7742 7742 1592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 373 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3F
-Encoding: 7743 7743 7743
+Encoding: 7743 7743 1593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E40
-Encoding: 7744 7744 7744
+Encoding: 7744 7744 1594
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E41
-Encoding: 7745 7745 7745
+Encoding: 7745 7745 1595
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E42
-Encoding: 7746 7746 7746
+Encoding: 7746 7746 1596
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E43
-Encoding: 7747 7747 7747
+Encoding: 7747 7747 1597
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E44
-Encoding: 7748 7748 7748
+Encoding: 7748 7748 1598
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E45
-Encoding: 7749 7749 7749
+Encoding: 7749 7749 1599
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E46
-Encoding: 7750 7750 7750
+Encoding: 7750 7750 1600
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E47
-Encoding: 7751 7751 7751
+Encoding: 7751 7751 1601
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E48
-Encoding: 7752 7752 7752
+Encoding: 7752 7752 1602
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E49
-Encoding: 7753 7753 7753
+Encoding: 7753 7753 1603
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4A
-Encoding: 7754 7754 7754
+Encoding: 7754 7754 1604
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4B
-Encoding: 7755 7755 7755
+Encoding: 7755 7755 1605
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4C
-Encoding: 7756 7756 7756
+Encoding: 7756 7756 1606
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 50 515 2
+Refer: 3668 -1 N 1 0 0 1 0 262 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4D
-Encoding: 7757 7757 7757
+Encoding: 7757 7757 1607
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 0 404 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
 EndChar
+
 StartChar: uni1E54
-Encoding: 7764 7764 7764
+Encoding: 7764 7764 1608
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -137 380 2
+Refer: 49 80 N 1 0 0 1 0 0 3
+Refer: 3667 -1 N 1 0 0 1 -137 380 2
 EndChar
+
 StartChar: uni1E55
-Encoding: 7765 7765 7765
+Encoding: 7765 7765 1609
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 3
-Refer: 769 769 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
+Refer: 656 769 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E56
-Encoding: 7766 7766 7766
+Encoding: 7766 7766 1610
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E57
-Encoding: 7767 7767 7767
+Encoding: 7767 7767 1611
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E58
-Encoding: 7768 7768 7768
+Encoding: 7768 7768 1612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E59
-Encoding: 7769 7769 7769
+Encoding: 7769 7769 1613
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5A
-Encoding: 7770 7770 7770
+Encoding: 7770 7770 1614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E5B
-Encoding: 7771 7771 7771
+Encoding: 7771 7771 1615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5C
-Encoding: 7772 7772 7772
+Encoding: 7772 7772 1616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7770 7770 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 -50 0 2
+Refer: 1614 7770 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E5D
-Encoding: 7773 7773 7773
+Encoding: 7773 7773 1617
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7771 7771 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 1615 7771 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5E
-Encoding: 7774 7774 7774
+Encoding: 7774 7774 1618
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5F
-Encoding: 7775 7775 7775
+Encoding: 7775 7775 1619
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E60
-Encoding: 7776 7776 7776
+Encoding: 7776 7776 1620
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E61
-Encoding: 7777 7777 7777
+Encoding: 7777 7777 1621
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E62
-Encoding: 7778 7778 7778
+Encoding: 7778 7778 1622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E63
-Encoding: 7779 7779 7779
+Encoding: 7779 7779 1623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E68
-Encoding: 7784 7784 7784
+Encoding: 7784 7784 1624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E69
-Encoding: 7785 7785 7785
+Encoding: 7785 7785 1625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6A
-Encoding: 7786 7786 7786
+Encoding: 7786 7786 1626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6B
-Encoding: 7787 7787 7787
+Encoding: 7787 7787 1627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6C
-Encoding: 7788 7788 7788
+Encoding: 7788 7788 1628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6D
-Encoding: 7789 7789 7789
+Encoding: 7789 7789 1629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6E
-Encoding: 7790 7790 7790
+Encoding: 7790 7790 1630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6F
-Encoding: 7791 7791 7791
+Encoding: 7791 7791 1631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E70
-Encoding: 7792 7792 7792
+Encoding: 7792 7792 1632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E71
-Encoding: 7793 7793 7793
+Encoding: 7793 7793 1633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E72
-Encoding: 7794 7794 7794
+Encoding: 7794 7794 1634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 804 804 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E73
-Encoding: 7795 7795 7795
+Encoding: 7795 7795 1635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 804 804 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E74
-Encoding: 7796 7796 7796
+Encoding: 7796 7796 1636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E75
-Encoding: 7797 7797 7797
+Encoding: 7797 7797 1637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E76
-Encoding: 7798 7798 7798
+Encoding: 7798 7798 1638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E77
-Encoding: 7799 7799 7799
+Encoding: 7799 7799 1639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E78
-Encoding: 7800 7800 7800
+Encoding: 7800 7800 1640
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 50 515 2
+Refer: 3668 -1 N 1 0 0 1 0 262 2
 EndChar
+
 StartChar: uni1E79
-Encoding: 7801 7801 7801
+Encoding: 7801 7801 1641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 0 404 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
 EndChar
+
 StartChar: uni1E7C
-Encoding: 7804 7804 7804
+Encoding: 7804 7804 1642
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 0 348 2
+Refer: 55 86 N 1 0 0 1 0 0 3
+Refer: 3668 -1 N 1 0 0 1 0 348 2
 EndChar
+
 StartChar: uni1E7D
-Encoding: 7805 7805 7805
+Encoding: 7805 7805 1643
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 0 -40 2
+Refer: 87 118 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 0 -40 2
 EndChar
+
 StartChar: uni1E7E
-Encoding: 7806 7806 7806
+Encoding: 7806 7806 1644
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7F
-Encoding: 7807 7807 7807
+Encoding: 7807 7807 1645
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wgrave
-Encoding: 7808 7808 7808
+Encoding: 7808 7808 1646
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wgrave
-Encoding: 7809 7809 7809
+Encoding: 7809 7809 1647
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -49 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -49 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wacute
-Encoding: 7810 7810 7810
+Encoding: 7810 7810 1648
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3667 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wacute
-Encoding: 7811 7811 7811
+Encoding: 7811 7811 1649
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 49 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 49 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wdieresis
-Encoding: 7812 7812 7812
+Encoding: 7812 7812 1650
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 303 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 303 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wdieresis
-Encoding: 7813 7813 7813
+Encoding: 7813 7813 1651
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -70 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -70 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E86
-Encoding: 7814 7814 7814
+Encoding: 7814 7814 1652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E87
-Encoding: 7815 7815 7815
+Encoding: 7815 7815 1653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E88
-Encoding: 7816 7816 7816
+Encoding: 7816 7816 1654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E89
-Encoding: 7817 7817 7817
+Encoding: 7817 7817 1655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8A
-Encoding: 7818 7818 7818
+Encoding: 7818 7818 1656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8B
-Encoding: 7819 7819 7819
+Encoding: 7819 7819 1657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8C
-Encoding: 7820 7820 7820
+Encoding: 7820 7820 1658
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 88 88 N 1 0 0 1 0 0 3
+Refer: 3666 -1 N 1 0 0 1 0 373 2
+Refer: 57 88 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8D
-Encoding: 7821 7821 7821
+Encoding: 7821 7821 1659
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 0.5 -81 2
+Refer: 89 120 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 0.5 -81 2
 EndChar
+
 StartChar: uni1E8E
-Encoding: 7822 7822 7822
+Encoding: 7822 7822 1660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8F
-Encoding: 7823 7823 7823
+Encoding: 7823 7823 1661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E90
-Encoding: 7824 7824 7824
+Encoding: 7824 7824 1662
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 46 380 2
+Refer: 59 90 N 1 0 0 1 0 0 3
+Refer: 3670 -1 N 1 0 0 1 46 380 2
 EndChar
+
 StartChar: uni1E91
-Encoding: 7825 7825 7825
+Encoding: 7825 7825 1663
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 17 7 2
+Refer: 91 122 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 17 7 2
 EndChar
+
 StartChar: uni1E92
-Encoding: 7826 7826 7826
+Encoding: 7826 7826 1664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 21 0 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 21 0 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E93
-Encoding: 7827 7827 7827
+Encoding: 7827 7827 1665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 5 0 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 5 0 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E94
-Encoding: 7828 7828 7828
+Encoding: 7828 7828 1666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E95
-Encoding: 7829 7829 7829
+Encoding: 7829 7829 1667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E96
-Encoding: 7830 7830 7830
+Encoding: 7830 7830 1668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E97
-Encoding: 7831 7831 7831
+Encoding: 7831 7831 1669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 -94 210 2
+Refer: 85 116 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 -94 210 2
 EndChar
+
 StartChar: uni1E98
-Encoding: 7832 7832 7832
+Encoding: 7832 7832 1670
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 0 20 2
+Refer: 88 119 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 0 20 2
 EndChar
+
 StartChar: uni1E99
-Encoding: 7833 7833 7833
+Encoding: 7833 7833 1671
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 12 20 2
+Refer: 90 121 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 12 20 2
 EndChar
+
 StartChar: uni1E9B
-Encoding: 7835 7835 7835
+Encoding: 7835 7835 1672
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 383 383 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 319 383 N 1 0 0 1 0 0 2
+Refer: 3675 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E9F
-Encoding: 7839 7839 7839
+Encoding: 7839 7839 1673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 948 948 N 1 0 0 1 0 0 2
+Refer: 777 948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA0
-Encoding: 7840 7840 7840
+Encoding: 7840 7840 1674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 34 65 S 1 0 0 1 0 -2 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA1
-Encoding: 7841 7841 7841
+Encoding: 7841 7841 1675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EAC
-Encoding: 7852 7852 7852
+Encoding: 7852 7852 1676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
+Refer: 3670 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: uni1EAD
-Encoding: 7853 7853 7853
+Encoding: 7853 7853 1677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -24.5 7 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -24.5 7 2
 EndChar
+
 StartChar: uni1EB0
-Encoding: 7856 7856 7856
+Encoding: 7856 7856 1678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 515 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 -128 2
+Refer: 3669 -1 N 1 0 0 1 -51 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB1
-Encoding: 7857 7857 7857
+Encoding: 7857 7857 1679
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 259 259 N 1 0 0 1 0 0 3
-Refer: 768 768 N 1 0 0 1 0 316 2
+Refer: 655 768 N 1 0 0 1 -49 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB6
-Encoding: 7862 7862 7862
+Encoding: 7862 7862 1680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB7
-Encoding: 7863 7863 7863
+Encoding: 7863 7863 1681
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 728 728 N 1 0 0 1 -24.5 -52 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
+Refer: 636 728 N 1 0 0 1 -24.5 -52 2
 EndChar
+
 StartChar: uni1EB8
-Encoding: 7864 7864 7864
+Encoding: 7864 7864 1682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: uni1EB9
-Encoding: 7865 7865 7865
+Encoding: 7865 7865 1683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: uni1EBC
-Encoding: 7868 7868 7868
+Encoding: 7868 7868 1684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 49 373 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 49 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBD
-Encoding: 7869 7869 7869
+Encoding: 7869 7869 1685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 -33 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 -33 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EC6
-Encoding: 7878 7878 7878
+Encoding: 7878 7878 1686
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7864 7864 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 23.5 380 2
+Refer: 1682 7864 N 1 0 0 1 0 0 3
+Refer: 3670 -1 N 1 0 0 1 23.5 380 2
 EndChar
+
 StartChar: uni1EC7
-Encoding: 7879 7879 7879
+Encoding: 7879 7879 1687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7865 7865 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 34.5 7 2
+Refer: 1683 7865 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 34.5 7 2
 EndChar
+
 StartChar: uni1ECA
-Encoding: 7882 7882 7882
+Encoding: 7882 7882 1688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECB
-Encoding: 7883 7883 7883
+Encoding: 7883 7883 1689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECC
-Encoding: 7884 7884 7884
+Encoding: 7884 7884 1690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECD
-Encoding: 7885 7885 7885
+Encoding: 7885 7885 1691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ED8
-Encoding: 7896 7896 7896
+Encoding: 7896 7896 1692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7884 7884 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 -0.5 380 2
+Refer: 1690 7884 N 1 0 0 1 0 0 3
+Refer: 3670 -1 N 1 0 0 1 -0.5 380 2
 EndChar
+
 StartChar: uni1ED9
-Encoding: 7897 7897 7897
+Encoding: 7897 7897 1693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7885 7885 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -0.5 7 2
+Refer: 1691 7885 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -0.5 7 2
 EndChar
+
 StartChar: uni1EDA
-Encoding: 7898 7898 7898
+Encoding: 7898 7898 1694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3667 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDB
-Encoding: 7899 7899 7899
+Encoding: 7899 7899 1695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EDC
-Encoding: 7900 7900 7900
+Encoding: 7900 7900 1696
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114117 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3669 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDD
-Encoding: 7901 7901 7901
+Encoding: 7901 7901 1697
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE0
-Encoding: 7904 7904 7904
+Encoding: 7904 7904 1698
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3668 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EE1
-Encoding: 7905 7905 7905
+Encoding: 7905 7905 1699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE2
-Encoding: 7906 7906 7906
+Encoding: 7906 7906 1700
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -111 0 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -111 0 2
 EndChar
+
 StartChar: uni1EE3
-Encoding: 7907 7907 7907
+Encoding: 7907 7907 1701
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE4
-Encoding: 7908 7908 7908
+Encoding: 7908 7908 1702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE5
-Encoding: 7909 7909 7909
+Encoding: 7909 7909 1703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE8
-Encoding: 7912 7912 7912
+Encoding: 7912 7912 1704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3667 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EE9
-Encoding: 7913 7913 7913
+Encoding: 7913 7913 1705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEA
-Encoding: 7914 7914 7914
+Encoding: 7914 7914 1706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114117 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3669 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEB
-Encoding: 7915 7915 7915
+Encoding: 7915 7915 1707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEE
-Encoding: 7918 7918 7918
+Encoding: 7918 7918 1708
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3668 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEF
-Encoding: 7919 7919 7919
+Encoding: 7919 7919 1709
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EF0
-Encoding: 7920 7920 7920
+Encoding: 7920 7920 1710
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -138 0 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -138 0 2
 EndChar
+
 StartChar: uni1EF1
-Encoding: 7921 7921 7921
+Encoding: 7921 7921 1711
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: Ygrave
-Encoding: 7922 7922 7922
+Encoding: 7922 7922 1712
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3669 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ygrave
-Encoding: 7923 7923 7923
+Encoding: 7923 7923 1713
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -48 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -48 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF4
-Encoding: 7924 7924 7924
+Encoding: 7924 7924 1714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF5
-Encoding: 7925 7925 7925
+Encoding: 7925 7925 1715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 300 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 300 0 2
 EndChar
+
 StartChar: uni1EF8
-Encoding: 7928 7928 7928
+Encoding: 7928 7928 1716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3668 -1 N 1 0 0 1 0 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF9
-Encoding: 7929 7929 7929
+Encoding: 7929 7929 1717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 -33 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 -33 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F00
-Encoding: 7936 7936 7936
+Encoding: 7936 7936 1718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F01
-Encoding: 7937 7937 7937
+Encoding: 7937 7937 1719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F02
-Encoding: 7938 7938 7938
+Encoding: 7938 7938 1720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F03
-Encoding: 7939 7939 7939
+Encoding: 7939 7939 1721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F04
-Encoding: 7940 7940 7940
+Encoding: 7940 7940 1722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F05
-Encoding: 7941 7941 7941
+Encoding: 7941 7941 1723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F06
-Encoding: 7942 7942 7942
+Encoding: 7942 7942 1724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F07
-Encoding: 7943 7943 7943
+Encoding: 7943 7943 1725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F08
-Encoding: 7944 7944 7944
+Encoding: 7944 7944 1726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -440 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -440 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F09
-Encoding: 7945 7945 7945
+Encoding: 7945 7945 1727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -490 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -490 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0A
-Encoding: 7946 7946 7946
+Encoding: 7946 7946 1728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -760 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -760 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0B
-Encoding: 7947 7947 7947
+Encoding: 7947 7947 1729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -760 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -760 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0C
-Encoding: 7948 7948 7948
+Encoding: 7948 7948 1730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -645 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -645 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0D
-Encoding: 7949 7949 7949
+Encoding: 7949 7949 1731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -665 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -665 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0E
-Encoding: 7950 7950 7950
+Encoding: 7950 7950 1732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -440 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -440 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0F
-Encoding: 7951 7951 7951
+Encoding: 7951 7951 1733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -490 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -490 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F10
-Encoding: 7952 7952 7952
+Encoding: 7952 7952 1734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F11
-Encoding: 7953 7953 7953
+Encoding: 7953 7953 1735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F12
-Encoding: 7954 7954 7954
+Encoding: 7954 7954 1736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F13
-Encoding: 7955 7955 7955
+Encoding: 7955 7955 1737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F14
-Encoding: 7956 7956 7956
+Encoding: 7956 7956 1738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F15
-Encoding: 7957 7957 7957
+Encoding: 7957 7957 1739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F18
-Encoding: 7960 7960 7960
+Encoding: 7960 7960 1740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -695 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -695 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F19
-Encoding: 7961 7961 7961
+Encoding: 7961 7961 1741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -695 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1A
-Encoding: 7962 7962 7962
+Encoding: 7962 7962 1742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -965 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -965 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1B
-Encoding: 7963 7963 7963
+Encoding: 7963 7963 1743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -965 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -965 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1C
-Encoding: 7964 7964 7964
+Encoding: 7964 7964 1744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -910 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -910 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1D
-Encoding: 7965 7965 7965
+Encoding: 7965 7965 1745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -920 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -920 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F20
-Encoding: 7968 7968 7968
+Encoding: 7968 7968 1746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F21
-Encoding: 7969 7969 7969
+Encoding: 7969 7969 1747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F22
-Encoding: 7970 7970 7970
+Encoding: 7970 7970 1748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F23
-Encoding: 7971 7971 7971
+Encoding: 7971 7971 1749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F24
-Encoding: 7972 7972 7972
+Encoding: 7972 7972 1750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F25
-Encoding: 7973 7973 7973
+Encoding: 7973 7973 1751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F26
-Encoding: 7974 7974 7974
+Encoding: 7974 7974 1752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F27
-Encoding: 7975 7975 7975
+Encoding: 7975 7975 1753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F28
-Encoding: 7976 7976 7976
+Encoding: 7976 7976 1754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -745 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -745 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F29
-Encoding: 7977 7977 7977
+Encoding: 7977 7977 1755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -745 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -745 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2A
-Encoding: 7978 7978 7978
+Encoding: 7978 7978 1756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -1020 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -1020 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2B
-Encoding: 7979 7979 7979
+Encoding: 7979 7979 1757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -1020 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -1020 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2C
-Encoding: 7980 7980 7980
+Encoding: 7980 7980 1758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -970 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -970 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2D
-Encoding: 7981 7981 7981
+Encoding: 7981 7981 1759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -970 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -970 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2E
-Encoding: 7982 7982 7982
+Encoding: 7982 7982 1760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -740 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -740 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2F
-Encoding: 7983 7983 7983
+Encoding: 7983 7983 1761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -740 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -740 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F30
-Encoding: 7984 7984 7984
+Encoding: 7984 7984 1762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F31
-Encoding: 7985 7985 7985
+Encoding: 7985 7985 1763
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F32
-Encoding: 7986 7986 7986
+Encoding: 7986 7986 1764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F33
-Encoding: 7987 7987 7987
+Encoding: 7987 7987 1765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F34
-Encoding: 7988 7988 7988
+Encoding: 7988 7988 1766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F35
-Encoding: 7989 7989 7989
+Encoding: 7989 7989 1767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F36
-Encoding: 7990 7990 7990
+Encoding: 7990 7990 1768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F37
-Encoding: 7991 7991 7991
+Encoding: 7991 7991 1769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F38
-Encoding: 7992 7992 7992
+Encoding: 7992 7992 1770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -695 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -695 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F39
-Encoding: 7993 7993 7993
+Encoding: 7993 7993 1771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -695 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3A
-Encoding: 7994 7994 7994
+Encoding: 7994 7994 1772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -940 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -940 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3B
-Encoding: 7995 7995 7995
+Encoding: 7995 7995 1773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -960 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -960 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3C
-Encoding: 7996 7996 7996
+Encoding: 7996 7996 1774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -900 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -900 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3D
-Encoding: 7997 7997 7997
+Encoding: 7997 7997 1775
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -910 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -910 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3E
-Encoding: 7998 7998 7998
+Encoding: 7998 7998 1776
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -695 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -695 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3F
-Encoding: 7999 7999 7999
+Encoding: 7999 7999 1777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -695 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -695 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F40
-Encoding: 8000 8000 8000
+Encoding: 8000 8000 1778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F41
-Encoding: 8001 8001 8001
+Encoding: 8001 8001 1779
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F42
-Encoding: 8002 8002 8002
+Encoding: 8002 8002 1780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F43
-Encoding: 8003 8003 8003
+Encoding: 8003 8003 1781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F44
-Encoding: 8004 8004 8004
+Encoding: 8004 8004 1782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F45
-Encoding: 8005 8005 8005
+Encoding: 8005 8005 1783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F48
-Encoding: 8008 8008 8008
+Encoding: 8008 8008 1784
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -620 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -620 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F49
-Encoding: 8009 8009 8009
+Encoding: 8009 8009 1785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -695 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4A
-Encoding: 8010 8010 8010
+Encoding: 8010 8010 1786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -945 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -945 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4B
-Encoding: 8011 8011 8011
+Encoding: 8011 8011 1787
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -945 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -945 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4C
-Encoding: 8012 8012 8012
+Encoding: 8012 8012 1788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -720 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -720 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4D
-Encoding: 8013 8013 8013
+Encoding: 8013 8013 1789
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -730 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -730 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F50
-Encoding: 8016 8016 8016
+Encoding: 8016 8016 1790
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F51
-Encoding: 8017 8017 8017
+Encoding: 8017 8017 1791
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F52
-Encoding: 8018 8018 8018
+Encoding: 8018 8018 1792
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F53
-Encoding: 8019 8019 8019
+Encoding: 8019 8019 1793
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F54
-Encoding: 8020 8020 8020
+Encoding: 8020 8020 1794
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F55
-Encoding: 8021 8021 8021
+Encoding: 8021 8021 1795
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F56
-Encoding: 8022 8022 8022
+Encoding: 8022 8022 1796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F57
-Encoding: 8023 8023 8023
+Encoding: 8023 8023 1797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F59
-Encoding: 8025 8025 8025
+Encoding: 8025 8025 1798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -845 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -845 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5B
-Encoding: 8027 8027 8027
+Encoding: 8027 8027 1799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -1050 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -1050 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5D
-Encoding: 8029 8029 8029
+Encoding: 8029 8029 1800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -1075 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -1075 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5F
-Encoding: 8031 8031 8031
+Encoding: 8031 8031 1801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -855 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -855 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F60
-Encoding: 8032 8032 8032
+Encoding: 8032 8032 1802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F61
-Encoding: 8033 8033 8033
+Encoding: 8033 8033 1803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F62
-Encoding: 8034 8034 8034
+Encoding: 8034 8034 1804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F63
-Encoding: 8035 8035 8035
+Encoding: 8035 8035 1805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F64
-Encoding: 8036 8036 8036
+Encoding: 8036 8036 1806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F65
-Encoding: 8037 8037 8037
+Encoding: 8037 8037 1807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F66
-Encoding: 8038 8038 8038
+Encoding: 8038 8038 1808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F67
-Encoding: 8039 8039 8039
+Encoding: 8039 8039 1809
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F68
-Encoding: 8040 8040 8040
+Encoding: 8040 8040 1810
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -600 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -600 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F69
-Encoding: 8041 8041 8041
+Encoding: 8041 8041 1811
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -670 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -670 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6A
-Encoding: 8042 8042 8042
+Encoding: 8042 8042 1812
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -945 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -945 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6B
-Encoding: 8043 8043 8043
+Encoding: 8043 8043 1813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -945 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -945 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6C
-Encoding: 8044 8044 8044
+Encoding: 8044 8044 1814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -695 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -695 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6D
-Encoding: 8045 8045 8045
+Encoding: 8045 8045 1815
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -695 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -695 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6E
-Encoding: 8046 8046 8046
+Encoding: 8046 8046 1816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -580 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -580 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6F
-Encoding: 8047 8047 8047
+Encoding: 8047 8047 1817
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -655 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -655 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F70
-Encoding: 8048 8048 8048
+Encoding: 8048 8048 1818
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F71
-Encoding: 8049 8049 8049
+Encoding: 8049 8049 1819
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F72
-Encoding: 8050 8050 8050
+Encoding: 8050 8050 1820
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F73
-Encoding: 8051 8051 8051
+Encoding: 8051 8051 1821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 941 941 N 1 0 0 1 0 0 2
+Refer: 770 941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F74
-Encoding: 8052 8052 8052
+Encoding: 8052 8052 1822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F75
-Encoding: 8053 8053 8053
+Encoding: 8053 8053 1823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F76
-Encoding: 8054 8054 8054
+Encoding: 8054 8054 1824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F77
-Encoding: 8055 8055 8055
+Encoding: 8055 8055 1825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 943 943 N 1 0 0 1 0 0 2
+Refer: 772 943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F78
-Encoding: 8056 8056 8056
+Encoding: 8056 8056 1826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F79
-Encoding: 8057 8057 8057
+Encoding: 8057 8057 1827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 972 972 N 1 0 0 1 0 0 2
+Refer: 801 972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7A
-Encoding: 8058 8058 8058
+Encoding: 8058 8058 1828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7B
-Encoding: 8059 8059 8059
+Encoding: 8059 8059 1829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 973 973 N 1 0 0 1 0 0 2
+Refer: 802 973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7C
-Encoding: 8060 8060 8060
+Encoding: 8060 8060 1830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7D
-Encoding: 8061 8061 8061
+Encoding: 8061 8061 1831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F80
-Encoding: 8064 8064 8064
+Encoding: 8064 8064 1832
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7936 7936 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1718 7936 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F81
-Encoding: 8065 8065 8065
+Encoding: 8065 8065 1833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7937 7937 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1719 7937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F82
-Encoding: 8066 8066 8066
+Encoding: 8066 8066 1834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7938 7938 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1720 7938 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F83
-Encoding: 8067 8067 8067
+Encoding: 8067 8067 1835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7939 7939 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1721 7939 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F84
-Encoding: 8068 8068 8068
+Encoding: 8068 8068 1836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7940 7940 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1722 7940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F85
-Encoding: 8069 8069 8069
+Encoding: 8069 8069 1837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7941 7941 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1723 7941 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F86
-Encoding: 8070 8070 8070
+Encoding: 8070 8070 1838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7942 7942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1724 7942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F87
-Encoding: 8071 8071 8071
+Encoding: 8071 8071 1839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7943 7943 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1725 7943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F88
-Encoding: 8072 8072 8072
+Encoding: 8072 8072 1840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7944 7944 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1726 7944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F89
-Encoding: 8073 8073 8073
+Encoding: 8073 8073 1841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7945 7945 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1727 7945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8A
-Encoding: 8074 8074 8074
+Encoding: 8074 8074 1842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7946 7946 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1728 7946 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8B
-Encoding: 8075 8075 8075
+Encoding: 8075 8075 1843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7947 7947 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1729 7947 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8C
-Encoding: 8076 8076 8076
+Encoding: 8076 8076 1844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7948 7948 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1730 7948 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8D
-Encoding: 8077 8077 8077
+Encoding: 8077 8077 1845
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7949 7949 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1731 7949 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8E
-Encoding: 8078 8078 8078
+Encoding: 8078 8078 1846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7950 7950 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1732 7950 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8F
-Encoding: 8079 8079 8079
+Encoding: 8079 8079 1847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7951 7951 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1733 7951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F90
-Encoding: 8080 8080 8080
+Encoding: 8080 8080 1848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7968 7968 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1746 7968 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F91
-Encoding: 8081 8081 8081
+Encoding: 8081 8081 1849
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7969 7969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1747 7969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F92
-Encoding: 8082 8082 8082
+Encoding: 8082 8082 1850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7970 7970 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1748 7970 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F93
-Encoding: 8083 8083 8083
+Encoding: 8083 8083 1851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7971 7971 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1749 7971 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F94
-Encoding: 8084 8084 8084
+Encoding: 8084 8084 1852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7972 7972 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1750 7972 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F95
-Encoding: 8085 8085 8085
+Encoding: 8085 8085 1853
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7973 7973 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1751 7973 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F96
-Encoding: 8086 8086 8086
+Encoding: 8086 8086 1854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7974 7974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1752 7974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F97
-Encoding: 8087 8087 8087
+Encoding: 8087 8087 1855
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7975 7975 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1753 7975 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F98
-Encoding: 8088 8088 8088
+Encoding: 8088 8088 1856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7976 7976 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1754 7976 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F99
-Encoding: 8089 8089 8089
+Encoding: 8089 8089 1857
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7977 7977 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1755 7977 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9A
-Encoding: 8090 8090 8090
+Encoding: 8090 8090 1858
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7978 7978 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1756 7978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9B
-Encoding: 8091 8091 8091
+Encoding: 8091 8091 1859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7979 7979 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1757 7979 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9C
-Encoding: 8092 8092 8092
+Encoding: 8092 8092 1860
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7980 7980 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1758 7980 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9D
-Encoding: 8093 8093 8093
+Encoding: 8093 8093 1861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7981 7981 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1759 7981 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9E
-Encoding: 8094 8094 8094
+Encoding: 8094 8094 1862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7982 7982 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1760 7982 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9F
-Encoding: 8095 8095 8095
+Encoding: 8095 8095 1863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7983 7983 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1761 7983 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA0
-Encoding: 8096 8096 8096
+Encoding: 8096 8096 1864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8032 8032 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1802 8032 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA1
-Encoding: 8097 8097 8097
+Encoding: 8097 8097 1865
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8033 8033 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1803 8033 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA2
-Encoding: 8098 8098 8098
+Encoding: 8098 8098 1866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8034 8034 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1804 8034 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA3
-Encoding: 8099 8099 8099
+Encoding: 8099 8099 1867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8035 8035 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1805 8035 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA4
-Encoding: 8100 8100 8100
+Encoding: 8100 8100 1868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8036 8036 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1806 8036 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA5
-Encoding: 8101 8101 8101
+Encoding: 8101 8101 1869
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8037 8037 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1807 8037 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA6
-Encoding: 8102 8102 8102
+Encoding: 8102 8102 1870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8038 8038 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1808 8038 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA7
-Encoding: 8103 8103 8103
+Encoding: 8103 8103 1871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8039 8039 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1809 8039 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA8
-Encoding: 8104 8104 8104
+Encoding: 8104 8104 1872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8040 8040 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1810 8040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA9
-Encoding: 8105 8105 8105
+Encoding: 8105 8105 1873
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8041 8041 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1811 8041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAA
-Encoding: 8106 8106 8106
+Encoding: 8106 8106 1874
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8042 8042 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1812 8042 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAB
-Encoding: 8107 8107 8107
+Encoding: 8107 8107 1875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8043 8043 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1813 8043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAC
-Encoding: 8108 8108 8108
+Encoding: 8108 8108 1876
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8044 8044 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1814 8044 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAD
-Encoding: 8109 8109 8109
+Encoding: 8109 8109 1877
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8045 8045 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1815 8045 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAE
-Encoding: 8110 8110 8110
+Encoding: 8110 8110 1878
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8046 8046 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1816 8046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAF
-Encoding: 8111 8111 8111
+Encoding: 8111 8111 1879
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8047 8047 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1817 8047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB0
-Encoding: 8112 8112 8112
+Encoding: 8112 8112 1880
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB1
-Encoding: 8113 8113 8113
+Encoding: 8113 8113 1881
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB2
-Encoding: 8114 8114 8114
+Encoding: 8114 8114 1882
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 8048 8048 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1818 8048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB3
-Encoding: 8115 8115 8115
+Encoding: 8115 8115 1883
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB4
-Encoding: 8116 8116 8116
+Encoding: 8116 8116 1884
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB6
-Encoding: 8118 8118 8118
+Encoding: 8118 8118 1885
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB7
-Encoding: 8119 8119 8119
+Encoding: 8119 8119 1886
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 8118 8118 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1885 8118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB8
-Encoding: 8120 8120 8120
+Encoding: 8120 8120 1887
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB9
-Encoding: 8121 8121 8121
+Encoding: 8121 8121 1888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBA
-Encoding: 8122 8122 8122
+Encoding: 8122 8122 1889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -470 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -470 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBB
-Encoding: 8123 8123 8123
+Encoding: 8123 8123 1890
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 902 902 N 1 0 0 1 0 0 2
+Refer: 734 902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBC
-Encoding: 8124 8124 8124
+Encoding: 8124 8124 1891
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBD
-Encoding: 8125 8125 8125
+Encoding: 8125 8125 1892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBE
-Encoding: 8126 8126 8126
+Encoding: 8126 8126 1893
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBF
-Encoding: 8127 8127 8127
+Encoding: 8127 8127 1894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53626,491 +55525,547 @@ SplineSet
  777 1475 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1FC0
-Encoding: 8128 8128 8128
+Encoding: 8128 8128 1895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC1
-Encoding: 8129 8129 8129
+Encoding: 8129 8129 1896
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 340 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 340 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC2
-Encoding: 8130 8130 8130
+Encoding: 8130 8130 1897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 8052 8052 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1822 8052 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC3
-Encoding: 8131 8131 8131
+Encoding: 8131 8131 1898
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC4
-Encoding: 8132 8132 8132
+Encoding: 8132 8132 1899
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC6
-Encoding: 8134 8134 8134
+Encoding: 8134 8134 1900
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC7
-Encoding: 8135 8135 8135
+Encoding: 8135 8135 1901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 8134 8134 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1900 8134 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC8
-Encoding: 8136 8136 8136
+Encoding: 8136 8136 1902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -700 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC9
-Encoding: 8137 8137 8137
+Encoding: 8137 8137 1903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 904 904 N 1 0 0 1 0 0 2
+Refer: 736 904 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCA
-Encoding: 8138 8138 8138
+Encoding: 8138 8138 1904
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -730 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -730 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCB
-Encoding: 8139 8139 8139
+Encoding: 8139 8139 1905
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 905 905 N 1 0 0 1 0 0 2
+Refer: 737 905 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCC
-Encoding: 8140 8140 8140
+Encoding: 8140 8140 1906
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCD
-Encoding: 8141 8141 8141
+Encoding: 8141 8141 1907
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 310 0 2
-Refer: 8127 8127 N 1 0 0 1 -310 0 2
+Refer: 1938 8175 N 1 0 0 1 310 0 2
+Refer: 1894 8127 N 1 0 0 1 -310 0 2
 EndChar
+
 StartChar: uni1FCE
-Encoding: 8142 8142 8142
+Encoding: 8142 8142 1908
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8189 8189 N 1 0 0 1 110 0 2
-Refer: 8127 8127 N 1 0 0 1 -210 0 2
+Refer: 1949 8189 N 1 0 0 1 110 0 2
+Refer: 1894 8127 N 1 0 0 1 -210 0 2
 EndChar
+
 StartChar: uni1FCF
-Encoding: 8143 8143 8143
+Encoding: 8143 8143 1909
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 410 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD0
-Encoding: 8144 8144 8144
+Encoding: 8144 8144 1910
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD1
-Encoding: 8145 8145 8145
+Encoding: 8145 8145 1911
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD2
-Encoding: 8146 8146 8146
+Encoding: 8146 8146 1912
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8173 8173 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD3
-Encoding: 8147 8147 8147
+Encoding: 8147 8147 1913
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 912 912 N 1 0 0 1 0 0 2
+Refer: 742 912 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD6
-Encoding: 8150 8150 8150
+Encoding: 8150 8150 1914
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD7
-Encoding: 8151 8151 8151
+Encoding: 8151 8151 1915
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8129 8129 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD8
-Encoding: 8152 8152 8152
+Encoding: 8152 8152 1916
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD9
-Encoding: 8153 8153 8153
+Encoding: 8153 8153 1917
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDA
-Encoding: 8154 8154 8154
+Encoding: 8154 8154 1918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -670 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -670 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDB
-Encoding: 8155 8155 8155
+Encoding: 8155 8155 1919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 906 906 N 1 0 0 1 0 0 2
+Refer: 738 906 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDD
-Encoding: 8157 8157 8157
+Encoding: 8157 8157 1920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 320 0 2
-Refer: 8190 8190 N 1 0 0 1 -320 0 2
+Refer: 1938 8175 N 1 0 0 1 320 0 2
+Refer: 1950 8190 N 1 0 0 1 -320 0 2
 EndChar
+
 StartChar: uni1FDE
-Encoding: 8158 8158 8158
+Encoding: 8158 8158 1921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8189 8189 N 1 0 0 1 130 0 2
-Refer: 8190 8190 N 1 0 0 1 -250 0 2
+Refer: 1949 8189 N 1 0 0 1 130 0 2
+Refer: 1950 8190 N 1 0 0 1 -250 0 2
 EndChar
+
 StartChar: uni1FDF
-Encoding: 8159 8159 8159
+Encoding: 8159 8159 1922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 410 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE0
-Encoding: 8160 8160 8160
+Encoding: 8160 8160 1923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE1
-Encoding: 8161 8161 8161
+Encoding: 8161 8161 1924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE2
-Encoding: 8162 8162 8162
+Encoding: 8162 8162 1925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8173 8173 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE3
-Encoding: 8163 8163 8163
+Encoding: 8163 8163 1926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 944 944 N 1 0 0 1 0 0 2
+Refer: 773 944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE4
-Encoding: 8164 8164 8164
+Encoding: 8164 8164 1927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE5
-Encoding: 8165 8165 8165
+Encoding: 8165 8165 1928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE6
-Encoding: 8166 8166 8166
+Encoding: 8166 8166 1929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE7
-Encoding: 8167 8167 8167
+Encoding: 8167 8167 1930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8129 8129 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE8
-Encoding: 8168 8168 8168
+Encoding: 8168 8168 1931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 3674 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE9
-Encoding: 8169 8169 8169
+Encoding: 8169 8169 1932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3679 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEA
-Encoding: 8170 8170 8170
+Encoding: 8170 8170 1933
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -750 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -750 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEB
-Encoding: 8171 8171 8171
+Encoding: 8171 8171 1934
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 910 910 N 1 0 0 1 0 0 2
+Refer: 740 910 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEC
-Encoding: 8172 8172 8172
+Encoding: 8172 8172 1935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -715 0 2
-Refer: 929 929 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -715 0 2
+Refer: 759 929 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FED
-Encoding: 8173 8173 8173
+Encoding: 8173 8173 1936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 0 370 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEE
-Encoding: 8174 8174 8174
+Encoding: 8174 8174 1937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEF
-Encoding: 8175 8175 8175
+Encoding: 8175 8175 1938
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF2
-Encoding: 8178 8178 8178
+Encoding: 8178 8178 1939
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8060 8060 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1830 8060 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF3
-Encoding: 8179 8179 8179
+Encoding: 8179 8179 1940
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF4
-Encoding: 8180 8180 8180
+Encoding: 8180 8180 1941
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF6
-Encoding: 8182 8182 8182
+Encoding: 8182 8182 1942
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF7
-Encoding: 8183 8183 8183
+Encoding: 8183 8183 1943
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8182 8182 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1942 8182 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF8
-Encoding: 8184 8184 8184
+Encoding: 8184 8184 1944
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -655 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -655 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF9
-Encoding: 8185 8185 8185
+Encoding: 8185 8185 1945
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 908 908 N 1 0 0 1 0 0 2
+Refer: 739 908 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFA
-Encoding: 8186 8186 8186
+Encoding: 8186 8186 1946
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -645 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -645 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFB
-Encoding: 8187 8187 8187
+Encoding: 8187 8187 1947
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 911 911 N 1 0 0 1 0 0 2
+Refer: 741 911 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFC
-Encoding: 8188 8188 8188
+Encoding: 8188 8188 1948
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFD
-Encoding: 8189 8189 8189
+Encoding: 8189 8189 1949
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFE
-Encoding: 8190 8190 8190
+Encoding: 8190 8190 1950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54126,74 +56081,86 @@ SplineSet
  455.5 1218 455.5 1218 455.5 1475 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2000
-Encoding: 8192 8192 8192
+Encoding: 8192 8192 1951
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2001
-Encoding: 8193 8193 8193
+Encoding: 8193 8193 1952
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2002
-Encoding: 8194 8194 8194
+Encoding: 8194 8194 1953
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2003
-Encoding: 8195 8195 8195
+Encoding: 8195 8195 1954
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2004
-Encoding: 8196 8196 8196
+Encoding: 8196 8196 1955
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2005
-Encoding: 8197 8197 8197
+Encoding: 8197 8197 1956
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2006
-Encoding: 8198 8198 8198
+Encoding: 8198 8198 1957
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2007
-Encoding: 8199 8199 8199
+Encoding: 8199 8199 1958
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2008
-Encoding: 8200 8200 8200
+Encoding: 8200 8200 1959
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2009
-Encoding: 8201 8201 8201
+Encoding: 8201 8201 1960
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni200A
-Encoding: 8202 8202 8202
+Encoding: 8202 8202 1961
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2010
-Encoding: 8208 8208 8208
+Encoding: 8208 8208 1962
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54224,16 +56191,18 @@ SplineSet
  301 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2011
-Encoding: 8209 8209 8209
+Encoding: 8209 8209 1963
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8208 8208 N 1 0 0 1 0 0 2
+Refer: 1962 8208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: figuredash
-Encoding: 8210 8210 8210
+Encoding: 8210 8210 1964
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54262,8 +56231,9 @@ SplineSet
  0 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: endash
-Encoding: 8211 8211 8211
+Encoding: 8211 8211 1965
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54292,8 +56262,9 @@ SplineSet
  0 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: emdash
-Encoding: 8212 8212 8212
+Encoding: 8212 8212 1966
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54322,8 +56293,9 @@ SplineSet
  0 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2015
-Encoding: 8213 8213 8213
+Encoding: 8213 8213 1967
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54352,26 +56324,29 @@ SplineSet
  0 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2016
-Encoding: 8214 8214 8214
+Encoding: 8214 8214 1968
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 245 0 2
-Refer: 124 124 N 1 0 0 1 -245 0 2
+Refer: 93 124 N 1 0 0 1 245 0 2
+Refer: 93 124 N 1 0 0 1 -245 0 2
 EndChar
+
 StartChar: underscoredbl
-Encoding: 8215 8215 8215
+Encoding: 8215 8215 1969
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
-Refer: 95 95 N 1 0 0 1 0 275 2
+Refer: 64 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 275 2
 EndChar
+
 StartChar: quoteleft
-Encoding: 8216 8216 8216
+Encoding: 8216 8216 1970
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54411,8 +56386,9 @@ SplineSet
  745 903 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quoteright
-Encoding: 8217 8217 8217
+Encoding: 8217 8217 1971
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54452,8 +56428,9 @@ SplineSet
  530 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotesinglbase
-Encoding: 8218 8218 8218
+Encoding: 8218 8218 1972
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54493,8 +56470,9 @@ SplineSet
  461 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotereversed
-Encoding: 8219 8219 8219
+Encoding: 8219 8219 1973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54509,8 +56487,9 @@ SplineSet
  746 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblleft
-Encoding: 8220 8220 8220
+Encoding: 8220 8220 1974
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54572,8 +56551,9 @@ SplineSet
  985 903 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblright
-Encoding: 8221 8221 8221
+Encoding: 8221 8221 1975
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54635,8 +56615,9 @@ SplineSet
  248 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblbase
-Encoding: 8222 8222 8222
+Encoding: 8222 8222 1976
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54698,8 +56679,9 @@ SplineSet
  248 367 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni201F
-Encoding: 8223 8223 8223
+Encoding: 8223 8223 1977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54721,8 +56703,9 @@ SplineSet
  983 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: dagger
-Encoding: 8224 8224 8224
+Encoding: 8224 8224 1978
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54781,8 +56764,9 @@ SplineSet
  487 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: daggerdbl
-Encoding: 8225 8225 8225
+Encoding: 8225 8225 1979
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54870,8 +56854,9 @@ SplineSet
  487 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bullet
-Encoding: 8226 8226 8226
+Encoding: 8226 8226 1980
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54914,8 +56899,9 @@ SplineSet
  256 688 256 688 256 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2023
-Encoding: 8227 8227 8227
+Encoding: 8227 8227 1981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54927,20 +56913,23 @@ SplineSet
  256 319 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: onedotenleader
-Encoding: 8228 8228 8228
+Encoding: 8228 8228 1982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: twodotenleader
-Encoding: 8229 8229 8229
+Encoding: 8229 8229 1983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: ellipsis
-Encoding: 8230 8230 8230
+Encoding: 8230 8230 1984
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55000,14 +56989,16 @@ SplineSet
  57 367 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni202F
-Encoding: 8239 8239 8239
+Encoding: 8239 8239 1985
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: perthousand
-Encoding: 8240 8240 8240
+Encoding: 8240 8240 1986
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55129,7 +57120,7 @@ Fore
 SplineSet
 662 289 m 2,0,1
  662 409 662 409 744.5 492 c 128,-1,2
- 827 575 827 575 946 575 c 0,3,4
+ 827 575 827 575 946 575 c 256,3,4
  1065 575 1065 575 1149 491.5 c 128,-1,5
  1233 408 1233 408 1233 289 c 0,6,7
  1233 169 1233 169 1149 84.5 c 128,-1,8
@@ -55141,7 +57132,7 @@ SplineSet
  896 414 896 414 859.5 376.5 c 128,-1,15
  823 339 823 339 823 289 c 0,16,17
  823 237 823 237 859 199.5 c 128,-1,18
- 895 162 895 162 946 162 c 0,19,20
+ 895 162 895 162 946 162 c 256,19,20
  997 162 997 162 1034 199.5 c 128,-1,21
  1071 237 1071 237 1071 289 c 0,22,23
  1071 339 1071 339 1034 375.5 c 128,-1,24
@@ -55159,7 +57150,7 @@ SplineSet
  233 1270 233 1270 197.5 1234.5 c 128,-1,39
  162 1199 162 1199 162 1147 c 0,40,41
  162 1094 162 1094 198 1056 c 128,-1,42
- 234 1018 234 1018 285 1018 c 0,43,44
+ 234 1018 234 1018 285 1018 c 256,43,44
  336 1018 336 1018 373 1056.5 c 128,-1,45
  410 1095 410 1095 410 1147 c 0,46,47
  410 1196 410 1196 372.5 1233 c 128,-1,48
@@ -55177,7 +57168,7 @@ SplineSet
  279 414 279 414 243 378 c 128,-1,63
  207 342 207 342 207 291 c 0,64,65
  207 238 207 238 243 200 c 128,-1,66
- 279 162 279 162 330 162 c 0,67,68
+ 279 162 279 162 330 162 c 256,67,68
  381 162 381 162 418 200.5 c 128,-1,69
  455 239 455 239 455 291 c 0,70,71
  455 340 455 340 417.5 377 c 128,-1,72
@@ -55189,8 +57180,9 @@ SplineSet
  35 664 l 1,73,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2031
-Encoding: 8241 8241 8241
+Encoding: 8241 8241 1987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55276,8 +57268,9 @@ SplineSet
  1023 412 1023 412 978 414 c 1,88,89
 EndSplineSet
 EndChar
+
 StartChar: minute
-Encoding: 8242 8242 8242
+Encoding: 8242 8242 1988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55290,27 +57283,30 @@ SplineSet
  391 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: second
-Encoding: 8243 8243 8243
+Encoding: 8243 8243 1989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 188 0 2
-Refer: 8242 8242 N 1 0 0 1 -188 0 2
+Refer: 1988 8242 N 1 0 0 1 188 0 2
+Refer: 1988 8242 N 1 0 0 1 -188 0 2
 EndChar
+
 StartChar: uni2034
-Encoding: 8244 8244 8244
+Encoding: 8244 8244 1990
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 375 0 2
-Refer: 8242 8242 N 1 0 0 1 -375 0 2
-Refer: 8242 8242 N 1 0 0 1 0 0 2
+Refer: 1988 8242 N 1 0 0 1 375 0 2
+Refer: 1988 8242 N 1 0 0 1 -375 0 2
+Refer: 1988 8242 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2035
-Encoding: 8245 8245 8245
+Encoding: 8245 8245 1991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55323,27 +57319,30 @@ SplineSet
  842 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2036
-Encoding: 8246 8246 8246
+Encoding: 8246 8246 1992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 190 0 2
-Refer: 8245 8245 N 1 0 0 1 -190 0 2
+Refer: 1991 8245 N 1 0 0 1 190 0 2
+Refer: 1991 8245 N 1 0 0 1 -190 0 2
 EndChar
+
 StartChar: uni2037
-Encoding: 8247 8247 8247
+Encoding: 8247 8247 1993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 375 0 2
-Refer: 8245 8245 N 1 0 0 1 5 0 2
-Refer: 8245 8245 N 1 0 0 1 -375 0 2
+Refer: 1991 8245 N 1 0 0 1 375 0 2
+Refer: 1991 8245 N 1 0 0 1 5 0 2
+Refer: 1991 8245 N 1 0 0 1 -375 0 2
 EndChar
+
 StartChar: guilsinglleft
-Encoding: 8249 8249 8249
+Encoding: 8249 8249 1994
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55385,8 +57384,9 @@ SplineSet
  815 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: guilsinglright
-Encoding: 8250 8250 8250
+Encoding: 8250 8250 1995
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55428,18 +57428,20 @@ SplineSet
  420 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdbl
-Encoding: 8252 8252 8252
+Encoding: 8252 8252 1996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni203D
-Encoding: 8253 8253 8253
+Encoding: 8253 8253 1997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55476,16 +57478,18 @@ SplineSet
  440 0 l 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni203E
-Encoding: 8254 8254 8254
+Encoding: 8254 8254 1998
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 1840 2
+Refer: 64 95 N 1 0 0 1 0 1840 2
 EndChar
+
 StartChar: uni203F
-Encoding: 8255 8255 8255
+Encoding: 8255 8255 1999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55504,8 +57508,9 @@ SplineSet
  1123 -231 1123 -231 1301 -161 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2045
-Encoding: 8261 8261 8261
+Encoding: 8261 8261 2000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55526,8 +57531,9 @@ SplineSet
  422 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2046
-Encoding: 8262 8262 8262
+Encoding: 8262 8262 2001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55548,38 +57554,42 @@ SplineSet
  811 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2047
-Encoding: 8263 8263 8263
+Encoding: 8263 8263 2002
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -308 0 2
-Refer: 1114126 -1 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3678 -1 N 1 0 0 1 -308 0 2
+Refer: 3678 -1 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2048
-Encoding: 8264 8264 8264
+Encoding: 8264 8264 2003
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 324.5 0 2
-LCarets2: 1 0 
+Refer: 3678 -1 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 324.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2049
-Encoding: 8265 8265 8265
+Encoding: 8265 8265 2004
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -324.5 0 2
-Refer: 1114126 -1 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -324.5 0 2
+Refer: 3678 -1 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni204B
-Encoding: 8267 8267 8267
+Encoding: 8267 8267 2005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55600,14 +57610,16 @@ SplineSet
  688 1493 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni205F
-Encoding: 8287 8287 8287
+Encoding: 8287 8287 2006
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2070
-Encoding: 8304 8304 8304
+Encoding: 8304 8304 2007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55642,8 +57654,9 @@ SplineSet
  278 869 278 869 278 1086 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2071
-Encoding: 8305 8305 8305
+Encoding: 8305 8305 2008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55667,8 +57680,9 @@ SplineSet
  524 1600 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2074
-Encoding: 8308 8308 8308
+Encoding: 8308 8308 2009
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55763,8 +57777,9 @@ SplineSet
  621 1503 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2075
-Encoding: 8309 8309 8309
+Encoding: 8309 8309 2010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55795,8 +57810,9 @@ SplineSet
  327 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2076
-Encoding: 8310 8310 8310
+Encoding: 8310 8310 2011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55831,8 +57847,9 @@ SplineSet
  849.965 1503.01 849.965 1503.01 902 1486 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2077
-Encoding: 8311 8311 8311
+Encoding: 8311 8311 2012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55848,8 +57865,9 @@ SplineSet
  284 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2078
-Encoding: 8312 8312 8312
+Encoding: 8312 8312 2013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55892,8 +57910,9 @@ SplineSet
  487 1329.99 487 1329.99 487 1282 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2079
-Encoding: 8313 8313 8313
+Encoding: 8313 8313 2014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55928,8 +57947,9 @@ SplineSet
  528.995 1091 528.995 1091 595 1091 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni207A
-Encoding: 8314 8314 8314
+Encoding: 8314 8314 2015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55950,8 +57970,9 @@ SplineSet
  692 1336 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207B
-Encoding: 8315 8315 8315
+Encoding: 8315 8315 2016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55964,8 +57985,9 @@ SplineSet
  270 1095 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207C
-Encoding: 8316 8316 8316
+Encoding: 8316 8316 2017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55983,8 +58005,9 @@ SplineSet
  284 1221 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207D
-Encoding: 8317 8317 8317
+Encoding: 8317 8317 2018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56003,8 +58026,9 @@ SplineSet
  787 1538 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207E
-Encoding: 8318 8318 8318
+Encoding: 8318 8318 2019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56023,8 +58047,9 @@ SplineSet
  529 1404 529 1404 446 1538 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207F
-Encoding: 8319 8319 8319
+Encoding: 8319 8319 2020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56049,232 +58074,261 @@ SplineSet
  904 1192 904 1192 904 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2080
-Encoding: 8320 8320 8320
+Encoding: 8320 8320 2021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 0 -668 3
+Refer: 2007 8304 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2081
-Encoding: 8321 8321 8321
+Encoding: 8321 8321 2022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 0 -668 3
+Refer: 121 185 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2082
-Encoding: 8322 8322 8322
+Encoding: 8322 8322 2023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 0 -668 3
+Refer: 114 178 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2083
-Encoding: 8323 8323 8323
+Encoding: 8323 8323 2024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 0 -668 3
+Refer: 115 179 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2084
-Encoding: 8324 8324 8324
+Encoding: 8324 8324 2025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 0 -668 3
+Refer: 2009 8308 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2085
-Encoding: 8325 8325 8325
+Encoding: 8325 8325 2026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 0 -668 3
+Refer: 2010 8309 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2086
-Encoding: 8326 8326 8326
+Encoding: 8326 8326 2027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 0 -668 3
+Refer: 2011 8310 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2087
-Encoding: 8327 8327 8327
+Encoding: 8327 8327 2028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 0 -668 3
+Refer: 2012 8311 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2088
-Encoding: 8328 8328 8328
+Encoding: 8328 8328 2029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 0 -668 3
+Refer: 2013 8312 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2089
-Encoding: 8329 8329 8329
+Encoding: 8329 8329 2030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8313 8313 N 1 0 0 1 0 -668 3
+Refer: 2014 8313 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208A
-Encoding: 8330 8330 8330
+Encoding: 8330 8330 2031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8314 8314 N 1 0 0 1 0 -668 3
+Refer: 2015 8314 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208B
-Encoding: 8331 8331 8331
+Encoding: 8331 8331 2032
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8315 8315 N 1 0 0 1 0 -668 3
+Refer: 2016 8315 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208C
-Encoding: 8332 8332 8332
+Encoding: 8332 8332 2033
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8316 8316 N 1 0 0 1 0 -668 3
+Refer: 2017 8316 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208D
-Encoding: 8333 8333 8333
+Encoding: 8333 8333 2034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8317 8317 N 1 0 0 1 0 -668 3
+Refer: 2018 8317 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208E
-Encoding: 8334 8334 8334
+Encoding: 8334 8334 2035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8318 8318 N 1 0 0 1 0 -668 3
+Refer: 2019 8318 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2090
-Encoding: 8336 8336 8336
+Encoding: 8336 8336 2036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7491 7491 N 1 0 0 1 0 -668 3
+Refer: 1467 7491 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2091
-Encoding: 8337 8337 8337
+Encoding: 8337 8337 2037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7497 7497 N 1 0 0 1 0 -668 3
+Refer: 1473 7497 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2092
-Encoding: 8338 8338 8338
+Encoding: 8338 8338 2038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7506 7506 N 1 0 0 1 0 -668 3
+Refer: 1482 7506 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2093
-Encoding: 8339 8339 8339
+Encoding: 8339 8339 2039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 739 739 N 1 0 0 1 0 -668 3
+Refer: 646 739 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2094
-Encoding: 8340 8340 8340
+Encoding: 8340 8340 2040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7498 7498 N 1 0 0 1 0 -668 3
+Refer: 1474 7498 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2095
-Encoding: 8341 8341 8341
+Encoding: 8341 8341 2041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 688 688 N 1 0 0 1 0 -668 3
+Refer: 605 688 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2096
-Encoding: 8342 8342 8342
+Encoding: 8342 8342 2042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7503 7503 N 1 0 0 1 0 -668 3
+Refer: 1479 7503 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2097
-Encoding: 8343 8343 8343
+Encoding: 8343 8343 2043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 737 737 N 1 0 0 1 0 -668 3
+Refer: 644 737 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2098
-Encoding: 8344 8344 8344
+Encoding: 8344 8344 2044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7504 7504 N 1 0 0 1 0 -668 3
+Refer: 1480 7504 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2099
-Encoding: 8345 8345 8345
+Encoding: 8345 8345 2045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8319 8319 N 1 0 0 1 0 -668 3
+Refer: 2020 8319 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209A
-Encoding: 8346 8346 8346
+Encoding: 8346 8346 2046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7510 7510 N 1 0 0 1 0 -668 3
+Refer: 1486 7510 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209B
-Encoding: 8347 8347 8347
+Encoding: 8347 8347 2047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 738 738 N 1 0 0 1 0 -668 3
+Refer: 645 738 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209C
-Encoding: 8348 8348 8348
+Encoding: 8348 8348 2048
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7511 7511 N 1 0 0 1 0 -668 3
+Refer: 1487 7511 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni20A0
-Encoding: 8352 8352 8352
+Encoding: 8352 8352 2049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56313,8 +58367,9 @@ SplineSet
  659 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: colonmonetary
-Encoding: 8353 8353 8353
+Encoding: 8353 8353 2050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56362,8 +58417,9 @@ SplineSet
  551 336 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uni20A2
-Encoding: 8354 8354 8354
+Encoding: 8354 8354 2051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56403,8 +58459,9 @@ SplineSet
  801 259 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: franc
-Encoding: 8355 8355 8355
+Encoding: 8355 8355 2052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56431,8 +58488,9 @@ SplineSet
  169 378 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lira
-Encoding: 8356 8356 8356
+Encoding: 8356 8356 2053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56471,8 +58529,9 @@ SplineSet
  310 1023 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20A5
-Encoding: 8357 8357 8357
+Encoding: 8357 8357 2054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56516,8 +58575,9 @@ SplineSet
  451 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A6
-Encoding: 8358 8358 8358
+Encoding: 8358 8358 2055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56564,8 +58624,9 @@ SplineSet
  430.5 861 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: peseta
-Encoding: 8359 8359 8359
+Encoding: 8359 8359 2056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56634,8 +58695,9 @@ SplineSet
  530 864 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni20A8
-Encoding: 8360 8360 8360
+Encoding: 8360 8360 2057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56696,8 +58758,9 @@ SplineSet
  781 -5 781 -5 759 2 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A9
-Encoding: 8361 8361 8361
+Encoding: 8361 8361 2058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56761,8 +58824,9 @@ SplineSet
  275 1118 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AA
-Encoding: 8362 8362 8362
+Encoding: 8362 8362 2059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56796,17 +58860,19 @@ SplineSet
  1231 -29 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dong
-Encoding: 8363 8363 8363
+Encoding: 8363 8363 2060
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 273 273 N 1 0 0 1 -30 0 2
-Refer: 717 717 N 1 0 0 1 176 4 2
+Refer: 209 273 N 1 0 0 1 -30 0 2
+Refer: 627 717 N 1 0 0 1 176 4 2
 EndChar
+
 StartChar: Euro
-Encoding: 8364 8364 8364
+Encoding: 8364 8364 2061
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56984,8 +59050,9 @@ SplineSet
  209 1010 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20AD
-Encoding: 8365 8365 8365
+Encoding: 8365 8365 2062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57012,8 +59079,9 @@ SplineSet
  143 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AE
-Encoding: 8366 8366 8366
+Encoding: 8366 8366 2063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57046,8 +59114,9 @@ SplineSet
  775 572 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AF
-Encoding: 8367 8367 8367
+Encoding: 8367 8367 2064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57130,8 +59199,9 @@ SplineSet
  170 154 170 154 180 218 c 1,113,114
 EndSplineSet
 EndChar
+
 StartChar: uni20B0
-Encoding: 8368 8368 8368
+Encoding: 8368 8368 2065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57169,8 +59239,9 @@ SplineSet
  743 1013 743 1013 849 925 c 1,41,42
 EndSplineSet
 EndChar
+
 StartChar: uni20B1
-Encoding: 8369 8369 8369
+Encoding: 8369 8369 2066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57220,8 +59291,9 @@ SplineSet
  805.075 1170 l 1,41,42
 EndSplineSet
 EndChar
+
 StartChar: uni20B2
-Encoding: 8370 8370 8370
+Encoding: 8370 8370 2067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57261,8 +59333,9 @@ SplineSet
  583 1265 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni20B3
-Encoding: 8371 8371 8371
+Encoding: 8371 8371 2068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57304,8 +59377,9 @@ SplineSet
  576 896 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B4
-Encoding: 8372 8372 8372
+Encoding: 8372 8372 2069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57353,8 +59427,9 @@ SplineSet
  430.92 438 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B5
-Encoding: 8373 8373 8373
+Encoding: 8373 8373 2070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57390,8 +59465,9 @@ SplineSet
  653.219 261.051 653.219 261.051 712 245.899 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B8
-Encoding: 8376 8376 8376
+Encoding: 8376 8376 2071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57413,8 +59489,9 @@ SplineSet
  764 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B9
-Encoding: 8377 8377 8377
+Encoding: 8377 8377 2072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57451,8 +59528,9 @@ SplineSet
  1146 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20BA
-Encoding: 8378 8378 8378
+Encoding: 8378 8378 2073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57488,8 +59566,9 @@ SplineSet
  1193 748 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20BD
-Encoding: 8381 8381 8381
+Encoding: 8381 8381 2074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57527,8 +59606,9 @@ SplineSet
  599 1245 l 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2102
-Encoding: 8450 8450 8450
+Encoding: 8450 8450 2075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57560,8 +59640,9 @@ SplineSet
  408 1282 l 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2105
-Encoding: 8453 8453 8453
+Encoding: 8453 8453 2076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57611,8 +59692,9 @@ SplineSet
  818 880 818 880 949 880 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni210D
-Encoding: 8461 8461 8461
+Encoding: 8461 8461 2077
 Width: 1233
 Flags: W
 AnchorPoint: "below" 615 0 basechar 0
@@ -57645,8 +59727,9 @@ SplineSet
  22 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210E
-Encoding: 8462 8462 8462
+Encoding: 8462 8462 2078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57675,8 +59758,9 @@ SplineSet
  1111 775 1111 775 1102 728 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210F
-Encoding: 8463 8463 8463
+Encoding: 8463 8463 2079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57710,8 +59794,9 @@ SplineSet
  811 734 811 734 811 788 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2115
-Encoding: 8469 8469 8469
+Encoding: 8469 8469 2080
 Width: 1233
 Flags: W
 AnchorPoint: "above" 614 1520 basechar 0
@@ -57737,8 +59822,9 @@ SplineSet
  50 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2116
-Encoding: 8470 8470 8470
+Encoding: 8470 8470 2081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57780,8 +59866,9 @@ SplineSet
  119 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2117
-Encoding: 8471 8471 8471
+Encoding: 8471 8471 2082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57841,8 +59928,9 @@ SplineSet
  543.099 969.953 l 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2119
-Encoding: 8473 8473 8473
+Encoding: 8473 8473 2083
 Width: 1233
 Flags: W
 AnchorPoint: "above" 617 1520 basechar 0
@@ -57880,8 +59968,9 @@ SplineSet
  932 1315 932 1315 871 1338 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211A
-Encoding: 8474 8474 8474
+Encoding: 8474 8474 2084
 Width: 1233
 Flags: W
 AnchorPoint: "below" 613 0 basechar 0
@@ -57923,8 +60012,9 @@ SplineSet
  960 1248 960 1248 938 1270 c 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211D
-Encoding: 8477 8477 8477
+Encoding: 8477 8477 2085
 Width: 1233
 Flags: W
 AnchorPoint: "above" 617 1506 basechar 0
@@ -57976,8 +60066,9 @@ SplineSet
  110 1373 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: trademark
-Encoding: 8482 8482 8482
+Encoding: 8482 8482 2086
 Width: 1233
 Flags: W
 TtInstrs:
@@ -58075,8 +60166,9 @@ SplineSet
  438 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2124
-Encoding: 8484 8484 8484
+Encoding: 8484 8484 2087
 Width: 1233
 Flags: W
 AnchorPoint: "above" 612 1506 basechar 0
@@ -58102,32 +60194,36 @@ SplineSet
  33 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2126
-Encoding: 8486 8486 8486
+Encoding: 8486 8486 2088
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212A
-Encoding: 8490 8490 8490
+Encoding: 8490 8490 2089
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212B
-Encoding: 8491 8491 8491
+Encoding: 8491 8491 2090
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 197 197 N 1 0 0 1 0 0 2
+Refer: 133 197 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: estimated
-Encoding: 8494 8494 8494
+Encoding: 8494 8494 2091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58165,8 +60261,9 @@ SplineSet
  237 714 l 2,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2148
-Encoding: 8520 8520 8520
+Encoding: 8520 8520 2092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58195,167 +60292,184 @@ SplineSet
  597 1000 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2150
-Encoding: 8528 8528 8528
+Encoding: 8528 8528 2093
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2012 8311 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2151
-Encoding: 8529 8529 8529
+Encoding: 8529 8529 2094
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8313 8313 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2014 8313 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: onethird
-Encoding: 8531 8531 8531
+Encoding: 8531 8531 2095
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: twothirds
-Encoding: 8532 8532 8532
+Encoding: 8532 8532 2096
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 201 -938 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2155
-Encoding: 8533 8533 8533
+Encoding: 8533 8533 2097
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2156
-Encoding: 8534 8534 8534
+Encoding: 8534 8534 2098
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2157
-Encoding: 8535 8535 8535
+Encoding: 8535 8535 2099
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2158
-Encoding: 8536 8536 8536
+Encoding: 8536 8536 2100
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
+Refer: 2009 8308 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2159
-Encoding: 8537 8537 8537
+Encoding: 8537 8537 2101
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni215A
-Encoding: 8538 8538 8538
+Encoding: 8538 8538 2102
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: oneeighth
-Encoding: 8539 8539 8539
+Encoding: 8539 8539 2103
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: threeeighths
-Encoding: 8540 8540 8540
+Encoding: 8540 8540 2104
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: fiveeighths
-Encoding: 8541 8541 8541
+Encoding: 8541 8541 2105
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: seveneighths
-Encoding: 8542 8542 8542
+Encoding: 8542 8542 2106
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
+Refer: 2012 8311 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni215F
-Encoding: 8543 8543 8543
+Encoding: 8543 8543 2107
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2189
-Encoding: 8585 8585 8585
+Encoding: 8585 8585 2108
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 201 -938 2
-Refer: 8304 8304 N 1 0 0 1 -258 156 2
+Refer: 3672 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
+Refer: 2007 8304 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: arrowleft
-Encoding: 8592 8592 8592
+Encoding: 8592 8592 2109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58374,8 +60488,9 @@ SplineSet
  66 490 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowup
-Encoding: 8593 8593 8593
+Encoding: 8593 8593 2110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58394,8 +60509,9 @@ SplineSet
  687.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowright
-Encoding: 8594 8594 8594
+Encoding: 8594 8594 2111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58414,8 +60530,9 @@ SplineSet
  1167 490 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdown
-Encoding: 8595 8595 8595
+Encoding: 8595 8595 2112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58434,8 +60551,9 @@ SplineSet
  545.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowboth
-Encoding: 8596 8596 8596
+Encoding: 8596 8596 2113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58460,8 +60578,9 @@ SplineSet
  347 449 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowupdn
-Encoding: 8597 8597 8597
+Encoding: 8597 8597 2114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58486,8 +60605,9 @@ SplineSet
  504.5 281 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2196
-Encoding: 8598 8598 8598
+Encoding: 8598 8598 2115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58506,8 +60626,9 @@ SplineSet
  154 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2197
-Encoding: 8599 8599 8599
+Encoding: 8599 8599 2116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58526,8 +60647,9 @@ SplineSet
  1079 777 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2198
-Encoding: 8600 8600 8600
+Encoding: 8600 8600 2117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58546,8 +60668,9 @@ SplineSet
  1078 87 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2199
-Encoding: 8601 8601 8601
+Encoding: 8601 8601 2118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58566,8 +60689,9 @@ SplineSet
  272 -30 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219A
-Encoding: 8602 8602 8602
+Encoding: 8602 8602 2119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58594,8 +60718,9 @@ SplineSet
  1011 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219B
-Encoding: 8603 8603 8603
+Encoding: 8603 8603 2120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58622,8 +60747,9 @@ SplineSet
  222 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219C
-Encoding: 8604 8604 8604
+Encoding: 8604 8604 2121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58664,8 +60790,9 @@ SplineSet
  246.641 552 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219D
-Encoding: 8605 8605 8605
+Encoding: 8605 8605 2122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58706,8 +60833,9 @@ SplineSet
  986.359 552 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219E
-Encoding: 8606 8606 8606
+Encoding: 8606 8606 2123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58734,8 +60862,9 @@ SplineSet
  677 673 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219F
-Encoding: 8607 8607 8607
+Encoding: 8607 8607 2124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58762,8 +60891,9 @@ SplineSet
  504.5 490 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A0
-Encoding: 8608 8608 8608
+Encoding: 8608 8608 2125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58790,8 +60920,9 @@ SplineSet
  556 673 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A1
-Encoding: 8609 8609 8609
+Encoding: 8609 8609 2126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58818,8 +60949,9 @@ SplineSet
  728.5 611 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A2
-Encoding: 8610 8610 8610
+Encoding: 8610 8610 2127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58843,8 +60975,9 @@ SplineSet
  925 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A3
-Encoding: 8611 8611 8611
+Encoding: 8611 8611 2128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58868,8 +61001,9 @@ SplineSet
  308 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A4
-Encoding: 8612 8612 8612
+Encoding: 8612 8612 2129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58892,8 +61026,9 @@ SplineSet
  973 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A5
-Encoding: 8613 8613 8613
+Encoding: 8613 8613 2130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58916,8 +61051,9 @@ SplineSet
  504.5 194 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A6
-Encoding: 8614 8614 8614
+Encoding: 8614 8614 2131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58940,8 +61076,9 @@ SplineSet
  260 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A7
-Encoding: 8615 8615 8615
+Encoding: 8615 8615 2132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58964,8 +61101,9 @@ SplineSet
  728.5 907 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdnbse
-Encoding: 8616 8616 8616
+Encoding: 8616 8616 2133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58994,8 +61132,9 @@ SplineSet
  545.5 194 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A9
-Encoding: 8617 8617 8617
+Encoding: 8617 8617 2134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59030,8 +61169,9 @@ SplineSet
  871 673 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AA
-Encoding: 8618 8618 8618
+Encoding: 8618 8618 2135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59066,8 +61206,9 @@ SplineSet
  349.868 673.479 349.868 673.479 362 673 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AB
-Encoding: 8619 8619 8619
+Encoding: 8619 8619 2136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59117,8 +61258,9 @@ SplineSet
  886.332 817.895 886.332 817.895 871 818 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21AC
-Encoding: 8620 8620 8620
+Encoding: 8620 8620 2137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59168,8 +61310,9 @@ SplineSet
  375.373 817.528 375.373 817.528 362 818 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21AD
-Encoding: 8621 8621 8621
+Encoding: 8621 8621 2138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59224,8 +61367,9 @@ SplineSet
  347 673 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AE
-Encoding: 8622 8622 8622
+Encoding: 8622 8622 2139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59258,8 +61402,9 @@ SplineSet
  886 449 l 17,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AF
-Encoding: 8623 8623 8623
+Encoding: 8623 8623 2140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59282,8 +61427,9 @@ SplineSet
  901.479 265.154 l 9,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B0
-Encoding: 8624 8624 8624
+Encoding: 8624 8624 2141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59304,8 +61450,9 @@ SplineSet
  464.5 937 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B1
-Encoding: 8625 8625 8625
+Encoding: 8625 8625 2142
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59326,8 +61473,9 @@ SplineSet
  768.5 937 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B2
-Encoding: 8626 8626 8626
+Encoding: 8626 8626 2143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59348,8 +61496,9 @@ SplineSet
  464.5 444 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B3
-Encoding: 8627 8627 8627
+Encoding: 8627 8627 2144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59370,8 +61519,9 @@ SplineSet
  768.5 444 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B4
-Encoding: 8628 8628 8628
+Encoding: 8628 8628 2145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59392,8 +61542,9 @@ SplineSet
  603 281 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: carriagereturn
-Encoding: 8629 8629 8629
+Encoding: 8629 8629 2146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59414,8 +61565,9 @@ SplineSet
  344.5 444.003 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B6
-Encoding: 8630 8630 8630
+Encoding: 8630 8630 2147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59449,8 +61601,9 @@ SplineSet
  300.121 625 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B7
-Encoding: 8631 8631 8631
+Encoding: 8631 8631 2148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59484,8 +61637,9 @@ SplineSet
  932.879 625 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B8
-Encoding: 8632 8632 8632
+Encoding: 8632 8632 2149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59509,8 +61663,9 @@ SplineSet
  154 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B9
-Encoding: 8633 8633 8633
+Encoding: 8633 8633 2150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59548,8 +61703,9 @@ SplineSet
  973 433.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21BA
-Encoding: 8634 8634 8634
+Encoding: 8634 8634 2151
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59590,8 +61746,9 @@ SplineSet
  991 860 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21BB
-Encoding: 8635 8635 8635
+Encoding: 8635 8635 2152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59632,8 +61789,9 @@ SplineSet
  203 860 203 860 242 860 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BC
-Encoding: 8636 8636 8636
+Encoding: 8636 8636 2153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59649,8 +61807,9 @@ SplineSet
  66 449 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BD
-Encoding: 8637 8637 8637
+Encoding: 8637 8637 2154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59666,8 +61825,9 @@ SplineSet
  66 673 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BE
-Encoding: 8638 8638 8638
+Encoding: 8638 8638 2155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59683,8 +61843,9 @@ SplineSet
  504.5 1101 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BF
-Encoding: 8639 8639 8639
+Encoding: 8639 8639 2156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59700,8 +61861,9 @@ SplineSet
  728.5 1101 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C0
-Encoding: 8640 8640 8640
+Encoding: 8640 8640 2157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59717,8 +61879,9 @@ SplineSet
  1167 449 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C1
-Encoding: 8641 8641 8641
+Encoding: 8641 8641 2158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59734,8 +61897,9 @@ SplineSet
  1167 673 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C2
-Encoding: 8642 8642 8642
+Encoding: 8642 8642 2159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59751,8 +61915,9 @@ SplineSet
  504.5 0 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C3
-Encoding: 8643 8643 8643
+Encoding: 8643 8643 2160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59768,8 +61933,9 @@ SplineSet
  728.5 0 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C4
-Encoding: 8644 8644 8644
+Encoding: 8644 8644 2161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59799,8 +61965,9 @@ SplineSet
  66 261 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C5
-Encoding: 8645 8645 8645
+Encoding: 8645 8645 2162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59830,8 +61997,9 @@ SplineSet
  929.5 0 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C6
-Encoding: 8646 8646 8646
+Encoding: 8646 8646 2163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59861,8 +62029,9 @@ SplineSet
  1167 261 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C7
-Encoding: 8647 8647 8647
+Encoding: 8647 8647 2164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59889,8 +62058,9 @@ SplineSet
  237.002 573.997 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C8
-Encoding: 8648 8648 8648
+Encoding: 8648 8648 2165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59917,8 +62087,9 @@ SplineSet
  616.503 929.998 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C9
-Encoding: 8649 8649 8649
+Encoding: 8649 8649 2166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59945,8 +62116,9 @@ SplineSet
  995.998 573.997 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CA
-Encoding: 8650 8650 8650
+Encoding: 8650 8650 2167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59973,8 +62145,9 @@ SplineSet
  616.497 171.002 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CB
-Encoding: 8651 8651 8651
+Encoding: 8651 8651 2168
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59998,8 +62171,9 @@ SplineSet
  66 704 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CC
-Encoding: 8652 8652 8652
+Encoding: 8652 8652 2169
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60023,8 +62197,9 @@ SplineSet
  1167 704 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CD
-Encoding: 8653 8653 8653
+Encoding: 8653 8653 2170
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60061,8 +62236,9 @@ SplineSet
  727 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CE
-Encoding: 8654 8654 8654
+Encoding: 8654 8654 2171
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60107,8 +62283,9 @@ SplineSet
  307 489 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CF
-Encoding: 8655 8655 8655
+Encoding: 8655 8655 2172
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60145,8 +62322,9 @@ SplineSet
  506 489 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblleft
-Encoding: 8656 8656 8656
+Encoding: 8656 8656 2173
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60170,8 +62348,9 @@ SplineSet
  307 633.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblup
-Encoding: 8657 8657 8657
+Encoding: 8657 8657 2174
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60195,8 +62374,9 @@ SplineSet
  544.499 860 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblright
-Encoding: 8658 8658 8658
+Encoding: 8658 8658 2175
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60220,8 +62400,9 @@ SplineSet
  926 633.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdbldown
-Encoding: 8659 8659 8659
+Encoding: 8659 8659 2176
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60245,8 +62426,9 @@ SplineSet
  688.501 241 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblboth
-Encoding: 8660 8660 8660
+Encoding: 8660 8660 2177
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60278,8 +62460,9 @@ SplineSet
  307 488.999 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D5
-Encoding: 8661 8661 8661
+Encoding: 8661 8661 2178
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60311,8 +62494,9 @@ SplineSet
  544.499 241 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D6
-Encoding: 8662 8662 8662
+Encoding: 8662 8662 2179
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60336,8 +62520,9 @@ SplineSet
  398 708 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D7
-Encoding: 8663 8663 8663
+Encoding: 8663 8663 2180
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60361,8 +62546,9 @@ SplineSet
  835 708 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D8
-Encoding: 8664 8664 8664
+Encoding: 8664 8664 2181
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60386,8 +62572,9 @@ SplineSet
  921 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D9
-Encoding: 8665 8665 8665
+Encoding: 8665 8665 2182
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60411,8 +62598,9 @@ SplineSet
  312 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DA
-Encoding: 8666 8666 8666
+Encoding: 8666 8666 2183
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60437,8 +62625,9 @@ SplineSet
  286 612 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DB
-Encoding: 8667 8667 8667
+Encoding: 8667 8667 2184
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60463,8 +62652,9 @@ SplineSet
  947 612 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DC
-Encoding: 8668 8668 8668
+Encoding: 8668 8668 2185
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60493,8 +62683,9 @@ SplineSet
  347 673 l 17,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DD
-Encoding: 8669 8669 8669
+Encoding: 8669 8669 2186
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60523,8 +62714,9 @@ SplineSet
  886 673 l 9,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DE
-Encoding: 8670 8670 8670
+Encoding: 8670 8670 2187
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60559,8 +62751,9 @@ SplineSet
  728.5 158.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DF
-Encoding: 8671 8671 8671
+Encoding: 8671 8671 2188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60595,8 +62788,9 @@ SplineSet
  728.5 942.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E0
-Encoding: 8672 8672 8672
+Encoding: 8672 8672 2189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60625,8 +62819,9 @@ SplineSet
  980.001 449.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E1
-Encoding: 8673 8673 8673
+Encoding: 8673 8673 2190
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60655,8 +62850,9 @@ SplineSet
  728.499 186.999 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E2
-Encoding: 8674 8674 8674
+Encoding: 8674 8674 2191
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60685,8 +62881,9 @@ SplineSet
  252.999 449.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E3
-Encoding: 8675 8675 8675
+Encoding: 8675 8675 2192
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60715,8 +62912,9 @@ SplineSet
  504.501 914.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E4
-Encoding: 8676 8676 8676
+Encoding: 8676 8676 2193
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60739,8 +62937,9 @@ SplineSet
  260 662.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E5
-Encoding: 8677 8677 8677
+Encoding: 8677 8677 2194
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60763,8 +62962,9 @@ SplineSet
  973 662.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E6
-Encoding: 8678 8678 8678
+Encoding: 8678 8678 2195
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60788,8 +62988,9 @@ SplineSet
  408 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E7
-Encoding: 8679 8679 8679
+Encoding: 8679 8679 2196
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60813,8 +63014,9 @@ SplineSet
  1039.5 759 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E8
-Encoding: 8680 8680 8680
+Encoding: 8680 8680 2197
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60838,8 +63040,9 @@ SplineSet
  824.5 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E9
-Encoding: 8681 8681 8681
+Encoding: 8681 8681 2198
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60863,8 +63066,9 @@ SplineSet
  193.5 403 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EA
-Encoding: 8682 8682 8682
+Encoding: 8682 8682 2199
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60898,8 +63102,9 @@ SplineSet
  424.5 400 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EB
-Encoding: 8683 8683 8683
+Encoding: 8683 8683 2200
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60931,8 +63136,9 @@ SplineSet
  424.495 280 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EC
-Encoding: 8684 8684 8684
+Encoding: 8684 8684 2201
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60965,8 +63171,9 @@ SplineSet
  424.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21ED
-Encoding: 8685 8685 8685
+Encoding: 8685 8685 2202
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61002,8 +63209,9 @@ SplineSet
  651.504 1007 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EE
-Encoding: 8686 8686 8686
+Encoding: 8686 8686 2203
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61038,8 +63246,9 @@ SplineSet
  801.5 858 l 17,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EF
-Encoding: 8687 8687 8687
+Encoding: 8687 8687 2204
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61082,8 +63291,9 @@ SplineSet
  801.5 858 l 17,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F0
-Encoding: 8688 8688 8688
+Encoding: 8688 8688 2205
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61115,8 +63325,9 @@ SplineSet
  346 373.995 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F1
-Encoding: 8689 8689 8689
+Encoding: 8689 8689 2206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61142,8 +63353,9 @@ SplineSet
  268.26 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F2
-Encoding: 8690 8690 8690
+Encoding: 8690 8690 2207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61169,8 +63381,9 @@ SplineSet
  841.5 228.52 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F3
-Encoding: 8691 8691 8691
+Encoding: 8691 8691 2208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61200,8 +63413,9 @@ SplineSet
  424.5 759 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F4
-Encoding: 8692 8692 8692
+Encoding: 8692 8692 2209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61231,8 +63445,9 @@ SplineSet
  144.07 673 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21F5
-Encoding: 8693 8693 8693
+Encoding: 8693 8693 2210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61262,8 +63477,9 @@ SplineSet
  303.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F6
-Encoding: 8694 8694 8694
+Encoding: 8694 8694 2211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61298,8 +63514,9 @@ SplineSet
  996 319 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F7
-Encoding: 8695 8695 8695
+Encoding: 8695 8695 2212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61326,8 +63543,9 @@ SplineSet
  828.5 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F8
-Encoding: 8696 8696 8696
+Encoding: 8696 8696 2213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61354,8 +63572,9 @@ SplineSet
  404.5 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F9
-Encoding: 8697 8697 8697
+Encoding: 8697 8697 2214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61388,8 +63607,9 @@ SplineSet
  886 673 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FA
-Encoding: 8698 8698 8698
+Encoding: 8698 8698 2215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61424,8 +63644,9 @@ SplineSet
  846 673 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FB
-Encoding: 8699 8699 8699
+Encoding: 8699 8699 2216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61460,8 +63681,9 @@ SplineSet
  387 673 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FC
-Encoding: 8700 8700 8700
+Encoding: 8700 8700 2217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61502,8 +63724,9 @@ SplineSet
  741.365 449 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FD
-Encoding: 8701 8701 8701
+Encoding: 8701 8701 2218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61523,8 +63746,9 @@ SplineSet
  408 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FE
-Encoding: 8702 8702 8702
+Encoding: 8702 8702 2219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61544,8 +63768,9 @@ SplineSet
  825 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FF
-Encoding: 8703 8703 8703
+Encoding: 8703 8703 2220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61572,8 +63797,9 @@ SplineSet
  924 746 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: universal
-Encoding: 8704 8704 8704
+Encoding: 8704 8704 2221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61594,8 +63820,9 @@ SplineSet
  436 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2201
-Encoding: 8705 8705 8705
+Encoding: 8705 8705 2222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61624,8 +63851,9 @@ SplineSet
  23 746 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: partialdiff
-Encoding: 8706 8706 8706
+Encoding: 8706 8706 2223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61660,8 +63888,9 @@ SplineSet
  366 408 366 408 366 331 c 0,33,34
 EndSplineSet
 EndChar
+
 StartChar: existential
-Encoding: 8707 8707 8707
+Encoding: 8707 8707 2224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61682,8 +63911,9 @@ SplineSet
  163 251 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2204
-Encoding: 8708 8708 8708
+Encoding: 8708 8708 2225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61721,8 +63951,9 @@ SplineSet
  605 631 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: emptyset
-Encoding: 8709 8709 8709
+Encoding: 8709 8709 2226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61773,8 +64004,9 @@ SplineSet
  943.354 809.282 943.354 809.282 927.939 833.822 c 1,49,-1
 EndSplineSet
 EndChar
+
 StartChar: Delta
-Encoding: 8710 8710 8710
+Encoding: 8710 8710 2227
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61868,8 +64100,9 @@ SplineSet
  487 1423 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: gradient
-Encoding: 8711 8711 8711
+Encoding: 8711 8711 2228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61886,8 +64119,9 @@ SplineSet
  487 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: element
-Encoding: 8712 8712 8712
+Encoding: 8712 8712 2229
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -61987,8 +64221,9 @@ SplineSet
  337.073 647 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: notelement
-Encoding: 8713 8713 8713
+Encoding: 8713 8713 2230
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -62146,8 +64381,9 @@ SplineSet
  853.5 1524 l 9,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220A
-Encoding: 8714 8714 8714
+Encoding: 8714 8714 2231
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62243,8 +64479,9 @@ SplineSet
  360.148 791.86 360.148 791.86 341 753 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: suchthat
-Encoding: 8715 8715 8715
+Encoding: 8715 8715 2232
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -62344,8 +64581,9 @@ SplineSet
  895.927 877 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni220C
-Encoding: 8716 8716 8716
+Encoding: 8716 8716 2233
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -62501,8 +64739,9 @@ SplineSet
  389.5 0 l 9,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220D
-Encoding: 8717 8717 8717
+Encoding: 8717 8717 2234
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62598,8 +64837,9 @@ SplineSet
  872.852 492.141 872.852 492.141 892 531 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220E
-Encoding: 8718 8718 8718
+Encoding: 8718 8718 2235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62612,8 +64852,9 @@ SplineSet
  250 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: product
-Encoding: 8719 8719 8719
+Encoding: 8719 8719 2236
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62661,8 +64902,9 @@ SplineSet
  1081 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2210
-Encoding: 8720 8720 8720
+Encoding: 8720 8720 2237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62679,8 +64921,9 @@ SplineSet
  152 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: summation
-Encoding: 8721 8721 8721
+Encoding: 8721 8721 2238
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62745,8 +64988,9 @@ SplineSet
  621 569 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: minus
-Encoding: 8722 8722 8722
+Encoding: 8722 8722 2239
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62779,8 +65023,9 @@ SplineSet
  66 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2213
-Encoding: 8723 8723 8723
+Encoding: 8723 8723 2240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62806,40 +65051,45 @@ SplineSet
  1145 1046 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2215
-Encoding: 8725 8725 8725
+Encoding: 8725 8725 2241
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 47 47 N 1 0 0 1 0 0 2
+Refer: 16 47 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: asteriskmath
-Encoding: 8727 8727 8727
+Encoding: 8727 8727 2242
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42 42 N 1 0 0 1 0 -411 2
+Refer: 11 42 N 1 0 0 1 0 -411 2
 EndChar
+
 StartChar: uni2218
-Encoding: 8728 8728 8728
+Encoding: 8728 8728 2243
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 176 176 N 1 0 0 1 0 -482 2
+Refer: 112 176 N 1 0 0 1 0 -482 2
 EndChar
+
 StartChar: uni2219
-Encoding: 8729 8729 8729
+Encoding: 8729 8729 2244
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8226 8226 N 1 0 0 1 0 -55 2
+Refer: 1980 8226 N 1 0 0 1 0 -55 2
 EndChar
+
 StartChar: radical
-Encoding: 8730 8730 8730
+Encoding: 8730 8730 2245
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62905,26 +65155,29 @@ SplineSet
  113 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221B
-Encoding: 8731 8731 8731
+Encoding: 8731 8731 2246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8730 8730 N 1 0 0 1 0 0 3
-Refer: 179 179 N 1 0 0 1 -215 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
+Refer: 115 179 N 1 0 0 1 -215 390 2
 EndChar
+
 StartChar: uni221C
-Encoding: 8732 8732 8732
+Encoding: 8732 8732 2247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8730 8730 N 1 0 0 1 0 0 3
-Refer: 8308 8308 N 1 0 0 1 -195 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
+Refer: 2009 8308 N 1 0 0 1 -195 390 2
 EndChar
+
 StartChar: proportional
-Encoding: 8733 8733 8733
+Encoding: 8733 8733 2248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62960,8 +65213,9 @@ SplineSet
  1056 223 l 17,33,34
 EndSplineSet
 EndChar
+
 StartChar: infinity
-Encoding: 8734 8734 8734
+Encoding: 8734 8734 2249
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63030,7 +65284,7 @@ SplineSet
  962 422 962 422 999 480.5 c 128,-1,5
  1036 539 1036 539 1036 633 c 0,6,7
  1036 728 1036 728 1002.5 785 c 128,-1,8
- 969 842 969 842 913 842 c 0,9,10
+ 969 842 969 842 913 842 c 256,9,10
  857 842 857 842 808 787 c 128,-1,11
  759 732 759 732 725 629 c 1,0,1
 506 635 m 1,12,13
@@ -63061,8 +65315,9 @@ SplineSet
  566 936 566 936 616 831 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: orthogonal
-Encoding: 8735 8735 8735
+Encoding: 8735 8735 2250
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63077,8 +65332,9 @@ SplineSet
  1145 250 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: angle
-Encoding: 8736 8736 8736
+Encoding: 8736 8736 2251
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63093,16 +65349,18 @@ SplineSet
  1145 250 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2223
-Encoding: 8739 8739 8739
+Encoding: 8739 8739 2252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 0 0 3
+Refer: 93 124 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: logicaland
-Encoding: 8743 8743 8743
+Encoding: 8743 8743 2253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63118,8 +65376,9 @@ SplineSet
  1049.5 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalor
-Encoding: 8744 8744 8744
+Encoding: 8744 8744 2254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63135,8 +65394,9 @@ SplineSet
  1049.5 1186 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: intersection
-Encoding: 8745 8745 8745
+Encoding: 8745 8745 2255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63159,8 +65419,9 @@ SplineSet
  182.5 602 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: union
-Encoding: 8746 8746 8746
+Encoding: 8746 8746 2256
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63183,8 +65444,9 @@ SplineSet
  182.5 276 182.5 276 182.5 584 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integral
-Encoding: 8747 8747 8747
+Encoding: 8747 8747 2257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63235,8 +65497,9 @@ SplineSet
  491 -237 491 -237 491 -68 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni222C
-Encoding: 8748 8748 8748
+Encoding: 8748 8748 2258
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63273,10 +65536,11 @@ SplineSet
  127.143 -237 127.143 -237 192 -237 c 0,34,35
  230 -237 230 -237 230 -68 c 2,36,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uni222D
-Encoding: 8749 8749 8749
+Encoding: 8749 8749 2259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63328,59 +65592,65 @@ SplineSet
  56 -237 56 -237 80 -237 c 0,34,35
  118 -237 118 -237 118 -68 c 2,36,-1
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
+
 StartChar: therefore
-Encoding: 8756 8756 8756
+Encoding: 8756 8756 2260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
 EndChar
+
 StartChar: uni2235
-Encoding: 8757 8757 8757
+Encoding: 8757 8757 2261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 304 292 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
 EndChar
+
 StartChar: uni2236
-Encoding: 8758 8758 8758
+Encoding: 8758 8758 2262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
 EndChar
+
 StartChar: uni2237
-Encoding: 8759 8759 8759
+Encoding: 8759 8759 2263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 304 292 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
 EndChar
+
 StartChar: uni2238
-Encoding: 8760 8760 8760
+Encoding: 8760 8760 2264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 372 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 372 2
 EndChar
+
 StartChar: uni2239
-Encoding: 8761 8761 8761
+Encoding: 8761 8761 2265
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63403,30 +65673,33 @@ SplineSet
  74 760 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni223A
-Encoding: 8762 8762 8762
+Encoding: 8762 8762 2266
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -402 -476 2
-Refer: 8901 8901 N 1 0 0 1 -401 340 2
-Refer: 8901 8901 N 1 0 0 1 408 -476 2
-Refer: 8901 8901 N 1 0 0 1 404 340 2
-Refer: 8722 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -402 -476 2
+Refer: 2375 8901 N 1 0 0 1 -401 340 2
+Refer: 2375 8901 N 1 0 0 1 408 -476 2
+Refer: 2375 8901 N 1 0 0 1 404 340 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni223B
-Encoding: 8763 8763 8763
+Encoding: 8763 8763 2267
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 -530 2
-Refer: 8901 8901 N 1 0 0 1 2 382 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 -530 2
+Refer: 2375 8901 N 1 0 0 1 2 382 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: similar
-Encoding: 8764 8764 8764
+Encoding: 8764 8764 2268
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63453,8 +65726,9 @@ SplineSet
  1071.01 751.008 1071.01 751.008 1145 816 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni223D
-Encoding: 8765 8765 8765
+Encoding: 8765 8765 2269
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63481,8 +65755,9 @@ SplineSet
  88 816 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2241
-Encoding: 8769 8769 8769
+Encoding: 8769 8769 2270
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63511,8 +65786,9 @@ SplineSet
  483.5 579 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2242
-Encoding: 8770 8770 8770
+Encoding: 8770 8770 2271
 Width: 1233
 LayerCount: 2
 Fore
@@ -63543,8 +65819,9 @@ SplineSet
  88 987 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2243
-Encoding: 8771 8771 8771
+Encoding: 8771 8771 2272
 Width: 1233
 LayerCount: 2
 Fore
@@ -63575,8 +65852,9 @@ SplineSet
  88 532 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2244
-Encoding: 8772 8772 8772
+Encoding: 8772 8772 2273
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63614,8 +65892,9 @@ SplineSet
  1010 1222 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: congruent
-Encoding: 8773 8773 8773
+Encoding: 8773 8773 2274
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63652,8 +65931,9 @@ SplineSet
  88 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2246
-Encoding: 8774 8774 8774
+Encoding: 8774 8774 2275
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63701,8 +65981,9 @@ SplineSet
  975 760.5 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2247
-Encoding: 8775 8775 8775
+Encoding: 8775 8775 2276
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63749,8 +66030,9 @@ SplineSet
  254 60.25 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: approxequal
-Encoding: 8776 8776 8776
+Encoding: 8776 8776 2277
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63888,8 +66170,9 @@ SplineSet
  1071 955 1071 955 1145 1020 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2249
-Encoding: 8777 8777 8777
+Encoding: 8777 8777 2278
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63934,8 +66217,9 @@ SplineSet
  540 765.991 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224A
-Encoding: 8778 8778 8778
+Encoding: 8778 8778 2279
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63986,8 +66270,9 @@ SplineSet
  88 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224B
-Encoding: 8779 8779 8779
+Encoding: 8779 8779 2280
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64052,8 +66337,9 @@ SplineSet
  1071.01 720.258 1071.01 720.258 1145 785.25 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224C
-Encoding: 8780 8780 8780
+Encoding: 8780 8780 2281
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64090,8 +66376,9 @@ SplineSet
  1145 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224D
-Encoding: 8781 8781 8781
+Encoding: 8781 8781 2282
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64113,8 +66400,9 @@ SplineSet
  416 554 416 554 616 554 c 129,-1,4
 EndSplineSet
 EndChar
+
 StartChar: uni224E
-Encoding: 8782 8782 8782
+Encoding: 8782 8782 2283
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64160,8 +66448,9 @@ SplineSet
  666 1016 666 1016 617 1013 c 24,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224F
-Encoding: 8783 8783 8783
+Encoding: 8783 8783 2284
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64193,47 +66482,52 @@ SplineSet
  88 532 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2250
-Encoding: 8784 8784 8784
+Encoding: 8784 8784 2285
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 553 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 553 2
 EndChar
+
 StartChar: uni2251
-Encoding: 8785 8785 8785
+Encoding: 8785 8785 2286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 -696 2
-Refer: 8901 8901 N 1 0 0 1 1 553 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 -696 2
+Refer: 2375 8901 N 1 0 0 1 1 553 2
 EndChar
+
 StartChar: uni2252
-Encoding: 8786 8786 8786
+Encoding: 8786 8786 2287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -361 553 2
-Refer: 8901 8901 N 1 0 0 1 363 -696 2
-Refer: 61 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -361 553 2
+Refer: 2375 8901 N 1 0 0 1 363 -696 2
+Refer: 30 61 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2253
-Encoding: 8787 8787 8787
+Encoding: 8787 8787 2288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 -361 -696 2
-Refer: 8901 8901 N 1 0 0 1 364 553 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -361 -696 2
+Refer: 2375 8901 N 1 0 0 1 364 553 2
 EndChar
+
 StartChar: uni2254
-Encoding: 8788 8788 8788
+Encoding: 8788 8788 2289
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64261,8 +66555,9 @@ SplineSet
  81 1030 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2255
-Encoding: 8789 8789 8789
+Encoding: 8789 8789 2290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64290,8 +66585,9 @@ SplineSet
  1152 1030 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2256
-Encoding: 8790 8790 8790
+Encoding: 8790 8790 2291
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64321,8 +66617,9 @@ SplineSet
  915 595 915 595 888 532 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2257
-Encoding: 8791 8791 8791
+Encoding: 8791 8791 2292
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64358,8 +66655,9 @@ SplineSet
  495.526 1672.36 495.526 1672.36 617 1666.87 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni2258
-Encoding: 8792 8792 8792
+Encoding: 8792 8792 2293
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64384,8 +66682,9 @@ SplineSet
  391.646 1465 391.646 1465 617.1 1465 c 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni2259
-Encoding: 8793 8793 8793
+Encoding: 8793 8793 2294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64411,8 +66710,9 @@ SplineSet
  302 1085 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225A
-Encoding: 8794 8794 8794
+Encoding: 8794 8794 2295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64438,8 +66738,9 @@ SplineSet
  302 1688 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225B
-Encoding: 8795 8795 8795
+Encoding: 8795 8795 2296
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64468,8 +66769,9 @@ SplineSet
  194 1609 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225C
-Encoding: 8796 8796 8796
+Encoding: 8796 8796 2297
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64496,8 +66798,9 @@ SplineSet
  561.06 1820.32 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225D
-Encoding: 8797 8797 8797
+Encoding: 8797 8797 2298
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64579,8 +66882,9 @@ SplineSet
  1116.52 1535.14 l 1,65,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225E
-Encoding: 8798 8798 8798
+Encoding: 8798 8798 2299
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64628,8 +66932,9 @@ SplineSet
  661.509 1585.12 661.509 1585.12 683.772 1535.64 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni225F
-Encoding: 8799 8799 8799
+Encoding: 8799 8799 2300
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64675,8 +66980,9 @@ SplineSet
  491.5 1268 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: notequal
-Encoding: 8800 8800 8800
+Encoding: 8800 8800 2301
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64768,10 +67074,11 @@ SplineSet
  78 752 l 1,19,-1
  78 987 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: equivalence
-Encoding: 8801 8801 8801
+Encoding: 8801 8801 2302
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64794,8 +67101,9 @@ SplineSet
  88 1221.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2262
-Encoding: 8802 8802 8802
+Encoding: 8802 8802 2303
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64832,8 +67140,9 @@ SplineSet
  638 986.75 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2263
-Encoding: 8803 8803 8803
+Encoding: 8803 8803 2304
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64861,8 +67170,9 @@ SplineSet
  88 141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lessequal
-Encoding: 8804 8804 8804
+Encoding: 8804 8804 2305
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64923,8 +67233,9 @@ SplineSet
  1145 238 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: greaterequal
-Encoding: 8805 8805 8805
+Encoding: 8805 8805 2306
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64985,8 +67296,9 @@ SplineSet
  88 238 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2266
-Encoding: 8806 8806 8806
+Encoding: 8806 8806 2307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65012,8 +67324,9 @@ SplineSet
  1145 343 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2267
-Encoding: 8807 8807 8807
+Encoding: 8807 8807 2308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65039,8 +67352,9 @@ SplineSet
  1145 343 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2268
-Encoding: 8808 8808 8808
+Encoding: 8808 8808 2309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65077,8 +67391,9 @@ SplineSet
  1145 1053 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2269
-Encoding: 8809 8809 8809
+Encoding: 8809 8809 2310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65115,8 +67430,9 @@ SplineSet
  88 1053 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni226D
-Encoding: 8813 8813 8813
+Encoding: 8813 8813 2311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65145,8 +67461,9 @@ SplineSet
  538 733.41 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226E
-Encoding: 8814 8814 8814
+Encoding: 8814 8814 2312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65175,8 +67492,9 @@ SplineSet
  595 728.83 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226F
-Encoding: 8815 8815 8815
+Encoding: 8815 8815 2313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65205,8 +67523,9 @@ SplineSet
  638 553.17 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2270
-Encoding: 8816 8816 8816
+Encoding: 8816 8816 2314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65243,8 +67562,9 @@ SplineSet
  954 1131.48 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2271
-Encoding: 8817 8817 8817
+Encoding: 8817 8817 2315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65281,8 +67601,9 @@ SplineSet
  210 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2272
-Encoding: 8818 8818 8818
+Encoding: 8818 8818 2316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65317,8 +67638,9 @@ SplineSet
  1145 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2273
-Encoding: 8819 8819 8819
+Encoding: 8819 8819 2317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65353,8 +67675,9 @@ SplineSet
  88 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2274
-Encoding: 8820 8820 8820
+Encoding: 8820 8820 2318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65401,8 +67724,9 @@ SplineSet
  631 802.633 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2275
-Encoding: 8821 8821 8821
+Encoding: 8821 8821 2319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65450,8 +67774,9 @@ SplineSet
  660 691.77 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2276
-Encoding: 8822 8822 8822
+Encoding: 8822 8822 2320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65475,8 +67800,9 @@ SplineSet
  1145 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2277
-Encoding: 8823 8823 8823
+Encoding: 8823 8823 2321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65500,8 +67826,9 @@ SplineSet
  88 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2278
-Encoding: 8824 8824 8824
+Encoding: 8824 8824 2322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65546,8 +67873,9 @@ SplineSet
  592.253 895.325 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2279
-Encoding: 8825 8825 8825
+Encoding: 8825 8825 2323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65584,8 +67912,9 @@ SplineSet
  88 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227A
-Encoding: 8826 8826 8826
+Encoding: 8826 8826 2324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65603,8 +67932,9 @@ SplineSet
  1143 1023 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227B
-Encoding: 8827 8827 8827
+Encoding: 8827 8827 2325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65622,8 +67952,9 @@ SplineSet
  371.366 675 371.366 675 86 1023 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227C
-Encoding: 8828 8828 8828
+Encoding: 8828 8828 2326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65644,8 +67975,9 @@ SplineSet
  1145 1185 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227D
-Encoding: 8829 8829 8829
+Encoding: 8829 8829 2327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65666,8 +67998,9 @@ SplineSet
  360.511 910 360.511 910 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227E
-Encoding: 8830 8830 8830
+Encoding: 8830 8830 2328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65702,8 +68035,9 @@ SplineSet
  1145 1185 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227F
-Encoding: 8831 8831 8831
+Encoding: 8831 8831 2329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65738,8 +68072,9 @@ SplineSet
  360.511 910 360.511 910 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2280
-Encoding: 8832 8832 8832
+Encoding: 8832 8832 2330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65769,8 +68104,9 @@ SplineSet
  543.487 637.327 543.487 637.327 569.658 631.896 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2281
-Encoding: 8833 8833 8833
+Encoding: 8833 8833 2331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65800,8 +68136,9 @@ SplineSet
  685.513 644.673 685.513 644.673 659.343 650.104 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: propersubset
-Encoding: 8834 8834 8834
+Encoding: 8834 8834 2332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65824,8 +68161,9 @@ SplineSet
  371 1144 371 1144 575 1144 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: propersuperset
-Encoding: 8835 8835 8835
+Encoding: 8835 8835 2333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65848,8 +68186,9 @@ SplineSet
  658 1144 l 18,0,-1
 EndSplineSet
 EndChar
+
 StartChar: notsubset
-Encoding: 8836 8836 8836
+Encoding: 8836 8836 2334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65884,8 +68223,9 @@ SplineSet
  621 919 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2285
-Encoding: 8837 8837 8837
+Encoding: 8837 8837 2335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65920,8 +68260,9 @@ SplineSet
  612 364 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: reflexsubset
-Encoding: 8838 8838 8838
+Encoding: 8838 8838 2336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65949,8 +68290,9 @@ SplineSet
  371 1321 371 1321 575 1321 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: reflexsuperset
-Encoding: 8839 8839 8839
+Encoding: 8839 8839 2337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65978,8 +68320,9 @@ SplineSet
  658 1321 l 18,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2288
-Encoding: 8840 8840 8840
+Encoding: 8840 8840 2338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66022,8 +68365,9 @@ SplineSet
  947.43 1321 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2289
-Encoding: 8841 8841 8841
+Encoding: 8841 8841 2339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66066,8 +68410,9 @@ SplineSet
  647 540 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228A
-Encoding: 8842 8842 8842
+Encoding: 8842 8842 2340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66103,8 +68448,9 @@ SplineSet
  1145 198 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228B
-Encoding: 8843 8843 8843
+Encoding: 8843 8843 2341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66139,8 +68485,9 @@ SplineSet
  658 1321 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni228D
-Encoding: 8845 8845 8845
+Encoding: 8845 8845 2342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66168,8 +68515,9 @@ SplineSet
  90 246 90 246 90 582 c 2,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228E
-Encoding: 8846 8846 8846
+Encoding: 8846 8846 2343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66205,8 +68553,9 @@ SplineSet
  682 848 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228F
-Encoding: 8847 8847 8847
+Encoding: 8847 8847 2344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66223,8 +68572,9 @@ SplineSet
  88 1196 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2290
-Encoding: 8848 8848 8848
+Encoding: 8848 8848 2345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66241,8 +68591,9 @@ SplineSet
  1145 1196 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2291
-Encoding: 8849 8849 8849
+Encoding: 8849 8849 2346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66264,8 +68615,9 @@ SplineSet
  88 1302 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2292
-Encoding: 8850 8850 8850
+Encoding: 8850 8850 2347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66287,8 +68639,9 @@ SplineSet
  1145 1302 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2293
-Encoding: 8851 8851 8851
+Encoding: 8851 8851 2348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66305,8 +68658,9 @@ SplineSet
  1172 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2294
-Encoding: 8852 8852 8852
+Encoding: 8852 8852 2349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66323,8 +68677,9 @@ SplineSet
  62 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circleplus
-Encoding: 8853 8853 8853
+Encoding: 8853 8853 2350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66379,8 +68734,9 @@ SplineSet
  531 989 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2296
-Encoding: 8854 8854 8854
+Encoding: 8854 8854 2351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66427,8 +68783,9 @@ SplineSet
  271 727 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: circlemultiply
-Encoding: 8855 8855 8855
+Encoding: 8855 8855 2352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66483,8 +68840,9 @@ SplineSet
  311.737 827.348 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2298
-Encoding: 8856 8856 8856
+Encoding: 8856 8856 2353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66531,8 +68889,9 @@ SplineSet
  433.359 338.03 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2299
-Encoding: 8857 8857 8857
+Encoding: 8857 8857 2354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66579,8 +68938,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229A
-Encoding: 8858 8858 8858
+Encoding: 8858 8858 2355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66642,8 +69002,9 @@ SplineSet
  660.46 749.92 660.46 749.92 616.22 749.92 c 128,-1,16
 EndSplineSet
 EndChar
+
 StartChar: uni229B
-Encoding: 8859 8859 8859
+Encoding: 8859 8859 2356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66702,8 +69063,9 @@ SplineSet
  993.659 519.289 l 1,63,64
 EndSplineSet
 EndChar
+
 StartChar: uni229C
-Encoding: 8860 8860 8860
+Encoding: 8860 8860 2357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66755,8 +69117,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229D
-Encoding: 8861 8861 8861
+Encoding: 8861 8861 2358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66803,8 +69166,9 @@ SplineSet
  399 727 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229E
-Encoding: 8862 8862 8862
+Encoding: 8862 8862 2359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66835,8 +69199,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229F
-Encoding: 8863 8863 8863
+Encoding: 8863 8863 2360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66859,8 +69224,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A0
-Encoding: 8864 8864 8864
+Encoding: 8864 8864 2361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66891,8 +69257,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A1
-Encoding: 8865 8865 8865
+Encoding: 8865 8865 2362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66915,8 +69282,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A2
-Encoding: 8866 8866 8866
+Encoding: 8866 8866 2363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66933,8 +69301,9 @@ SplineSet
  303 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A3
-Encoding: 8867 8867 8867
+Encoding: 8867 8867 2364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66951,8 +69320,9 @@ SplineSet
  928 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A4
-Encoding: 8868 8868 8868
+Encoding: 8868 8868 2365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66969,8 +69339,9 @@ SplineSet
  1165 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: perpendicular
-Encoding: 8869 8869 8869
+Encoding: 8869 8869 2366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66987,8 +69358,9 @@ SplineSet
  66 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B2
-Encoding: 8882 8882 8882
+Encoding: 8882 8882 2367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67007,8 +69379,9 @@ SplineSet
  908 841 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B3
-Encoding: 8883 8883 8883
+Encoding: 8883 8883 2368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67027,8 +69400,9 @@ SplineSet
  88 926 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B4
-Encoding: 8884 8884 8884
+Encoding: 8884 8884 2369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67053,8 +69427,9 @@ SplineSet
  908 881 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B5
-Encoding: 8885 8885 8885
+Encoding: 8885 8885 2370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67079,8 +69454,9 @@ SplineSet
  88 530 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B8
-Encoding: 8888 8888 8888
+Encoding: 8888 8888 2371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67109,8 +69485,9 @@ SplineSet
  679 478 679 478 659 524 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C2
-Encoding: 8898 8898 8898
+Encoding: 8898 8898 2372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67133,8 +69510,9 @@ SplineSet
  1143 1272 1143 1272 1143 936 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C3
-Encoding: 8899 8899 8899
+Encoding: 8899 8899 2373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67157,8 +69535,9 @@ SplineSet
  90 -190 90 -190 90 146 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C4
-Encoding: 8900 8900 8900
+Encoding: 8900 8900 2374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67176,8 +69555,9 @@ SplineSet
  6 730 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dotmath
-Encoding: 8901 8901 8901
+Encoding: 8901 8901 2375
 Width: 1233
 Flags: W
 TtInstrs:
@@ -67210,8 +69590,9 @@ SplineSet
  449 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C6
-Encoding: 8902 8902 8902
+Encoding: 8902 8902 2376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67230,8 +69611,9 @@ SplineSet
  225.841 832.462 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22CD
-Encoding: 8909 8909 8909
+Encoding: 8909 8909 2377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67263,8 +69645,9 @@ SplineSet
  1145 532 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni22CE
-Encoding: 8910 8910 8910
+Encoding: 8910 8910 2378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67280,8 +69663,9 @@ SplineSet
  1234 1284 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22CF
-Encoding: 8911 8911 8911
+Encoding: 8911 8911 2379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67297,8 +69681,9 @@ SplineSet
  -2 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22D0
-Encoding: 8912 8912 8912
+Encoding: 8912 8912 2380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67336,8 +69721,9 @@ SplineSet
  778 -46 l 18,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni22D1
-Encoding: 8913 8913 8913
+Encoding: 8913 8913 2381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67375,8 +69761,9 @@ SplineSet
  455 1330 l 18,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni22DA
-Encoding: 8922 8922 8922
+Encoding: 8922 8922 2382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67405,8 +69792,9 @@ SplineSet
  1145 635 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DB
-Encoding: 8923 8923 8923
+Encoding: 8923 8923 2383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67435,8 +69823,9 @@ SplineSet
  88 635 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DC
-Encoding: 8924 8924 8924
+Encoding: 8924 8924 2384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67457,8 +69846,9 @@ SplineSet
  1145 954 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DD
-Encoding: 8925 8925 8925
+Encoding: 8925 8925 2385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67479,8 +69869,9 @@ SplineSet
  88 954 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DE
-Encoding: 8926 8926 8926
+Encoding: 8926 8926 2386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67501,8 +69892,9 @@ SplineSet
  872.489 192 872.489 192 1145 -83 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DF
-Encoding: 8927 8927 8927
+Encoding: 8927 8927 2387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67523,8 +69915,9 @@ SplineSet
  88 -83 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E0
-Encoding: 8928 8928 8928
+Encoding: 8928 8928 2388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67561,8 +69954,9 @@ SplineSet
  554.343 831.099 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E1
-Encoding: 8929 8929 8929
+Encoding: 8929 8929 2389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67595,8 +69989,9 @@ SplineSet
  305.621 965.391 305.621 965.391 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E2
-Encoding: 8930 8930 8930
+Encoding: 8930 8930 2390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67634,8 +70029,9 @@ SplineSet
  486.563 619 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E3
-Encoding: 8931 8931 8931
+Encoding: 8931 8931 2391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67673,8 +70069,9 @@ SplineSet
  891.723 1067 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E4
-Encoding: 8932 8932 8932
+Encoding: 8932 8932 2392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67704,8 +70101,9 @@ SplineSet
  88 -20 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E5
-Encoding: 8933 8933 8933
+Encoding: 8933 8933 2393
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67735,8 +70133,9 @@ SplineSet
  1145 1302 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E6
-Encoding: 8934 8934 8934
+Encoding: 8934 8934 2394
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67772,8 +70171,9 @@ SplineSet
  1145 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E7
-Encoding: 8935 8935 8935
+Encoding: 8935 8935 2395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67810,8 +70210,9 @@ SplineSet
  88 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E8
-Encoding: 8936 8936 8936
+Encoding: 8936 8936 2396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67848,8 +70249,9 @@ SplineSet
  483.5 -95 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22E9
-Encoding: 8937 8937 8937
+Encoding: 8937 8937 2397
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67886,23 +70288,26 @@ SplineSet
  483.5 -95 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22EF
-Encoding: 8943 8943 8943
+Encoding: 8943 8943 2398
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 8230 8230 N 1 0 0 1 0 460 2
+Refer: 1984 8230 N 1 0 0 1 0 460 2
 EndChar
+
 StartChar: uni2300
-Encoding: 8960 8960 8960
+Encoding: 8960 8960 2399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8709 8709 N 1 0 0 1 0 0 2
+Refer: 2226 8709 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2301
-Encoding: 8961 8961 8961
+Encoding: 8961 8961 2400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67919,8 +70324,9 @@ SplineSet
  684 634 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: house
-Encoding: 8962 8962 8962
+Encoding: 8962 8962 2401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67940,8 +70346,9 @@ SplineSet
  298 187 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2303
-Encoding: 8963 8963 8963
+Encoding: 8963 8963 2402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67956,8 +70363,9 @@ SplineSet
  616 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2304
-Encoding: 8964 8964 8964
+Encoding: 8964 8964 2403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67972,8 +70380,9 @@ SplineSet
  616 -269.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2305
-Encoding: 8965 8965 8965
+Encoding: 8965 8965 2404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67993,8 +70402,9 @@ SplineSet
  156 939.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2306
-Encoding: 8966 8966 8966
+Encoding: 8966 8966 2405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68019,8 +70429,9 @@ SplineSet
  156 939.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2308
-Encoding: 8968 8968 8968
+Encoding: 8968 8968 2406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68035,8 +70446,9 @@ SplineSet
  422 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2309
-Encoding: 8969 8969 8969
+Encoding: 8969 8969 2407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68051,8 +70463,9 @@ SplineSet
  811 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230A
-Encoding: 8970 8970 8970
+Encoding: 8970 8970 2408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68067,8 +70480,9 @@ SplineSet
  422 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230B
-Encoding: 8971 8971 8971
+Encoding: 8971 8971 2409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68083,8 +70497,9 @@ SplineSet
  811 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230C
-Encoding: 8972 8972 8972
+Encoding: 8972 8972 2410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68102,8 +70517,9 @@ SplineSet
  534 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230D
-Encoding: 8973 8973 8973
+Encoding: 8973 8973 2411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68121,8 +70537,9 @@ SplineSet
  534 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230E
-Encoding: 8974 8974 8974
+Encoding: 8974 8974 2412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68140,8 +70557,9 @@ SplineSet
  754 850 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230F
-Encoding: 8975 8975 8975
+Encoding: 8975 8975 2413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68159,8 +70577,9 @@ SplineSet
  534 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: revlogicalnot
-Encoding: 8976 8976 8976
+Encoding: 8976 8976 2414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68175,8 +70594,9 @@ SplineSet
  1145 899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2311
-Encoding: 8977 8977 8977
+Encoding: 8977 8977 2415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68194,16 +70614,18 @@ SplineSet
  617 418.5 617 418.5 71 232.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2312
-Encoding: 8978 8978 8978
+Encoding: 8978 8978 2416
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9696 9696 N 1 0 0 1 0 -100 2
+Refer: 2760 9696 N 1 0 0 1 0 -100 2
 EndChar
+
 StartChar: uni2313
-Encoding: 8979 8979 8979
+Encoding: 8979 8979 2417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68223,8 +70645,9 @@ SplineSet
  242.347 734.534 242.347 734.534 192.232 591 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2314
-Encoding: 8980 8980 8980
+Encoding: 8980 8980 2418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68244,8 +70667,9 @@ SplineSet
  715.74 887.046 715.74 887.046 616 887.046 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2315
-Encoding: 8981 8981 8981
+Encoding: 8981 8981 2419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68275,8 +70699,9 @@ SplineSet
  518.878 1103.87 518.878 1103.87 674.11 1103.87 c 0,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2318
-Encoding: 8984 8984 8984
+Encoding: 8984 8984 2420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68362,8 +70787,9 @@ SplineSet
  423 583 l 1,85,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2319
-Encoding: 8985 8985 8985
+Encoding: 8985 8985 2421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68378,8 +70804,9 @@ SplineSet
  1145 362 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni231C
-Encoding: 8988 8988 8988
+Encoding: 8988 8988 2422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68394,8 +70821,9 @@ SplineSet
  949 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231D
-Encoding: 8989 8989 8989
+Encoding: 8989 8989 2423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68410,8 +70838,9 @@ SplineSet
  284 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231E
-Encoding: 8990 8990 8990
+Encoding: 8990 8990 2424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68426,8 +70855,9 @@ SplineSet
  949 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231F
-Encoding: 8991 8991 8991
+Encoding: 8991 8991 2425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68442,8 +70872,9 @@ SplineSet
  284 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: integraltp
-Encoding: 8992 8992 8992
+Encoding: 8992 8992 2426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68468,8 +70899,9 @@ SplineSet
  485 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integralbt
-Encoding: 8993 8993 8993
+Encoding: 8993 8993 2427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68494,8 +70926,9 @@ SplineSet
  741 1926 l 25,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2325
-Encoding: 8997 8997 8997
+Encoding: 8997 8997 2428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68517,8 +70950,9 @@ SplineSet
  720 1255 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2326
-Encoding: 8998 8998 8998
+Encoding: 8998 8998 2429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68553,8 +70987,9 @@ SplineSet
  547.019 440 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2327
-Encoding: 8999 8999 8999
+Encoding: 8999 8999 2430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68587,8 +71022,9 @@ SplineSet
  716.019 440 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2328
-Encoding: 9000 9000 9000
+Encoding: 9000 9000 2431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68986,8 +71422,9 @@ SplineSet
  402 535 l 2,509,510
 EndSplineSet
 EndChar
+
 StartChar: uni232B
-Encoding: 9003 9003 9003
+Encoding: 9003 9003 2432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69022,8 +71459,9 @@ SplineSet
  685.981 440 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2335
-Encoding: 9013 9013 9013
+Encoding: 9013 9013 2433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69038,8 +71476,9 @@ SplineSet
  616 -68 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2336
-Encoding: 9014 9014 9014
+Encoding: 9014 9014 2434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69060,8 +71499,9 @@ SplineSet
  1165 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2337
-Encoding: 9015 9015 9015
+Encoding: 9015 9015 2435
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69079,8 +71519,9 @@ SplineSet
  256 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2338
-Encoding: 9016 9016 9016
+Encoding: 9016 9016 2436
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69108,8 +71549,9 @@ SplineSet
  150 987 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2339
-Encoding: 9017 9017 9017
+Encoding: 9017 9017 2437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69142,8 +71584,9 @@ SplineSet
  150 762 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233A
-Encoding: 9018 9018 9018
+Encoding: 9018 9018 2438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69173,17 +71616,19 @@ SplineSet
  1083 875.764 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233B
-Encoding: 9019 9019 9019
+Encoding: 9019 9019 2439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 3683 -1 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233C
-Encoding: 9020 9020 9020
+Encoding: 9020 9020 2440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69221,8 +71666,9 @@ SplineSet
  1227 1727 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233D
-Encoding: 9021 9021 9021
+Encoding: 9021 9021 2441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69257,17 +71703,19 @@ SplineSet
  778.695 1156.22 778.695 1156.22 717 1172.25 c 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233E
-Encoding: 9022 9022 9022
+Encoding: 9022 9022 2442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3683 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni233F
-Encoding: 9023 9023 9023
+Encoding: 9023 9023 2443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69288,8 +71736,9 @@ SplineSet
  899 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2340
-Encoding: 9024 9024 9024
+Encoding: 9024 9024 2444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69310,8 +71759,9 @@ SplineSet
  787 524 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2341
-Encoding: 9025 9025 9025
+Encoding: 9025 9025 2445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69332,8 +71782,9 @@ SplineSet
  1113 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2342
-Encoding: 9026 9026 9026
+Encoding: 9026 9026 2446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69354,8 +71805,9 @@ SplineSet
  120 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2343
-Encoding: 9027 9027 9027
+Encoding: 9027 9027 2447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69382,8 +71834,9 @@ SplineSet
  1083 480.07 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2344
-Encoding: 9028 9028 9028
+Encoding: 9028 9028 2448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69410,8 +71863,9 @@ SplineSet
  150 480.07 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2345
-Encoding: 9029 9029 9029
+Encoding: 9029 9029 2449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69438,8 +71892,9 @@ SplineSet
  66 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2346
-Encoding: 9030 9030 9030
+Encoding: 9030 9030 2450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69466,8 +71921,9 @@ SplineSet
  1167 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2347
-Encoding: 9031 9031 9031
+Encoding: 9031 9031 2451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69496,8 +71952,9 @@ SplineSet
  1083 873 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2348
-Encoding: 9032 9032 9032
+Encoding: 9032 9032 2452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69526,8 +71983,9 @@ SplineSet
  150 873 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2349
-Encoding: 9033 9033 9033
+Encoding: 9033 9033 2453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69562,8 +72020,9 @@ SplineSet
  568.604 1185.38 568.604 1185.38 521.161 1173.81 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234A
-Encoding: 9034 9034 9034
+Encoding: 9034 9034 2454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69585,8 +72044,9 @@ SplineSet
  66 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234B
-Encoding: 9035 9035 9035
+Encoding: 9035 9035 2455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69597,10 +72057,10 @@ SplineSet
  717 1493 l 1,2,-1
  797 1493 l 1,3,-1
  1200 0 l 1,4,-1
- 717 -3.28626e-14 l 1,5,-1
+ 717 -3.28626e-014 l 1,5,-1
  717 -350 l 1,6,-1
  515 -350 l 1,7,-1
- 515 -2.42861e-15 l 1,8,-1
+ 515 -2.42861e-015 l 1,8,-1
  33 0 l 1,9,-1
  436 1493 l 1,10,-1
  515 1493 l 1,11,-1
@@ -69615,8 +72075,9 @@ SplineSet
  717 260 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234C
-Encoding: 9036 9036 9036
+Encoding: 9036 9036 2456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69642,8 +72103,9 @@ SplineSet
  120 889.059 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234D
-Encoding: 9037 9037 9037
+Encoding: 9037 9037 2457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69672,8 +72134,9 @@ SplineSet
  120 91 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234E
-Encoding: 9038 9038 9038
+Encoding: 9038 9038 2458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69708,8 +72171,9 @@ SplineSet
  496 800 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni234F
-Encoding: 9039 9039 9039
+Encoding: 9039 9039 2459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69736,8 +72200,9 @@ SplineSet
  688 1550 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2350
-Encoding: 9040 9040 9040
+Encoding: 9040 9040 2460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69766,8 +72231,9 @@ SplineSet
  504.5 -90 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2351
-Encoding: 9041 9041 9041
+Encoding: 9041 9041 2461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69789,8 +72255,9 @@ SplineSet
  1165 1284 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2352
-Encoding: 9042 9042 9042
+Encoding: 9042 9042 2462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69801,10 +72268,10 @@ SplineSet
  717 1493 l 1,2,-1
  1200 1493 l 1,3,-1
  797 0 l 1,4,-1
- 717 -3.28626e-14 l 1,5,-1
+ 717 -3.28626e-014 l 1,5,-1
  717 -350 l 1,6,-1
  515 -350 l 1,7,-1
- 515 -2.42861e-15 l 1,8,-1
+ 515 -2.42861e-015 l 1,8,-1
  436 0 l 1,9,-1
  33 1493 l 1,10,-1
  515 1493 l 1,11,-1
@@ -69819,8 +72286,9 @@ SplineSet
  515 694.729 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2353
-Encoding: 9043 9043 9043
+Encoding: 9043 9043 2463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69846,8 +72314,9 @@ SplineSet
  120 603.941 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2354
-Encoding: 9044 9044 9044
+Encoding: 9044 9044 2464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69876,8 +72345,9 @@ SplineSet
  120 1402 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2355
-Encoding: 9045 9045 9045
+Encoding: 9045 9045 2465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69912,8 +72382,9 @@ SplineSet
  498 802 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni2356
-Encoding: 9046 9046 9046
+Encoding: 9046 9046 2466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69940,8 +72411,9 @@ SplineSet
  546 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2357
-Encoding: 9047 9047 9047
+Encoding: 9047 9047 2467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69970,53 +72442,59 @@ SplineSet
  504.5 1583 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2358
-Encoding: 9048 9048 9048
+Encoding: 9048 9048 2468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 3682 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2359
-Encoding: 9049 9049 9049
+Encoding: 9049 9049 2469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 916 916 N 1 0 0 1 0 0 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 746 916 N 1 0 0 1 0 0 2
+Refer: 3681 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235A
-Encoding: 9050 9050 9050
+Encoding: 9050 9050 2470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9671 9671 N 1 0 0 1 0 200 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 2735 9671 N 1 0 0 1 0 200 2
+Refer: 3681 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235B
-Encoding: 9051 9051 9051
+Encoding: 9051 9051 2471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 3683 -1 N 1 0 0 1 0 0 2
+Refer: 3682 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235C
-Encoding: 9052 9052 9052
+Encoding: 9052 9052 2472
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
+Refer: 3681 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235D
-Encoding: 9053 9053 9053
+Encoding: 9053 9053 2473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70051,35 +72529,39 @@ SplineSet
  799 381 l 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni235E
-Encoding: 9054 9054 9054
+Encoding: 9054 9054 2474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 39 39 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235F
-Encoding: 9055 9055 9055
+Encoding: 9055 9055 2475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8902 8902 N 1 0 0 1 0 0 2
-Refer: 9711 9711 N 1 0 0 1 0 200 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
+Refer: 2775 9711 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni2360
-Encoding: 9056 9056 9056
+Encoding: 9056 9056 2476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 58 58 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
+Refer: 27 58 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2361
-Encoding: 9057 9057 9057
+Encoding: 9057 9057 2477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70106,8 +72588,9 @@ SplineSet
  1165 1284 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2362
-Encoding: 9058 9058 9058
+Encoding: 9058 9058 2478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70134,35 +72617,39 @@ SplineSet
  496 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2363
-Encoding: 9059 9059 9059
+Encoding: 9059 9059 2479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8902 8902 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -250 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
+Refer: 3684 -1 N 1 0 0 1 0 -250 2
 EndChar
+
 StartChar: uni2364
-Encoding: 9060 9060 9060
+Encoding: 9060 9060 2480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 3683 -1 N 1 0 0 1 0 0 2
+Refer: 3684 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni2365
-Encoding: 9061 9061 9061
+Encoding: 9061 9061 2481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114132 -1 N 1 0 0 1 0 150 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
+Refer: 3684 -1 N 1 0 0 1 0 150 2
 EndChar
+
 StartChar: uni2366
-Encoding: 9062 9062 9062
+Encoding: 9062 9062 2482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70189,8 +72676,9 @@ SplineSet
  717 297 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2367
-Encoding: 9063 9063 9063
+Encoding: 9063 9063 2483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70222,26 +72710,29 @@ SplineSet
  444 385 444 385 515 369 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2368
-Encoding: 9064 9064 9064
+Encoding: 9064 9064 2484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 126 126 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 95 126 N 1 0 0 1 0 0 2
+Refer: 3684 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni2369
-Encoding: 9065 9065 9065
+Encoding: 9065 9065 2485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 62 62 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 31 62 N 1 0 0 1 0 0 2
+Refer: 3684 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni236A
-Encoding: 9066 9066 9066
+Encoding: 9066 9066 2486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70261,8 +72752,9 @@ SplineSet
  461 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236B
-Encoding: 9067 9067 9067
+Encoding: 9067 9067 2487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70299,8 +72791,9 @@ SplineSet
  695.285 603.412 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni236C
-Encoding: 9068 9068 9068
+Encoding: 9068 9068 2488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70341,8 +72834,9 @@ SplineSet
  796.971 428.37 796.971 428.37 807.533 575.439 c 1,41,42
 EndSplineSet
 EndChar
+
 StartChar: uni236D
-Encoding: 9069 9069 9069
+Encoding: 9069 9069 2489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70373,8 +72867,9 @@ SplineSet
  1072 857 1072 857 1145 921 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236E
-Encoding: 9070 9070 9070
+Encoding: 9070 9070 2490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70402,8 +72897,9 @@ SplineSet
  449 1063 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236F
-Encoding: 9071 9071 9071
+Encoding: 9071 9071 2491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70442,17 +72938,19 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2370
-Encoding: 9072 9072 9072
+Encoding: 9072 9072 2492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 63 63 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
+Refer: 32 63 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2371
-Encoding: 9073 9073 9073
+Encoding: 9073 9073 2493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70485,8 +72983,9 @@ SplineSet
  647 513 l 2,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni2372
-Encoding: 9074 9074 9074
+Encoding: 9074 9074 2494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70517,76 +73016,85 @@ SplineSet
  599 765 l 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni2373
-Encoding: 9075 9075 9075
+Encoding: 9075 9075 2495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2374
-Encoding: 9076 9076 9076
+Encoding: 9076 9076 2496
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2375
-Encoding: 9077 9077 9077
+Encoding: 9077 9077 2497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2376
-Encoding: 9078 9078 9078
+Encoding: 9078 9078 2498
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 3681 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2377
-Encoding: 9079 9079 9079
+Encoding: 9079 9079 2499
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1013 1013 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 827 1013 N 1 0 0 1 0 0 2
+Refer: 3680 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2378
-Encoding: 9080 9080 9080
+Encoding: 9080 9080 2500
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 3682 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2379
-Encoding: 9081 9081 9081
+Encoding: 9081 9081 2501
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 3681 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237A
-Encoding: 9082 9082 9082
+Encoding: 9082 9082 2502
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237D
-Encoding: 9085 9085 9085
+Encoding: 9085 9085 2503
 Width: 1233
 Flags: W
 TtInstrs:
@@ -70642,8 +73150,9 @@ SplineSet
  16 -31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2380
-Encoding: 9088 9088 9088
+Encoding: 9088 9088 2504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70688,8 +73197,9 @@ SplineSet
  616 -68 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2381
-Encoding: 9089 9089 9089
+Encoding: 9089 9089 2505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70747,8 +73257,9 @@ SplineSet
  601 958 601 958 601 798 c 2,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2382
-Encoding: 9090 9090 9090
+Encoding: 9090 9090 2506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70826,8 +73337,9 @@ SplineSet
  601 958 601 958 601 798 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2383
-Encoding: 9091 9091 9091
+Encoding: 9091 9091 2507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70895,8 +73407,9 @@ SplineSet
  898 958 898 958 898 798 c 2,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2388
-Encoding: 9096 9096 9096
+Encoding: 9096 9096 2508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70969,8 +73482,9 @@ SplineSet
  871.113 577.04 l 1,80,81
 EndSplineSet
 EndChar
+
 StartChar: uni2389
-Encoding: 9097 9097 9097
+Encoding: 9097 9097 2509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71022,8 +73536,9 @@ SplineSet
  494.559 251.411 494.559 251.411 532.544 243.474 c 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238A
-Encoding: 9098 9098 9098
+Encoding: 9098 9098 2510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71074,8 +73589,9 @@ SplineSet
  1021 719.981 1021 719.981 991.526 791.878 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238B
-Encoding: 9099 9099 9099
+Encoding: 9099 9099 2511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71122,8 +73638,9 @@ SplineSet
  70 528.7 70 528.7 70 640 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2395
-Encoding: 9109 9109 9109
+Encoding: 9109 9109 2512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71141,8 +73658,9 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni239B
-Encoding: 9115 9115 9115
+Encoding: 9115 9115 2513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71159,8 +73677,9 @@ SplineSet
  523 -516 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239C
-Encoding: 9116 9116 9116
+Encoding: 9116 9116 2514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71173,8 +73692,9 @@ SplineSet
  232 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni239D
-Encoding: 9117 9117 9117
+Encoding: 9117 9117 2515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71191,8 +73711,9 @@ SplineSet
  523 1926 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239E
-Encoding: 9118 9118 9118
+Encoding: 9118 9118 2516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71209,8 +73730,9 @@ SplineSet
  710 -516 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239F
-Encoding: 9119 9119 9119
+Encoding: 9119 9119 2517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71223,8 +73745,9 @@ SplineSet
  1001 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A0
-Encoding: 9120 9120 9120
+Encoding: 9120 9120 2518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71241,8 +73764,9 @@ SplineSet
  710 1926 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A1
-Encoding: 9121 9121 9121
+Encoding: 9121 9121 2519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71257,8 +73781,9 @@ SplineSet
  523 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A2
-Encoding: 9122 9122 9122
+Encoding: 9122 9122 2520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71271,8 +73796,9 @@ SplineSet
  232 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A3
-Encoding: 9123 9123 9123
+Encoding: 9123 9123 2521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71287,8 +73813,9 @@ SplineSet
  523 1926 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A4
-Encoding: 9124 9124 9124
+Encoding: 9124 9124 2522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71303,8 +73830,9 @@ SplineSet
  709 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A5
-Encoding: 9125 9125 9125
+Encoding: 9125 9125 2523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71317,8 +73845,9 @@ SplineSet
  1000 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A6
-Encoding: 9126 9126 9126
+Encoding: 9126 9126 2524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71333,8 +73862,9 @@ SplineSet
  709 1926 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A7
-Encoding: 9127 9127 9127
+Encoding: 9127 9127 2525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71353,8 +73883,9 @@ SplineSet
  758 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23A8
-Encoding: 9128 9128 9128
+Encoding: 9128 9128 2526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71380,8 +73911,9 @@ SplineSet
  617 738 617 738 557 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23A9
-Encoding: 9129 9129 9129
+Encoding: 9129 9129 2527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71400,8 +73932,9 @@ SplineSet
  758 1913 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AA
-Encoding: 9130 9130 9130
+Encoding: 9130 9130 2528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71414,8 +73947,9 @@ SplineSet
  758 -524 l 25,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23AB
-Encoding: 9131 9131 9131
+Encoding: 9131 9131 2529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71434,8 +73968,9 @@ SplineSet
  475 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AC
-Encoding: 9132 9132 9132
+Encoding: 9132 9132 2530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71461,8 +73996,9 @@ SplineSet
  618.663 673.465 618.663 673.465 676 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23AD
-Encoding: 9133 9133 9133
+Encoding: 9133 9133 2531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71481,8 +74017,9 @@ SplineSet
  475 1913 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AE
-Encoding: 9134 9134 9134
+Encoding: 9134 9134 2532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71495,8 +74032,9 @@ SplineSet
  485 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CE
-Encoding: 9166 9166 9166
+Encoding: 9166 9166 2533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71524,8 +74062,9 @@ SplineSet
  1067 1072 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CF
-Encoding: 9167 9167 9167
+Encoding: 9167 9167 2534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71542,8 +74081,9 @@ SplineSet
  1227 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2423
-Encoding: 9251 9251 9251
+Encoding: 9251 9251 2535
 Width: 1233
 Flags: W
 TtInstrs:
@@ -71590,8 +74130,9 @@ SplineSet
  110 -476 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF100000
-Encoding: 9472 9472 9472
+Encoding: 9472 9472 2536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71604,8 +74145,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2501
-Encoding: 9473 9473 9473
+Encoding: 9473 9473 2537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71618,8 +74160,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF110000
-Encoding: 9474 9474 9474
+Encoding: 9474 9474 2538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71632,8 +74175,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2503
-Encoding: 9475 9475 9475
+Encoding: 9475 9475 2539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71646,8 +74190,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2504
-Encoding: 9476 9476 9476
+Encoding: 9476 9476 2540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71670,8 +74215,9 @@ SplineSet
  60 618 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2505
-Encoding: 9477 9477 9477
+Encoding: 9477 9477 2541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71694,8 +74240,9 @@ SplineSet
  60 532 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2506
-Encoding: 9478 9478 9478
+Encoding: 9478 9478 2542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71718,8 +74265,9 @@ SplineSet
  536 1193 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2507
-Encoding: 9479 9479 9479
+Encoding: 9479 9479 2543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71742,8 +74290,9 @@ SplineSet
  456 1193 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2508
-Encoding: 9480 9480 9480
+Encoding: 9480 9480 2544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71771,8 +74320,9 @@ SplineSet
  984 618 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2509
-Encoding: 9481 9481 9481
+Encoding: 9481 9481 2545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71800,8 +74350,9 @@ SplineSet
  984 532 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250A
-Encoding: 9482 9482 9482
+Encoding: 9482 9482 2546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71829,8 +74380,9 @@ SplineSet
  536 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250B
-Encoding: 9483 9483 9483
+Encoding: 9483 9483 2547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71858,8 +74410,9 @@ SplineSet
  456 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF010000
-Encoding: 9484 9484 9484
+Encoding: 9484 9484 2548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71874,8 +74427,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250D
-Encoding: 9485 9485 9485
+Encoding: 9485 9485 2549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71890,8 +74444,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250E
-Encoding: 9486 9486 9486
+Encoding: 9486 9486 2550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71906,8 +74461,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250F
-Encoding: 9487 9487 9487
+Encoding: 9487 9487 2551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71922,8 +74478,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF030000
-Encoding: 9488 9488 9488
+Encoding: 9488 9488 2552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71938,8 +74495,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2511
-Encoding: 9489 9489 9489
+Encoding: 9489 9489 2553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71954,8 +74512,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2512
-Encoding: 9490 9490 9490
+Encoding: 9490 9490 2554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71970,8 +74529,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2513
-Encoding: 9491 9491 9491
+Encoding: 9491 9491 2555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71986,8 +74546,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF020000
-Encoding: 9492 9492 9492
+Encoding: 9492 9492 2556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72002,8 +74563,9 @@ SplineSet
  536 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2515
-Encoding: 9493 9493 9493
+Encoding: 9493 9493 2557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72018,8 +74580,9 @@ SplineSet
  536 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2516
-Encoding: 9494 9494 9494
+Encoding: 9494 9494 2558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72034,8 +74597,9 @@ SplineSet
  456 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2517
-Encoding: 9495 9495 9495
+Encoding: 9495 9495 2559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72050,8 +74614,9 @@ SplineSet
  456 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF040000
-Encoding: 9496 9496 9496
+Encoding: 9496 9496 2560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72066,8 +74631,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2519
-Encoding: 9497 9497 9497
+Encoding: 9497 9497 2561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72082,8 +74648,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251A
-Encoding: 9498 9498 9498
+Encoding: 9498 9498 2562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72098,8 +74665,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251B
-Encoding: 9499 9499 9499
+Encoding: 9499 9499 2563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72114,8 +74682,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF080000
-Encoding: 9500 9500 9500
+Encoding: 9500 9500 2564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72132,8 +74701,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251D
-Encoding: 9501 9501 9501
+Encoding: 9501 9501 2565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72150,8 +74720,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251E
-Encoding: 9502 9502 9502
+Encoding: 9502 9502 2566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72170,8 +74741,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251F
-Encoding: 9503 9503 9503
+Encoding: 9503 9503 2567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72190,8 +74762,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2520
-Encoding: 9504 9504 9504
+Encoding: 9504 9504 2568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72208,8 +74781,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2521
-Encoding: 9505 9505 9505
+Encoding: 9505 9505 2569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72228,8 +74802,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2522
-Encoding: 9506 9506 9506
+Encoding: 9506 9506 2570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72248,8 +74823,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2523
-Encoding: 9507 9507 9507
+Encoding: 9507 9507 2571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72266,8 +74842,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF090000
-Encoding: 9508 9508 9508
+Encoding: 9508 9508 2572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72284,8 +74861,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2525
-Encoding: 9509 9509 9509
+Encoding: 9509 9509 2573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72302,8 +74880,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2526
-Encoding: 9510 9510 9510
+Encoding: 9510 9510 2574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72322,8 +74901,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2527
-Encoding: 9511 9511 9511
+Encoding: 9511 9511 2575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72342,8 +74922,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2528
-Encoding: 9512 9512 9512
+Encoding: 9512 9512 2576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72360,8 +74941,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2529
-Encoding: 9513 9513 9513
+Encoding: 9513 9513 2577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72380,8 +74962,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252A
-Encoding: 9514 9514 9514
+Encoding: 9514 9514 2578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72400,8 +74983,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252B
-Encoding: 9515 9515 9515
+Encoding: 9515 9515 2579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72418,8 +75002,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF060000
-Encoding: 9516 9516 9516
+Encoding: 9516 9516 2580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72436,8 +75021,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252D
-Encoding: 9517 9517 9517
+Encoding: 9517 9517 2581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72456,8 +75042,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252E
-Encoding: 9518 9518 9518
+Encoding: 9518 9518 2582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72476,8 +75063,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252F
-Encoding: 9519 9519 9519
+Encoding: 9519 9519 2583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72494,8 +75082,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2530
-Encoding: 9520 9520 9520
+Encoding: 9520 9520 2584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72512,8 +75101,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2531
-Encoding: 9521 9521 9521
+Encoding: 9521 9521 2585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72532,8 +75122,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2532
-Encoding: 9522 9522 9522
+Encoding: 9522 9522 2586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72552,8 +75143,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2533
-Encoding: 9523 9523 9523
+Encoding: 9523 9523 2587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72570,8 +75162,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF070000
-Encoding: 9524 9524 9524
+Encoding: 9524 9524 2588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72588,8 +75181,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2535
-Encoding: 9525 9525 9525
+Encoding: 9525 9525 2589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72608,8 +75202,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2536
-Encoding: 9526 9526 9526
+Encoding: 9526 9526 2590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72628,8 +75223,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2537
-Encoding: 9527 9527 9527
+Encoding: 9527 9527 2591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72646,8 +75242,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2538
-Encoding: 9528 9528 9528
+Encoding: 9528 9528 2592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72664,8 +75261,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2539
-Encoding: 9529 9529 9529
+Encoding: 9529 9529 2593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72684,8 +75282,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253A
-Encoding: 9530 9530 9530
+Encoding: 9530 9530 2594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72704,8 +75303,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253B
-Encoding: 9531 9531 9531
+Encoding: 9531 9531 2595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72722,8 +75322,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF050000
-Encoding: 9532 9532 9532
+Encoding: 9532 9532 2596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72744,8 +75345,9 @@ SplineSet
  696 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253D
-Encoding: 9533 9533 9533
+Encoding: 9533 9533 2597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72766,8 +75368,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253E
-Encoding: 9534 9534 9534
+Encoding: 9534 9534 2598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72788,8 +75391,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253F
-Encoding: 9535 9535 9535
+Encoding: 9535 9535 2599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72810,8 +75414,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2540
-Encoding: 9536 9536 9536
+Encoding: 9536 9536 2600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72832,8 +75437,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2541
-Encoding: 9537 9537 9537
+Encoding: 9537 9537 2601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72854,8 +75460,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2542
-Encoding: 9538 9538 9538
+Encoding: 9538 9538 2602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72876,8 +75483,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2543
-Encoding: 9539 9539 9539
+Encoding: 9539 9539 2603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72900,8 +75508,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2544
-Encoding: 9540 9540 9540
+Encoding: 9540 9540 2604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72924,8 +75533,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2545
-Encoding: 9541 9541 9541
+Encoding: 9541 9541 2605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72948,8 +75558,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2546
-Encoding: 9542 9542 9542
+Encoding: 9542 9542 2606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72972,8 +75583,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2547
-Encoding: 9543 9543 9543
+Encoding: 9543 9543 2607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72994,8 +75606,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2548
-Encoding: 9544 9544 9544
+Encoding: 9544 9544 2608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73016,8 +75629,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2549
-Encoding: 9545 9545 9545
+Encoding: 9545 9545 2609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73038,8 +75652,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254A
-Encoding: 9546 9546 9546
+Encoding: 9546 9546 2610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73060,8 +75675,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254B
-Encoding: 9547 9547 9547
+Encoding: 9547 9547 2611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73082,8 +75698,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254C
-Encoding: 9548 9548 9548
+Encoding: 9548 9548 2612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73101,8 +75718,9 @@ SplineSet
  677 618 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254D
-Encoding: 9549 9549 9549
+Encoding: 9549 9549 2613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73120,8 +75738,9 @@ SplineSet
  60 532 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254E
-Encoding: 9550 9550 9550
+Encoding: 9550 9550 2614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73139,8 +75758,9 @@ SplineSet
  536 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254F
-Encoding: 9551 9551 9551
+Encoding: 9551 9551 2615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73158,8 +75778,9 @@ SplineSet
  456 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF430000
-Encoding: 9552 9552 9552
+Encoding: 9552 9552 2616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73177,8 +75798,9 @@ SplineSet
  -20 446 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF240000
-Encoding: 9553 9553 9553
+Encoding: 9553 9553 2617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73196,8 +75818,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF510000
-Encoding: 9554 9554 9554
+Encoding: 9554 9554 2618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73216,8 +75839,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF520000
-Encoding: 9555 9555 9555
+Encoding: 9555 9555 2619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73236,8 +75860,9 @@ SplineSet
  376 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF390000
-Encoding: 9556 9556 9556
+Encoding: 9556 9556 2620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73259,8 +75884,9 @@ SplineSet
  696 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF220000
-Encoding: 9557 9557 9557
+Encoding: 9557 9557 2621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73279,8 +75905,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF210000
-Encoding: 9558 9558 9558
+Encoding: 9558 9558 2622
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73299,8 +75926,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF250000
-Encoding: 9559 9559 9559
+Encoding: 9559 9559 2623
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73322,8 +75950,9 @@ SplineSet
  376 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF500000
-Encoding: 9560 9560 9560
+Encoding: 9560 9560 2624
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73342,8 +75971,9 @@ SplineSet
  536 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF490000
-Encoding: 9561 9561 9561
+Encoding: 9561 9561 2625
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73362,8 +75992,9 @@ SplineSet
  376 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF380000
-Encoding: 9562 9562 9562
+Encoding: 9562 9562 2626
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73385,8 +76016,9 @@ SplineSet
  376 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF280000
-Encoding: 9563 9563 9563
+Encoding: 9563 9563 2627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73405,8 +76037,9 @@ SplineSet
  -20 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF270000
-Encoding: 9564 9564 9564
+Encoding: 9564 9564 2628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73425,8 +76058,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF260000
-Encoding: 9565 9565 9565
+Encoding: 9565 9565 2629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73448,8 +76082,9 @@ SplineSet
  -20 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF360000
-Encoding: 9566 9566 9566
+Encoding: 9566 9566 2630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73470,8 +76105,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF370000
-Encoding: 9567 9567 9567
+Encoding: 9567 9567 2631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73493,8 +76129,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF420000
-Encoding: 9568 9568 9568
+Encoding: 9568 9568 2632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73521,8 +76158,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF190000
-Encoding: 9569 9569 9569
+Encoding: 9569 9569 2633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73543,8 +76181,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF200000
-Encoding: 9570 9570 9570
+Encoding: 9570 9570 2634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73566,8 +76205,9 @@ SplineSet
  696 -512 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF230000
-Encoding: 9571 9571 9571
+Encoding: 9571 9571 2635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73594,8 +76234,9 @@ SplineSet
  696 -512 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF470000
-Encoding: 9572 9572 9572
+Encoding: 9572 9572 2636
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73617,8 +76258,9 @@ SplineSet
  -20 790 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF480000
-Encoding: 9573 9573 9573
+Encoding: 9573 9573 2637
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73639,8 +76281,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF410000
-Encoding: 9574 9574 9574
+Encoding: 9574 9574 2638
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73667,8 +76310,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF450000
-Encoding: 9575 9575 9575
+Encoding: 9575 9575 2639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73690,8 +76334,9 @@ SplineSet
  -20 790 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF460000
-Encoding: 9576 9576 9576
+Encoding: 9576 9576 2640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73712,8 +76357,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF400000
-Encoding: 9577 9577 9577
+Encoding: 9577 9577 2641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73740,8 +76386,9 @@ SplineSet
  696 790 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF540000
-Encoding: 9578 9578 9578
+Encoding: 9578 9578 2642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73770,8 +76417,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF530000
-Encoding: 9579 9579 9579
+Encoding: 9579 9579 2643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73800,8 +76448,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF440000
-Encoding: 9580 9580 9580
+Encoding: 9580 9580 2644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73837,8 +76486,9 @@ SplineSet
  696 790 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256D
-Encoding: 9581 9581 9581
+Encoding: 9581 9581 2645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73857,8 +76507,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256E
-Encoding: 9582 9582 9582
+Encoding: 9582 9582 2646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73877,8 +76528,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256F
-Encoding: 9583 9583 9583
+Encoding: 9583 9583 2647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73897,8 +76549,9 @@ SplineSet
  -20 618 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2570
-Encoding: 9584 9584 9584
+Encoding: 9584 9584 2648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73917,8 +76570,9 @@ SplineSet
  1253 618 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2571
-Encoding: 9585 9585 9585
+Encoding: 9585 9585 2649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73931,8 +76585,9 @@ SplineSet
  -89 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2572
-Encoding: 9586 9586 9586
+Encoding: 9586 9586 2650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73945,8 +76600,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2573
-Encoding: 9587 9587 9587
+Encoding: 9587 9587 2651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73967,8 +76623,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2574
-Encoding: 9588 9588 9588
+Encoding: 9588 9588 2652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73981,8 +76638,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2575
-Encoding: 9589 9589 9589
+Encoding: 9589 9589 2653
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73995,8 +76653,9 @@ SplineSet
  536 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2576
-Encoding: 9590 9590 9590
+Encoding: 9590 9590 2654
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74009,8 +76668,9 @@ SplineSet
  616 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2577
-Encoding: 9591 9591 9591
+Encoding: 9591 9591 2655
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74023,8 +76683,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2578
-Encoding: 9592 9592 9592
+Encoding: 9592 9592 2656
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74037,8 +76698,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2579
-Encoding: 9593 9593 9593
+Encoding: 9593 9593 2657
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74051,8 +76713,9 @@ SplineSet
  456 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257A
-Encoding: 9594 9594 9594
+Encoding: 9594 9594 2658
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74065,8 +76728,9 @@ SplineSet
  616 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257B
-Encoding: 9595 9595 9595
+Encoding: 9595 9595 2659
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74079,8 +76743,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257C
-Encoding: 9596 9596 9596
+Encoding: 9596 9596 2660
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74097,8 +76762,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257D
-Encoding: 9597 9597 9597
+Encoding: 9597 9597 2661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74115,8 +76781,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257E
-Encoding: 9598 9598 9598
+Encoding: 9598 9598 2662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74133,8 +76800,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257F
-Encoding: 9599 9599 9599
+Encoding: 9599 9599 2663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74151,16 +76819,18 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: upblock
-Encoding: 9600 9600 9600
+Encoding: 9600 9600 2664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9604 9604 N 1 0 0 1 0 1216 2
+Refer: 2668 9604 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2581
-Encoding: 9601 9601 9601
+Encoding: 9601 9601 2665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74173,8 +76843,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2582
-Encoding: 9602 9602 9602
+Encoding: 9602 9602 2666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74187,8 +76858,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2583
-Encoding: 9603 9603 9603
+Encoding: 9603 9603 2667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74201,8 +76873,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dnblock
-Encoding: 9604 9604 9604
+Encoding: 9604 9604 2668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74215,8 +76888,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2585
-Encoding: 9605 9605 9605
+Encoding: 9605 9605 2669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74229,8 +76903,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2586
-Encoding: 9606 9606 9606
+Encoding: 9606 9606 2670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74243,8 +76918,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2587
-Encoding: 9607 9607 9607
+Encoding: 9607 9607 2671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74257,8 +76933,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: block
-Encoding: 9608 9608 9608
+Encoding: 9608 9608 2672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74271,8 +76948,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2589
-Encoding: 9609 9609 9609
+Encoding: 9609 9609 2673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74285,8 +76963,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258A
-Encoding: 9610 9610 9610
+Encoding: 9610 9610 2674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74299,8 +76978,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258B
-Encoding: 9611 9611 9611
+Encoding: 9611 9611 2675
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74313,8 +76993,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lfblock
-Encoding: 9612 9612 9612
+Encoding: 9612 9612 2676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74327,8 +77008,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258D
-Encoding: 9613 9613 9613
+Encoding: 9613 9613 2677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74341,8 +77023,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258E
-Encoding: 9614 9614 9614
+Encoding: 9614 9614 2678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74355,8 +77038,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258F
-Encoding: 9615 9615 9615
+Encoding: 9615 9615 2679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74369,16 +77053,18 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rtblock
-Encoding: 9616 9616 9616
+Encoding: 9616 9616 2680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9612 9612 N 1 0 0 1 637 0 2
+Refer: 2676 9612 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: ltshade
-Encoding: 9617 9617 9617
+Encoding: 9617 9617 2681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74466,8 +77152,9 @@ SplineSet
  0 1059 l 25,60,-1
 EndSplineSet
 EndChar
+
 StartChar: shade
-Encoding: 9618 9618 9618
+Encoding: 9618 9618 2682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74625,8 +77312,9 @@ SplineSet
  0 1661 l 1,116,-1
 EndSplineSet
 EndChar
+
 StartChar: dkshade
-Encoding: 9619 9619 9619
+Encoding: 9619 9619 2683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74710,24 +77398,27 @@ SplineSet
  770 1901 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2594
-Encoding: 9620 9620 9620
+Encoding: 9620 9620 2684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9601 9601 N 1 0 0 1 0 2114 2
+Refer: 2665 9601 N 1 0 0 1 0 2114 2
 EndChar
+
 StartChar: uni2595
-Encoding: 9621 9621 9621
+Encoding: 9621 9621 2685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9615 9615 N 1 0 0 1 1114 0 2
+Refer: 2679 9615 N 1 0 0 1 1114 0 2
 EndChar
+
 StartChar: uni2596
-Encoding: 9622 9622 9622
+Encoding: 9622 9622 2686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74740,24 +77431,27 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2597
-Encoding: 9623 9623 9623
+Encoding: 9623 9623 2687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 0 2
+Refer: 2686 9622 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: uni2598
-Encoding: 9624 9624 9624
+Encoding: 9624 9624 2688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 1216 2
+Refer: 2686 9622 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2599
-Encoding: 9625 9625 9625
+Encoding: 9625 9625 2689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74772,17 +77466,19 @@ SplineSet
  -20 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259A
-Encoding: 9626 9626 9626
+Encoding: 9626 9626 2690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9624 9624 N 1 0 0 1 0 0 2
-Refer: 9623 9623 N 1 0 0 1 0 0 2
+Refer: 2688 9624 N 1 0 0 1 0 0 2
+Refer: 2687 9623 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259B
-Encoding: 9627 9627 9627
+Encoding: 9627 9627 2691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74797,8 +77493,9 @@ SplineSet
  -20 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259C
-Encoding: 9628 9628 9628
+Encoding: 9628 9628 2692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74813,25 +77510,28 @@ SplineSet
  1254 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259D
-Encoding: 9629 9629 9629
+Encoding: 9629 9629 2693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 1216 2
+Refer: 2686 9622 N 1 0 0 1 637 1216 2
 EndChar
+
 StartChar: uni259E
-Encoding: 9630 9630 9630
+Encoding: 9630 9630 2694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 0 2
-Refer: 9629 9629 N 1 0 0 1 0 0 2
+Refer: 2686 9622 N 1 0 0 1 0 0 2
+Refer: 2693 9629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259F
-Encoding: 9631 9631 9631
+Encoding: 9631 9631 2695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74846,8 +77546,9 @@ SplineSet
  1254 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: filledbox
-Encoding: 9632 9632 9632
+Encoding: 9632 9632 2696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74860,8 +77561,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H22073
-Encoding: 9633 9633 9633
+Encoding: 9633 9633 2697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74879,8 +77581,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A2
-Encoding: 9634 9634 9634
+Encoding: 9634 9634 2698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74906,17 +77609,19 @@ SplineSet
  6 -78.5 6 -78.5 6 263.5 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A3
-Encoding: 9635 9635 9635
+Encoding: 9635 9635 2699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9642 9642 N 1 0 0 1 0 0 2
-Refer: 9633 9633 N 1 0 0 1 0 0 2
+Refer: 2706 9642 N 1 0 0 1 0 0 2
+Refer: 2697 9633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni25A4
-Encoding: 9636 9636 9636
+Encoding: 9636 9636 2700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74954,8 +77659,9 @@ SplineSet
  120 922 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A5
-Encoding: 9637 9637 9637
+Encoding: 9637 9637 2701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74993,8 +77699,9 @@ SplineSet
  120 36 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A6
-Encoding: 9638 9638 9638
+Encoding: 9638 9638 2702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75132,8 +77839,9 @@ SplineSet
  6 -78.5 l 1,100,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A7
-Encoding: 9639 9639 9639
+Encoding: 9639 9639 2703
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75181,8 +77889,9 @@ SplineSet
  120 182 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A8
-Encoding: 9640 9640 9640
+Encoding: 9640 9640 2704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75230,8 +77939,9 @@ SplineSet
  967 36 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A9
-Encoding: 9641 9641 9641
+Encoding: 9641 9641 2705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75381,8 +78091,9 @@ SplineSet
  6 -78.5 l 1,112,-1
 EndSplineSet
 EndChar
+
 StartChar: H18543
-Encoding: 9642 9642 9642
+Encoding: 9642 9642 2706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75395,8 +78106,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H18551
-Encoding: 9643 9643 9643
+Encoding: 9643 9643 2707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75414,8 +78126,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: filledrect
-Encoding: 9644 9644 9644
+Encoding: 9644 9644 2708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75428,8 +78141,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AD
-Encoding: 9645 9645 9645
+Encoding: 9645 9645 2709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75447,8 +78161,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AE
-Encoding: 9646 9646 9646
+Encoding: 9646 9646 2710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75461,8 +78176,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AF
-Encoding: 9647 9647 9647
+Encoding: 9647 9647 2711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75480,8 +78196,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B0
-Encoding: 9648 9648 9648
+Encoding: 9648 9648 2712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75494,8 +78211,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B1
-Encoding: 9649 9649 9649
+Encoding: 9649 9649 2713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75513,8 +78231,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagup
-Encoding: 9650 9650 9650
+Encoding: 9650 9650 2714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75526,8 +78245,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B3
-Encoding: 9651 9651 9651
+Encoding: 9651 9651 2715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75543,8 +78263,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B4
-Encoding: 9652 9652 9652
+Encoding: 9652 9652 2716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75556,8 +78277,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B5
-Encoding: 9653 9653 9653
+Encoding: 9653 9653 2717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75573,8 +78295,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B6
-Encoding: 9654 9654 9654
+Encoding: 9654 9654 2718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75586,8 +78309,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B7
-Encoding: 9655 9655 9655
+Encoding: 9655 9655 2719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75603,8 +78327,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B8
-Encoding: 9656 9656 9656
+Encoding: 9656 9656 2720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75616,8 +78341,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B9
-Encoding: 9657 9657 9657
+Encoding: 9657 9657 2721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75633,8 +78359,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagrt
-Encoding: 9658 9658 9658
+Encoding: 9658 9658 2722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75646,8 +78373,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BB
-Encoding: 9659 9659 9659
+Encoding: 9659 9659 2723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75663,8 +78391,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagdn
-Encoding: 9660 9660 9660
+Encoding: 9660 9660 2724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75676,8 +78405,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BD
-Encoding: 9661 9661 9661
+Encoding: 9661 9661 2725
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75693,8 +78423,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BE
-Encoding: 9662 9662 9662
+Encoding: 9662 9662 2726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75706,8 +78437,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BF
-Encoding: 9663 9663 9663
+Encoding: 9663 9663 2727
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75723,8 +78455,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C0
-Encoding: 9664 9664 9664
+Encoding: 9664 9664 2728
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75736,8 +78469,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C1
-Encoding: 9665 9665 9665
+Encoding: 9665 9665 2729
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75753,8 +78487,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C2
-Encoding: 9666 9666 9666
+Encoding: 9666 9666 2730
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75766,8 +78501,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C3
-Encoding: 9667 9667 9667
+Encoding: 9667 9667 2731
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75783,8 +78519,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triaglf
-Encoding: 9668 9668 9668
+Encoding: 9668 9668 2732
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75796,8 +78533,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C5
-Encoding: 9669 9669 9669
+Encoding: 9669 9669 2733
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75813,8 +78551,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C6
-Encoding: 9670 9670 9670
+Encoding: 9670 9670 2734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75827,8 +78566,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C7
-Encoding: 9671 9671 9671
+Encoding: 9671 9671 2735
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75846,8 +78586,9 @@ SplineSet
  6 532 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25C8
-Encoding: 9672 9672 9672
+Encoding: 9672 9672 2736
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75870,8 +78611,9 @@ SplineSet
  6 532 l 25,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25C9
-Encoding: 9673 9673 9673
+Encoding: 9673 9673 2737
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75906,8 +78648,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: lozenge
-Encoding: 9674 9674 9674
+Encoding: 9674 9674 2738
 Width: 1233
 Flags: W
 TtInstrs:
@@ -75961,8 +78704,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: circle
-Encoding: 9675 9675 9675
+Encoding: 9675 9675 2739
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75988,8 +78732,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni25CC
-Encoding: 9676 9676 9676
+Encoding: 9676 9676 2740
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76053,8 +78798,9 @@ SplineSet
  179.04 642.4 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25CD
-Encoding: 9677 9677 9677
+Encoding: 9677 9677 2741
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76100,8 +78846,9 @@ SplineSet
  1105 714 1105 714 1002 838 c 1,51,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25CE
-Encoding: 9678 9678 9678
+Encoding: 9678 9678 2742
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76145,8 +78892,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: H18533
-Encoding: 9679 9679 9679
+Encoding: 9679 9679 2743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76163,8 +78911,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D0
-Encoding: 9680 9680 9680
+Encoding: 9680 9680 2744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76187,8 +78936,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D1
-Encoding: 9681 9681 9681
+Encoding: 9681 9681 2745
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76211,8 +78961,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D2
-Encoding: 9682 9682 9682
+Encoding: 9682 9682 2746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76235,8 +78986,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D3
-Encoding: 9683 9683 9683
+Encoding: 9683 9683 2747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76259,8 +79011,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D4
-Encoding: 9684 9684 9684
+Encoding: 9684 9684 2748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76286,8 +79039,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D5
-Encoding: 9685 9685 9685
+Encoding: 9685 9685 2749
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76309,8 +79063,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D6
-Encoding: 9686 9686 9686
+Encoding: 9686 9686 2750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76324,8 +79079,9 @@ SplineSet
  921.5 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25D7
-Encoding: 9687 9687 9687
+Encoding: 9687 9687 2751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76339,8 +79095,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: invbullet
-Encoding: 9688 9688 9688
+Encoding: 9688 9688 2752
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76370,8 +79127,9 @@ SplineSet
  -20 -20 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: invcircle
-Encoding: 9689 9689 9689
+Encoding: 9689 9689 2753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76402,8 +79160,9 @@ SplineSet
  -20 -512 l 25,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DA
-Encoding: 9690 9690 9690
+Encoding: 9690 9690 2754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76427,8 +79186,9 @@ SplineSet
  1104.9 813.293 1104.9 813.293 1104.9 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DB
-Encoding: 9691 9691 9691
+Encoding: 9691 9691 2755
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76452,8 +79212,9 @@ SplineSet
  128.1 250.631 128.1 250.631 128.1 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DC
-Encoding: 9692 9692 9692
+Encoding: 9692 9692 2756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76468,8 +79229,9 @@ SplineSet
  311.45 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25DD
-Encoding: 9693 9693 9693
+Encoding: 9693 9693 2757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76484,8 +79246,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DE
-Encoding: 9694 9694 9694
+Encoding: 9694 9694 2758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76500,8 +79263,9 @@ SplineSet
  462.5 -84 462.5 -84 311.5 -84 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DF
-Encoding: 9695 9695 9695
+Encoding: 9695 9695 2759
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76516,8 +79280,9 @@ SplineSet
  921.45 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E0
-Encoding: 9696 9696 9696
+Encoding: 9696 9696 2760
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76536,8 +79301,9 @@ SplineSet
  1227 883 1227 883 1227 532 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E1
-Encoding: 9697 9697 9697
+Encoding: 9697 9697 2761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76556,8 +79322,9 @@ SplineSet
  167.172 532 l 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E2
-Encoding: 9698 9698 9698
+Encoding: 9698 9698 2762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76569,8 +79336,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E3
-Encoding: 9699 9699 9699
+Encoding: 9699 9699 2763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76582,8 +79350,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E4
-Encoding: 9700 9700 9700
+Encoding: 9700 9700 2764
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76595,8 +79364,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E5
-Encoding: 9701 9701 9701
+Encoding: 9701 9701 2765
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76608,8 +79378,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: openbullet
-Encoding: 9702 9702 9702
+Encoding: 9702 9702 2766
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76651,8 +79422,9 @@ SplineSet
  256 688 256 688 256 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E7
-Encoding: 9703 9703 9703
+Encoding: 9703 9703 2767
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76670,8 +79442,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E8
-Encoding: 9704 9704 9704
+Encoding: 9704 9704 2768
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76689,8 +79462,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E9
-Encoding: 9705 9705 9705
+Encoding: 9705 9705 2769
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76707,8 +79481,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EA
-Encoding: 9706 9706 9706
+Encoding: 9706 9706 2770
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76725,8 +79500,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EB
-Encoding: 9707 9707 9707
+Encoding: 9707 9707 2771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76749,8 +79525,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EC
-Encoding: 9708 9708 9708
+Encoding: 9708 9708 2772
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76775,8 +79552,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25ED
-Encoding: 9709 9709 9709
+Encoding: 9709 9709 2773
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76792,8 +79570,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EE
-Encoding: 9710 9710 9710
+Encoding: 9710 9710 2774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76809,8 +79588,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EF
-Encoding: 9711 9711 9711
+Encoding: 9711 9711 2775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76836,8 +79616,9 @@ SplineSet
  -20 165 -20 165 -20 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25F0
-Encoding: 9712 9712 9712
+Encoding: 9712 9712 2776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76862,8 +79643,9 @@ SplineSet
  120 35.5 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F1
-Encoding: 9713 9713 9713
+Encoding: 9713 9713 2777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76888,8 +79670,9 @@ SplineSet
  120 588.5 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F2
-Encoding: 9714 9714 9714
+Encoding: 9714 9714 2778
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76914,8 +79697,9 @@ SplineSet
  120 35.5 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F3
-Encoding: 9715 9715 9715
+Encoding: 9715 9715 2779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76940,8 +79724,9 @@ SplineSet
  120 35.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F4
-Encoding: 9716 9716 9716
+Encoding: 9716 9716 2780
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76972,8 +79757,9 @@ SplineSet
  130.784 474.5 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni25F5
-Encoding: 9717 9717 9717
+Encoding: 9717 9717 2781
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77004,8 +79790,9 @@ SplineSet
  130.784 474.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F6
-Encoding: 9718 9718 9718
+Encoding: 9718 9718 2782
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77036,8 +79823,9 @@ SplineSet
  673 43.0479 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F7
-Encoding: 9719 9719 9719
+Encoding: 9719 9719 2783
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77068,8 +79856,9 @@ SplineSet
  1102.3 588.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F8
-Encoding: 9720 9720 9720
+Encoding: 9720 9720 2784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77085,8 +79874,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25F9
-Encoding: 9721 9721 9721
+Encoding: 9721 9721 2785
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77102,8 +79892,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FA
-Encoding: 9722 9722 9722
+Encoding: 9722 9722 2786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77119,8 +79910,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FB
-Encoding: 9723 9723 9723
+Encoding: 9723 9723 2787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77138,8 +79930,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FC
-Encoding: 9724 9724 9724
+Encoding: 9724 9724 2788
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77152,8 +79945,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FD
-Encoding: 9725 9725 9725
+Encoding: 9725 9725 2789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77171,8 +79965,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FE
-Encoding: 9726 9726 9726
+Encoding: 9726 9726 2790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77185,8 +79980,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FF
-Encoding: 9727 9727 9727
+Encoding: 9727 9727 2791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77202,8 +79998,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2600
-Encoding: 9728 9728 9728
+Encoding: 9728 9728 2792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77285,8 +80082,9 @@ SplineSet
  590 446 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2601
-Encoding: 9729 9729 9729
+Encoding: 9729 9729 2793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77318,8 +80116,9 @@ SplineSet
  684.717 460 684.717 460 766.699 460 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2602
-Encoding: 9730 9730 9730
+Encoding: 9730 9730 2794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77375,8 +80174,9 @@ SplineSet
  608.679 1068.13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2603
-Encoding: 9731 9731 9731
+Encoding: 9731 9731 2795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77631,8 +80431,9 @@ SplineSet
  106.419 947 106.419 947 110 944 c 2,822,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2604
-Encoding: 9732 9732 9732
+Encoding: 9732 9732 2796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77806,8 +80607,9 @@ SplineSet
  1158.24 928.015 1158.24 928.015 1166.45 928.015 c 0,238,239
 EndSplineSet
 EndChar
+
 StartChar: uni2605
-Encoding: 9733 9733 9733
+Encoding: 9733 9733 2797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77826,8 +80628,9 @@ SplineSet
  58.4141 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2606
-Encoding: 9734 9734 9734
+Encoding: 9734 9734 2798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77857,8 +80660,9 @@ SplineSet
  450.852 439.516 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2607
-Encoding: 9735 9735 9735
+Encoding: 9735 9735 2799
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77880,8 +80684,9 @@ SplineSet
  935 1494 935 1494 974 1494 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2608
-Encoding: 9736 9736 9736
+Encoding: 9736 9736 2800
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77909,8 +80714,9 @@ SplineSet
  59.1592 1497 59.1592 1497 121.972 1497 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2609
-Encoding: 9737 9737 9737
+Encoding: 9737 9737 2801
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77951,8 +80757,9 @@ SplineSet
  759.672 617.719 759.672 617.719 759.672 580.203 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni260A
-Encoding: 9738 9738 9738
+Encoding: 9738 9738 2802
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78007,8 +80814,9 @@ SplineSet
  1199.91 630 1199.91 630 1111.86 507.5 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260B
-Encoding: 9739 9739 9739
+Encoding: 9739 9739 2803
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78063,8 +80871,9 @@ SplineSet
  1196.93 720.938 1196.93 720.938 1196.93 556.875 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260C
-Encoding: 9740 9740 9740
+Encoding: 9740 9740 2804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78094,8 +80903,9 @@ SplineSet
  909 926 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni260D
-Encoding: 9741 9741 9741
+Encoding: 9741 9741 2805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78142,8 +80952,9 @@ SplineSet
  571.188 625 l 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260E
-Encoding: 9742 9742 9742
+Encoding: 9742 9742 2806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78289,8 +81100,9 @@ SplineSet
  684.987 660.66 684.987 660.66 691.811 676.24 c 0,174,175
 EndSplineSet
 EndChar
+
 StartChar: uni260F
-Encoding: 9743 9743 9743
+Encoding: 9743 9743 2807
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78469,8 +81281,9 @@ SplineSet
  942.763 1038.94 l 1,207,208
 EndSplineSet
 EndChar
+
 StartChar: uni2610
-Encoding: 9744 9744 9744
+Encoding: 9744 9744 2808
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78492,8 +81305,9 @@ SplineSet
  187.157 955 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2611
-Encoding: 9745 9745 9745
+Encoding: 9745 9745 2809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78530,8 +81344,9 @@ SplineSet
  867.865 841.719 867.865 841.719 959.974 859.297 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2612
-Encoding: 9746 9746 9746
+Encoding: 9746 9746 2810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78569,8 +81384,9 @@ SplineSet
  347.768 825 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2613
-Encoding: 9747 9747 9747
+Encoding: 9747 9747 2811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78597,8 +81413,9 @@ SplineSet
  294.031 1347.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2614
-Encoding: 9748 9748 9748
+Encoding: 9748 9748 2812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78703,8 +81520,9 @@ SplineSet
  593.062 925.823 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2615
-Encoding: 9749 9749 9749
+Encoding: 9749 9749 2813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78806,8 +81624,9 @@ SplineSet
  737.088 1005 737.088 1005 735.682 940.312 c 0,120,121
 EndSplineSet
 EndChar
+
 StartChar: uni2616
-Encoding: 9750 9750 9750
+Encoding: 9750 9750 2814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78830,8 +81649,9 @@ SplineSet
  197.625 1044 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2617
-Encoding: 9751 9751 9751
+Encoding: 9751 9751 2815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78849,8 +81669,9 @@ SplineSet
  619.926 1490 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2618
-Encoding: 9752 9752 9752
+Encoding: 9752 9752 2816
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78899,8 +81720,9 @@ SplineSet
  593.65 637.562 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2619
-Encoding: 9753 9753 9753
+Encoding: 9753 9753 2817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78946,8 +81768,9 @@ SplineSet
  1050.67 821.25 1050.67 821.25 901.382 852.125 c 1,58,59
 EndSplineSet
 EndChar
+
 StartChar: uni261A
-Encoding: 9754 9754 9754
+Encoding: 9754 9754 2818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78993,8 +81816,9 @@ SplineSet
  1127.99 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261B
-Encoding: 9755 9755 9755
+Encoding: 9755 9755 2819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79040,8 +81864,9 @@ SplineSet
  105 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261C
-Encoding: 9756 9756 9756
+Encoding: 9756 9756 2820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79099,8 +81924,9 @@ SplineSet
  559.22 282.062 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261D
-Encoding: 9757 9757 9757
+Encoding: 9757 9757 2821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79159,8 +81985,9 @@ SplineSet
  141 812 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261E
-Encoding: 9758 9758 9758
+Encoding: 9758 9758 2822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79218,8 +82045,9 @@ SplineSet
  750 283 750 283 674 282 c 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261F
-Encoding: 9759 9759 9759
+Encoding: 9759 9759 2823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79277,8 +82105,9 @@ SplineSet
  140 1399 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2620
-Encoding: 9760 9760 9760
+Encoding: 9760 9760 2824
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79538,8 +82367,9 @@ SplineSet
  726.951 305.125 l 1,306,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2621
-Encoding: 9761 9761 9761
+Encoding: 9761 9761 2825
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79573,8 +82403,9 @@ SplineSet
  755.843 1491 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2622
-Encoding: 9762 9762 9762
+Encoding: 9762 9762 2826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79640,8 +82471,9 @@ SplineSet
  577.5 740.562 577.5 740.562 614.062 740.562 c 0,71,72
 EndSplineSet
 EndChar
+
 StartChar: uni2623
-Encoding: 9763 9763 9763
+Encoding: 9763 9763 2827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79719,8 +82551,9 @@ SplineSet
  76.8975 426.156 76.8975 426.156 37.7959 289.656 c 1,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2624
-Encoding: 9764 9764 9764
+Encoding: 9764 9764 2828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79906,8 +82739,9 @@ SplineSet
  714.02 1077.92 714.02 1077.92 652.38 1012.6 c 1,210,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2625
-Encoding: 9765 9765 9765
+Encoding: 9765 9765 2829
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79940,8 +82774,9 @@ SplineSet
  553.497 966 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2626
-Encoding: 9766 9766 9766
+Encoding: 9766 9766 2830
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79997,8 +82832,9 @@ SplineSet
  573.5 579 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2627
-Encoding: 9767 9767 9767
+Encoding: 9767 9767 2831
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80038,8 +82874,9 @@ SplineSet
  485.709 567.6 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2628
-Encoding: 9768 9768 9768
+Encoding: 9768 9768 2832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80080,8 +82917,9 @@ SplineSet
  524.061 1485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2629
-Encoding: 9769 9769 9769
+Encoding: 9769 9769 2833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80134,8 +82972,9 @@ SplineSet
  452.25 1123.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262A
-Encoding: 9770 9770 9770
+Encoding: 9770 9770 2834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80177,8 +83016,9 @@ SplineSet
  980.764 913.609 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262B
-Encoding: 9771 9771 9771
+Encoding: 9771 9771 2835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80264,8 +83104,9 @@ SplineSet
  868.784 1079.81 l 1,99,100
 EndSplineSet
 EndChar
+
 StartChar: uni262C
-Encoding: 9772 9772 9772
+Encoding: 9772 9772 2836
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80337,8 +83178,9 @@ SplineSet
  863.52 1046.96 863.52 1046.96 702.52 1113.2 c 1,96,97
 EndSplineSet
 EndChar
+
 StartChar: uni262D
-Encoding: 9773 9773 9773
+Encoding: 9773 9773 2837
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80380,8 +83222,9 @@ SplineSet
  507.019 1313.12 507.019 1313.12 682.509 1313.12 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni262E
-Encoding: 9774 9774 9774
+Encoding: 9774 9774 2838
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80418,8 +83261,9 @@ SplineSet
  998.438 312.013 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni262F
-Encoding: 9775 9775 9775
+Encoding: 9775 9775 2839
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80468,8 +83312,9 @@ SplineSet
  1218.64 856.245 1218.64 856.245 1218.64 605.891 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni2638
-Encoding: 9784 9784 9784
+Encoding: 9784 9784 2840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80559,8 +83404,9 @@ SplineSet
  563 548 l 1,106,107
 EndSplineSet
 EndChar
+
 StartChar: uni2639
-Encoding: 9785 9785 9785
+Encoding: 9785 9785 2841
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80603,8 +83449,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: smileface
-Encoding: 9786 9786 9786
+Encoding: 9786 9786 2842
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80647,8 +83494,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: invsmileface
-Encoding: 9787 9787 9787
+Encoding: 9787 9787 2843
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80682,8 +83530,9 @@ SplineSet
  496 860 496 860 501 970 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: sun
-Encoding: 9788 9788 9788
+Encoding: 9788 9788 2844
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80774,8 +83623,9 @@ SplineSet
  592 924 592 924 556 910 c 0,74,75
 EndSplineSet
 EndChar
+
 StartChar: uni263D
-Encoding: 9789 9789 9789
+Encoding: 9789 9789 2845
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80812,8 +83662,9 @@ SplineSet
  342.844 1416.19 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263E
-Encoding: 9790 9790 9790
+Encoding: 9790 9790 2846
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80850,8 +83701,9 @@ SplineSet
  894.5 69 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263F
-Encoding: 9791 9791 9791
+Encoding: 9791 9791 2847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80904,8 +83756,9 @@ SplineSet
  744 1012 744 1012 635 1018 c 2,50,-1
 EndSplineSet
 EndChar
+
 StartChar: female
-Encoding: 9792 9792 9792
+Encoding: 9792 9792 2848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80942,8 +83795,9 @@ SplineSet
  397 443 397 443 284 548 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2641
-Encoding: 9793 9793 9793
+Encoding: 9793 9793 2849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80980,8 +83834,9 @@ SplineSet
  397 798 397 798 550 811 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: male
-Encoding: 9794 9794 9794
+Encoding: 9794 9794 2850
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81017,8 +83872,9 @@ SplineSet
  910 411 910 411 781 282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2643
-Encoding: 9795 9795 9795
+Encoding: 9795 9795 2851
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81050,8 +83906,9 @@ SplineSet
  488 543 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2644
-Encoding: 9796 9796 9796
+Encoding: 9796 9796 2852
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81086,8 +83943,9 @@ SplineSet
  274 1141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2645
-Encoding: 9797 9797 9797
+Encoding: 9797 9797 2853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81140,8 +83998,9 @@ SplineSet
  679 553 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2646
-Encoding: 9798 9798 9798
+Encoding: 9798 9798 2854
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81203,8 +84062,9 @@ SplineSet
  679 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2647
-Encoding: 9799 9799 9799
+Encoding: 9799 9799 2855
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81236,8 +84096,9 @@ SplineSet
  352 1322 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2648
-Encoding: 9800 9800 9800
+Encoding: 9800 9800 2856
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81267,8 +84128,9 @@ SplineSet
  570.919 1.8125 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2649
-Encoding: 9801 9801 9801
+Encoding: 9801 9801 2857
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81310,8 +84172,9 @@ SplineSet
  516.966 824.688 516.966 824.688 615.731 820.586 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264A
-Encoding: 9802 9802 9802
+Encoding: 9802 9802 2858
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81339,8 +84202,9 @@ SplineSet
  425.56 202.312 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni264B
-Encoding: 9803 9803 9803
+Encoding: 9803 9803 2859
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81394,8 +84258,9 @@ SplineSet
  399.116 1293.75 399.116 1293.75 499.193 1294.69 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni264C
-Encoding: 9804 9804 9804
+Encoding: 9804 9804 2860
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81444,8 +84309,9 @@ SplineSet
  400.728 931.328 400.728 931.328 400.728 994.609 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264D
-Encoding: 9805 9805 9805
+Encoding: 9805 9805 2861
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81499,8 +84365,9 @@ SplineSet
  921.845 596.469 921.845 596.469 899.305 478.562 c 2,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264E
-Encoding: 9806 9806 9806
+Encoding: 9806 9806 2862
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81537,8 +84404,9 @@ SplineSet
  481.424 530.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264F
-Encoding: 9807 9807 9807
+Encoding: 9807 9807 2863
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81587,8 +84455,9 @@ SplineSet
  857.441 226.344 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2650
-Encoding: 9808 9808 9808
+Encoding: 9808 9808 2864
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81617,8 +84486,9 @@ SplineSet
  981.282 1098.94 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2651
-Encoding: 9809 9809 9809
+Encoding: 9809 9809 2865
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81659,8 +84529,9 @@ SplineSet
  858.493 608.398 858.493 608.398 796.969 421.367 c 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni2652
-Encoding: 9810 9810 9810
+Encoding: 9810 9810 2866
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81708,8 +84579,9 @@ SplineSet
  89.3398 726.484 l 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni2653
-Encoding: 9811 9811 9811
+Encoding: 9811 9811 2867
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81739,8 +84611,9 @@ SplineSet
  721.938 587.625 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2654
-Encoding: 9812 9812 9812
+Encoding: 9812 9812 2868
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81827,8 +84700,9 @@ SplineSet
  545.296 903.977 545.296 903.977 545.296 885.602 c 0,86,87
 EndSplineSet
 EndChar
+
 StartChar: uni2655
-Encoding: 9813 9813 9813
+Encoding: 9813 9813 2869
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81986,8 +84860,9 @@ SplineSet
  840.062 398.125 l 1,170,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2656
-Encoding: 9814 9814 9814
+Encoding: 9814 9814 2870
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82051,8 +84926,9 @@ SplineSet
  896.94 402.5 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2657
-Encoding: 9815 9815 9815
+Encoding: 9815 9815 2871
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82132,8 +85008,9 @@ SplineSet
  525.446 1115.9 525.446 1115.9 525.446 1092.11 c 0,83,84
 EndSplineSet
 EndChar
+
 StartChar: uni2658
-Encoding: 9816 9816 9816
+Encoding: 9816 9816 2872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82200,8 +85077,9 @@ SplineSet
  419.874 1010.81 l 1,52,53
 EndSplineSet
 EndChar
+
 StartChar: uni2659
-Encoding: 9817 9817 9817
+Encoding: 9817 9817 2873
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82277,8 +85155,9 @@ SplineSet
  998.625 105 l 1,85,86
 EndSplineSet
 EndChar
+
 StartChar: uni265A
-Encoding: 9818 9818 9818
+Encoding: 9818 9818 2874
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82394,8 +85273,9 @@ SplineSet
  702.521 662.305 l 2,123,124
 EndSplineSet
 EndChar
+
 StartChar: uni265B
-Encoding: 9819 9819 9819
+Encoding: 9819 9819 2875
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82467,8 +85347,9 @@ SplineSet
  911.438 51.75 l 1,77,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265C
-Encoding: 9820 9820 9820
+Encoding: 9820 9820 2876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82522,8 +85403,9 @@ SplineSet
  1040.22 50.5 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265D
-Encoding: 9821 9821 9821
+Encoding: 9821 9821 2877
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82576,8 +85458,9 @@ SplineSet
  664.439 606.5 l 1,53,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265E
-Encoding: 9822 9822 9822
+Encoding: 9822 9822 2878
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82629,8 +85512,9 @@ SplineSet
  1026.88 792 1026.88 792 620 1030 c 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265F
-Encoding: 9823 9823 9823
+Encoding: 9823 9823 2879
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82668,8 +85552,9 @@ SplineSet
  126.971 5.9375 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: spade
-Encoding: 9824 9824 9824
+Encoding: 9824 9824 2880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82702,8 +85587,9 @@ SplineSet
  619 1359 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2661
-Encoding: 9825 9825 9825
+Encoding: 9825 9825 2881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82743,8 +85629,9 @@ SplineSet
  56 1112 56 1112 56 1053 c 2,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2662
-Encoding: 9826 9826 9826
+Encoding: 9826 9826 2882
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82765,8 +85652,9 @@ SplineSet
  614 1293 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: club
-Encoding: 9827 9827 9827
+Encoding: 9827 9827 2883
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82810,8 +85698,9 @@ SplineSet
  586 1359 586 1359 618 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2664
-Encoding: 9828 9828 9828
+Encoding: 9828 9828 2884
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82864,8 +85753,9 @@ SplineSet
  592 176 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: heart
-Encoding: 9829 9829 9829
+Encoding: 9829 9829 2885
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82888,8 +85778,9 @@ SplineSet
  244 1359 244 1359 315 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: diamond
-Encoding: 9830 9830 9830
+Encoding: 9830 9830 2886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82904,8 +85795,9 @@ SplineSet
  617 1359 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2667
-Encoding: 9831 9831 9831
+Encoding: 9831 9831 2887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82980,8 +85872,9 @@ SplineSet
  617 277 l 1,97,98
 EndSplineSet
 EndChar
+
 StartChar: uni2668
-Encoding: 9832 9832 9832
+Encoding: 9832 9832 2888
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83045,8 +85938,9 @@ SplineSet
  895.998 570.281 l 2,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni2669
-Encoding: 9833 9833 9833
+Encoding: 9833 9833 2889
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83069,8 +85963,9 @@ SplineSet
  789 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnote
-Encoding: 9834 9834 9834
+Encoding: 9834 9834 2890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83099,8 +85994,9 @@ SplineSet
  566 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnotedbl
-Encoding: 9835 9835 9835
+Encoding: 9835 9835 2891
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83132,8 +86028,9 @@ SplineSet
  473 1445 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266C
-Encoding: 9836 9836 9836
+Encoding: 9836 9836 2892
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83164,8 +86061,9 @@ SplineSet
  438 1189 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266D
-Encoding: 9837 9837 9837
+Encoding: 9837 9837 2893
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83189,8 +86087,9 @@ SplineSet
  519 658 519 658 376 441 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266E
-Encoding: 9838 9838 9838
+Encoding: 9838 9838 2894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83220,8 +86119,9 @@ SplineSet
  483 870 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266F
-Encoding: 9839 9839 9839
+Encoding: 9839 9839 2895
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83273,8 +86173,9 @@ SplineSet
  482 867 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2670
-Encoding: 9840 9840 9840
+Encoding: 9840 9840 2896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83331,8 +86232,9 @@ SplineSet
  553.5 685 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2671
-Encoding: 9841 9841 9841
+Encoding: 9841 9841 2897
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83402,8 +86304,9 @@ SplineSet
  593.75 894.375 l 1,60,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2672
-Encoding: 9842 9842 9842
+Encoding: 9842 9842 2898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83559,8 +86462,9 @@ SplineSet
  319.811 333.77 l 1,167,168
 EndSplineSet
 EndChar
+
 StartChar: uni2673
-Encoding: 9843 9843 9843
+Encoding: 9843 9843 2899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83626,8 +86530,9 @@ SplineSet
  549.741 1076.68 549.741 1076.68 592.787 1079.6 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni2674
-Encoding: 9844 9844 9844
+Encoding: 9844 9844 2900
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83703,8 +86608,9 @@ SplineSet
  551.45 1048.24 551.45 1048.24 593.396 1051.09 c 0,69,70
 EndSplineSet
 EndChar
+
 StartChar: uni2675
-Encoding: 9845 9845 9845
+Encoding: 9845 9845 2901
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83788,8 +86694,9 @@ SplineSet
  550.62 1062.8 550.62 1062.8 593.1 1065.68 c 0,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2676
-Encoding: 9846 9846 9846
+Encoding: 9846 9846 2902
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83859,8 +86766,9 @@ SplineSet
  546.805 1120.55 546.805 1120.55 591.745 1123.59 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: uni2677
-Encoding: 9847 9847 9847
+Encoding: 9847 9847 2903
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83937,8 +86845,9 @@ SplineSet
  549.938 1072.09 549.938 1072.09 592.857 1075 c 0,70,71
 EndSplineSet
 EndChar
+
 StartChar: uni2678
-Encoding: 9848 9848 9848
+Encoding: 9848 9848 2904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84019,8 +86928,9 @@ SplineSet
  551.449 1039.09 551.449 1039.09 593.395 1041.94 c 0,77,78
 EndSplineSet
 EndChar
+
 StartChar: uni2679
-Encoding: 9849 9849 9849
+Encoding: 9849 9849 2905
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84082,8 +86992,9 @@ SplineSet
  547.875 1108.25 547.875 1108.25 592.125 1111.25 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni267A
-Encoding: 9850 9850 9850
+Encoding: 9850 9850 2906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84137,8 +87048,9 @@ SplineSet
  547.875 1095.75 547.875 1095.75 592.125 1098.75 c 0,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni267B
-Encoding: 9851 9851 9851
+Encoding: 9851 9851 2907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84213,8 +87125,9 @@ SplineSet
  583.125 351.25 l 1,73,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267C
-Encoding: 9852 9852 9852
+Encoding: 9852 9852 2908
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84301,8 +87214,9 @@ SplineSet
  338.853 421.074 l 1,93,94
 EndSplineSet
 EndChar
+
 StartChar: uni267D
-Encoding: 9853 9853 9853
+Encoding: 9853 9853 2909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84394,8 +87308,9 @@ SplineSet
  301.125 334 301.125 334 354.375 402.25 c 1,97,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267E
-Encoding: 9854 9854 9854
+Encoding: 9854 9854 2910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84449,8 +87364,9 @@ SplineSet
  79.1064 729.297 79.1064 729.297 79.1064 576.191 c 0,56,57
 EndSplineSet
 EndChar
+
 StartChar: uni267F
-Encoding: 9855 9855 9855
+Encoding: 9855 9855 2911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84492,8 +87408,9 @@ SplineSet
  757.812 92.875 757.812 92.875 702.688 63.125 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni2680
-Encoding: 9856 9856 9856
+Encoding: 9856 9856 2912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84524,8 +87441,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2681
-Encoding: 9857 9857 9857
+Encoding: 9857 9857 2913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84569,8 +87487,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2682
-Encoding: 9858 9858 9858
+Encoding: 9858 9858 2914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84627,8 +87546,9 @@ SplineSet
  184.5 128.75 l 1,76,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2683
-Encoding: 9859 9859 9859
+Encoding: 9859 9859 2915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84698,8 +87618,9 @@ SplineSet
  184.5 125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2684
-Encoding: 9860 9860 9860
+Encoding: 9860 9860 2916
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84782,8 +87703,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2685
-Encoding: 9861 9861 9861
+Encoding: 9861 9861 2917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84879,8 +87801,9 @@ SplineSet
  184.5 120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2686
-Encoding: 9862 9862 9862
+Encoding: 9862 9862 2918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84927,8 +87850,9 @@ SplineSet
  809.214 544.863 809.214 544.863 809.214 570 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni2687
-Encoding: 9863 9863 9863
+Encoding: 9863 9863 2919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84988,8 +87912,9 @@ SplineSet
  298.101 670.977 298.101 670.977 322.476 670.977 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni2688
-Encoding: 9864 9864 9864
+Encoding: 9864 9864 2920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85023,8 +87948,9 @@ SplineSet
  880.816 474.023 880.816 474.023 905.953 474.023 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2689
-Encoding: 9865 9865 9865
+Encoding: 9865 9865 2921
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85071,8 +87997,9 @@ SplineSet
  226.5 585.137 226.5 585.137 226.5 560 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni268A
-Encoding: 9866 9866 9866
+Encoding: 9866 9866 2922
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85085,8 +88012,9 @@ SplineSet
  82.3447 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni268B
-Encoding: 9867 9867 9867
+Encoding: 9867 9867 2923
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85104,8 +88032,9 @@ SplineSet
  716.476 150 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2690
-Encoding: 9872 9872 9872
+Encoding: 9872 9872 2924
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85136,8 +88065,9 @@ SplineSet
  212.689 1167.25 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2691
-Encoding: 9873 9873 9873
+Encoding: 9873 9873 2925
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85160,8 +88090,9 @@ SplineSet
  181.625 1263.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2692
-Encoding: 9874 9874 9874
+Encoding: 9874 9874 2926
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85201,8 +88132,9 @@ SplineSet
  548.606 451.891 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2693
-Encoding: 9875 9875 9875
+Encoding: 9875 9875 2927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85274,8 +88206,9 @@ SplineSet
  793.222 11.375 793.222 11.375 692.472 4.0625 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2694
-Encoding: 9876 9876 9876
+Encoding: 9876 9876 2928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85353,8 +88286,9 @@ SplineSet
  651 511.5 l 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2695
-Encoding: 9877 9877 9877
+Encoding: 9877 9877 2929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85423,8 +88357,9 @@ SplineSet
  663.5 1032 l 1,68,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2696
-Encoding: 9878 9878 9878
+Encoding: 9878 9878 2930
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85476,8 +88411,9 @@ SplineSet
  980.625 900 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2697
-Encoding: 9879 9879 9879
+Encoding: 9879 9879 2931
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85512,8 +88448,9 @@ SplineSet
  1139.62 457.75 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2698
-Encoding: 9880 9880 9880
+Encoding: 9880 9880 2932
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85562,8 +88499,9 @@ SplineSet
  723.25 744 723.25 744 671.625 736.125 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2699
-Encoding: 9881 9881 9881
+Encoding: 9881 9881 2933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85634,8 +88572,9 @@ SplineSet
  749 673 749 673 749 618 c 128,-1,70
 EndSplineSet
 EndChar
+
 StartChar: uni269A
-Encoding: 9882 9882 9882
+Encoding: 9882 9882 2934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85749,8 +88688,9 @@ SplineSet
  544.312 1119.88 544.312 1119.88 589.812 1128.62 c 1,82,-1
 EndSplineSet
 EndChar
+
 StartChar: uni269B
-Encoding: 9883 9883 9883
+Encoding: 9883 9883 2935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85889,8 +88829,9 @@ SplineSet
  683.936 353.938 683.936 353.938 614.874 388.062 c 1,204,205
 EndSplineSet
 EndChar
+
 StartChar: uni269C
-Encoding: 9884 9884 9884
+Encoding: 9884 9884 2936
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85990,8 +88931,9 @@ SplineSet
  542.562 833.375 542.562 833.375 616.938 833.375 c 0,131,132
 EndSplineSet
 EndChar
+
 StartChar: uni26A0
-Encoding: 9888 9888 9888
+Encoding: 9888 9888 2937
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86031,8 +88973,9 @@ SplineSet
  607.968 235.414 607.968 235.414 622.187 235.414 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni26A1
-Encoding: 9889 9889 9889
+Encoding: 9889 9889 2938
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86056,8 +88999,9 @@ SplineSet
  1066.25 1313.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B0
-Encoding: 9904 9904 9904
+Encoding: 9904 9904 2939
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86072,8 +89016,9 @@ SplineSet
  430 1496 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B1
-Encoding: 9905 9905 9905
+Encoding: 9905 9905 2940
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86096,8 +89041,9 @@ SplineSet
  714.812 1033.5 714.812 1033.5 810.688 1014 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2701
-Encoding: 9985 9985 9985
+Encoding: 9985 9985 2941
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86191,8 +89137,9 @@ SplineSet
  371.175 939.535 371.175 939.535 353.531 948.359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2702
-Encoding: 9986 9986 9986
+Encoding: 9986 9986 2942
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86287,8 +89234,9 @@ SplineSet
  206.625 975 206.625 975 189.375 975 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2703
-Encoding: 9987 9987 9987
+Encoding: 9987 9987 2943
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86382,8 +89330,9 @@ SplineSet
  340.812 374.5 340.812 374.5 359.375 380.688 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2704
-Encoding: 9988 9988 9988
+Encoding: 9988 9988 2944
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86581,8 +89530,9 @@ SplineSet
  601.031 686 601.031 686 601.031 678.438 c 152,-1,335
 EndSplineSet
 EndChar
+
 StartChar: uni2706
-Encoding: 9990 9990 9990
+Encoding: 9990 9990 2945
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86668,8 +89618,9 @@ SplineSet
  793.273 994.133 793.273 994.133 788.891 1013.12 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2707
-Encoding: 9991 9991 9991
+Encoding: 9991 9991 2946
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86757,8 +89708,9 @@ SplineSet
  499.5 1225 499.5 1225 616.5 1225 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2708
-Encoding: 9992 9992 9992
+Encoding: 9992 9992 2947
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86806,8 +89758,9 @@ SplineSet
  82.125 572.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2709
-Encoding: 9993 9993 9993
+Encoding: 9993 9993 2948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86852,8 +89805,9 @@ SplineSet
  63.4922 115.469 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270C
-Encoding: 9996 9996 9996
+Encoding: 9996 9996 2949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86996,8 +89950,9 @@ SplineSet
  386.49 675.2 l 1,5,6
 EndSplineSet
 EndChar
+
 StartChar: uni270D
-Encoding: 9997 9997 9997
+Encoding: 9997 9997 2950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87096,8 +90051,9 @@ SplineSet
  186.961 280.123 186.961 280.123 159.826 296.548 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270E
-Encoding: 9998 9998 9998
+Encoding: 9998 9998 2951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87170,8 +90126,9 @@ SplineSet
  279.719 812.875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270F
-Encoding: 9999 9999 9999
+Encoding: 9999 9999 2952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87242,8 +90199,9 @@ SplineSet
  272.762 352.531 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2710
-Encoding: 10000 10000 10000
+Encoding: 10000 10000 2953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87316,8 +90274,9 @@ SplineSet
  279.719 564.125 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2711
-Encoding: 10001 10001 10001
+Encoding: 10001 10001 2954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87371,8 +90330,9 @@ SplineSet
  176.227 632.793 176.227 632.793 176.227 580.234 c 152,-1,0
 EndSplineSet
 EndChar
+
 StartChar: uni2712
-Encoding: 10002 10002 10002
+Encoding: 10002 10002 2955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87405,8 +90365,9 @@ SplineSet
  738.727 489.023 738.727 489.023 744.469 502.969 c 9,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni2713
-Encoding: 10003 10003 10003
+Encoding: 10003 10003 2956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87430,8 +90391,9 @@ SplineSet
  251.273 591.5 251.273 591.5 280.5 591.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2714
-Encoding: 10004 10004 10004
+Encoding: 10004 10004 2957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87455,8 +90417,9 @@ SplineSet
  220.845 654.375 220.845 654.375 263 653.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2715
-Encoding: 10005 10005 10005
+Encoding: 10005 10005 2958
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87477,8 +90440,9 @@ SplineSet
  731.062 599.625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2716
-Encoding: 10006 10006 10006
+Encoding: 10006 10006 2959
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87499,8 +90463,9 @@ SplineSet
  821.312 709.043 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2717
-Encoding: 10007 10007 10007
+Encoding: 10007 10007 2960
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87543,8 +90508,9 @@ SplineSet
  957.344 1213.62 957.344 1213.62 968.719 1213.62 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2718
-Encoding: 10008 10008 10008
+Encoding: 10008 10008 2961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87594,8 +90560,9 @@ SplineSet
  1012 1322.25 1012 1322.25 1024.25 1322.25 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2719
-Encoding: 10009 10009 10009
+Encoding: 10009 10009 2962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87642,8 +90609,9 @@ SplineSet
  690.438 631.274 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271A
-Encoding: 10010 10010 10010
+Encoding: 10010 10010 2963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87664,8 +90632,9 @@ SplineSet
  758.688 655 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271B
-Encoding: 10011 10011 10011
+Encoding: 10011 10011 2964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87691,8 +90660,9 @@ SplineSet
  706.5 655.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271C
-Encoding: 10012 10012 10012
+Encoding: 10012 10012 2965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87718,8 +90688,9 @@ SplineSet
  768.844 720.762 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271D
-Encoding: 10013 10013 10013
+Encoding: 10013 10013 2966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87740,8 +90711,9 @@ SplineSet
  715 960 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271E
-Encoding: 10014 10014 10014
+Encoding: 10014 10014 2967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87779,8 +90751,9 @@ SplineSet
  669 957.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271F
-Encoding: 10015 10015 10015
+Encoding: 10015 10015 2968
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87827,8 +90800,9 @@ SplineSet
  704 860 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2720
-Encoding: 10016 10016 10016
+Encoding: 10016 10016 2969
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87889,8 +90863,9 @@ SplineSet
  559.371 515.742 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2721
-Encoding: 10017 10017 10017
+Encoding: 10017 10017 2970
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87942,8 +90917,9 @@ SplineSet
  299.625 713.062 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2722
-Encoding: 10018 10018 10018
+Encoding: 10018 10018 2971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87992,8 +90968,9 @@ SplineSet
  578.731 603.182 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2723
-Encoding: 10019 10019 10019
+Encoding: 10019 10019 2972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88082,8 +91059,9 @@ SplineSet
  562.418 492.695 562.418 492.695 549.469 504.883 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2724
-Encoding: 10020 10020 10020
+Encoding: 10020 10020 2973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88172,8 +91150,9 @@ SplineSet
  530.426 610 530.426 610 578.414 610 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2725
-Encoding: 10021 10021 10021
+Encoding: 10021 10021 2974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88342,8 +91321,9 @@ SplineSet
  592.766 1159.3 592.766 1159.3 616.5 1159.3 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2726
-Encoding: 10022 10022 10022
+Encoding: 10022 10022 2975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88368,8 +91348,9 @@ SplineSet
  158.27 552.941 158.27 552.941 43.1543 552.941 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2727
-Encoding: 10023 10023 10023
+Encoding: 10023 10023 2976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88411,8 +91392,9 @@ SplineSet
  153.75 557.25 153.75 557.25 37.5 557.25 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2729
-Encoding: 10025 10025 10025
+Encoding: 10025 10025 2977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88442,8 +91424,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272A
-Encoding: 10026 10026 10026
+Encoding: 10026 10026 2978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88479,8 +91462,9 @@ SplineSet
  505.594 1076.06 505.594 1076.06 616.5 1076.06 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni272B
-Encoding: 10027 10027 10027
+Encoding: 10027 10027 2979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88516,8 +91500,9 @@ SplineSet
  616.5 1070 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272C
-Encoding: 10028 10028 10028
+Encoding: 10028 10028 2980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88564,8 +91549,9 @@ SplineSet
  616.5 1083.74 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272D
-Encoding: 10029 10029 10029
+Encoding: 10029 10029 2981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88606,8 +91592,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272E
-Encoding: 10030 10030 10030
+Encoding: 10030 10030 2982
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88648,8 +91635,9 @@ SplineSet
  616.5 820 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272F
-Encoding: 10031 10031 10031
+Encoding: 10031 10031 2983
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88688,8 +91676,9 @@ SplineSet
  616.5 1086.43 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2730
-Encoding: 10032 10032 10032
+Encoding: 10032 10032 2984
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88723,8 +91712,9 @@ SplineSet
  559.547 909.375 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2731
-Encoding: 10033 10033 10033
+Encoding: 10033 10033 2985
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88751,8 +91741,9 @@ SplineSet
  492.75 790.773 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2732
-Encoding: 10034 10034 10034
+Encoding: 10034 10034 2986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88786,8 +91777,9 @@ SplineSet
  436.5 559.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2733
-Encoding: 10035 10035 10035
+Encoding: 10035 10035 2987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88820,8 +91812,9 @@ SplineSet
  709.43 527.91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2734
-Encoding: 10036 10036 10036
+Encoding: 10036 10036 2988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88846,8 +91839,9 @@ SplineSet
  616.5 1146 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2735
-Encoding: 10037 10037 10037
+Encoding: 10037 10037 2989
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88904,8 +91898,9 @@ SplineSet
  616.5 1157.77 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2736
-Encoding: 10038 10038 10038
+Encoding: 10038 10038 2990
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88926,8 +91921,9 @@ SplineSet
  616.5 1279.38 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2737
-Encoding: 10039 10039 10039
+Encoding: 10039 10039 2991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88952,8 +91948,9 @@ SplineSet
  616.499 1138.44 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2738
-Encoding: 10040 10040 10040
+Encoding: 10040 10040 2992
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88978,8 +91975,9 @@ SplineSet
  616.5 1157.91 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2739
-Encoding: 10041 10041 10041
+Encoding: 10041 10041 2993
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89012,8 +92010,9 @@ SplineSet
  616.5 1127.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni273A
-Encoding: 10042 10042 10042
+Encoding: 10042 10042 2994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89070,8 +92069,9 @@ SplineSet
  570.797 800 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273B
-Encoding: 10043 10043 10043
+Encoding: 10043 10043 2995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89168,8 +92168,9 @@ SplineSet
  568.922 757.695 568.922 757.695 574.664 760.156 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273C
-Encoding: 10044 10044 10044
+Encoding: 10044 10044 2996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89283,8 +92284,9 @@ SplineSet
  569.375 747.562 569.375 747.562 575.062 750 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273D
-Encoding: 10045 10045 10045
+Encoding: 10045 10045 2997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89353,8 +92355,9 @@ SplineSet
  530.469 613.646 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273E
-Encoding: 10046 10046 10046
+Encoding: 10046 10046 2998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89474,8 +92477,9 @@ SplineSet
  843.25 485.769 843.25 485.769 785.949 500 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni273F
-Encoding: 10047 10047 10047
+Encoding: 10047 10047 2999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89557,8 +92561,9 @@ SplineSet
  818.244 808.656 818.244 808.656 812.812 798.569 c 1,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni2740
-Encoding: 10048 10048 10048
+Encoding: 10048 10048 3000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89702,8 +92707,9 @@ SplineSet
  893.682 527.473 893.682 527.473 891.299 510 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2741
-Encoding: 10049 10049 10049
+Encoding: 10049 10049 3001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90009,8 +93015,9 @@ SplineSet
  644.141 807.139 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2742
-Encoding: 10050 10050 10050
+Encoding: 10050 10050 3002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90086,8 +93093,9 @@ SplineSet
  616.5 1123.25 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2743
-Encoding: 10051 10051 10051
+Encoding: 10051 10051 3003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90216,8 +93224,9 @@ SplineSet
  836.482 541.685 836.482 541.685 780.891 557.25 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2744
-Encoding: 10052 10052 10052
+Encoding: 10052 10052 3004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90292,8 +93301,9 @@ SplineSet
  512.906 685.062 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2745
-Encoding: 10053 10053 10053
+Encoding: 10053 10053 3005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90362,8 +93372,9 @@ SplineSet
  665.06 515 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2746
-Encoding: 10054 10054 10054
+Encoding: 10054 10054 3006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90438,8 +93449,9 @@ SplineSet
  568.562 1215.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2747
-Encoding: 10055 10055 10055
+Encoding: 10055 10055 3007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90532,8 +93544,9 @@ SplineSet
  1143.29 960.151 1143.29 960.151 1160.88 924.938 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2748
-Encoding: 10056 10056 10056
+Encoding: 10056 10056 3008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90622,8 +93635,9 @@ SplineSet
  824.982 511.552 824.982 511.552 779.66 554.607 c 1,104,105
 EndSplineSet
 EndChar
+
 StartChar: uni2749
-Encoding: 10057 10057 10057
+Encoding: 10057 10057 3009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90712,8 +93726,9 @@ SplineSet
  976.344 692.312 976.344 692.312 1019.22 692.312 c 152,-1,105
 EndSplineSet
 EndChar
+
 StartChar: uni274A
-Encoding: 10058 10058 10058
+Encoding: 10058 10058 3010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90810,8 +93825,9 @@ SplineSet
  647.891 -21.4375 647.891 -21.4375 616.5 -21.4375 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni274B
-Encoding: 10059 10059 10059
+Encoding: 10059 10059 3011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90884,8 +93900,9 @@ SplineSet
  583.785 1050.28 583.785 1050.28 616.5 1050.28 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni274D
-Encoding: 10061 10061 10061
+Encoding: 10061 10061 3012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90919,8 +93936,9 @@ SplineSet
  633.562 -10.1484 633.562 -10.1484 615.789 -8.72656 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni274F
-Encoding: 10063 10063 10063
+Encoding: 10063 10063 3013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90942,8 +93960,9 @@ SplineSet
  138 6.3125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2750
-Encoding: 10064 10064 10064
+Encoding: 10064 10064 3014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90965,8 +93984,9 @@ SplineSet
  1101.72 69.8516 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2751
-Encoding: 10065 10065 10065
+Encoding: 10065 10065 3015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90986,8 +94006,9 @@ SplineSet
  56.8125 -0.703125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2752
-Encoding: 10066 10066 10066
+Encoding: 10066 10066 3016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91007,8 +94028,9 @@ SplineSet
  1113.15 0.989258 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2756
-Encoding: 10070 10070 10070
+Encoding: 10070 10070 3017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91036,8 +94058,9 @@ SplineSet
  358.484 254.031 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2758
-Encoding: 10072 10072 10072
+Encoding: 10072 10072 3018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91050,8 +94073,9 @@ SplineSet
  693.85 1435.92 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2759
-Encoding: 10073 10073 10073
+Encoding: 10073 10073 3019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91064,8 +94088,9 @@ SplineSet
  771.2 1433 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275A
-Encoding: 10074 10074 10074
+Encoding: 10074 10074 3020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91078,8 +94103,9 @@ SplineSet
  895.3 1386.98 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275B
-Encoding: 10075 10075 10075
+Encoding: 10075 10075 3021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91095,8 +94121,9 @@ SplineSet
  755.895 975.215 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275C
-Encoding: 10076 10076 10076
+Encoding: 10076 10076 3022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91112,26 +94139,29 @@ SplineSet
  467.812 1478.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275D
-Encoding: 10077 10077 10077
+Encoding: 10077 10077 3023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10075 10075 N 1 0 0 1 221 0 2
-Refer: 10075 10075 N 1 0 0 1 -221 0 2
+Refer: 3021 10075 N 1 0 0 1 221 0 2
+Refer: 3021 10075 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni275E
-Encoding: 10078 10078 10078
+Encoding: 10078 10078 3024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10076 10076 N 1 0 0 1 221 0 2
-Refer: 10076 10076 N 1 0 0 1 -221 0 2
+Refer: 3022 10076 N 1 0 0 1 221 0 2
+Refer: 3022 10076 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni2761
-Encoding: 10081 10081 10081
+Encoding: 10081 10081 3025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91191,8 +94221,9 @@ SplineSet
  738.781 619.188 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2762
-Encoding: 10082 10082 10082
+Encoding: 10082 10082 3026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91230,8 +94261,9 @@ SplineSet
  566.125 449.875 566.125 449.875 616.5 449.875 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2763
-Encoding: 10083 10083 10083
+Encoding: 10083 10083 3027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91277,8 +94309,9 @@ SplineSet
  566.125 459.375 566.125 459.375 616.5 459.375 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2764
-Encoding: 10084 10084 10084
+Encoding: 10084 10084 3028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91307,8 +94340,9 @@ SplineSet
  720.855 299.188 720.855 299.188 616.5 105 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2765
-Encoding: 10085 10085 10085
+Encoding: 10085 10085 3029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91337,8 +94371,9 @@ SplineSet
  910.5 769.25 910.5 769.25 1118.75 650.25 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2766
-Encoding: 10086 10086 10086
+Encoding: 10086 10086 3030
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91402,8 +94437,9 @@ SplineSet
  824.094 798.625 824.094 798.625 758.281 810 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2767
-Encoding: 10087 10087 10087
+Encoding: 10087 10087 3031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91454,8 +94490,9 @@ SplineSet
  839.531 307.688 839.531 307.688 724.156 307.688 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2768
-Encoding: 10088 10088 10088
+Encoding: 10088 10088 3032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91482,8 +94519,9 @@ SplineSet
  992.688 -100.812 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2769
-Encoding: 10089 10089 10089
+Encoding: 10089 10089 3033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91510,8 +94548,9 @@ SplineSet
  391.438 -100.625 391.438 -100.625 240.312 -100.625 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276A
-Encoding: 10090 10090 10090
+Encoding: 10090 10090 3034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91530,8 +94569,9 @@ SplineSet
  874.469 1361.38 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276B
-Encoding: 10091 10091 10091
+Encoding: 10091 10091 3035
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91550,8 +94590,9 @@ SplineSet
  471.993 1134.7 471.993 1134.7 366.469 1315.82 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276C
-Encoding: 10092 10092 10092
+Encoding: 10092 10092 3036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91566,8 +94607,9 @@ SplineSet
  909.23 -130.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276D
-Encoding: 10093 10093 10093
+Encoding: 10093 10093 3037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91582,8 +94624,9 @@ SplineSet
  324.135 -130.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276E
-Encoding: 10094 10094 10094
+Encoding: 10094 10094 3038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91598,8 +94641,9 @@ SplineSet
  1022.38 -169.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276F
-Encoding: 10095 10095 10095
+Encoding: 10095 10095 3039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91614,8 +94658,9 @@ SplineSet
  210.62 -169.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2770
-Encoding: 10096 10096 10096
+Encoding: 10096 10096 3040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91630,8 +94675,9 @@ SplineSet
  1027.32 -190.36 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2771
-Encoding: 10097 10097 10097
+Encoding: 10097 10097 3041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91646,8 +94692,9 @@ SplineSet
  206.09 -189.68 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2772
-Encoding: 10098 10098 10098
+Encoding: 10098 10098 3042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91664,8 +94711,9 @@ SplineSet
  580.42 -0.0996094 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2773
-Encoding: 10099 10099 10099
+Encoding: 10099 10099 3043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91682,8 +94730,9 @@ SplineSet
  652.58 1121.92 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2774
-Encoding: 10100 10100 10100
+Encoding: 10100 10100 3044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91721,8 +94770,9 @@ SplineSet
  951.73 -198.35 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2775
-Encoding: 10101 10101 10101
+Encoding: 10101 10101 3045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91760,8 +94810,9 @@ SplineSet
  249.51 -204.12 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2794
-Encoding: 10132 10132 10132
+Encoding: 10132 10132 3046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91779,8 +94830,9 @@ SplineSet
  1149.35 650 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2798
-Encoding: 10136 10136 10136
+Encoding: 10136 10136 3047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91796,8 +94848,9 @@ SplineSet
  783.625 393.875 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2799
-Encoding: 10137 10137 10137
+Encoding: 10137 10137 3048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91813,8 +94866,9 @@ SplineSet
  815.206 680.234 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279A
-Encoding: 10138 10138 10138
+Encoding: 10138 10138 3049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91830,8 +94884,9 @@ SplineSet
  870.25 860.75 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279B
-Encoding: 10139 10139 10139
+Encoding: 10139 10139 3050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91847,8 +94902,9 @@ SplineSet
  45.5918 750.703 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279C
-Encoding: 10140 10140 10140
+Encoding: 10140 10140 3051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91891,8 +94947,9 @@ SplineSet
  1159.5 710 1159.5 710 1159.5 691.25 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni279D
-Encoding: 10141 10141 10141
+Encoding: 10141 10141 3052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91908,8 +94965,9 @@ SplineSet
  837.957 721.562 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279E
-Encoding: 10142 10142 10142
+Encoding: 10142 10142 3053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91925,8 +94983,9 @@ SplineSet
  853.775 626.211 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279F
-Encoding: 10143 10143 10143
+Encoding: 10143 10143 3054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91957,8 +95016,9 @@ SplineSet
  850.125 551.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A0
-Encoding: 10144 10144 10144
+Encoding: 10144 10144 3055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91989,8 +95049,9 @@ SplineSet
  126.31 510.328 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A1
-Encoding: 10145 10145 10145
+Encoding: 10145 10145 3056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92006,8 +95067,9 @@ SplineSet
  837.957 557.812 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A2
-Encoding: 10146 10146 10146
+Encoding: 10146 10146 3057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92024,8 +95086,9 @@ SplineSet
  433.5 710 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A3
-Encoding: 10147 10147 10147
+Encoding: 10147 10147 3058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92042,8 +95105,9 @@ SplineSet
  443.03 740 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A4
-Encoding: 10148 10148 10148
+Encoding: 10148 10148 3059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92056,8 +95120,9 @@ SplineSet
  371.938 750 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A5
-Encoding: 10149 10149 10149
+Encoding: 10149 10149 3060
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92081,8 +95146,9 @@ SplineSet
  54.375 689 54.375 689 54.375 725 c 10,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A6
-Encoding: 10150 10150 10150
+Encoding: 10150 10150 3061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92106,8 +95172,9 @@ SplineSet
  54.375 755 l 18,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A7
-Encoding: 10151 10151 10151
+Encoding: 10151 10151 3062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92123,8 +95190,9 @@ SplineSet
  613.125 530 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A8
-Encoding: 10152 10152 10152
+Encoding: 10152 10152 3063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92140,8 +95208,9 @@ SplineSet
  737.625 905 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A9
-Encoding: 10153 10153 10153
+Encoding: 10153 10153 3064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92167,8 +95236,9 @@ SplineSet
  663.777 589.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AA
-Encoding: 10154 10154 10154
+Encoding: 10154 10154 3065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92194,8 +95264,9 @@ SplineSet
  770.418 529.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AB
-Encoding: 10155 10155 10155
+Encoding: 10155 10155 3066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92224,8 +95295,9 @@ SplineSet
  748.38 552.203 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AC
-Encoding: 10156 10156 10156
+Encoding: 10156 10156 3067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92254,8 +95326,9 @@ SplineSet
  738.237 619.59 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AD
-Encoding: 10157 10157 10157
+Encoding: 10157 10157 3068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92283,8 +95356,9 @@ SplineSet
  643.875 547.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AE
-Encoding: 10158 10158 10158
+Encoding: 10158 10158 3069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92312,8 +95386,9 @@ SplineSet
  646.159 730 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AF
-Encoding: 10159 10159 10159
+Encoding: 10159 10159 3070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92344,8 +95419,9 @@ SplineSet
  232.125 775 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B1
-Encoding: 10161 10161 10161
+Encoding: 10161 10161 3071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92376,8 +95452,9 @@ SplineSet
  226.118 625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B2
-Encoding: 10162 10162 10162
+Encoding: 10162 10162 3072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92406,8 +95483,9 @@ SplineSet
  145.247 935 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B3
-Encoding: 10163 10163 10163
+Encoding: 10163 10163 3073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92469,8 +95547,9 @@ SplineSet
  263.877 590 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B4
-Encoding: 10164 10164 10164
+Encoding: 10164 10164 3074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92498,8 +95577,9 @@ SplineSet
  393.472 955.375 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B5
-Encoding: 10165 10165 10165
+Encoding: 10165 10165 3075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92525,8 +95605,9 @@ SplineSet
  225.84 698.438 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B6
-Encoding: 10166 10166 10166
+Encoding: 10166 10166 3076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92554,8 +95635,9 @@ SplineSet
  347.156 406.875 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B7
-Encoding: 10167 10167 10167
+Encoding: 10167 10167 3077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92592,8 +95674,9 @@ SplineSet
  1118.32 309.875 1118.32 309.875 1154.19 185.625 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B8
-Encoding: 10168 10168 10168
+Encoding: 10168 10168 3078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92628,8 +95711,9 @@ SplineSet
  1050.23 692.328 1050.23 692.328 1190.34 615 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B9
-Encoding: 10169 10169 10169
+Encoding: 10169 10169 3079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92666,8 +95750,9 @@ SplineSet
  999.593 1140.88 999.593 1140.88 1115.78 1175 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27BA
-Encoding: 10170 10170 10170
+Encoding: 10170 10170 3080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92714,8 +95799,9 @@ SplineSet
  906.375 725.75 906.375 725.75 770.625 785.75 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27BB
-Encoding: 10171 10171 10171
+Encoding: 10171 10171 3081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92749,8 +95835,9 @@ SplineSet
  889.5 623.312 889.5 623.312 919.562 655 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni27BC
-Encoding: 10172 10172 10172
+Encoding: 10172 10172 3082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92823,8 +95910,9 @@ SplineSet
  1195 697.312 1195 697.312 1195 690 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BD
-Encoding: 10173 10173 10173
+Encoding: 10173 10173 3083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92897,8 +95985,9 @@ SplineSet
  1195 690.312 1195 690.312 1195 683 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BE
-Encoding: 10174 10174 10174
+Encoding: 10174 10174 3084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92937,8 +96026,9 @@ SplineSet
  653.89 945.203 l 17,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni27BF
-Encoding: 10175 10175 10175
+Encoding: 10175 10175 3085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92956,16 +96046,18 @@ SplineSet
  1149.35 650 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27C2
-Encoding: 10178 10178 10178
+Encoding: 10178 10178 3086
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8869 8869 N 1 0 0 1 0 0 2
+Refer: 2366 8869 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni27C5
-Encoding: 10181 10181 10181
+Encoding: 10181 10181 3087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92990,8 +96082,9 @@ SplineSet
  977 -334 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27C6
-Encoding: 10182 10182 10182
+Encoding: 10182 10182 3088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93016,8 +96109,9 @@ SplineSet
  265 -334 265 -334 256 -334 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27DC
-Encoding: 10204 10204 10204
+Encoding: 10204 10204 3089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93046,8 +96140,9 @@ SplineSet
  554 811 554 811 574 765 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E0
-Encoding: 10208 10208 10208
+Encoding: 10208 10208 3090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93068,8 +96163,9 @@ SplineSet
  616 -233 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E6
-Encoding: 10214 10214 10214
+Encoding: 10214 10214 3091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93091,8 +96187,9 @@ SplineSet
  297 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E7
-Encoding: 10215 10215 10215
+Encoding: 10215 10215 3092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93114,8 +96211,9 @@ SplineSet
  936 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E8
-Encoding: 10216 10216 10216
+Encoding: 10216 10216 3093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93130,8 +96228,9 @@ SplineSet
  337.983 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E9
-Encoding: 10217 10217 10217
+Encoding: 10217 10217 3094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93146,26 +96245,29 @@ SplineSet
  895.017 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27EA
-Encoding: 10218 10218 10218
+Encoding: 10218 10218 3095
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10216 10216 N 1 0 0 1 250 0 2
-Refer: 10216 10216 N 1 0 0 1 -250 0 2
+Refer: 3093 10216 N 1 0 0 1 250 0 2
+Refer: 3093 10216 N 1 0 0 1 -250 0 2
 EndChar
+
 StartChar: uni27EB
-Encoding: 10219 10219 10219
+Encoding: 10219 10219 3096
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10217 10217 N 1 0 0 1 250 0 2
-Refer: 10217 10217 N 1 0 0 1 -250 0 2
+Refer: 3094 10217 N 1 0 0 1 250 0 2
+Refer: 3094 10217 N 1 0 0 1 -250 0 2
 EndChar
+
 StartChar: uni27F5
-Encoding: 10229 10229 10229
+Encoding: 10229 10229 3097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93184,8 +96286,9 @@ SplineSet
  -100 632 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F6
-Encoding: 10230 10230 10230
+Encoding: 10230 10230 3098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93204,8 +96307,9 @@ SplineSet
  1333 490 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F7
-Encoding: 10231 10231 10231
+Encoding: 10231 10231 3099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93230,1544 +96334,1801 @@ SplineSet
  -100 632 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2800
-Encoding: 10240 10240 10240
+Encoding: 10240 10240 3100
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2801
-Encoding: 10241 10241 10241
+Encoding: 10241 10241 3101
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2802
-Encoding: 10242 10242 10242
+Encoding: 10242 10242 3102
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2803
-Encoding: 10243 10243 10243
+Encoding: 10243 10243 3103
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2804
-Encoding: 10244 10244 10244
+Encoding: 10244 10244 3104
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2805
-Encoding: 10245 10245 10245
+Encoding: 10245 10245 3105
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2806
-Encoding: 10246 10246 10246
+Encoding: 10246 10246 3106
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2807
-Encoding: 10247 10247 10247
+Encoding: 10247 10247 3107
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2808
-Encoding: 10248 10248 10248
+Encoding: 10248 10248 3108
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2809
-Encoding: 10249 10249 10249
+Encoding: 10249 10249 3109
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280A
-Encoding: 10250 10250 10250
+Encoding: 10250 10250 3110
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280B
-Encoding: 10251 10251 10251
+Encoding: 10251 10251 3111
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280C
-Encoding: 10252 10252 10252
+Encoding: 10252 10252 3112
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280D
-Encoding: 10253 10253 10253
+Encoding: 10253 10253 3113
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280E
-Encoding: 10254 10254 10254
+Encoding: 10254 10254 3114
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280F
-Encoding: 10255 10255 10255
+Encoding: 10255 10255 3115
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2810
-Encoding: 10256 10256 10256
+Encoding: 10256 10256 3116
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2811
-Encoding: 10257 10257 10257
+Encoding: 10257 10257 3117
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2812
-Encoding: 10258 10258 10258
+Encoding: 10258 10258 3118
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2813
-Encoding: 10259 10259 10259
+Encoding: 10259 10259 3119
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2814
-Encoding: 10260 10260 10260
+Encoding: 10260 10260 3120
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2815
-Encoding: 10261 10261 10261
+Encoding: 10261 10261 3121
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2816
-Encoding: 10262 10262 10262
+Encoding: 10262 10262 3122
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2817
-Encoding: 10263 10263 10263
+Encoding: 10263 10263 3123
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2818
-Encoding: 10264 10264 10264
+Encoding: 10264 10264 3124
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2819
-Encoding: 10265 10265 10265
+Encoding: 10265 10265 3125
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281A
-Encoding: 10266 10266 10266
+Encoding: 10266 10266 3126
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281B
-Encoding: 10267 10267 10267
+Encoding: 10267 10267 3127
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281C
-Encoding: 10268 10268 10268
+Encoding: 10268 10268 3128
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281D
-Encoding: 10269 10269 10269
+Encoding: 10269 10269 3129
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281E
-Encoding: 10270 10270 10270
+Encoding: 10270 10270 3130
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281F
-Encoding: 10271 10271 10271
+Encoding: 10271 10271 3131
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2820
-Encoding: 10272 10272 10272
+Encoding: 10272 10272 3132
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2821
-Encoding: 10273 10273 10273
+Encoding: 10273 10273 3133
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2822
-Encoding: 10274 10274 10274
+Encoding: 10274 10274 3134
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2823
-Encoding: 10275 10275 10275
+Encoding: 10275 10275 3135
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2824
-Encoding: 10276 10276 10276
+Encoding: 10276 10276 3136
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2825
-Encoding: 10277 10277 10277
+Encoding: 10277 10277 3137
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2826
-Encoding: 10278 10278 10278
+Encoding: 10278 10278 3138
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2827
-Encoding: 10279 10279 10279
+Encoding: 10279 10279 3139
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2828
-Encoding: 10280 10280 10280
+Encoding: 10280 10280 3140
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2829
-Encoding: 10281 10281 10281
+Encoding: 10281 10281 3141
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282A
-Encoding: 10282 10282 10282
+Encoding: 10282 10282 3142
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282B
-Encoding: 10283 10283 10283
+Encoding: 10283 10283 3143
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282C
-Encoding: 10284 10284 10284
+Encoding: 10284 10284 3144
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282D
-Encoding: 10285 10285 10285
+Encoding: 10285 10285 3145
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282E
-Encoding: 10286 10286 10286
+Encoding: 10286 10286 3146
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282F
-Encoding: 10287 10287 10287
+Encoding: 10287 10287 3147
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2830
-Encoding: 10288 10288 10288
+Encoding: 10288 10288 3148
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2831
-Encoding: 10289 10289 10289
+Encoding: 10289 10289 3149
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2832
-Encoding: 10290 10290 10290
+Encoding: 10290 10290 3150
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2833
-Encoding: 10291 10291 10291
+Encoding: 10291 10291 3151
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2834
-Encoding: 10292 10292 10292
+Encoding: 10292 10292 3152
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2835
-Encoding: 10293 10293 10293
+Encoding: 10293 10293 3153
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2836
-Encoding: 10294 10294 10294
+Encoding: 10294 10294 3154
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2837
-Encoding: 10295 10295 10295
+Encoding: 10295 10295 3155
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2838
-Encoding: 10296 10296 10296
+Encoding: 10296 10296 3156
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2839
-Encoding: 10297 10297 10297
+Encoding: 10297 10297 3157
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283A
-Encoding: 10298 10298 10298
+Encoding: 10298 10298 3158
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283B
-Encoding: 10299 10299 10299
+Encoding: 10299 10299 3159
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283C
-Encoding: 10300 10300 10300
+Encoding: 10300 10300 3160
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283D
-Encoding: 10301 10301 10301
+Encoding: 10301 10301 3161
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283E
-Encoding: 10302 10302 10302
+Encoding: 10302 10302 3162
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283F
-Encoding: 10303 10303 10303
+Encoding: 10303 10303 3163
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2840
-Encoding: 10304 10304 10304
+Encoding: 10304 10304 3164
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2841
-Encoding: 10305 10305 10305
+Encoding: 10305 10305 3165
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2842
-Encoding: 10306 10306 10306
+Encoding: 10306 10306 3166
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2843
-Encoding: 10307 10307 10307
+Encoding: 10307 10307 3167
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2844
-Encoding: 10308 10308 10308
+Encoding: 10308 10308 3168
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2845
-Encoding: 10309 10309 10309
+Encoding: 10309 10309 3169
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2846
-Encoding: 10310 10310 10310
+Encoding: 10310 10310 3170
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2847
-Encoding: 10311 10311 10311
+Encoding: 10311 10311 3171
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2848
-Encoding: 10312 10312 10312
+Encoding: 10312 10312 3172
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2849
-Encoding: 10313 10313 10313
+Encoding: 10313 10313 3173
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284A
-Encoding: 10314 10314 10314
+Encoding: 10314 10314 3174
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284B
-Encoding: 10315 10315 10315
+Encoding: 10315 10315 3175
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284C
-Encoding: 10316 10316 10316
+Encoding: 10316 10316 3176
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284D
-Encoding: 10317 10317 10317
+Encoding: 10317 10317 3177
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284E
-Encoding: 10318 10318 10318
+Encoding: 10318 10318 3178
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284F
-Encoding: 10319 10319 10319
+Encoding: 10319 10319 3179
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2850
-Encoding: 10320 10320 10320
+Encoding: 10320 10320 3180
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2851
-Encoding: 10321 10321 10321
+Encoding: 10321 10321 3181
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2852
-Encoding: 10322 10322 10322
+Encoding: 10322 10322 3182
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2853
-Encoding: 10323 10323 10323
+Encoding: 10323 10323 3183
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2854
-Encoding: 10324 10324 10324
+Encoding: 10324 10324 3184
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2855
-Encoding: 10325 10325 10325
+Encoding: 10325 10325 3185
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2856
-Encoding: 10326 10326 10326
+Encoding: 10326 10326 3186
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2857
-Encoding: 10327 10327 10327
+Encoding: 10327 10327 3187
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2858
-Encoding: 10328 10328 10328
+Encoding: 10328 10328 3188
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2859
-Encoding: 10329 10329 10329
+Encoding: 10329 10329 3189
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285A
-Encoding: 10330 10330 10330
+Encoding: 10330 10330 3190
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285B
-Encoding: 10331 10331 10331
+Encoding: 10331 10331 3191
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285C
-Encoding: 10332 10332 10332
+Encoding: 10332 10332 3192
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285D
-Encoding: 10333 10333 10333
+Encoding: 10333 10333 3193
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285E
-Encoding: 10334 10334 10334
+Encoding: 10334 10334 3194
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285F
-Encoding: 10335 10335 10335
+Encoding: 10335 10335 3195
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2860
-Encoding: 10336 10336 10336
+Encoding: 10336 10336 3196
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2861
-Encoding: 10337 10337 10337
+Encoding: 10337 10337 3197
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2862
-Encoding: 10338 10338 10338
+Encoding: 10338 10338 3198
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2863
-Encoding: 10339 10339 10339
+Encoding: 10339 10339 3199
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2864
-Encoding: 10340 10340 10340
+Encoding: 10340 10340 3200
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2865
-Encoding: 10341 10341 10341
+Encoding: 10341 10341 3201
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2866
-Encoding: 10342 10342 10342
+Encoding: 10342 10342 3202
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2867
-Encoding: 10343 10343 10343
+Encoding: 10343 10343 3203
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2868
-Encoding: 10344 10344 10344
+Encoding: 10344 10344 3204
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2869
-Encoding: 10345 10345 10345
+Encoding: 10345 10345 3205
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286A
-Encoding: 10346 10346 10346
+Encoding: 10346 10346 3206
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286B
-Encoding: 10347 10347 10347
+Encoding: 10347 10347 3207
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286C
-Encoding: 10348 10348 10348
+Encoding: 10348 10348 3208
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286D
-Encoding: 10349 10349 10349
+Encoding: 10349 10349 3209
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286E
-Encoding: 10350 10350 10350
+Encoding: 10350 10350 3210
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286F
-Encoding: 10351 10351 10351
+Encoding: 10351 10351 3211
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2870
-Encoding: 10352 10352 10352
+Encoding: 10352 10352 3212
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2871
-Encoding: 10353 10353 10353
+Encoding: 10353 10353 3213
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2872
-Encoding: 10354 10354 10354
+Encoding: 10354 10354 3214
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2873
-Encoding: 10355 10355 10355
+Encoding: 10355 10355 3215
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2874
-Encoding: 10356 10356 10356
+Encoding: 10356 10356 3216
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2875
-Encoding: 10357 10357 10357
+Encoding: 10357 10357 3217
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2876
-Encoding: 10358 10358 10358
+Encoding: 10358 10358 3218
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2877
-Encoding: 10359 10359 10359
+Encoding: 10359 10359 3219
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2878
-Encoding: 10360 10360 10360
+Encoding: 10360 10360 3220
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2879
-Encoding: 10361 10361 10361
+Encoding: 10361 10361 3221
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287A
-Encoding: 10362 10362 10362
+Encoding: 10362 10362 3222
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287B
-Encoding: 10363 10363 10363
+Encoding: 10363 10363 3223
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287C
-Encoding: 10364 10364 10364
+Encoding: 10364 10364 3224
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287D
-Encoding: 10365 10365 10365
+Encoding: 10365 10365 3225
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287E
-Encoding: 10366 10366 10366
+Encoding: 10366 10366 3226
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287F
-Encoding: 10367 10367 10367
+Encoding: 10367 10367 3227
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2880
-Encoding: 10368 10368 10368
+Encoding: 10368 10368 3228
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2881
-Encoding: 10369 10369 10369
+Encoding: 10369 10369 3229
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2882
-Encoding: 10370 10370 10370
+Encoding: 10370 10370 3230
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2883
-Encoding: 10371 10371 10371
+Encoding: 10371 10371 3231
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2884
-Encoding: 10372 10372 10372
+Encoding: 10372 10372 3232
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2885
-Encoding: 10373 10373 10373
+Encoding: 10373 10373 3233
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2886
-Encoding: 10374 10374 10374
+Encoding: 10374 10374 3234
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2887
-Encoding: 10375 10375 10375
+Encoding: 10375 10375 3235
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2888
-Encoding: 10376 10376 10376
+Encoding: 10376 10376 3236
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2889
-Encoding: 10377 10377 10377
+Encoding: 10377 10377 3237
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288A
-Encoding: 10378 10378 10378
+Encoding: 10378 10378 3238
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288B
-Encoding: 10379 10379 10379
+Encoding: 10379 10379 3239
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288C
-Encoding: 10380 10380 10380
+Encoding: 10380 10380 3240
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288D
-Encoding: 10381 10381 10381
+Encoding: 10381 10381 3241
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288E
-Encoding: 10382 10382 10382
+Encoding: 10382 10382 3242
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288F
-Encoding: 10383 10383 10383
+Encoding: 10383 10383 3243
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2890
-Encoding: 10384 10384 10384
+Encoding: 10384 10384 3244
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2891
-Encoding: 10385 10385 10385
+Encoding: 10385 10385 3245
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2892
-Encoding: 10386 10386 10386
+Encoding: 10386 10386 3246
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2893
-Encoding: 10387 10387 10387
+Encoding: 10387 10387 3247
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2894
-Encoding: 10388 10388 10388
+Encoding: 10388 10388 3248
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2895
-Encoding: 10389 10389 10389
+Encoding: 10389 10389 3249
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2896
-Encoding: 10390 10390 10390
+Encoding: 10390 10390 3250
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2897
-Encoding: 10391 10391 10391
+Encoding: 10391 10391 3251
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2898
-Encoding: 10392 10392 10392
+Encoding: 10392 10392 3252
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2899
-Encoding: 10393 10393 10393
+Encoding: 10393 10393 3253
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289A
-Encoding: 10394 10394 10394
+Encoding: 10394 10394 3254
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289B
-Encoding: 10395 10395 10395
+Encoding: 10395 10395 3255
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289C
-Encoding: 10396 10396 10396
+Encoding: 10396 10396 3256
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289D
-Encoding: 10397 10397 10397
+Encoding: 10397 10397 3257
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289E
-Encoding: 10398 10398 10398
+Encoding: 10398 10398 3258
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289F
-Encoding: 10399 10399 10399
+Encoding: 10399 10399 3259
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A0
-Encoding: 10400 10400 10400
+Encoding: 10400 10400 3260
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A1
-Encoding: 10401 10401 10401
+Encoding: 10401 10401 3261
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A2
-Encoding: 10402 10402 10402
+Encoding: 10402 10402 3262
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A3
-Encoding: 10403 10403 10403
+Encoding: 10403 10403 3263
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A4
-Encoding: 10404 10404 10404
+Encoding: 10404 10404 3264
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A5
-Encoding: 10405 10405 10405
+Encoding: 10405 10405 3265
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A6
-Encoding: 10406 10406 10406
+Encoding: 10406 10406 3266
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A7
-Encoding: 10407 10407 10407
+Encoding: 10407 10407 3267
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A8
-Encoding: 10408 10408 10408
+Encoding: 10408 10408 3268
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A9
-Encoding: 10409 10409 10409
+Encoding: 10409 10409 3269
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AA
-Encoding: 10410 10410 10410
+Encoding: 10410 10410 3270
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AB
-Encoding: 10411 10411 10411
+Encoding: 10411 10411 3271
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AC
-Encoding: 10412 10412 10412
+Encoding: 10412 10412 3272
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AD
-Encoding: 10413 10413 10413
+Encoding: 10413 10413 3273
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AE
-Encoding: 10414 10414 10414
+Encoding: 10414 10414 3274
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AF
-Encoding: 10415 10415 10415
+Encoding: 10415 10415 3275
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B0
-Encoding: 10416 10416 10416
+Encoding: 10416 10416 3276
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B1
-Encoding: 10417 10417 10417
+Encoding: 10417 10417 3277
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B2
-Encoding: 10418 10418 10418
+Encoding: 10418 10418 3278
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B3
-Encoding: 10419 10419 10419
+Encoding: 10419 10419 3279
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B4
-Encoding: 10420 10420 10420
+Encoding: 10420 10420 3280
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B5
-Encoding: 10421 10421 10421
+Encoding: 10421 10421 3281
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B6
-Encoding: 10422 10422 10422
+Encoding: 10422 10422 3282
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B7
-Encoding: 10423 10423 10423
+Encoding: 10423 10423 3283
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B8
-Encoding: 10424 10424 10424
+Encoding: 10424 10424 3284
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B9
-Encoding: 10425 10425 10425
+Encoding: 10425 10425 3285
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BA
-Encoding: 10426 10426 10426
+Encoding: 10426 10426 3286
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BB
-Encoding: 10427 10427 10427
+Encoding: 10427 10427 3287
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BC
-Encoding: 10428 10428 10428
+Encoding: 10428 10428 3288
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BD
-Encoding: 10429 10429 10429
+Encoding: 10429 10429 3289
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BE
-Encoding: 10430 10430 10430
+Encoding: 10430 10430 3290
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BF
-Encoding: 10431 10431 10431
+Encoding: 10431 10431 3291
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C0
-Encoding: 10432 10432 10432
+Encoding: 10432 10432 3292
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C1
-Encoding: 10433 10433 10433
+Encoding: 10433 10433 3293
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C2
-Encoding: 10434 10434 10434
+Encoding: 10434 10434 3294
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C3
-Encoding: 10435 10435 10435
+Encoding: 10435 10435 3295
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C4
-Encoding: 10436 10436 10436
+Encoding: 10436 10436 3296
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C5
-Encoding: 10437 10437 10437
+Encoding: 10437 10437 3297
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C6
-Encoding: 10438 10438 10438
+Encoding: 10438 10438 3298
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C7
-Encoding: 10439 10439 10439
+Encoding: 10439 10439 3299
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C8
-Encoding: 10440 10440 10440
+Encoding: 10440 10440 3300
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C9
-Encoding: 10441 10441 10441
+Encoding: 10441 10441 3301
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CA
-Encoding: 10442 10442 10442
+Encoding: 10442 10442 3302
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CB
-Encoding: 10443 10443 10443
+Encoding: 10443 10443 3303
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CC
-Encoding: 10444 10444 10444
+Encoding: 10444 10444 3304
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CD
-Encoding: 10445 10445 10445
+Encoding: 10445 10445 3305
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CE
-Encoding: 10446 10446 10446
+Encoding: 10446 10446 3306
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CF
-Encoding: 10447 10447 10447
+Encoding: 10447 10447 3307
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D0
-Encoding: 10448 10448 10448
+Encoding: 10448 10448 3308
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D1
-Encoding: 10449 10449 10449
+Encoding: 10449 10449 3309
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D2
-Encoding: 10450 10450 10450
+Encoding: 10450 10450 3310
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D3
-Encoding: 10451 10451 10451
+Encoding: 10451 10451 3311
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D4
-Encoding: 10452 10452 10452
+Encoding: 10452 10452 3312
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D5
-Encoding: 10453 10453 10453
+Encoding: 10453 10453 3313
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D6
-Encoding: 10454 10454 10454
+Encoding: 10454 10454 3314
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D7
-Encoding: 10455 10455 10455
+Encoding: 10455 10455 3315
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D8
-Encoding: 10456 10456 10456
+Encoding: 10456 10456 3316
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D9
-Encoding: 10457 10457 10457
+Encoding: 10457 10457 3317
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DA
-Encoding: 10458 10458 10458
+Encoding: 10458 10458 3318
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DB
-Encoding: 10459 10459 10459
+Encoding: 10459 10459 3319
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DC
-Encoding: 10460 10460 10460
+Encoding: 10460 10460 3320
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DD
-Encoding: 10461 10461 10461
+Encoding: 10461 10461 3321
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DE
-Encoding: 10462 10462 10462
+Encoding: 10462 10462 3322
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DF
-Encoding: 10463 10463 10463
+Encoding: 10463 10463 3323
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E0
-Encoding: 10464 10464 10464
+Encoding: 10464 10464 3324
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E1
-Encoding: 10465 10465 10465
+Encoding: 10465 10465 3325
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E2
-Encoding: 10466 10466 10466
+Encoding: 10466 10466 3326
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E3
-Encoding: 10467 10467 10467
+Encoding: 10467 10467 3327
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E4
-Encoding: 10468 10468 10468
+Encoding: 10468 10468 3328
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E5
-Encoding: 10469 10469 10469
+Encoding: 10469 10469 3329
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E6
-Encoding: 10470 10470 10470
+Encoding: 10470 10470 3330
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E7
-Encoding: 10471 10471 10471
+Encoding: 10471 10471 3331
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E8
-Encoding: 10472 10472 10472
+Encoding: 10472 10472 3332
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E9
-Encoding: 10473 10473 10473
+Encoding: 10473 10473 3333
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EA
-Encoding: 10474 10474 10474
+Encoding: 10474 10474 3334
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EB
-Encoding: 10475 10475 10475
+Encoding: 10475 10475 3335
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EC
-Encoding: 10476 10476 10476
+Encoding: 10476 10476 3336
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28ED
-Encoding: 10477 10477 10477
+Encoding: 10477 10477 3337
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EE
-Encoding: 10478 10478 10478
+Encoding: 10478 10478 3338
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EF
-Encoding: 10479 10479 10479
+Encoding: 10479 10479 3339
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F0
-Encoding: 10480 10480 10480
+Encoding: 10480 10480 3340
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F1
-Encoding: 10481 10481 10481
+Encoding: 10481 10481 3341
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F2
-Encoding: 10482 10482 10482
+Encoding: 10482 10482 3342
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F3
-Encoding: 10483 10483 10483
+Encoding: 10483 10483 3343
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F4
-Encoding: 10484 10484 10484
+Encoding: 10484 10484 3344
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F5
-Encoding: 10485 10485 10485
+Encoding: 10485 10485 3345
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F6
-Encoding: 10486 10486 10486
+Encoding: 10486 10486 3346
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F7
-Encoding: 10487 10487 10487
+Encoding: 10487 10487 3347
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F8
-Encoding: 10488 10488 10488
+Encoding: 10488 10488 3348
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F9
-Encoding: 10489 10489 10489
+Encoding: 10489 10489 3349
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FA
-Encoding: 10490 10490 10490
+Encoding: 10490 10490 3350
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FB
-Encoding: 10491 10491 10491
+Encoding: 10491 10491 3351
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FC
-Encoding: 10492 10492 10492
+Encoding: 10492 10492 3352
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FD
-Encoding: 10493 10493 10493
+Encoding: 10493 10493 3353
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FE
-Encoding: 10494 10494 10494
+Encoding: 10494 10494 3354
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FF
-Encoding: 10495 10495 10495
+Encoding: 10495 10495 3355
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2987
-Encoding: 10631 10631 10631
+Encoding: 10631 10631 3356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94787,8 +98148,9 @@ SplineSet
  858 1373 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2988
-Encoding: 10632 10632 10632
+Encoding: 10632 10632 3357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94808,8 +98170,9 @@ SplineSet
  375 -89 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2997
-Encoding: 10647 10647 10647
+Encoding: 10647 10647 3358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94826,8 +98189,9 @@ SplineSet
  882 -322 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2998
-Encoding: 10648 10648 10648
+Encoding: 10648 10648 3359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94844,8 +98208,9 @@ SplineSet
  351 1608 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29EB
-Encoding: 10731 10731 10731
+Encoding: 10731 10731 3360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94858,8 +98223,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FA
-Encoding: 10746 10746 10746
+Encoding: 10746 10746 3361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94888,8 +98254,9 @@ SplineSet
  748 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FB
-Encoding: 10747 10747 10747
+Encoding: 10747 10747 3362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94926,8 +98293,9 @@ SplineSet
  148 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2A00
-Encoding: 10752 10752 10752
+Encoding: 10752 10752 3363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94950,35 +98318,39 @@ SplineSet
  80 1547 80 1547 616 1547 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2A2F
-Encoding: 10799 10799 10799
+Encoding: 10799 10799 3364
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 215 215 N 1 0 0 1 0 0 2
+Refer: 151 215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6A
-Encoding: 10858 10858 10858
+Encoding: 10858 10858 3365
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 2 382 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 382 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6B
-Encoding: 10859 10859 10859
+Encoding: 10859 10859 3366
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -239 -530 2
-Refer: 8901 8901 N 1 0 0 1 242 382 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -239 -530 2
+Refer: 2375 8901 N 1 0 0 1 242 382 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2B05
-Encoding: 11013 11013 11013
+Encoding: 11013 11013 3367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94994,8 +98366,9 @@ SplineSet
  395 842 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B06
-Encoding: 11014 11014 11014
+Encoding: 11014 11014 3368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95011,8 +98384,9 @@ SplineSet
  759 921 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B07
-Encoding: 11015 11015 11015
+Encoding: 11015 11015 3369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95028,8 +98402,9 @@ SplineSet
  474 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B08
-Encoding: 11016 11016 11016
+Encoding: 11016 11016 3370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95045,8 +98420,9 @@ SplineSet
  874 756 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B09
-Encoding: 11017 11017 11017
+Encoding: 11017 11017 3371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95062,8 +98438,9 @@ SplineSet
  560 957 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0A
-Encoding: 11018 11018 11018
+Encoding: 11018 11018 3372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95079,8 +98456,9 @@ SplineSet
  773 342 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0B
-Encoding: 11019 11019 11019
+Encoding: 11019 11019 3373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95096,8 +98474,9 @@ SplineSet
  259 543 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0C
-Encoding: 11020 11020 11020
+Encoding: 11020 11020 3374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95116,8 +98495,9 @@ SplineSet
  395 842 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0D
-Encoding: 11021 11021 11021
+Encoding: 11021 11021 3375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95136,8 +98516,9 @@ SplineSet
  474 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B12
-Encoding: 11026 11026 11026
+Encoding: 11026 11026 3376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95155,8 +98536,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B13
-Encoding: 11027 11027 11027
+Encoding: 11027 11027 3377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95174,8 +98556,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B14
-Encoding: 11028 11028 11028
+Encoding: 11028 11028 3378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95192,8 +98575,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B15
-Encoding: 11029 11029 11029
+Encoding: 11029 11029 3379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95210,8 +98594,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B16
-Encoding: 11030 11030 11030
+Encoding: 11030 11030 3380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95228,8 +98613,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B17
-Encoding: 11031 11031 11031
+Encoding: 11031 11031 3381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95246,8 +98632,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B18
-Encoding: 11032 11032 11032
+Encoding: 11032 11032 3382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95264,8 +98651,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B19
-Encoding: 11033 11033 11033
+Encoding: 11033 11033 3383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95282,8 +98670,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B1A
-Encoding: 11034 11034 11034
+Encoding: 11034 11034 3384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95359,8 +98748,9 @@ SplineSet
  206 1142.5 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C64
-Encoding: 11364 11364 11364
+Encoding: 11364 11364 3385
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 -436 basechar 0
@@ -95401,8 +98791,9 @@ SplineSet
  428 1245 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6D
-Encoding: 11373 11373 11373
+Encoding: 11373 11373 3386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95433,8 +98824,9 @@ SplineSet
  403 984 403 984 403 746 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C6E
-Encoding: 11374 11374 11374
+Encoding: 11374 11374 3387
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -95464,8 +98856,9 @@ SplineSet
  893 1196 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6F
-Encoding: 11375 11375 11375
+Encoding: 11375 11375 3388
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -95488,8 +98881,9 @@ SplineSet
  797 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C70
-Encoding: 11376 11376 11376
+Encoding: 11376 11376 3389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95520,8 +98914,9 @@ SplineSet
  843 507 843 507 843 745 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C75
-Encoding: 11381 11381 11381
+Encoding: 11381 11381 3390
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -95540,8 +98935,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C76
-Encoding: 11382 11382 11382
+Encoding: 11382 11382 3391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95558,8 +98954,9 @@ SplineSet
  1071 739 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C77
-Encoding: 11383 11383 11383
+Encoding: 11383 11383 3392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95587,8 +98984,9 @@ SplineSet
  854.87 867.855 854.87 867.855 817 864 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2C79
-Encoding: 11385 11385 11385
+Encoding: 11385 11385 3393
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -95621,8 +99019,9 @@ SplineSet
  1046 1340 1046 1340 1046 1088 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7A
-Encoding: 11386 11386 11386
+Encoding: 11386 11386 3394
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -95659,16 +99058,18 @@ SplineSet
  391 550 l 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C7C
-Encoding: 11388 11388 11388
+Encoding: 11388 11388 3395
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 690 690 N 1 0 0 1 0 -668 3
+Refer: 607 690 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2C7D
-Encoding: 11389 11389 11389
+Encoding: 11389 11389 3396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95684,8 +99085,9 @@ SplineSet
  616 806 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7E
-Encoding: 11390 11390 11390
+Encoding: 11390 11390 3397
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -95732,8 +99134,9 @@ SplineSet
  510 655 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7F
-Encoding: 11391 11391 11391
+Encoding: 11391 11391 3398
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 -426 basechar 0
@@ -95760,8 +99163,9 @@ SplineSet
  392 170 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18
-Encoding: 11800 11800 11800
+Encoding: 11800 11800 3399
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95799,17 +99203,19 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" uni2E18.case
 EndChar
+
 StartChar: uni2E1F
-Encoding: 11807 11807 11807
+Encoding: 11807 11807 3400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 -530 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 -530 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2E22
-Encoding: 11810 11810 11810
+Encoding: 11810 11810 3401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95824,8 +99230,9 @@ SplineSet
  422 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E23
-Encoding: 11811 11811 11811
+Encoding: 11811 11811 3402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95840,8 +99247,9 @@ SplineSet
  545 1366 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E24
-Encoding: 11812 11812 11812
+Encoding: 11812 11812 3403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95856,8 +99264,9 @@ SplineSet
  688 -80 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E25
-Encoding: 11813 11813 11813
+Encoding: 11813 11813 3404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95872,16 +99281,18 @@ SplineSet
  811 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E2E
-Encoding: 11822 11822 11822
+Encoding: 11822 11822 3405
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1567 1567 N 1 0 0 1 0 0 2
+Refer: 1167 1567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniA708
-Encoding: 42760 42760 42760
+Encoding: 42760 42760 3406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95899,8 +99310,9 @@ SplineSet
  771 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA709
-Encoding: 42761 42761 42761
+Encoding: 42761 42761 3407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95918,8 +99330,9 @@ SplineSet
  771 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70A
-Encoding: 42762 42762 42762
+Encoding: 42762 42762 3408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95937,8 +99350,9 @@ SplineSet
  771 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70B
-Encoding: 42763 42763 42763
+Encoding: 42763 42763 3409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95956,8 +99370,9 @@ SplineSet
  771 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70C
-Encoding: 42764 42764 42764
+Encoding: 42764 42764 3410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95975,8 +99390,9 @@ SplineSet
  771 1420 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70D
-Encoding: 42765 42765 42765
+Encoding: 42765 42765 3411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95994,8 +99410,9 @@ SplineSet
  462 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70E
-Encoding: 42766 42766 42766
+Encoding: 42766 42766 3412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96013,8 +99430,9 @@ SplineSet
  462 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70F
-Encoding: 42767 42767 42767
+Encoding: 42767 42767 3413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96032,8 +99450,9 @@ SplineSet
  462 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA710
-Encoding: 42768 42768 42768
+Encoding: 42768 42768 3414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96051,8 +99470,9 @@ SplineSet
  462 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA711
-Encoding: 42769 42769 42769
+Encoding: 42769 42769 3415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96070,8 +99490,9 @@ SplineSet
  462 1420 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA712
-Encoding: 42770 42770 42770
+Encoding: 42770 42770 3416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96086,8 +99507,9 @@ SplineSet
  274 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA713
-Encoding: 42771 42771 42771
+Encoding: 42771 42771 3417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96104,8 +99526,9 @@ SplineSet
  274 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA714
-Encoding: 42772 42772 42772
+Encoding: 42772 42772 3418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96122,8 +99545,9 @@ SplineSet
  274 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA715
-Encoding: 42773 42773 42773
+Encoding: 42773 42773 3419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96140,8 +99564,9 @@ SplineSet
  274 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA716
-Encoding: 42774 42774 42774
+Encoding: 42774 42774 3420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96156,8 +99581,9 @@ SplineSet
  274 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71B
-Encoding: 42779 42779 42779
+Encoding: 42779 42779 3421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96176,8 +99602,9 @@ SplineSet
  572 1508 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71C
-Encoding: 42780 42780 42780
+Encoding: 42780 42780 3422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96196,8 +99623,9 @@ SplineSet
  661 664 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71D
-Encoding: 42781 42781 42781
+Encoding: 42781 42781 3423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96217,8 +99645,9 @@ SplineSet
  502 867 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71E
-Encoding: 42782 42782 42782
+Encoding: 42782 42782 3424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96238,16 +99667,18 @@ SplineSet
  502 1305 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71F
-Encoding: 42783 42783 42783
+Encoding: 42783 42783 3425
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42782 42782 N 1 0 0 1 0 -668 2
+Refer: 3424 42782 N 1 0 0 1 0 -668 2
 EndChar
+
 StartChar: uniA722
-Encoding: 42786 42786 42786
+Encoding: 42786 42786 3426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96267,8 +99698,9 @@ SplineSet
  1017 0 1017 0 327 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA723
-Encoding: 42787 42787 42787
+Encoding: 42787 42787 3427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96288,8 +99720,9 @@ SplineSet
  967 0 967 0 377 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA724
-Encoding: 42788 42788 42788
+Encoding: 42788 42788 3428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96304,8 +99737,9 @@ SplineSet
  501 1190 501 1190 501 976 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA725
-Encoding: 42789 42789 42789
+Encoding: 42789 42789 3429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96320,8 +99754,9 @@ SplineSet
  493 857 493 857 493 606 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA726
-Encoding: 42790 42790 42790
+Encoding: 42790 42790 3430
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -96350,8 +99785,9 @@ SplineSet
  1096 58 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA727
-Encoding: 42791 42791 42791
+Encoding: 42791 42791 3431
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -96384,16 +99820,18 @@ SplineSet
  780 682 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA789
-Encoding: 42889 42889 42889
+Encoding: 42889 42889 3432
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 3
+Refer: 27 58 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78A
-Encoding: 42890 42890 42890
+Encoding: 42890 42890 3433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96411,8 +99849,9 @@ SplineSet
  842 649 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78B
-Encoding: 42891 42891 42891
+Encoding: 42891 42891 3434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96427,8 +99866,9 @@ SplineSet
  483 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78C
-Encoding: 42892 42892 42892
+Encoding: 42892 42892 3435
 Width: 1233
 Flags: W
 TtInstrs:
@@ -96460,16 +99900,18 @@ SplineSet
  743 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78D
-Encoding: 42893 42893 42893
+Encoding: 42893 42893 3436
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1063 1063 N 1 0 0 1 0 0 3
+Refer: 877 1063 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78E
-Encoding: 42894 42894 42894
+Encoding: 42894 42894 3437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96505,8 +99947,9 @@ SplineSet
  711 579.043 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA790
-Encoding: 42896 42896 42896
+Encoding: 42896 42896 3438
 Width: 1233
 Flags: W
 AnchorPoint: "below" 577 0 basechar 0
@@ -96531,8 +99974,9 @@ SplineSet
  80 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA791
-Encoding: 42897 42897 42897
+Encoding: 42897 42897 3439
 Width: 1233
 Flags: W
 AnchorPoint: "above" 541 1120 basechar 0
@@ -96563,8 +100007,9 @@ SplineSet
  996 936 996 936 996 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7AA
-Encoding: 42922 42922 42922
+Encoding: 42922 42922 3440
 Width: 1233
 Flags: W
 AnchorPoint: "above" 788 1493 basechar 0
@@ -96594,8 +100039,9 @@ SplineSet
  168.008 1496.9 168.008 1496.9 396 1495 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F8
-Encoding: 43000 43000 43000
+Encoding: 43000 43000 3441
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1504 basechar 0
@@ -96631,8 +100077,9 @@ SplineSet
  500 1287 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F9
-Encoding: 43001 43001 43001
+Encoding: 43001 43001 3442
 Width: 1233
 Flags: W
 AnchorPoint: "above" 619 1295 basechar 0
@@ -96677,8 +100124,9 @@ SplineSet
  443 1177 443 1177 376 1177 c 0,35,36
 EndSplineSet
 EndChar
+
 StartChar: uniF6C5
-Encoding: 63173 63173 63173
+Encoding: 63173 63173 3443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96715,8 +100163,9 @@ SplineSet
  722 909 722 909 616 909 c 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: fi
-Encoding: 64257 64257 64257
+Encoding: 64257 64257 3444
 Width: 1233
 Flags: W
 TtInstrs:
@@ -96822,11 +100271,12 @@ SplineSet
  542 1331 542 1331 518.5 1307 c 128,-1,25
  495 1283 495 1283 494 1219 c 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 9" f i
 EndChar
+
 StartChar: fl
-Encoding: 64258 64258 64258
+Encoding: 64258 64258 3445
 Width: 1233
 Flags: W
 TtInstrs:
@@ -96919,374 +100369,408 @@ SplineSet
  542 1331 542 1331 518.5 1307 c 128,-1,21
  495 1283 495 1283 494 1219 c 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 9" f l
 EndChar
+
 StartChar: uniFB52
-Encoding: 64338 64338 64338
+Encoding: 64338 64338 3446
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 621.5 -748 basechar 0
 AnchorPoint: "rtl-above" 617.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 498.5 -342 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 498.5 -342 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB53
-Encoding: 64339 64339 64339
+Encoding: 64339 64339 3447
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 566.5 -748 basechar 0
 AnchorPoint: "rtl-above" 582.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 451.5 -342 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 451.5 -342 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB54
-Encoding: 64340 64340 64340
+Encoding: 64340 64340 3448
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 591 -742 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 472 -314 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 472 -314 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB55
-Encoding: 64341 64341 64341
+Encoding: 64341 64341 3449
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 575 -714 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 484 -286 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 484 -286 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB56
-Encoding: 64342 64342 64342
+Encoding: 64342 64342 3450
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 629 -768 basechar 0
 AnchorPoint: "rtl-above" 645 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 353 -342 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 353 -342 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB57
-Encoding: 64343 64343 64343
+Encoding: 64343 64343 3451
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -756 basechar 0
 AnchorPoint: "rtl-above" 576 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 324 -342 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 324 -342 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB58
-Encoding: 64344 64344 64344
+Encoding: 64344 64344 3452
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -738 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 320 -310 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 320 -310 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB59
-Encoding: 64345 64345 64345
+Encoding: 64345 64345 3453
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 589 -722 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 312 -310 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 312 -310 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5A
-Encoding: 64346 64346 64346
+Encoding: 64346 64346 3454
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -808 basechar 0
 AnchorPoint: "rtl-above" 603 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 339 -370 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 339 -370 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5B
-Encoding: 64347 64347 64347
+Encoding: 64347 64347 3455
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 570 -752 basechar 0
 AnchorPoint: "rtl-above" 570 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 302 -322 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 302 -322 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5C
-Encoding: 64348 64348 64348
+Encoding: 64348 64348 3456
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 558 -738 basechar 0
 AnchorPoint: "rtl-above" 578 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 286 -318 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 286 -318 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5D
-Encoding: 64349 64349 64349
+Encoding: 64349 64349 3457
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -762 basechar 0
 AnchorPoint: "rtl-above" 608 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 324 -322 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 324 -322 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5E
-Encoding: 64350 64350 64350
+Encoding: 64350 64350 3458
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 590 -150 basechar 0
 AnchorPoint: "rtl-above" 606 1240 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 491 951 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 491 951 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB5F
-Encoding: 64351 64351 64351
+Encoding: 64351 64351 3459
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 588 1244 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 501 933 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 501 933 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB60
-Encoding: 64352 64352 64352
+Encoding: 64352 64352 3460
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -101 basechar 0
 AnchorPoint: "rtl-above" 575 1379 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 500 1074 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 500 1074 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB61
-Encoding: 64353 64353 64353
+Encoding: 64353 64353 3461
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 602 -100 basechar 0
 AnchorPoint: "rtl-above" 570 1424 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 495 1107 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 495 1107 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB62
-Encoding: 64354 64354 64354
+Encoding: 64354 64354 3462
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -150 basechar 0
 AnchorPoint: "rtl-above" 527 1349 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 327 1004 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 327 1004 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB63
-Encoding: 64355 64355 64355
+Encoding: 64355 64355 3463
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 585 -150 basechar 0
 AnchorPoint: "rtl-above" 533 1395 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 309 1012 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 309 1012 2
 EndChar
+
 StartChar: uniFB64
-Encoding: 64356 64356 64356
+Encoding: 64356 64356 3464
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -100 basechar 0
 AnchorPoint: "rtl-above" 603 1476 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 315 1115 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 315 1115 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB65
-Encoding: 64357 64357 64357
+Encoding: 64357 64357 3465
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -100 basechar 0
 AnchorPoint: "rtl-above" 596 1496 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 320 1150 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 320 1150 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB66
-Encoding: 64358 64358 64358
+Encoding: 64358 64358 3466
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 536 1398 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 36 -590 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 36 -590 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB67
-Encoding: 64359 64359 64359
+Encoding: 64359 64359 3467
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -150 basechar 0
 AnchorPoint: "rtl-above" 484 1422 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 32 -549 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 32 -549 2
 EndChar
+
 StartChar: uniFB68
-Encoding: 64360 64360 64360
+Encoding: 64360 64360 3468
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 587 -100 basechar 0
 AnchorPoint: "rtl-above" 571 1482 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 7 -488 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 7 -488 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB69
-Encoding: 64361 64361 64361
+Encoding: 64361 64361 3469
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -100 basechar 0
 AnchorPoint: "rtl-above" 605 1494 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 17 -493 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 17 -493 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6A
-Encoding: 64362 64362 64362
+Encoding: 64362 64362 3470
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 -180 basechar 0
 AnchorPoint: "rtl-above" 308 1528 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 560 994 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 560 994 2
+Refer: 3708 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6B
-Encoding: 64363 64363 64363
+Encoding: 64363 64363 3471
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 404 -192 basechar 0
 AnchorPoint: "rtl-above" 312 1484 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 564 962 2
+Refer: 3692 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 564 962 2
 EndChar
+
 StartChar: uniFB6C
-Encoding: 64364 64364 64364
+Encoding: 64364 64364 3472
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 376 1836 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 200 1130 2
+Refer: 3689 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 200 1130 2
 EndChar
+
 StartChar: uniFB6D
-Encoding: 64365 64365 64365
+Encoding: 64365 64365 3473
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 598 -150 basechar 0
 AnchorPoint: "rtl-above" 526 1738 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 342 984 2
+Refer: 3690 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 342 984 2
 EndChar
+
 StartChar: uniFB6E
-Encoding: 64366 64366 64366
+Encoding: 64366 64366 3474
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -200 basechar 0
 AnchorPoint: "rtl-above" 288 1516 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 568 1360 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 568 1360 2
+Refer: 3708 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6F
-Encoding: 64367 64367 64367
+Encoding: 64367 64367 3475
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 392 -200 basechar 0
 AnchorPoint: "rtl-above" 264 1524 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 556 1320 2
+Refer: 3692 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 556 1320 2
 EndChar
+
 StartChar: uniFB70
-Encoding: 64368 64368 64368
+Encoding: 64368 64368 3476
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 444 1880 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 220 1460 2
+Refer: 3689 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 220 1460 2
 EndChar
+
 StartChar: uniFB71
-Encoding: 64369 64369 64369
+Encoding: 64369 64369 3477
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 610 -150 basechar 0
 AnchorPoint: "rtl-above" 550 1698 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 322 1314 2
+Refer: 3690 -1 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 322 1314 2
 EndChar
+
 StartChar: uniFB72
-Encoding: 64370 64370 64370
+Encoding: 64370 64370 3478
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -600 basechar 0
 AnchorPoint: "rtl-above" 466 1064 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 691 227 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 691 227 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB73
-Encoding: 64371 64371 64371
+Encoding: 64371 64371 3479
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -777 basechar 0
@@ -97334,41 +100818,45 @@ SplineSet
  927.5 452.5 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uniFB74
-Encoding: 64372 64372 64372
+Encoding: 64372 64372 3480
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 392 -704 basechar 0
 AnchorPoint: "rtl-above" 384 1024 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 281 -292 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 281 -292 2
 EndChar
+
 StartChar: uniFB75
-Encoding: 64373 64373 64373
+Encoding: 64373 64373 3481
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 632 -612 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 525 -200 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 525 -200 2
 EndChar
+
 StartChar: uniFB76
-Encoding: 64374 64374 64374
+Encoding: 64374 64374 3482
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 516 -560 basechar 0
 AnchorPoint: "rtl-above" 406 1040 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 518 25 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 518 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB77
-Encoding: 64375 64375 64375
+Encoding: 64375 64375 3483
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -777 basechar 0
@@ -97416,41 +100904,45 @@ SplineSet
  927.5 452.5 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uniFB78
-Encoding: 64376 64376 64376
+Encoding: 64376 64376 3484
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 400 -394 basechar 0
 AnchorPoint: "rtl-above" 388 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 108 -312 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 108 -312 2
 EndChar
+
 StartChar: uniFB79
-Encoding: 64377 64377 64377
+Encoding: 64377 64377 3485
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -342 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 320 -272 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 320 -272 2
 EndChar
+
 StartChar: uniFB7A
-Encoding: 64378 64378 64378
+Encoding: 64378 64378 3486
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -600 basechar 0
 AnchorPoint: "rtl-above" 434 1132 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 514 162 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 514 162 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7B
-Encoding: 64379 64379 64379
+Encoding: 64379 64379 3487
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -777 basechar 0
@@ -97503,41 +100995,45 @@ SplineSet
  390 -132 l 1,57,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFB7C
-Encoding: 64380 64380 64380
+Encoding: 64380 64380 3488
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 452 -724 basechar 0
 AnchorPoint: "rtl-above" 440 1104 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 168 -308 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 168 -308 2
 EndChar
+
 StartChar: uniFB7D
-Encoding: 64381 64381 64381
+Encoding: 64381 64381 3489
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -728 basechar 0
 AnchorPoint: "rtl-above" 600 1124 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 320 -288 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 320 -288 2
 EndChar
+
 StartChar: uniFB7E
-Encoding: 64382 64382 64382
+Encoding: 64382 64382 3490
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -600 basechar 0
 AnchorPoint: "rtl-above" 454 1108 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 550 187 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 550 187 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7F
-Encoding: 64383 64383 64383
+Encoding: 64383 64383 3491
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -777 basechar 0
@@ -97593,84 +101089,92 @@ SplineSet
  421 -71 l 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFB80
-Encoding: 64384 64384 64384
+Encoding: 64384 64384 3492
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 476 -696 basechar 0
 AnchorPoint: "rtl-above" 452 1052 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 252 -280 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 252 -280 2
 EndChar
+
 StartChar: uniFB81
-Encoding: 64385 64385 64385
+Encoding: 64385 64385 3493
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -716 basechar 0
 AnchorPoint: "rtl-above" 600 1048 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 340 -288 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3695 -1 N 1 0 0 1 340 -288 2
 EndChar
+
 StartChar: uniFB8A
-Encoding: 64394 64394 64394
+Encoding: 64394 64394 3494
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 591.5 1257.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 659 710 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 659 710 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8B
-Encoding: 64395 64395 64395
+Encoding: 64395 64395 3495
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 708 1354 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 539 710 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 539 710 2
+Refer: 3579 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8C
-Encoding: 64396 64396 64396
+Encoding: 64396 64396 3496
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 578 1275.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 341 -582.5 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 341 -582.5 2
 EndChar
+
 StartChar: uniFB8D
-Encoding: 64397 64397 64397
+Encoding: 64397 64397 3497
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 572 1349 basechar 0
 LayerCount: 2
 Fore
-Refer: 65198 65198 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 233 -553 2
+Refer: 3579 65198 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 233 -553 2
 EndChar
+
 StartChar: uniFB8E
-Encoding: 64398 64398 64398
+Encoding: 64398 64398 3498
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 640 -180 basechar 0
 AnchorPoint: "rtl-above" 500 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8F
-Encoding: 64399 64399 64399
+Encoding: 64399 64399 3499
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 449 -190 basechar 0
@@ -97711,80 +101215,88 @@ SplineSet
  907 72 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFB90
-Encoding: 64400 64400 64400
+Encoding: 64400 64400 3500
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65243 65243 N 1 0 0 1 0 0 2
+Refer: 3624 65243 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB91
-Encoding: 64401 64401 64401
+Encoding: 64401 64401 3501
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65244 65244 N 1 0 0 1 0 0 2
+Refer: 3625 65244 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB92
-Encoding: 64402 64402 64402
+Encoding: 64402 64402 3502
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 661.5 -206 basechar 0
 AnchorPoint: "rtl-above" 341.5 1460 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 684 14.5 2
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 3696 -1 N 1 0 0 1 684 14.5 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB93
-Encoding: 64403 64403 64403
+Encoding: 64403 64403 3503
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 479 -215 basechar 0
 AnchorPoint: "rtl-above" 193.5 1465 basechar 0
 LayerCount: 2
 Fore
-Refer: 64399 64399 N 1 0 0 1 0 0 2
-Refer: 1114144 -1 N 1 0 0 1 596.5 18 2
+Refer: 3499 64399 N 1 0 0 1 0 0 2
+Refer: 3696 -1 N 1 0 0 1 596.5 18 2
 EndChar
+
 StartChar: uniFB94
-Encoding: 64404 64404 64404
+Encoding: 64404 64404 3504
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1780 basechar 0
 LayerCount: 2
 Fore
-Refer: 64400 64400 N 1 0 0 1 0 0 2
-Refer: 1114145 -1 N 1 0 0 1 143 0 2
+Refer: 3500 64400 N 1 0 0 1 0 0 2
+Refer: 3697 -1 N 1 0 0 1 143 0 2
 EndChar
+
 StartChar: uniFB95
-Encoding: 64405 64405 64405
+Encoding: 64405 64405 3505
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1800 basechar 0
 LayerCount: 2
 Fore
-Refer: 64401 64401 N 1 0 0 1 0 0 2
-Refer: 1114145 -1 N 1 0 0 1 156 0 2
+Refer: 3501 64401 N 1 0 0 1 0 0 2
+Refer: 3697 -1 N 1 0 0 1 156 0 2
 EndChar
+
 StartChar: uniFB9E
-Encoding: 64414 64414 64414
+Encoding: 64414 64414 3506
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3710 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB9F
-Encoding: 64415 64415 64415
+Encoding: 64415 64415 3507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97815,18 +101327,20 @@ SplineSet
  1098 0 1098 0 1093 16 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBAA
-Encoding: 64426 64426 64426
+Encoding: 64426 64426 3508
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -156 basechar 0
 AnchorPoint: "rtl-above" 596 1152 basechar 0
 LayerCount: 2
 Fore
-Refer: 1726 1726 N 1 0 0 1 0 0 2
+Refer: 1247 1726 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAB
-Encoding: 64427 64427 64427
+Encoding: 64427 64427 3509
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -156 basechar 0
@@ -97874,18 +101388,20 @@ SplineSet
  556 385 556 385 616 346 c 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uniFBAC
-Encoding: 64428 64428 64428
+Encoding: 64428 64428 3510
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 440 1152 basechar 0
 AnchorPoint: "rtl-below" 440 -156 basechar 0
 LayerCount: 2
 Fore
-Refer: 65259 65259 N 1 0 0 1 0 0 2
+Refer: 3640 65259 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAD
-Encoding: 64429 64429 64429
+Encoding: 64429 64429 3511
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -156 basechar 0
@@ -97927,8 +101443,9 @@ SplineSet
  556 385 556 385 616 346 c 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uniFBE8
-Encoding: 64488 64488 64488
+Encoding: 64488 64488 3512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97947,8 +101464,9 @@ SplineSet
  750 196 750 196 658 86 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBE9
-Encoding: 64489 64489 64489
+Encoding: 64489 64489 3513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97972,75 +101490,83 @@ SplineSet
  673 0 673 0 606 72 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBFC
-Encoding: 64508 64508 64508
+Encoding: 64508 64508 3514
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -400 basechar 0
 AnchorPoint: "rtl-above" 388 850 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFD
-Encoding: 64509 64509 64509
+Encoding: 64509 64509 3515
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 436 -400 basechar 0
 AnchorPoint: "rtl-above" 364 610 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 3645 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFE
-Encoding: 64510 64510 64510
+Encoding: 64510 64510 3516
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 591 -350 basechar 0
 AnchorPoint: "rtl-above" 591 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 307 -300 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 307 -300 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFF
-Encoding: 64511 64511 64511
+Encoding: 64511 64511 3517
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 607 -350 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 319 -300 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 319 -300 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE70
-Encoding: 65136 65136 65136
+Encoding: 65136 65136 3518
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1611 1611 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE71
-Encoding: 65137 65137 65137
+Encoding: 65137 65137 3519
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1611 1611 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE72
-Encoding: 65138 65138 65138
+Encoding: 65138 65138 3520
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1612 1612 N 1 0 0 1 0 0 2
+Refer: 1206 1612 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE73
-Encoding: 65139 65139 65139
+Encoding: 65139 65139 3521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98059,243 +101585,269 @@ SplineSet
  986 373 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFE74
-Encoding: 65140 65140 65140
+Encoding: 65140 65140 3522
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1613 1613 N 1 0 0 1 0 0 2
+Refer: 1207 1613 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE76
-Encoding: 65142 65142 65142
+Encoding: 65142 65142 3523
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1614 1614 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE77
-Encoding: 65143 65143 65143
+Encoding: 65143 65143 3524
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1614 1614 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE78
-Encoding: 65144 65144 65144
+Encoding: 65144 65144 3525
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1615 1615 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE79
-Encoding: 65145 65145 65145
+Encoding: 65145 65145 3526
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1615 1615 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7A
-Encoding: 65146 65146 65146
+Encoding: 65146 65146 3527
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1616 1616 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7B
-Encoding: 65147 65147 65147
+Encoding: 65147 65147 3528
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1616 1616 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7C
-Encoding: 65148 65148 65148
+Encoding: 65148 65148 3529
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1617 1617 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7D
-Encoding: 65149 65149 65149
+Encoding: 65149 65149 3530
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1617 1617 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7E
-Encoding: 65150 65150 65150
+Encoding: 65150 65150 3531
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1618 1618 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7F
-Encoding: 65151 65151 65151
+Encoding: 65151 65151 3532
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1618 1618 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE80
-Encoding: 65152 65152 65152
+Encoding: 65152 65152 3533
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 748 11 basechar 0
 AnchorPoint: "rtl-above" 666 1159 basechar 0
 LayerCount: 2
 Fore
-Refer: 1569 1569 N 1 0 0 1 0 0 2
+Refer: 1168 1569 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE81
-Encoding: 65153 65153 65153
+Encoding: 65153 65153 3534
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 0 450 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE82
-Encoding: 65154 65154 65154
+Encoding: 65154 65154 3535
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65166 65166 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 0 450 2
+Refer: 3547 65166 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
 EndChar
+
 StartChar: uniFE83
-Encoding: 65155 65155 65155
+Encoding: 65155 65155 3536
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 550 2235 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -10 450 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -10 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE84
-Encoding: 65156 65156 65156
+Encoding: 65156 65156 3537
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 602 2247 basechar 0
 LayerCount: 2
 Fore
-Refer: 65166 65166 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 39 450 2
+Refer: 3547 65166 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 39 450 2
 EndChar
+
 StartChar: uniFE85
-Encoding: 65157 65157 65157
+Encoding: 65157 65157 3538
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 602 1395 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 96 -410 2
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 96 -410 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE86
-Encoding: 65158 65158 65158
+Encoding: 65158 65158 3539
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 542 1403 basechar 0
 LayerCount: 2
 Fore
-Refer: 65262 65262 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -4 -414 2
+Refer: 3643 65262 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -4 -414 2
 EndChar
+
 StartChar: uniFE87
-Encoding: 65159 65159 65159
+Encoding: 65159 65159 3540
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 617 -569 basechar 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 -7 0 2
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -7 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE88
-Encoding: 65160 65160 65160
+Encoding: 65160 65160 3541
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 721 -573 basechar 0
 LayerCount: 2
 Fore
-Refer: 65166 65166 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 86 0 2
+Refer: 3547 65166 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 86 0 2
 EndChar
+
 StartChar: uniFE89
-Encoding: 65161 65161 65161
+Encoding: 65161 65161 3542
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 569 -453 basechar 0
 AnchorPoint: "rtl-above" 270 1339 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -271 -453 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -271 -453 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8A
-Encoding: 65162 65162 65162
+Encoding: 65162 65162 3543
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 349 -433 basechar 0
 AnchorPoint: "rtl-above" 226 1059 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -284 -792 2
+Refer: 3645 65264 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -284 -792 2
 EndChar
+
 StartChar: uniFE8B
-Encoding: 65163 65163 65163
+Encoding: 65163 65163 3544
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 533 -81 basechar 0
 AnchorPoint: "rtl-above" 567 1382 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -22 -400 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -22 -400 2
 EndChar
+
 StartChar: uniFE8C
-Encoding: 65164 65164 65164
+Encoding: 65164 65164 3545
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -97 basechar 0
 AnchorPoint: "rtl-above" 526 1387 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 0 -400 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 -400 2
 EndChar
+
 StartChar: uniFE8D
-Encoding: 65165 65165 65165
+Encoding: 65165 65165 3546
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -97 basechar 0
 AnchorPoint: "rtl-above" 614 1735 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8E
-Encoding: 65166 65166 65166
+Encoding: 65166 65166 3547
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 673 -149 basechar 0
@@ -98316,216 +101868,236 @@ SplineSet
  539 193 539 193 539 412 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFE8F
-Encoding: 65167 65167 65167
+Encoding: 65167 65167 3548
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 613 -409 basechar 0
 AnchorPoint: "rtl-above" 554 903 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 539 -350 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 539 -350 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE90
-Encoding: 65168 65168 65168
+Encoding: 65168 65168 3549
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 565 -409 basechar 0
 AnchorPoint: "rtl-above" 538 911 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 465 -350 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 465 -350 2
 EndChar
+
 StartChar: uniFE91
-Encoding: 65169 65169 65169
+Encoding: 65169 65169 3550
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 585 -437 basechar 0
 AnchorPoint: "rtl-above" 554 947 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 484 -380 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 484 -380 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE92
-Encoding: 65170 65170 65170
+Encoding: 65170 65170 3551
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -481 basechar 0
 AnchorPoint: "rtl-above" 558 1011 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 504 -400 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 504 -400 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE93
-Encoding: 65171 65171 65171
+Encoding: 65171 65171 3552
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 421 -149 basechar 0
 AnchorPoint: "rtl-above" 450 1304 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 230 904 2
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 230 904 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE94
-Encoding: 65172 65172 65172
+Encoding: 65172 65172 3553
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 493 -81 basechar 0
 AnchorPoint: "rtl-above" 491.5 1402 basechar 0
 LayerCount: 2
 Fore
-Refer: 65258 65258 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 269.5 1048.5 2
+Refer: 3639 65258 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 269.5 1048.5 2
 EndChar
+
 StartChar: uniFE95
-Encoding: 65173 65173 65173
+Encoding: 65173 65173 3554
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 546 1071 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 323 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 323 650 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE96
-Encoding: 65174 65174 65174
+Encoding: 65174 65174 3555
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 569 -149 basechar 0
 AnchorPoint: "rtl-above" 554 1075 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 332 650 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 332 650 2
 EndChar
+
 StartChar: uniFE97
-Encoding: 65175 65175 65175
+Encoding: 65175 65175 3556
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 526 1263 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 308 850 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 308 850 2
 EndChar
+
 StartChar: uniFE98
-Encoding: 65176 65176 65176
+Encoding: 65176 65176 3557
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 526 1247 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 318 850 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 318 850 2
 EndChar
+
 StartChar: uniFE99
-Encoding: 65177 65177 65177
+Encoding: 65177 65177 3558
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 502 1371 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 318 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 318 650 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9A
-Encoding: 65178 65178 65178
+Encoding: 65178 65178 3559
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 482 1379 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 304 650 2
+Refer: 3688 -1 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 304 650 2
 EndChar
+
 StartChar: uniFE9B
-Encoding: 65179 65179 65179
+Encoding: 65179 65179 3560
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 482 1547 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 306 850 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 306 850 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9C
-Encoding: 65180 65180 65180
+Encoding: 65180 65180 3561
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 545 -161 basechar 0
 AnchorPoint: "rtl-above" 494 1535 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 311 812 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 311 812 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9D
-Encoding: 65181 65181 65181
+Encoding: 65181 65181 3562
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
 AnchorPoint: "rtl-above" 422 1131 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 671 25 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 671 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9E
-Encoding: 65182 65182 65182
+Encoding: 65182 65182 3563
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
 AnchorPoint: "rtl-above" 466 1163 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 552 -50 2
+Refer: 3567 65186 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 552 -50 2
 EndChar
+
 StartChar: uniFE9F
-Encoding: 65183 65183 65183
+Encoding: 65183 65183 3564
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -381 basechar 0
 AnchorPoint: "rtl-above" 314 1195 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 525 -300 2
 EndChar
+
 StartChar: uniFEA0
-Encoding: 65184 65184 65184
+Encoding: 65184 65184 3565
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 529 -397 basechar 0
 AnchorPoint: "rtl-above" 322 1183 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 525 -300 2
 EndChar
+
 StartChar: uniFEA1
-Encoding: 65185 65185 65185
+Encoding: 65185 65185 3566
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
 AnchorPoint: "rtl-above" 462 1135 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA2
-Encoding: 65186 65186 65186
+Encoding: 65186 65186 3567
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
@@ -98563,8 +102135,9 @@ SplineSet
  981 669 981 669 940 660 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA3
-Encoding: 65187 65187 65187
+Encoding: 65187 65187 3568
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 345 -117 basechar 0
@@ -98593,8 +102166,9 @@ SplineSet
  675 457 675 457 839 541 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA4
-Encoding: 65188 65188 65188
+Encoding: 65188 65188 3569
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 317 -153 basechar 0
@@ -98630,62 +102204,68 @@ SplineSet
  855 245 855 245 835 285 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA5
-Encoding: 65189 65189 65189
+Encoding: 65189 65189 3570
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
 AnchorPoint: "rtl-above" 482 1451 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 476 1050 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 476 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA6
-Encoding: 65190 65190 65190
+Encoding: 65190 65190 3571
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 501 -561 basechar 0
 AnchorPoint: "rtl-above" 482 1503 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 472 1050 2
+Refer: 3567 65186 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 472 1050 2
 EndChar
+
 StartChar: uniFEA7
-Encoding: 65191 65191 65191
+Encoding: 65191 65191 3572
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 341 -137 basechar 0
 AnchorPoint: "rtl-above" 306 1471 basechar 0
 LayerCount: 2
 Fore
-Refer: 65187 65187 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 412 1022 2
+Refer: 3568 65187 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 412 1022 2
 EndChar
+
 StartChar: uniFEA8
-Encoding: 65192 65192 65192
+Encoding: 65192 65192 3573
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 293 -149 basechar 0
 AnchorPoint: "rtl-above" 402 1347 basechar 0
 LayerCount: 2
 Fore
-Refer: 65188 65188 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 525 950 2
+Refer: 3569 65188 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 525 950 2
 EndChar
+
 StartChar: uniFEA9
-Encoding: 65193 65193 65193
+Encoding: 65193 65193 3574
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 509 -165 basechar 0
 AnchorPoint: "rtl-above" 498 1191 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAA
-Encoding: 65194 65194 65194
+Encoding: 65194 65194 3575
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 509 -165 basechar 0
@@ -98716,40 +102296,44 @@ SplineSet
  1095 555 1095 555 1100 438 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAB
-Encoding: 65195 65195 65195
+Encoding: 65195 65195 3576
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 509 -165 basechar 0
 AnchorPoint: "rtl-above" 562 1555 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 556 1102 2
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 556 1102 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAC
-Encoding: 65196 65196 65196
+Encoding: 65196 65196 3577
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 509 -165 basechar 0
 AnchorPoint: "rtl-above" 574 1547 basechar 0
 LayerCount: 2
 Fore
-Refer: 65194 65194 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 561 1126 2
+Refer: 3575 65194 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 561 1126 2
 EndChar
+
 StartChar: uniFEAD
-Encoding: 65197 65197 65197
+Encoding: 65197 65197 3578
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -529 basechar 0
 AnchorPoint: "rtl-above" 350 999 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAE
-Encoding: 65198 65198 65198
+Encoding: 65198 65198 3579
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -529 basechar 0
@@ -98775,40 +102359,44 @@ SplineSet
  1025 500 1025 500 1033 448 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAF
-Encoding: 65199 65199 65199
+Encoding: 65199 65199 3580
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -529 basechar 0
 AnchorPoint: "rtl-above" 446 1195 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 845 780 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 845 780 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB0
-Encoding: 65200 65200 65200
+Encoding: 65200 65200 3581
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -529 basechar 0
 AnchorPoint: "rtl-above" 366 1227 basechar 0
 LayerCount: 2
 Fore
-Refer: 65198 65198 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 728 796 2
+Refer: 3579 65198 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 728 796 2
 EndChar
+
 StartChar: uniFEB1
-Encoding: 65201 65201 65201
+Encoding: 65201 65201 3582
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -529 basechar 0
 AnchorPoint: "rtl-above" 527 971 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB2
-Encoding: 65202 65202 65202
+Encoding: 65202 65202 3583
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 417 -525 basechar 0
@@ -98860,8 +102448,9 @@ SplineSet
  1165 750 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB3
-Encoding: 65203 65203 65203
+Encoding: 65203 65203 3584
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 377 -149 basechar 0
@@ -98902,8 +102491,9 @@ SplineSet
  662 -21 662 -21 552 -18 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB4
-Encoding: 65204 65204 65204
+Encoding: 65204 65204 3585
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 349 -149 basechar 0
@@ -98949,62 +102539,68 @@ SplineSet
  776 600 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB5
-Encoding: 65205 65205 65205
+Encoding: 65205 65205 3586
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 409 -525 basechar 0
 AnchorPoint: "rtl-above" 382 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 310 800 2
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 310 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB6
-Encoding: 65206 65206 65206
+Encoding: 65206 65206 3587
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 417 -521 basechar 0
 AnchorPoint: "rtl-above" 298 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 65202 65202 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 236 800 2
+Refer: 3583 65202 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 236 800 2
 EndChar
+
 StartChar: uniFEB7
-Encoding: 65207 65207 65207
+Encoding: 65207 65207 3588
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 377 -149 basechar 0
 AnchorPoint: "rtl-above" 310 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 65203 65203 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 282 800 2
+Refer: 3584 65203 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 282 800 2
 EndChar
+
 StartChar: uniFEB8
-Encoding: 65208 65208 65208
+Encoding: 65208 65208 3589
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 321 -149 basechar 0
 AnchorPoint: "rtl-above" 302 1559 basechar 0
 LayerCount: 2
 Fore
-Refer: 65204 65204 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 198 800 2
+Refer: 3585 65204 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 198 800 2
 EndChar
+
 StartChar: uniFEB9
-Encoding: 65209 65209 65209
+Encoding: 65209 65209 3590
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 757 -125 basechar 0
 AnchorPoint: "rtl-above" 346 887 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBA
-Encoding: 65210 65210 65210
+Encoding: 65210 65210 3591
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 729 -129 basechar 0
@@ -99057,8 +102653,9 @@ SplineSet
  1162 298 1162 298 1155 280 c 1,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBB
-Encoding: 65211 65211 65211
+Encoding: 65211 65211 3592
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 409 -113 basechar 0
@@ -99097,8 +102694,9 @@ SplineSet
  637 267 637 267 612 225 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEBC
-Encoding: 65212 65212 65212
+Encoding: 65212 65212 3593
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -125 basechar 0
@@ -99145,62 +102743,68 @@ SplineSet
  921 0 921 0 742 0 c 2,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEBD
-Encoding: 65213 65213 65213
+Encoding: 65213 65213 3594
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 757 -125 basechar 0
 AnchorPoint: "rtl-above" 342 1099 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 335 670 2
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 335 670 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBE
-Encoding: 65214 65214 65214
+Encoding: 65214 65214 3595
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 705 -125 basechar 0
 AnchorPoint: "rtl-above" 262 1103 basechar 0
 LayerCount: 2
 Fore
-Refer: 65210 65210 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 260 670 2
+Refer: 3591 65210 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 260 670 2
 EndChar
+
 StartChar: uniFEBF
-Encoding: 65215 65215 65215
+Encoding: 65215 65215 3596
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
 AnchorPoint: "rtl-above" 286 1171 basechar 0
 LayerCount: 2
 Fore
-Refer: 65211 65211 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 287 736 2
+Refer: 3592 65211 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 287 736 2
 EndChar
+
 StartChar: uniFEC0
-Encoding: 65216 65216 65216
+Encoding: 65216 65216 3597
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
 AnchorPoint: "rtl-above" 234 1167 basechar 0
 LayerCount: 2
 Fore
-Refer: 65212 65212 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 232 722 2
+Refer: 3593 65212 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 232 722 2
 EndChar
+
 StartChar: uniFEC1
-Encoding: 65217 65217 65217
+Encoding: 65217 65217 3598
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
 AnchorPoint: "rtl-above" 229 1795 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC2
-Encoding: 65218 65218 65218
+Encoding: 65218 65218 3599
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 321 -117 basechar 0
@@ -99237,8 +102841,9 @@ SplineSet
  1141 472 1141 472 1141 348 c 0,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC3
-Encoding: 65219 65219 65219
+Encoding: 65219 65219 3600
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
@@ -99269,8 +102874,9 @@ SplineSet
  895 0 895 0 768 0 c 2,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEC4
-Encoding: 65220 65220 65220
+Encoding: 65220 65220 3601
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 317 -121 basechar 0
@@ -99307,62 +102913,68 @@ SplineSet
  1141 464 1141 464 1141 348 c 0,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC5
-Encoding: 65221 65221 65221
+Encoding: 65221 65221 3602
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
 AnchorPoint: "rtl-above" 228 1735 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 634 812 2
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 634 812 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC6
-Encoding: 65222 65222 65222
+Encoding: 65222 65222 3603
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 305 -117 basechar 0
 AnchorPoint: "rtl-above" 170 1719 basechar 0
 LayerCount: 2
 Fore
-Refer: 65218 65218 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 579 817 2
+Refer: 3599 65218 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 579 817 2
 EndChar
+
 StartChar: uniFEC7
-Encoding: 65223 65223 65223
+Encoding: 65223 65223 3604
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -121 basechar 0
 AnchorPoint: "rtl-above" 227 1743 basechar 0
 LayerCount: 2
 Fore
-Refer: 65219 65219 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 645 822 2
+Refer: 3600 65219 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 645 822 2
 EndChar
+
 StartChar: uniFEC8
-Encoding: 65224 65224 65224
+Encoding: 65224 65224 3605
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 293 -121 basechar 0
 AnchorPoint: "rtl-above" 166 1719 basechar 0
 LayerCount: 2
 Fore
-Refer: 65220 65220 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 579 812 2
+Refer: 3601 65220 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 579 812 2
 EndChar
+
 StartChar: uniFEC9
-Encoding: 65225 65225 65225
+Encoding: 65225 65225 3606
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 505 -557 basechar 0
 AnchorPoint: "rtl-above" 437 1330 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECA
-Encoding: 65226 65226 65226
+Encoding: 65226 65226 3607
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 505 -557 basechar 0
@@ -99408,8 +103020,9 @@ SplineSet
  721 0 721 0 482 186 c 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uniFECB
-Encoding: 65227 65227 65227
+Encoding: 65227 65227 3608
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -89 basechar 0
@@ -99438,8 +103051,9 @@ SplineSet
  61 225 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFECC
-Encoding: 65228 65228 65228
+Encoding: 65228 65228 3609
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 609 -93 basechar 0
@@ -99477,150 +103091,164 @@ SplineSet
  535 521 535 521 616 443 c 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uniFECD
-Encoding: 65229 65229 65229
+Encoding: 65229 65229 3610
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 505 -557 basechar 0
 AnchorPoint: "rtl-above" 312 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 310 1230 2
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 310 1230 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECE
-Encoding: 65230 65230 65230
+Encoding: 65230 65230 3611
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 505 -557 basechar 0
 AnchorPoint: "rtl-above" 472 1392 basechar 0
 LayerCount: 2
 Fore
-Refer: 65226 65226 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 425 950 2
+Refer: 3607 65226 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 425 950 2
 EndChar
+
 StartChar: uniFECF
-Encoding: 65231 65231 65231
+Encoding: 65231 65231 3612
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 353 -89 basechar 0
 AnchorPoint: "rtl-above" 322 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 65227 65227 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 375 1200 2
+Refer: 3608 65227 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 375 1200 2
 EndChar
+
 StartChar: uniFED0
-Encoding: 65232 65232 65232
+Encoding: 65232 65232 3613
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 609 -97 basechar 0
 AnchorPoint: "rtl-above" 616 1340 basechar 0
 LayerCount: 2
 Fore
-Refer: 65228 65228 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 508 950 2
+Refer: 3609 65228 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 508 950 2
 EndChar
+
 StartChar: uniFED1
-Encoding: 65233 65233 65233
+Encoding: 65233 65233 3614
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 537 -209 basechar 0
 AnchorPoint: "rtl-above" 597 1341 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 732 1066 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 732 1066 2
+Refer: 3708 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED2
-Encoding: 65234 65234 65234
+Encoding: 65234 65234 3615
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 509 -181 basechar 0
 AnchorPoint: "rtl-above" 567 1281 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 736 959 2
+Refer: 3692 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 736 959 2
 EndChar
+
 StartChar: uniFED3
-Encoding: 65235 65235 65235
+Encoding: 65235 65235 3616
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 421 -109 basechar 0
 AnchorPoint: "rtl-above" 382 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 375 1170 2
+Refer: 3689 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 375 1170 2
 EndChar
+
 StartChar: uniFED4
-Encoding: 65236 65236 65236
+Encoding: 65236 65236 3617
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 601 -101 basechar 0
 AnchorPoint: "rtl-above" 502 1381 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 492 1000 2
+Refer: 3690 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 492 1000 2
 EndChar
+
 StartChar: uniFED5
-Encoding: 65237 65237 65237
+Encoding: 65237 65237 3618
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 589 -533 basechar 0
 AnchorPoint: "rtl-above" 572 1561 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 515 1200 2
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 515 1200 2
+Refer: 3701 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED6
-Encoding: 65238 65238 65238
+Encoding: 65238 65238 3619
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 565 -557 basechar 0
 AnchorPoint: "rtl-above" 592 1261 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114139 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 482 906 2
+Refer: 3691 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 482 906 2
 EndChar
+
 StartChar: uniFED7
-Encoding: 65239 65239 65239
+Encoding: 65239 65239 3620
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 401 -77 basechar 0
 AnchorPoint: "rtl-above" 332 1491 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 210 1150 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 210 1150 2
+Refer: 3689 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED8
-Encoding: 65240 65240 65240
+Encoding: 65240 65240 3621
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 609 -105 basechar 0
 AnchorPoint: "rtl-above" 547 1386 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 326 1000 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 326 1000 2
+Refer: 3690 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED9
-Encoding: 65241 65241 65241
+Encoding: 65241 65241 3622
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 429 -181 basechar 0
 AnchorPoint: "rtl-above" 607 1546 basechar 0
 LayerCount: 2
 Fore
-Refer: 1603 1603 N 1 0 0 1 0 0 2
+Refer: 1197 1603 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDA
-Encoding: 65242 65242 65242
+Encoding: 65242 65242 3623
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 429 -181 basechar 0
@@ -99671,8 +103299,9 @@ SplineSet
  1107 1556 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDB
-Encoding: 65243 65243 65243
+Encoding: 65243 65243 3624
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 357 -145 basechar 0
@@ -99702,8 +103331,9 @@ SplineSet
  718 0 718 0 402 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDC
-Encoding: 65244 65244 65244
+Encoding: 65244 65244 3625
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 381 -129 basechar 0
@@ -99739,18 +103369,20 @@ SplineSet
  816 164 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDD
-Encoding: 65245 65245 65245
+Encoding: 65245 65245 3626
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 593 -441 basechar 0
 AnchorPoint: "rtl-above" 512 1551 basechar 0
 LayerCount: 2
 Fore
-Refer: 1604 1604 N 1 0 0 1 0 0 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDE
-Encoding: 65246 65246 65246
+Encoding: 65246 65246 3627
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 513 -465 basechar 0
@@ -99783,8 +103415,9 @@ SplineSet
  1088 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDF
-Encoding: 65247 65247 65247
+Encoding: 65247 65247 3628
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -133 basechar 0
@@ -99805,8 +103438,9 @@ SplineSet
  1050 412 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE0
-Encoding: 65248 65248 65248
+Encoding: 65248 65248 3629
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -145 basechar 0
@@ -99832,18 +103466,20 @@ SplineSet
  673 0 673 0 606 72 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE1
-Encoding: 65249 65249 65249
+Encoding: 65249 65249 3630
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 765 -89 basechar 0
 AnchorPoint: "rtl-above" 647 961 basechar 0
 LayerCount: 2
 Fore
-Refer: 1605 1605 N 1 0 0 1 0 0 2
+Refer: 1199 1605 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE2
-Encoding: 65250 65250 65250
+Encoding: 65250 65250 3631
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 681 -177 basechar 0
@@ -99886,8 +103522,9 @@ SplineSet
  582 293 582 293 592 240 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE3
-Encoding: 65251 65251 65251
+Encoding: 65251 65251 3632
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -185 basechar 0
@@ -99922,8 +103559,9 @@ SplineSet
  495 -48 495 -48 390 60 c 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uniFEE4
-Encoding: 65252 65252 65252
+Encoding: 65252 65252 3633
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 465 -193 basechar 0
@@ -99962,62 +103600,68 @@ SplineSet
  932 0 932 0 912 32 c 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uniFEE5
-Encoding: 65253 65253 65253
+Encoding: 65253 65253 3634
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 613 -405 basechar 0
 AnchorPoint: "rtl-above" 537 1181 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 439 758 2
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 439 758 2
+Refer: 3710 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE6
-Encoding: 65254 65254 65254
+Encoding: 65254 65254 3635
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 473 -577 basechar 0
 AnchorPoint: "rtl-above" 387 1011 basechar 0
 LayerCount: 2
 Fore
-Refer: 64415 64415 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 335 557 2
+Refer: 3507 64415 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 335 557 2
 EndChar
+
 StartChar: uniFEE7
-Encoding: 65255 65255 65255
+Encoding: 65255 65255 3636
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 413 -89 basechar 0
 AnchorPoint: "rtl-above" 497 1321 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 488 850 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 488 850 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE8
-Encoding: 65256 65256 65256
+Encoding: 65256 65256 3637
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -113 basechar 0
 AnchorPoint: "rtl-above" 587 1281 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 497 850 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3685 -1 N 1 0 0 1 497 850 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE9
-Encoding: 65257 65257 65257
+Encoding: 65257 65257 3638
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 481 -149 basechar 0
 AnchorPoint: "rtl-above" 467 971 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEA
-Encoding: 65258 65258 65258
+Encoding: 65258 65258 3639
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 421 -65 basechar 0
@@ -100050,8 +103694,9 @@ SplineSet
  444 795 444 795 595 810 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uniFEEB
-Encoding: 65259 65259 65259
+Encoding: 65259 65259 3640
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 361 -141 basechar 0
@@ -100097,8 +103742,9 @@ SplineSet
  403 385 403 385 443 324 c 1,46,47
 EndSplineSet
 EndChar
+
 StartChar: uniFEEC
-Encoding: 65260 65260 65260
+Encoding: 65260 65260 3641
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 409 -560 basechar 0
@@ -100141,18 +103787,20 @@ SplineSet
  508 342 508 342 508 225 c 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEED
-Encoding: 65261 65261 65261
+Encoding: 65261 65261 3642
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 409 -560 basechar 0
 AnchorPoint: "rtl-above" 614 907 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEE
-Encoding: 65262 65262 65262
+Encoding: 65262 65262 3643
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 409 -560 basechar 0
@@ -100187,18 +103835,20 @@ SplineSet
  1075 0 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uniFEEF
-Encoding: 65263 65263 65263
+Encoding: 65263 65263 3644
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 533 -420 basechar 0
 AnchorPoint: "rtl-above" 506 1067 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF0
-Encoding: 65264 65264 65264
+Encoding: 65264 65264 3645
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 429 -428 basechar 0
@@ -100240,52 +103890,57 @@ SplineSet
  743 11 743 11 743 36 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEF1
-Encoding: 65265 65265 65265
+Encoding: 65265 65265 3646
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 493 -724 basechar 0
 AnchorPoint: "rtl-above" 462 971 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 279 -661 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 279 -661 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF2
-Encoding: 65266 65266 65266
+Encoding: 65266 65266 3647
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 361 -748 basechar 0
 AnchorPoint: "rtl-above" 398 787 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 172 -668 2
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 172 -668 2
+Refer: 3645 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF3
-Encoding: 65267 65267 65267
+Encoding: 65267 65267 3648
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -428 basechar 0
 AnchorPoint: "rtl-above" 574 931 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 306 -360 2
+Refer: 3512 64488 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 306 -360 2
 EndChar
+
 StartChar: uniFEF4
-Encoding: 65268 65268 65268
+Encoding: 65268 65268 3649
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 601 -452 basechar 0
 AnchorPoint: "rtl-above" 598 943 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 319 -364 2
+Refer: 3513 64489 N 1 0 0 1 0 0 2
+Refer: 3686 -1 N 1 0 0 1 319 -364 2
 EndChar
+
 StartChar: uniFEF5
-Encoding: 65269 65269 65269
+Encoding: 65269 65269 3650
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
@@ -100294,13 +103949,14 @@ AnchorPoint: "Ligature rtl-below" 828 -60 baselig 1
 AnchorPoint: "Ligature rtl-above" 131 1877.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65275 65275 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 -362 300 2
+Refer: 3656 65275 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -362 300 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEDF uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF6
-Encoding: 65270 65270 65270
+Encoding: 65270 65270 3651
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 888 -76 baselig 0
@@ -100309,13 +103965,14 @@ AnchorPoint: "Ligature rtl-below" 712 -112 baselig 1
 AnchorPoint: "Ligature rtl-above" 143 1861.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65276 65276 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 -372 300 2
+Refer: 3657 65276 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -372 300 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEE0 uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF7
-Encoding: 65271 65271 65271
+Encoding: 65271 65271 3652
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
@@ -100324,13 +103981,14 @@ AnchorPoint: "Ligature rtl-below" 828 -60 baselig 1
 AnchorPoint: "Ligature rtl-above" 99 2042.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65275 65275 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -450 300 2
+Refer: 3656 65275 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -450 300 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEDF uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF8
-Encoding: 65272 65272 65272
+Encoding: 65272 65272 3653
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 828 -60 baselig 0
@@ -100339,13 +103997,14 @@ AnchorPoint: "Ligature rtl-below" 668 -92 baselig 1
 AnchorPoint: "Ligature rtl-above" 71 2077.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65276 65276 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -477 300 2
+Refer: 3657 65276 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -477 300 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEE0 uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF9
-Encoding: 65273 65273 65273
+Encoding: 65273 65273 3654
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 892 -32 baselig 0
@@ -100354,13 +104013,14 @@ AnchorPoint: "Ligature rtl-below" 320 -640 baselig 1
 AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65275 65275 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 -312 -55 2
+Refer: 3656 65275 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 -55 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEDF uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFA
-Encoding: 65274 65274 65274
+Encoding: 65274 65274 3655
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 788 -88 baselig 0
@@ -100369,13 +104029,14 @@ AnchorPoint: "Ligature rtl-below" 308 -680 baselig 1
 AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
 LayerCount: 2
 Fore
-Refer: 65276 65276 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 -312 -82 2
+Refer: 3657 65276 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 -82 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 6" uniFEE0 uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFB
-Encoding: 65275 65275 65275
+Encoding: 65275 65275 3656
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
@@ -100402,10 +104063,11 @@ SplineSet
  1107 834 l 2,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 5" uniFEDF uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFC
-Encoding: 65276 65276 65276
+Encoding: 65276 65276 3657
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 880 -112 baselig 0
@@ -100436,40 +104098,46 @@ SplineSet
  953 0 953 0 872 177 c 1,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 5" uniFEE0 uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFF
-Encoding: 65279 65279 65279
+Encoding: 65279 65279 3658
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFF9
-Encoding: 65529 65529 65529
+Encoding: 65529 65529 3659
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFA
-Encoding: 65530 65530 65530
+Encoding: 65530 65530 3660
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFB
-Encoding: 65531 65531 65531
+Encoding: 65531 65531 3661
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFC
-Encoding: 65532 65532 65532
+Encoding: 65532 65532 3662
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFD
-Encoding: 65533 65533 65533
+Encoding: 65533 65533 3663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -100513,8 +104181,9 @@ SplineSet
  751 571 l 2,33,34
 EndSplineSet
 EndChar
+
 StartChar: u1D55A
-Encoding: 120154 120154 120154
+Encoding: 120154 120154 3664
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -100543,8 +104212,9 @@ SplineSet
  564 1000 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dlLtcaron
-Encoding: 1114113 -1 1114113
+Encoding: 1114113 -1 3665
 Width: 1233
 Flags: W
 TtInstrs:
@@ -100576,8 +104246,9 @@ SplineSet
  545 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Dieresis
-Encoding: 1114114 -1 1114114
+Encoding: 1114114 -1 3666
 Width: 1233
 Flags: W
 TtInstrs:
@@ -100640,8 +104311,9 @@ SplineSet
  301 1526 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Acute
-Encoding: 1114115 -1 1114115
+Encoding: 1114115 -1 3667
 Width: 1233
 Flags: W
 TtInstrs:
@@ -100706,8 +104378,9 @@ SplineSet
  668 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tilde
-Encoding: 1114116 -1 1114116
+Encoding: 1114116 -1 3668
 Width: 1233
 Flags: W
 TtInstrs:
@@ -100939,8 +104612,9 @@ SplineSet
  660 1284 660 1284 618 1311 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Grave
-Encoding: 1114117 -1 1114117
+Encoding: 1114117 -1 3669
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101005,8 +104679,9 @@ SplineSet
  567 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Circumflex
-Encoding: 1114118 -1 1114118
+Encoding: 1114118 -1 3670
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101110,8 +104785,9 @@ SplineSet
  461 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Caron
-Encoding: 1114119 -1 1114119
+Encoding: 1114119 -1 3671
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101221,8 +104897,9 @@ SplineSet
  461 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: fractionslash
-Encoding: 1114120 -1 1114120
+Encoding: 1114120 -1 3672
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101297,8 +104974,9 @@ SplineSet
  84 500 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0311.case
-Encoding: 1114121 -1 1114121
+Encoding: 1114121 -1 3673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101317,8 +104995,9 @@ SplineSet
  296 1764 296 1764 281 1635 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0306.case
-Encoding: 1114122 -1 1114122
+Encoding: 1114122 -1 3674
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101366,8 +105045,9 @@ SplineSet
  296 1770 296 1770 281 1899 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307.case
-Encoding: 1114123 -1 1114123
+Encoding: 1114123 -1 3675
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101398,8 +105078,9 @@ SplineSet
  479 1899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030B.case
-Encoding: 1114124 -1 1114124
+Encoding: 1114124 -1 3676
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101464,8 +105145,9 @@ SplineSet
  463 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030F.case
-Encoding: 1114125 -1 1114125
+Encoding: 1114125 -1 3677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101483,8 +105165,9 @@ SplineSet
  770 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: thinquestion
-Encoding: 1114126 -1 1114126
+Encoding: 1114126 -1 3678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101518,8 +105201,9 @@ SplineSet
  707 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0304.case
-Encoding: 1114127 -1 1114127
+Encoding: 1114127 -1 3679
 Width: 1233
 Flags: W
 TtInstrs:
@@ -101550,8 +105234,9 @@ SplineSet
  301 1870 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar
-Encoding: 1114128 -1 1114128
+Encoding: 1114128 -1 3680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101564,8 +105249,9 @@ SplineSet
  1102 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.wide
-Encoding: 1114129 -1 1114129
+Encoding: 1114129 -1 3681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101578,8 +105264,9 @@ SplineSet
  1227 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.small
-Encoding: 1114130 -1 1114130
+Encoding: 1114130 -1 3682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101592,8 +105279,9 @@ SplineSet
  1002 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: jot
-Encoding: 1114131 -1 1114131
+Encoding: 1114131 -1 3683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101620,8 +105308,9 @@ SplineSet
  670.651 865.151 670.651 865.151 616.003 865.151 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: diaeresis.symbols
-Encoding: 1114132 -1 1114132
+Encoding: 1114132 -1 3684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101639,8 +105328,9 @@ SplineSet
  301 1585 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_dot
-Encoding: 1114133 -1 1114133
+Encoding: 1114133 -1 3685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101653,8 +105343,9 @@ SplineSet
  0 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots
-Encoding: 1114134 -1 1114134
+Encoding: 1114134 -1 3686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101672,8 +105363,9 @@ SplineSet
  0 225 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots
-Encoding: 1114135 -1 1114135
+Encoding: 1114135 -1 3687
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101696,8 +105388,9 @@ SplineSet
  0 225 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E.fina
-Encoding: 1114136 -1 1114136
+Encoding: 1114136 -1 3688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101728,8 +105421,9 @@ SplineSet
  745.5 -20 745.5 -20 603 -20 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.init
-Encoding: 1114137 -1 1114137
+Encoding: 1114137 -1 3689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101765,8 +105459,9 @@ SplineSet
  -20 225 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.medi
-Encoding: 1114138 -1 1114138
+Encoding: 1114138 -1 3690
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101806,8 +105501,9 @@ SplineSet
  641 610 641 610 616 610 c 0,1,2
 EndSplineSet
 EndChar
+
 StartChar: uni066F.fina
-Encoding: 1114139 -1 1114139
+Encoding: 1114139 -1 3691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101852,8 +105548,9 @@ SplineSet
  890.397 238.697 890.397 238.697 932 240 c 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.fina
-Encoding: 1114140 -1 1114140
+Encoding: 1114140 -1 3692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101896,8 +105593,9 @@ SplineSet
  800 334 800 334 883 297 c 1,45,46
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots_a
-Encoding: 1114141 -1 1114141
+Encoding: 1114141 -1 3693
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101920,8 +105618,9 @@ SplineSet
  0 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots_a
-Encoding: 1114142 -1 1114142
+Encoding: 1114142 -1 3694
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101939,8 +105638,9 @@ SplineSet
  0 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_4dots
-Encoding: 1114143 -1 1114143
+Encoding: 1114143 -1 3695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101968,8 +105668,9 @@ SplineSet
  0 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar
-Encoding: 1114144 -1 1114144
+Encoding: 1114144 -1 3696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101982,8 +105683,9 @@ SplineSet
  695 1768 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar_a
-Encoding: 1114145 -1 1114145
+Encoding: 1114145 -1 3697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -101996,8 +105698,9 @@ SplineSet
  924 1716 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_ring
-Encoding: 1114146 -1 1114146
+Encoding: 1114146 -1 3698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102023,8 +105726,9 @@ SplineSet
  438 312 438 312 438 220 c 128,-1,13
 EndSplineSet
 EndChar
+
 StartChar: Eng.alt
-Encoding: 1114147 -1 1114147
+Encoding: 1114147 -1 3699
 Width: 1233
 Flags: W
 TtInstrs:
@@ -102115,8 +105819,9 @@ SplineSet
  108 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E
-Encoding: 1114148 -1 1114148
+Encoding: 1114148 -1 3700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102139,8 +105844,9 @@ SplineSet
  1208 539 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni066F
-Encoding: 1114149 -1 1114149
+Encoding: 1114149 -1 3701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102179,75 +105885,82 @@ SplineSet
  400 -196 400 -196 522 -196 c 0,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni067C
-Encoding: 1114150 -1 1114150
+Encoding: 1114150 -1 3702
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -576 basechar 0
 AnchorPoint: "rtl-above" 538 1083 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114146 -1 N 1 0 0 1 392 -524 2
-Refer: 1114134 -1 N 1 0 0 1 320 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3698 -1 N 1 0 0 1 392 -524 2
+Refer: 3686 -1 N 1 0 0 1 320 650 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni067D
-Encoding: 1114151 -1 1114151
+Encoding: 1114151 -1 3703
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -133 basechar 0
 AnchorPoint: "rtl-above" 534 1319 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 313 932 2
+Refer: 3700 -1 N 1 0 0 1 0 0 2
+Refer: 3693 -1 N 1 0 0 1 313 932 2
 EndChar
+
 StartChar: uni0681
-Encoding: 1114152 -1 1114152
+Encoding: 1114152 -1 3704
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -557 basechar 0
 AnchorPoint: "rtl-above" 454 1563 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -82 -200 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -82 -200 2
 EndChar
+
 StartChar: uni0682
-Encoding: 1114153 -1 1114153
+Encoding: 1114153 -1 3705
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -557 basechar 0
 AnchorPoint: "rtl-above" 450 1711 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 446 1360 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3694 -1 N 1 0 0 1 446 1360 2
 EndChar
+
 StartChar: uni0685
-Encoding: 1114154 -1 1114154
+Encoding: 1114154 -1 3706
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 484 -553 basechar 0
 AnchorPoint: "rtl-above" 438 1763 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 272 1090 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3687 -1 N 1 0 0 1 272 1090 2
 EndChar
+
 StartChar: uni0692
-Encoding: 1114155 -1 1114155
+Encoding: 1114155 -1 3707
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 623.5 1186.5 basechar 0
 AnchorPoint: "rtl-below" 581 -545 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 318.5 -558 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 318.5 -558 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06A1
-Encoding: 1114156 -1 1114156
+Encoding: 1114156 -1 3708
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 456 -209 basechar 0
@@ -102289,19 +106002,21 @@ SplineSet
  1233 210 1233 210 1108 56 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni06B5
-Encoding: 1114157 -1 1114157
+Encoding: 1114157 -1 3709
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 1002 2100 basechar 0
 AnchorPoint: "rtl-below" 586 -450 basechar 0
 LayerCount: 2
 Fore
-Refer: 1604 1604 N 1 0 0 1 0 0 2
-Refer: 1626 1626 N 1 0 0 1 388 400 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 388 400 2
 EndChar
+
 StartChar: uni06BA
-Encoding: 1114158 -1 1114158
+Encoding: 1114158 -1 3710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102327,38 +106042,42 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 2" uniFB9F
 EndChar
+
 StartChar: uni06C6
-Encoding: 1114159 -1 1114159
+Encoding: 1114159 -1 3711
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -548 basechar 0
 AnchorPoint: "rtl-above" 744 1244 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
-Refer: 1626 1626 N 1 0 0 1 140 -448 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 140 -448 2
 EndChar
+
 StartChar: uni06CE
-Encoding: 1114160 -1 1114160
+Encoding: 1114160 -1 3712
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -400 basechar 0
 AnchorPoint: "rtl-above" 343 1228 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1626 1626 N 1 0 0 1 -276 -476 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 -276 -476 2
 EndChar
+
 StartChar: uni06D5
-Encoding: 1114161 -1 1114161
+Encoding: 1114161 -1 3713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: exclamdown.case
-Encoding: 1114162 -1 1114162
+Encoding: 1114162 -1 3714
 Width: 1233
 Flags: W
 TtInstrs:
@@ -102409,8 +106128,9 @@ SplineSet
  750 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: questiondown.case
-Encoding: 1114163 -1 1114163
+Encoding: 1114163 -1 3715
 Width: 1233
 Flags: W
 TtInstrs:
@@ -102570,13 +106290,474 @@ SplineSet
  532 1092 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18.case
-Encoding: 1114164 -1 1114164
+Encoding: 1114164 -1 3716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 11800 11800 N 1 0 0 1 0 373 3
+Refer: 3399 11800 N 1 0 0 1 0 373 3
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3717
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 400 2
+Refer: 34 65 N 1 0 0 1 0 -2 2
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3718
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 3 75 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3719
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 433 589 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3720
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 394 294 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3721
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -447 574 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3722
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -384 344 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3723
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 352 540 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3724
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 372 252 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3725
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 -1 759 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3726
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3727
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 N 1 0 0 1 49 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3728
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 N 1 0 0 1 49 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3729
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -5 631 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3730
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 352 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3731
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 0 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3732
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3733
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 43 390 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3734
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 28 70 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3735
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 469 562 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3736
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 453 283 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3737
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -441 594 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3738
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -345 324 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3739
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 387 547 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3740
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 396 274 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3741
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 30 759 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3742
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 39 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3743
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 400 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3744
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 33 55 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3745
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 400 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3746
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 30 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3747
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3667 -1 S 1 0 0 1 420 579 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3748
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 386 312 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3749
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3669 -1 S 1 0 0 1 -432 550 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3750
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -409 291 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3751
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 338 561 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3752
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 336 256 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3753
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3668 -1 N 1 0 0 1 -1 759 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3754
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 454 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3755
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -66 400 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3756
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -92 45 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3757
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 400 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3758
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -27 45 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3759
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -72 400 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3760
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -167 25 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3761
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -12 400 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3762
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 6 64 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansMono-BoldOblique.sfd
+++ b/src/DejaVuSansMono-BoldOblique.sfd
@@ -10,13 +10,16 @@ UnderlinePosition: -85
 UnderlineWidth: 90
 Ascent: 1556
 Descent: 492
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 1 "Back"  1
-Layer: 1 1 "Fore"  0
+Layer: 0 1 "Back" 1
+Layer: 1 1 "Fore" 0
 FSType: 0
 OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
+CreationTime: 1470372098
+ModificationTime: 1492785867
 PfmFamily: 17
 TTFWeight: 700
 TTFWidth: 5
@@ -37,11 +40,11 @@ HheadAOffset: 0
 HheadDescent: -483
 HheadDOffset: 0
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "'locl' Localized Forms lookup 0"  {"'locl' Localized Forms lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
-Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0"  {"'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 3"  {"'dlig' Discretionary Ligatures in Latin lookup 3"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "'case' Case-Sensitive Forms"  {"'case' Case-Sensitive Forms" ("case" ) } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark positioning in Lao"  {"'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms lookup 0" { "'locl' Localized Forms lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0" { "'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 3" { "'dlig' Discretionary Ligatures in Latin lookup 3"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "'case' Case-Sensitive Forms" { "'case' Case-Sensitive Forms" ("case") } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark positioning in Lao" { "'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
 DEI: 91125
 TtTable: prep
 PUSHW_1
@@ -1267,12 +1270,14 @@ ShortTable: maxp 16
   3
   1
 EndShort
-LangName: 1033 "" "" "Bold Oblique" "DejaVu Sans Mono Bold Oblique" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License" 
+LangName: 1033 "" "" "Bold Oblique" "DejaVu Sans Mono Bold Oblique" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License"
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
+WinInfo: 7776 27 8
 GridOrder2: 1
 Grid
 1 740 m 25,0,-1
@@ -1282,50 +1287,50 @@ Grid
  1 894 l 25,1,-1
  -139 1034 l 25,0,0
 1 1510 m 9,0,-1
- -139 1650 l 17,0,0
+ -139 1650 l 1041,0,0
 1 1202 m 9,1,-1
- -139 1342 l 17,0,0
+ -139 1342 l 1041,0,0
 1 1818 m 9,1,-1
- -139 1958 l 17,0,0
+ -139 1958 l 1041,0,0
 1 1048 m 9,1,-1
- -139 1188 l 17,0,0
+ -139 1188 l 1041,0,0
 1 1664 m 9,1,-1
- -139 1804 l 17,0,0
+ -139 1804 l 1041,0,0
 1 1356 m 9,1,-1
- -139 1496 l 17,0,0
+ -139 1496 l 1041,0,0
 -139 -352 m 9,0,0
  1 -492 l 25,1,-1
- 141 -632 l 17
+ 141 -632 l 1041
 -139 -198 m 25,0,0
  1 -338 l 25,1,-1
  -139 -198 l 25,0,0
 1 278 m 9,0,-1
- -139 418 l 17,0,0
+ -139 418 l 1041,0,0
 1 -30 m 9,1,-1
- -139 110 l 17,0,0
+ -139 110 l 1041,0,0
 1 586 m 9,1,-1
- -139 726 l 17,0,0
+ -139 726 l 1041,0,0
 1 -184 m 9,1,-1
- -139 -44 l 17,0,0
+ -139 -44 l 1041,0,0
 1 432 m 9,1,-1
- -139 572 l 17,0,0
+ -139 572 l 1041,0,0
 1 124 m 9,1,-1
- -139 264 l 17,0,0
+ -139 264 l 1041,0,0
 1232 -409 m 25,0,0
  1372 -549 l 25,1,-1
  1232 -409 l 25,0,0
 1372 67 m 9,0,-1
- 1232 207 l 17,0,0
+ 1232 207 l 1041,0,0
 1372 -241 m 9,1,-1
- 1232 -101 l 17,0,0
+ 1232 -101 l 1041,0,0
 1372 375 m 9,1,-1
- 1232 515 l 17,0,0
+ 1232 515 l 1041,0,0
 1372 -395 m 9,1,-1
- 1232 -255 l 17,0,0
+ 1232 -255 l 1041,0,0
 1372 221 m 9,1,-1
- 1232 361 l 17,0,0
+ 1232 361 l 1041,0,0
 1372 -87 m 9,1,-1
- 1232 53 l 17,0,0
+ 1232 53 l 1041,0,0
 1232 669 m 25,0,0
  1372 529 l 25,1,-1
  1232 669 l 25,0,0
@@ -1333,56 +1338,56 @@ Grid
  1372 683 l 25,1,-1
  1232 823 l 25,0,0
 1372 1299 m 9,0,-1
- 1232 1439 l 17,0,0
+ 1232 1439 l 1041,0,0
 1372 991 m 9,1,-1
- 1232 1131 l 17,0,0
+ 1232 1131 l 1041,0,0
 1372 1607 m 9,1,-1
- 1232 1747 l 17,0,0
+ 1232 1747 l 1041,0,0
 1372 837 m 9,1,-1
- 1232 977 l 17,0,0
+ 1232 977 l 1041,0,0
 1372 1453 m 9,1,-1
- 1232 1593 l 17,0,0
+ 1232 1593 l 1041,0,0
 1372 1145 m 9,1,-1
- 1232 1285 l 17,0,0
+ 1232 1285 l 1041,0,0
 1372 1761 m 9,1,-1
  1232 1901 l 25,0,0
- 1092 2041 l 17,0,0
+ 1092 2041 l 1041,0,0
 1373 -632 m 9,1,-1
- 1233 -492 l 17,0,0
+ 1233 -492 l 1041,0,0
 1079 -492 m 25,0,0
  1219 -632 l 25,1,-1
  1079 -492 l 25,0,0
 603 -632 m 9,0,-1
- 463 -492 l 17,0,0
+ 463 -492 l 1041,0,0
 911 -632 m 9,1,-1
- 771 -492 l 17,0,0
+ 771 -492 l 1041,0,0
 295 -632 m 9,1,-1
- 155 -492 l 17,0,0
+ 155 -492 l 1041,0,0
 1065 -632 m 9,1,-1
- 925 -492 l 17,0,0
+ 925 -492 l 1041,0,0
 449 -632 m 9,1,-1
- 309 -492 l 17,0,0
+ 309 -492 l 1041,0,0
 757 -632 m 9,1,-1
- 617 -492 l 17,0,0
+ 617 -492 l 1041,0,0
 1386 1901 m 9,1,-1
- 1246 2041 l 17,0,0
+ 1246 2041 l 1041,0,0
 938 2041 m 25,0,0
  1078 1901 l 25,1,-1
  938 2041 l 25,0,0
 462 1901 m 9,0,-1
- 322 2041 l 17,0,0
+ 322 2041 l 1041,0,0
 770 1901 m 9,1,-1
- 630 2041 l 17,0,0
+ 630 2041 l 1041,0,0
 154 1901 m 9,1,-1
- 14 2041 l 17,0,0
+ 14 2041 l 1041,0,0
 924 1901 m 9,1,-1
- 784 2041 l 17,0,0
+ 784 2041 l 1041,0,0
 308 1901 m 9,1,-1
- 168 2041 l 17,0,0
+ 168 2041 l 1041,0,0
 616 1901 m 9,1,-1
- 476 2041 l 17,0,0
+ 476 2041 l 1041,0,0
 0 1901 m 9,1,-1
- -140 2041 l 17,0,0
+ -140 2041 l 1041,0,0
 -140 2041 m 1,1,-1
  1373 2041 l 1,2,-1
  1373 -632 l 1,3,-1
@@ -1394,8 +1399,9 @@ Grid
  0 -492 l 1,8,-1
  0 1901 l 1,5,-1
 EndSplineSet
-AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" 
-BeginChars: 1114138 0
+AnchorClass2: "lao-below" "'mark' Mark positioning in Lao" "lao-above" "'mark' Mark positioning in Lao"
+BeginChars: 1114138 3158
+
 StartChar: .notdef
 Encoding: 0 -1 0
 Width: 1233
@@ -1443,14 +1449,16 @@ SplineSet
  219 -248 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: space
-Encoding: 32 32 32
+Encoding: 32 32 1
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclam
-Encoding: 33 33 33
+Encoding: 33 33 2
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1565,8 +1573,9 @@ SplineSet
  629 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedbl
-Encoding: 34 34 34
+Encoding: 34 34 3
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1612,8 +1621,9 @@ SplineSet
  487 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: numbersign
-Encoding: 35 35 35
+Encoding: 35 35 4
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1735,8 +1745,9 @@ SplineSet
  696 1470 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dollar
-Encoding: 36 36 36
+Encoding: 36 36 5
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1894,8 +1905,9 @@ SplineSet
  485 -301 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: percent
-Encoding: 37 37 37
+Encoding: 37 37 6
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1989,30 +2001,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-33 1112 m 0,0,1
+33 1112 m 256,0,1
  33 1246 33 1246 126 1339 c 128,-1,2
- 219 1432 219 1432 352 1432 c 0,3,4
+ 219 1432 219 1432 352 1432 c 256,3,4
  485 1432 485 1432 578.5 1338.5 c 128,-1,5
- 672 1245 672 1245 672 1112 c 0,6,7
+ 672 1245 672 1245 672 1112 c 256,6,7
  672 979 672 979 578.5 886 c 128,-1,8
- 485 793 485 793 352 793 c 0,9,10
+ 485 793 485 793 352 793 c 256,9,10
  219 793 219 793 126 885.5 c 128,-1,11
- 33 978 33 978 33 1112 c 0,0,1
-352 1249 m 0,12,13
+ 33 978 33 978 33 1112 c 256,0,1
+352 1249 m 256,12,13
  295 1249 295 1249 255 1209.5 c 128,-1,14
- 215 1170 215 1170 215 1112 c 0,15,16
+ 215 1170 215 1170 215 1112 c 256,15,16
  215 1054 215 1054 255 1014.5 c 128,-1,17
  295 975 295 975 352 975 c 0,18,19
  410 975 410 975 449.5 1014.5 c 128,-1,20
  489 1054 489 1054 489 1112 c 0,21,22
  489 1169 489 1169 449 1209 c 128,-1,23
- 409 1249 409 1249 352 1249 c 0,12,13
+ 409 1249 409 1249 352 1249 c 256,12,13
 86 561 m 1,24,-1
  1128 979 l 1,25,-1
  1169 883 l 1,26,-1
  121 465 l 1,27,-1
  86 561 l 1,24,-1
-580 319 m 0,28,29
+580 319 m 256,28,29
  580 453 580 453 672.5 546 c 128,-1,30
  765 639 765 639 899 639 c 0,31,32
  1031 639 1031 639 1125 545.5 c 128,-1,33
@@ -2020,20 +2032,21 @@ SplineSet
  1219 187 1219 187 1125 93.5 c 128,-1,36
  1031 0 1031 0 899 0 c 0,37,38
  765 0 765 0 672.5 92.5 c 128,-1,39
- 580 185 580 185 580 319 c 0,28,29
+ 580 185 580 185 580 319 c 256,28,29
 897 457 m 0,40,41
  841 457 841 457 801.5 417 c 128,-1,42
- 762 377 762 377 762 319 c 0,43,44
+ 762 377 762 377 762 319 c 256,43,44
  762 261 762 261 801 221.5 c 128,-1,45
  840 182 840 182 897 182 c 0,46,47
  955 182 955 182 995.5 222 c 128,-1,48
- 1036 262 1036 262 1036 319 c 0,49,50
+ 1036 262 1036 262 1036 319 c 256,49,50
  1036 376 1036 376 995 416.5 c 128,-1,51
  954 457 954 457 897 457 c 0,40,41
 EndSplineSet
 EndChar
+
 StartChar: ampersand
-Encoding: 38 38 38
+Encoding: 38 38 7
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2231,8 +2244,9 @@ SplineSet
  436 731 l 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: quotesingle
-Encoding: 39 39 39
+Encoding: 39 39 8
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2264,8 +2278,9 @@ SplineSet
  743 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: parenleft
-Encoding: 40 40 40
+Encoding: 40 40 9
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2315,8 +2330,9 @@ SplineSet
  1079 1554 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: parenright
-Encoding: 41 41 41
+Encoding: 41 41 10
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2368,8 +2384,9 @@ SplineSet
  113 -270 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: asterisk
-Encoding: 42 42 42
+Encoding: 42 42 11
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2472,8 +2489,9 @@ SplineSet
  1108 1217 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: plus
-Encoding: 43 43 43
+Encoding: 43 43 12
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2531,8 +2549,9 @@ SplineSet
  735 1192 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: comma
-Encoding: 44 44 44
+Encoding: 44 44 13
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2601,8 +2620,9 @@ SplineSet
  434 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: hyphen
-Encoding: 45 45 45
+Encoding: 45 45 14
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2637,8 +2657,9 @@ SplineSet
  299 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: period
-Encoding: 46 46 46
+Encoding: 46 46 15
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2700,8 +2721,9 @@ SplineSet
  418 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: slash
-Encoding: 47 47 47
+Encoding: 47 47 16
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2742,8 +2764,9 @@ SplineSet
  852 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zero
-Encoding: 48 48 48
+Encoding: 48 48 17
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2993,7 +3016,7 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-489 745 m 0,0,1
+489 745 m 256,0,1
  489 798 489 798 525.5 834 c 128,-1,2
  562 870 562 870 614 870 c 0,3,4
  667 870 667 870 704 833.5 c 128,-1,5
@@ -3001,7 +3024,7 @@ SplineSet
  741 694 741 694 704 657.5 c 128,-1,8
  667 621 667 621 614 621 c 0,9,10
  562 621 562 621 525.5 656.5 c 128,-1,11
- 489 692 489 692 489 745 c 0,0,1
+ 489 692 489 692 489 745 c 256,0,1
 383 440 m 0,12,13
  383 327 383 327 417 273 c 128,-1,14
  451 219 451 219 522 219 c 0,15,16
@@ -3030,8 +3053,9 @@ SplineSet
  1143 1283 1143 1283 1143 1071 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: one
-Encoding: 49 49 49
+Encoding: 49 49 18
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3132,8 +3156,9 @@ SplineSet
  94 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: two
-Encoding: 50 50 50
+Encoding: 50 50 19
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3262,8 +3287,9 @@ SplineSet
  354 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: three
-Encoding: 51 51 51
+Encoding: 51 51 20
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3380,8 +3406,9 @@ SplineSet
  621 668 621 668 514 668 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: four
-Encoding: 52 52 52
+Encoding: 52 52 21
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3518,8 +3545,9 @@ SplineSet
  811 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: five
-Encoding: 53 53 53
+Encoding: 53 53 22
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3658,8 +3686,9 @@ SplineSet
  340 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: six
-Encoding: 54 54 54
+Encoding: 54 54 23
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3754,8 +3783,9 @@ SplineSet
  1093 1488 1093 1488 1169 1458 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: seven
-Encoding: 55 55 55
+Encoding: 55 55 24
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3824,8 +3854,9 @@ SplineSet
  262 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: eight
-Encoding: 56 56 56
+Encoding: 56 56 25
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3948,8 +3979,9 @@ SplineSet
  485 1160 485 1160 485 1069 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: nine
-Encoding: 57 57 57
+Encoding: 57 57 26
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4040,8 +4072,9 @@ SplineSet
  424 1078 424 1078 424 928 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: colon
-Encoding: 58 58 58
+Encoding: 58 58 27
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4140,8 +4173,9 @@ SplineSet
  375 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: semicolon
-Encoding: 59 59 59
+Encoding: 59 59 28
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4233,8 +4267,9 @@ SplineSet
  510 1063 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: less
-Encoding: 60 60 60
+Encoding: 60 60 29
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4283,8 +4318,9 @@ SplineSet
  1145 926 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equal
-Encoding: 61 61 61
+Encoding: 61 61 30
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4333,8 +4369,9 @@ SplineSet
  88 987 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: greater
-Encoding: 62 62 62
+Encoding: 62 62 31
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4383,8 +4420,9 @@ SplineSet
  88 926 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: question
-Encoding: 63 63 63
+Encoding: 63 63 32
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4557,8 +4595,9 @@ SplineSet
  635 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: at
-Encoding: 64 64 64
+Encoding: 64 64 33
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4711,8 +4750,9 @@ SplineSet
  1067 135 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: A
-Encoding: 65 65 65
+Encoding: 65 65 34
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4845,8 +4885,9 @@ SplineSet
  582 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: B
-Encoding: 66 66 66
+Encoding: 66 66 35
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5030,8 +5071,9 @@ SplineSet
  270 1495 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: C
-Encoding: 67 67 67
+Encoding: 67 67 36
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5132,8 +5174,9 @@ SplineSet
  946 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: D
-Encoding: 68 68 68
+Encoding: 68 68 37
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5258,8 +5301,9 @@ SplineSet
  283 1493 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: E
-Encoding: 69 69 69
+Encoding: 69 69 38
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5367,8 +5411,9 @@ SplineSet
  958 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: F
-Encoding: 70 70 70
+Encoding: 70 70 39
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5469,8 +5514,9 @@ SplineSet
  1217 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: G
-Encoding: 71 71 71
+Encoding: 71 71 40
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5623,8 +5669,9 @@ SplineSet
  991 94 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: H
-Encoding: 72 72 72
+Encoding: 72 72 41
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5782,8 +5829,9 @@ SplineSet
  283 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: I
-Encoding: 73 73 73
+Encoding: 73 73 42
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5880,8 +5928,9 @@ SplineSet
  266 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: J
-Encoding: 74 74 74
+Encoding: 74 74 43
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5983,15 +6032,16 @@ SplineSet
  1153 1493 l 1,11,-1
  954 479 l 1,12,13
  921 309 921 309 880 223 c 128,-1,14
- 839 137 839 137 772 82 c 0,15,16
+ 839 137 839 137 772 82 c 256,15,16
  705 27 705 27 614 -1 c 128,-1,17
  523 -29 523 -29 410 -29 c 0,18,19
  299 -29 299 -29 192 -2.5 c 128,-1,20
  85 24 85 24 -20 78 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: K
-Encoding: 75 75 75
+Encoding: 75 75 44
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6133,8 +6183,9 @@ SplineSet
  270 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: L
-Encoding: 76 76 76
+Encoding: 76 76 45
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6205,8 +6256,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: M
-Encoding: 77 77 77
+Encoding: 77 77 46
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6450,8 +6502,9 @@ SplineSet
  231 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: N
-Encoding: 78 78 78
+Encoding: 78 78 47
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6636,8 +6689,9 @@ SplineSet
  266 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: O
-Encoding: 79 79 79
+Encoding: 79 79 48
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6757,8 +6811,9 @@ SplineSet
  61 224 61 224 61 465 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: P
-Encoding: 80 80 80
+Encoding: 80 80 49
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6895,8 +6950,9 @@ SplineSet
  307 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Q
-Encoding: 81 81 81
+Encoding: 81 81 50
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7064,8 +7120,9 @@ SplineSet
  868 945 868 945 868 1020 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: R
-Encoding: 82 82 82
+Encoding: 82 82 51
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7260,8 +7317,9 @@ SplineSet
  547 1245 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: S
-Encoding: 83 83 83
+Encoding: 83 83 52
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7483,8 +7541,9 @@ SplineSet
  506 664 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: T
-Encoding: 84 84 84
+Encoding: 84 84 53
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7622,8 +7681,9 @@ SplineSet
  618 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: U
-Encoding: 85 85 85
+Encoding: 85 85 54
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7769,8 +7829,9 @@ SplineSet
  56 494 56 494 68 551 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: V
-Encoding: 86 86 86
+Encoding: 86 86 55
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7858,8 +7919,9 @@ SplineSet
  518 242 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: W
-Encoding: 87 87 87
+Encoding: 87 87 56
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8026,8 +8088,9 @@ SplineSet
  143 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: X
-Encoding: 88 88 88
+Encoding: 88 88 57
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8167,8 +8230,9 @@ SplineSet
  1071 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Y
-Encoding: 89 89 89
+Encoding: 89 89 58
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8284,8 +8348,9 @@ SplineSet
  145 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Z
-Encoding: 90 90 90
+Encoding: 90 90 59
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8361,8 +8426,9 @@ SplineSet
  281 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketleft
-Encoding: 91 91 91
+Encoding: 91 91 60
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8451,8 +8517,9 @@ SplineSet
  580 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: backslash
-Encoding: 92 92 92
+Encoding: 92 92 61
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8513,8 +8580,9 @@ SplineSet
  543 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketright
-Encoding: 93 93 93
+Encoding: 93 93 62
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8599,8 +8667,9 @@ SplineSet
  612 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciicircum
-Encoding: 94 94 94
+Encoding: 94 94 63
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8642,8 +8711,9 @@ SplineSet
  739 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underscore
-Encoding: 95 95 95
+Encoding: 95 95 64
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8673,8 +8743,9 @@ SplineSet
  1233 -293 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: grave
-Encoding: 96 96 96
+Encoding: 96 96 65
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8730,8 +8801,9 @@ SplineSet
  655 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: a
-Encoding: 97 97 97
+Encoding: 97 97 66
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9024,8 +9096,9 @@ SplineSet
  1127 703 1127 703 1114 639 c 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: b
-Encoding: 98 98 98
+Encoding: 98 98 67
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9234,8 +9307,9 @@ SplineSet
  398 96 398 96 381 207 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: c
-Encoding: 99 99 99
+Encoding: 99 99 68
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9345,8 +9419,9 @@ SplineSet
  956 37 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: d
-Encoding: 100 100 100
+Encoding: 100 100 69
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9555,8 +9630,9 @@ SplineSet
  839 1022 839 1022 854 911 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: e
-Encoding: 101 101 101
+Encoding: 101 101 70
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9708,8 +9784,9 @@ SplineSet
  876 684 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: f
-Encoding: 102 102 102
+Encoding: 102 102 71
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9895,8 +9972,9 @@ SplineSet
  872 1276 872 1276 856 1196 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: g
-Encoding: 103 103 103
+Encoding: 103 103 72
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10143,8 +10221,9 @@ SplineSet
  987 84 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: h
-Encoding: 104 104 104
+Encoding: 104 104 73
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10388,8 +10467,9 @@ SplineSet
  1111 775 1111 775 1102 728 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: i
-Encoding: 105 105 105
+Encoding: 105 105 74
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10556,8 +10636,9 @@ SplineSet
  702 1665 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: j
-Encoding: 106 106 106
+Encoding: 106 106 75
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10759,8 +10840,9 @@ SplineSet
  983 1323 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: k
-Encoding: 107 107 107
+Encoding: 107 107 76
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10924,8 +11006,9 @@ SplineSet
  383 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: l
-Encoding: 108 108 108
+Encoding: 108 108 77
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11086,8 +11169,9 @@ SplineSet
  625 365 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: m
-Encoding: 109 109 109
+Encoding: 109 109 78
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11513,13 +11597,14 @@ SplineSet
  397 1120 l 1,37,-1
  375 1004 l 1,38,39
  416 1072 416 1072 476.5 1109.5 c 128,-1,40
- 537 1147 537 1147 606 1147 c 0,41,42
+ 537 1147 537 1147 606 1147 c 256,41,42
  675 1147 675 1147 718.5 1109.5 c 128,-1,43
  762 1072 762 1072 770 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: n
-Encoding: 110 110 110
+Encoding: 110 110 79
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11750,8 +11835,9 @@ SplineSet
  1111 775 1111 775 1102 728 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: o
-Encoding: 111 111 111
+Encoding: 111 111 80
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11812,8 +11898,9 @@ SplineSet
  88 212 88 212 88 426 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: p
-Encoding: 112 112 112
+Encoding: 112 112 81
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12012,8 +12099,9 @@ SplineSet
  526 209 526 209 602 209 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: q
-Encoding: 113 113 113
+Encoding: 113 113 82
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12224,8 +12312,9 @@ SplineSet
  709 909 709 909 633 909 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: r
-Encoding: 114 114 114
+Encoding: 114 114 83
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12369,8 +12458,9 @@ SplineSet
  1174 815 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: s
-Encoding: 115 115 115
+Encoding: 115 115 84
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12591,8 +12681,9 @@ SplineSet
  1002 1116 1002 1116 1094 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: t
-Encoding: 116 116 116
+Encoding: 116 116 85
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12779,8 +12870,9 @@ SplineSet
  848 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: u
-Encoding: 117 117 117
+Encoding: 117 117 86
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13014,8 +13106,9 @@ SplineSet
  114 344 114 344 123 391 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: v
-Encoding: 118 118 118
+Encoding: 118 118 87
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13189,8 +13282,9 @@ SplineSet
  1231 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: w
-Encoding: 119 119 119
+Encoding: 119 119 88
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13390,8 +13484,9 @@ SplineSet
  96 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: x
-Encoding: 120 120 120
+Encoding: 120 120 89
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13620,8 +13715,9 @@ SplineSet
  1227 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: y
-Encoding: 121 121 121
+Encoding: 121 121 90
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13817,8 +13913,9 @@ SplineSet
  551 -121 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: z
-Encoding: 122 122 122
+Encoding: 122 122 91
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13953,8 +14050,9 @@ SplineSet
  293 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceleft
-Encoding: 123 123 123
+Encoding: 123 123 92
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14177,8 +14275,9 @@ SplineSet
  879 -143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bar
-Encoding: 124 124 124
+Encoding: 124 124 93
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14210,8 +14309,9 @@ SplineSet
  729 1565 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceright
-Encoding: 125 125 125
+Encoding: 125 125 94
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14440,8 +14540,9 @@ SplineSet
  6 -143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciitilde
-Encoding: 126 126 126
+Encoding: 126 126 95
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14513,14 +14614,16 @@ SplineSet
  1072 747 1072 747 1145 811 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: nonbreakingspace
-Encoding: 160 160 160
+Encoding: 160 160 96
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclamdown
-Encoding: 161 161 161
+Encoding: 161 161 97
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14639,8 +14742,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" exclamdown.case
 EndChar
+
 StartChar: cent
-Encoding: 162 162 162
+Encoding: 162 162 98
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14762,8 +14866,9 @@ SplineSet
  469 218 469 218 552 215 c 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: sterling
-Encoding: 163 163 163
+Encoding: 163 163 99
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14927,8 +15032,9 @@ SplineSet
  1174 1488 1174 1488 1245 1456 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: currency
-Encoding: 164 164 164
+Encoding: 164 164 100
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15075,8 +15181,9 @@ SplineSet
  773 961 773 961 819 938 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: yen
-Encoding: 165 165 165
+Encoding: 165 165 101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15246,8 +15353,9 @@ SplineSet
  127 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: brokenbar
-Encoding: 166 166 166
+Encoding: 166 166 102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15292,8 +15400,9 @@ SplineSet
  729 1432 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: section
-Encoding: 167 167 167
+Encoding: 167 167 103
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15492,8 +15601,9 @@ SplineSet
  972 1490 972 1490 1059 1460 c 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: dieresis
-Encoding: 168 168 168
+Encoding: 168 168 104
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15603,10 +15713,11 @@ SplineSet
  416 1339 l 1,7,-1
  463 1585 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: copyright
-Encoding: 169 169 169
+Encoding: 169 169 105
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15687,7 +15798,7 @@ SplineSet
  796 912 796 912 750.5 926 c 128,-1,3
  705 940 705 940 657 940 c 0,4,5
  560 940 560 940 506.5 888 c 128,-1,6
- 453 836 453 836 453 741 c 0,7,8
+ 453 836 453 836 453 741 c 256,7,8
  453 646 453 646 506 594.5 c 128,-1,9
  559 543 559 543 657 543 c 0,10,11
  710 543 710 543 758 557.5 c 128,-1,12
@@ -15707,11 +15818,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,31
  1233 867 1233 867 1233 741 c 0,32,33
  1233 616 1233 616 1187.5 507 c 128,-1,34
- 1142 398 1142 398 1051 307 c 0,35,36
+ 1142 398 1142 398 1051 307 c 256,35,36
  960 216 960 216 851 170.5 c 128,-1,37
  742 125 742 125 616 125 c 0,38,39
  491 125 491 125 382 170.5 c 128,-1,40
- 273 216 273 216 182 307 c 0,41,42
+ 273 216 273 216 182 307 c 256,41,42
  91 398 91 398 45.5 507 c 128,-1,43
  0 616 0 616 0 741 c 0,44,45
  0 867 0 867 46 977 c 128,-1,46
@@ -15724,7 +15835,7 @@ SplineSet
  203 1014 203 1014 167 928 c 128,-1,55
  131 842 131 842 131 741 c 0,56,57
  131 643 131 643 167 558 c 128,-1,58
- 203 473 203 473 274 401 c 0,59,60
+ 203 473 203 473 274 401 c 256,59,60
  345 329 345 329 431 292.5 c 128,-1,61
  517 256 517 256 616 256 c 0,62,63
  716 256 716 256 802 292.5 c 128,-1,64
@@ -15737,8 +15848,9 @@ SplineSet
  717 1229 717 1229 616 1229 c 0,50,51
 EndSplineSet
 EndChar
+
 StartChar: ordfeminine
-Encoding: 170 170 170
+Encoding: 170 170 106
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15902,8 +16014,9 @@ SplineSet
  246 598 l 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotleft
-Encoding: 171 171 171
+Encoding: 171 171 107
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15978,8 +16091,9 @@ SplineSet
  649 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalnot
-Encoding: 172 172 172
+Encoding: 172 172 108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16021,8 +16135,9 @@ SplineSet
  88 899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: sfthyphen
-Encoding: 173 173 173
+Encoding: 173 173 109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16057,8 +16172,9 @@ SplineSet
  299 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: registered
-Encoding: 174 174 174
+Encoding: 174 174 110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16164,11 +16280,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,5
  1233 867 1233 867 1233 741 c 0,6,7
  1233 616 1233 616 1187.5 507 c 128,-1,8
- 1142 398 1142 398 1051 307 c 0,9,10
+ 1142 398 1142 398 1051 307 c 256,9,10
  960 216 960 216 851 170.5 c 128,-1,11
  742 125 742 125 616 125 c 0,12,13
  491 125 491 125 382 170.5 c 128,-1,14
- 273 216 273 216 182 307 c 0,15,16
+ 273 216 273 216 182 307 c 256,15,16
  91 398 91 398 45.5 507 c 128,-1,17
  0 616 0 616 0 741 c 0,18,19
  0 867 0 867 46 977 c 128,-1,20
@@ -16208,7 +16324,7 @@ SplineSet
  131 643 131 643 167 558 c 128,-1,61
  203 473 203 473 274 399 c 1,62,63
  346 328 346 328 431.5 292 c 128,-1,64
- 517 256 517 256 616 256 c 0,65,66
+ 517 256 517 256 616 256 c 256,65,66
  715 256 715 256 801 292 c 128,-1,67
  887 328 887 328 958 399 c 0,68,69
  1030 473 1030 473 1066 558 c 128,-1,70
@@ -16219,8 +16335,9 @@ SplineSet
  717 1229 717 1229 616 1229 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: macron
-Encoding: 175 175 175
+Encoding: 175 175 111
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16277,10 +16394,11 @@ SplineSet
  422 1368 l 1,3,-1
  459 1556 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: degree
-Encoding: 176 176 176
+Encoding: 176 176 112
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16333,17 +16451,18 @@ SplineSet
  475 1520 475 1520 616 1520 c 0,0,1
 616 1358 m 0,18,19
  544 1358 544 1358 494 1308 c 128,-1,20
- 444 1258 444 1258 444 1186 c 0,21,22
+ 444 1258 444 1258 444 1186 c 256,21,22
  444 1114 444 1114 493 1065 c 128,-1,23
- 542 1016 542 1016 614 1016 c 0,24,25
+ 542 1016 542 1016 614 1016 c 256,24,25
  686 1016 686 1016 736 1065.5 c 128,-1,26
  786 1115 786 1115 786 1186 c 0,27,28
  786 1258 786 1258 736.5 1308 c 128,-1,29
  687 1358 687 1358 616 1358 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: plusminus
-Encoding: 177 177 177
+Encoding: 177 177 113
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16413,8 +16532,9 @@ SplineSet
  88 238 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: twosuperior
-Encoding: 178 178 178
+Encoding: 178 178 114
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16518,8 +16638,9 @@ SplineSet
  550 839 550 839 514 813 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: threesuperior
-Encoding: 179 179 179
+Encoding: 179 179 115
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16634,8 +16755,9 @@ SplineSet
  714 1042 714 1042 639 1042 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: acute
-Encoding: 180 180 180
+Encoding: 180 180 116
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16688,10 +16810,11 @@ SplineSet
  569 1262 l 1,3,-1
  887 1638 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: mu
-Encoding: 181 181 181
+Encoding: 181 181 117
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16880,8 +17003,9 @@ SplineSet
  -55 -428 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: paragraph
-Encoding: 182 182 182
+Encoding: 182 182 118
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17000,8 +17124,9 @@ SplineSet
  427 1493 427 1493 672 1493 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: periodcentered
-Encoding: 183 183 183
+Encoding: 183 183 119
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17063,17 +17188,19 @@ SplineSet
  479 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: cedilla
-Encoding: 184 184 184
+Encoding: 184 184 120
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 692 807 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: onesuperior
-Encoding: 185 185 185
+Encoding: 185 185 121
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17178,8 +17305,9 @@ SplineSet
  315 813 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ordmasculine
-Encoding: 186 186 186
+Encoding: 186 186 122
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17264,8 +17392,9 @@ SplineSet
  254 598 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotright
-Encoding: 187 187 187
+Encoding: 187 187 123
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17340,40 +17469,44 @@ SplineSet
  715 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: onequarter
-Encoding: 188 188 188
+Encoding: 188 188 124
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1908 8308 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: onehalf
-Encoding: 189 189 189
+Encoding: 189 189 125
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 154 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 154 -938 2
 EndChar
+
 StartChar: threequarters
-Encoding: 190 190 190
+Encoding: 190 190 126
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 137 -938 2
-Refer: 179 179 N 1 0 0 1 -227 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1908 8308 N 1 0 0 1 137 -938 2
+Refer: 115 179 N 1 0 0 1 -227 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: questiondown
-Encoding: 191 191 191
+Encoding: 191 191 127
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17548,53 +17681,59 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" questiondown.case
 EndChar
+
 StartChar: Agrave
-Encoding: 192 192 192
+Encoding: 192 192 128
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Aacute
-Encoding: 193 193 193
+Encoding: 193 193 129
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Acircumflex
-Encoding: 194 194 194
+Encoding: 194 194 130
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Atilde
-Encoding: 195 195 195
+Encoding: 195 195 131
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Adieresis
-Encoding: 196 196 196
+Encoding: 196 196 132
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Aring
-Encoding: 197 197 197
+Encoding: 197 197 133
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17747,15 +17886,15 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-623 1616 m 0,0,1
+623 1616 m 256,0,1
  623 1562 623 1562 661.5 1523.5 c 128,-1,2
- 700 1485 700 1485 754 1485 c 0,3,4
+ 700 1485 700 1485 754 1485 c 256,3,4
  808 1485 808 1485 846.5 1523.5 c 128,-1,5
- 885 1562 885 1562 885 1616 c 0,6,7
+ 885 1562 885 1562 885 1616 c 256,6,7
  885 1670 885 1670 846 1708.5 c 128,-1,8
  807 1747 807 1747 754 1747 c 0,9,10
  700 1747 700 1747 661.5 1708.5 c 128,-1,11
- 623 1670 623 1670 623 1616 c 0,0,1
+ 623 1670 623 1670 623 1616 c 256,0,1
 948 1409 m 1,12,-1
  1055 0 l 1,13,-1
  760 0 l 1,14,-1
@@ -17778,8 +17917,9 @@ SplineSet
  709 1223 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: AE
-Encoding: 198 198 198
+Encoding: 198 198 134
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17944,90 +18084,100 @@ SplineSet
  637 1233 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: Ccedilla
-Encoding: 199 199 199
+Encoding: 199 199 135
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 117 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 117 0 2
 EndChar
+
 StartChar: Egrave
-Encoding: 200 200 200
+Encoding: 200 200 136
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 88 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: Eacute
-Encoding: 201 201 201
+Encoding: 201 201 137
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 88 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: Ecircumflex
-Encoding: 202 202 202
+Encoding: 202 202 138
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 88 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: Edieresis
-Encoding: 203 203 203
+Encoding: 203 203 139
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 88 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: Igrave
-Encoding: 204 204 204
+Encoding: 204 204 140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 47 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Iacute
-Encoding: 205 205 205
+Encoding: 205 205 141
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 47 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Icircumflex
-Encoding: 206 206 206
+Encoding: 206 206 142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 47 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Idieresis
-Encoding: 207 207 207
+Encoding: 207 207 143
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 47 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 47 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eth
-Encoding: 208 208 208
+Encoding: 208 208 144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18192,62 +18342,69 @@ SplineSet
  524 1227 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: Ntilde
-Encoding: 209 209 209
+Encoding: 209 209 145
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 51 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Ograve
-Encoding: 210 210 210
+Encoding: 210 210 146
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 51 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Oacute
-Encoding: 211 211 211
+Encoding: 211 211 147
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 51 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Ocircumflex
-Encoding: 212 212 212
+Encoding: 212 212 148
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 51 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Otilde
-Encoding: 213 213 213
+Encoding: 213 213 149
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 51 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Odieresis
-Encoding: 214 214 214
+Encoding: 214 214 150
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: multiply
-Encoding: 215 215 215
+Encoding: 215 215 151
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18318,8 +18475,9 @@ SplineSet
  1112 971 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Oslash
-Encoding: 216 216 216
+Encoding: 216 216 152
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18474,54 +18632,60 @@ SplineSet
  852 1153 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: Ugrave
-Encoding: 217 217 217
+Encoding: 217 217 153
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 57 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Uacute
-Encoding: 218 218 218
+Encoding: 218 218 154
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 57 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Ucircumflex
-Encoding: 219 219 219
+Encoding: 219 219 155
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Udieresis
-Encoding: 220 220 220
+Encoding: 220 220 156
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Yacute
-Encoding: 221 221 221
+Encoding: 221 221 157
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 47 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Thorn
-Encoding: 222 222 222
+Encoding: 222 222 158
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18689,8 +18853,9 @@ SplineSet
  510 1018 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: germandbls
-Encoding: 223 223 223
+Encoding: 223 223 159
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18994,62 +19159,69 @@ SplineSet
  1145 1059 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: agrave
-Encoding: 224 224 224
+Encoding: 224 224 160
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: aacute
-Encoding: 225 225 225
+Encoding: 225 225 161
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: acircumflex
-Encoding: 226 226 226
+Encoding: 226 226 162
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: atilde
-Encoding: 227 227 227
+Encoding: 227 227 163
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: adieresis
-Encoding: 228 228 228
+Encoding: 228 228 164
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: aring
-Encoding: 229 229 229
+Encoding: 229 229 165
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 31 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 636 730 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: ae
-Encoding: 230 230 230
+Encoding: 230 230 166
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19418,90 +19590,100 @@ SplineSet
  1176 477 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: ccedilla
-Encoding: 231 231 231
+Encoding: 231 231 167
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 72 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 72 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: egrave
-Encoding: 232 232 232
+Encoding: 232 232 168
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eacute
-Encoding: 233 233 233
+Encoding: 233 233 169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ecircumflex
-Encoding: 234 234 234
+Encoding: 234 234 170
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: edieresis
-Encoding: 235 235 235
+Encoding: 235 235 171
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: igrave
-Encoding: 236 236 236
+Encoding: 236 236 172
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 -45 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -45 0 2
 EndChar
+
 StartChar: iacute
-Encoding: 237 237 237
+Encoding: 237 237 173
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 -45 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -45 0 2
 EndChar
+
 StartChar: icircumflex
-Encoding: 238 238 238
+Encoding: 238 238 174
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 -45 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 -45 0 2
 EndChar
+
 StartChar: idieresis
-Encoding: 239 239 239
+Encoding: 239 239 175
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 -45 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -45 0 2
 EndChar
+
 StartChar: eth
-Encoding: 240 240 240
+Encoding: 240 240 176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19674,62 +19856,69 @@ SplineSet
  903 1329 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: ntilde
-Encoding: 241 241 241
+Encoding: 241 241 177
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ograve
-Encoding: 242 242 242
+Encoding: 242 242 178
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: oacute
-Encoding: 243 243 243
+Encoding: 243 243 179
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ocircumflex
-Encoding: 244 244 244
+Encoding: 244 244 180
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: otilde
-Encoding: 245 245 245
+Encoding: 245 245 181
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: odieresis
-Encoding: 246 246 246
+Encoding: 246 246 182
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: divide
-Encoding: 247 247 247
+Encoding: 247 247 183
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19790,8 +19979,9 @@ SplineSet
  66 762 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: oslash
-Encoding: 248 248 248
+Encoding: 248 248 184
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19948,54 +20138,60 @@ SplineSet
  801 856 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: ugrave
-Encoding: 249 249 249
+Encoding: 249 249 185
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uacute
-Encoding: 250 250 250
+Encoding: 250 250 186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ucircumflex
-Encoding: 251 251 251
+Encoding: 251 251 187
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: udieresis
-Encoding: 252 252 252
+Encoding: 252 252 188
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: yacute
-Encoding: 253 253 253
+Encoding: 253 253 189
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: thorn
-Encoding: 254 254 254
+Encoding: 254 254 190
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20177,171 +20373,190 @@ SplineSet
  399 95 399 95 379 207 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: ydieresis
-Encoding: 255 255 255
+Encoding: 255 255 191
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Amacron
-Encoding: 256 256 256
+Encoding: 256 256 192
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: amacron
-Encoding: 257 257 257
+Encoding: 257 257 193
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Abreve
-Encoding: 258 258 258
+Encoding: 258 258 194
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: abreve
-Encoding: 259 259 259
+Encoding: 259 259 195
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Aogonek
-Encoding: 260 260 260
+Encoding: 260 260 196
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 355 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 355 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aogonek
-Encoding: 261 261 261
+Encoding: 261 261 197
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 288 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 288 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cacute
-Encoding: 262 262 262
+Encoding: 262 262 198
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 193 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 193 373 2
 EndChar
+
 StartChar: cacute
-Encoding: 263 263 263
+Encoding: 263 263 199
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 86 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 86 0 2
 EndChar
+
 StartChar: Ccircumflex
-Encoding: 264 264 264
+Encoding: 264 264 200
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 193 373 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 193 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ccircumflex
-Encoding: 265 265 265
+Encoding: 265 265 201
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 86 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 86 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cdotaccent
-Encoding: 266 266 266
+Encoding: 266 266 202
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 100 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: cdotaccent
-Encoding: 267 267 267
+Encoding: 267 267 203
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 75 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 75 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ccaron
-Encoding: 268 268 268
+Encoding: 268 268 204
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 193 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 193 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ccaron
-Encoding: 269 269 269
+Encoding: 269 269 205
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 86 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 86 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcaron
-Encoding: 270 270 270
+Encoding: 270 270 206
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 73 373 2
-LCarets2: 1 0 
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 73 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dcaron
-Encoding: 271 271 271
+Encoding: 271 271 207
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 631 -82 2
-Refer: 100 100 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 1 0 0 1 631 -82 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcroat
-Encoding: 272 272 272
+Encoding: 272 272 208
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dcroat
-Encoding: 273 273 273
+Encoding: 273 273 209
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20576,187 +20791,208 @@ SplineSet
  709 909 709 909 633 909 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: Emacron
-Encoding: 274 274 274
+Encoding: 274 274 210
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 31 0 2
 EndChar
+
 StartChar: emacron
-Encoding: 275 275 275
+Encoding: 275 275 211
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 39 0 2
 EndChar
+
 StartChar: Ebreve
-Encoding: 276 276 276
+Encoding: 276 276 212
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ebreve
-Encoding: 277 277 277
+Encoding: 277 277 213
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Edotaccent
-Encoding: 278 278 278
+Encoding: 278 278 214
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: edotaccent
-Encoding: 279 279 279
+Encoding: 279 279 215
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eogonek
-Encoding: 280 280 280
+Encoding: 280 280 216
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 275 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 275 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eogonek
-Encoding: 281 281 281
+Encoding: 281 281 217
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 276 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 276 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ecaron
-Encoding: 282 282 282
+Encoding: 282 282 218
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 109 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 109 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecaron
-Encoding: 283 283 283
+Encoding: 283 283 219
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 66 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 66 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gcircumflex
-Encoding: 284 284 284
+Encoding: 284 284 220
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 185 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 185 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcircumflex
-Encoding: 285 285 285
+Encoding: 285 285 221
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gbreve
-Encoding: 286 286 286
+Encoding: 286 286 222
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gbreve
-Encoding: 287 287 287
+Encoding: 287 287 223
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gdotaccent
-Encoding: 288 288 288
+Encoding: 288 288 224
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gdotaccent
-Encoding: 289 289 289
+Encoding: 289 289 225
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcommaaccent
-Encoding: 290 290 290
+Encoding: 290 290 226
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 205.74 11 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 205.74 11 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcommaaccent
-Encoding: 291 291 291
+Encoding: 291 291 227
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 786 786 N 1 0 0 1 90.3739 370 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 671 786 N 1 0 0 1 90.3739 370 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hcircumflex
-Encoding: 292 292 292
+Encoding: 292 292 228
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 76 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 76 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hcircumflex
-Encoding: 293 293 293
+Encoding: 293 293 229
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 -211 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 -211 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hbar
-Encoding: 294 294 294
+Encoding: 294 294 230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20790,8 +21026,9 @@ SplineSet
  502 1105 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: hbar
-Encoding: 295 295 295
+Encoding: 295 295 231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20828,88 +21065,98 @@ SplineSet
  1072 784 1072 784 1061 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Itilde
-Encoding: 296 296 296
+Encoding: 296 296 232
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 47 373 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 47 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: itilde
-Encoding: 297 297 297
+Encoding: 297 297 233
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -45 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 -45 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Imacron
-Encoding: 298 298 298
+Encoding: 298 298 234
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: imacron
-Encoding: 299 299 299
+Encoding: 299 299 235
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ibreve
-Encoding: 300 300 300
+Encoding: 300 300 236
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ibreve
-Encoding: 301 301 301
+Encoding: 301 301 237
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iogonek
-Encoding: 302 302 302
+Encoding: 302 302 238
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 39.8711 -0.00195312 2
-Refer: 731 731 N 1 0 0 1 104.868 0.000455856 2
+Refer: 42 73 N 1 0 0 1 39.8711 -0.00195312 2
+Refer: 637 731 N 1 0 0 1 104.868 0.000455856 2
 EndChar
+
 StartChar: iogonek
-Encoding: 303 303 303
+Encoding: 303 303 239
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 6.15137 0 2
-Refer: 731 731 N 1 0 0 1 125.152 0.000455856 2
+Refer: 74 105 N 1 0 0 1 6.15137 0 2
+Refer: 637 731 N 1 0 0 1 125.152 0.000455856 2
 EndChar
+
 StartChar: Idotaccent
-Encoding: 304 304 304
+Encoding: 304 304 240
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotlessi
-Encoding: 305 305 305
+Encoding: 305 305 241
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21030,8 +21277,9 @@ SplineSet
  309 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: IJ
-Encoding: 306 306 306
+Encoding: 306 306 242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21069,8 +21317,9 @@ SplineSet
  242.572 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ij
-Encoding: 307 307 307
+Encoding: 307 307 243
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21114,42 +21363,47 @@ SplineSet
  620.501 1665 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: Jcircumflex
-Encoding: 308 308 308
+Encoding: 308 308 244
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 139 373 2
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 139 373 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: jcircumflex
-Encoding: 309 309 309
+Encoding: 309 309 245
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -38 0 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 -38 0 2
+Refer: 491 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kcommaaccent
-Encoding: 310 310 310
+Encoding: 310 310 246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 136.74 40 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 136.74 40 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kcommaaccent
-Encoding: 311 311 311
+Encoding: 311 311 247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 189.74 40 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 189.74 40 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kgreenlandic
-Encoding: 312 312 312
+Encoding: 312 312 248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21170,85 +21424,94 @@ SplineSet
  283 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Lacute
-Encoding: 313 313 313
+Encoding: 313 313 249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 47 374 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 47 374 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lacute
-Encoding: 314 314 314
+Encoding: 314 314 250
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 46 375 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 46 375 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lcommaaccent
-Encoding: 315 315 315
+Encoding: 315 315 251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 138.74 40 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 138.74 40 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lcommaaccent
-Encoding: 316 316 316
+Encoding: 316 316 252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 76.24 45 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 76.24 45 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lcaron
-Encoding: 317 317 317
+Encoding: 317 317 253
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 206 -146 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 1 0 0 1 206 -146 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lcaron
-Encoding: 318 318 318
+Encoding: 318 318 254
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 290 -82 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 1 0 0 1 290 -82 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ldot
-Encoding: 319 319 319
+Encoding: 319 319 255
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 423.03 172.5 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 423.03 172.5 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ldot
-Encoding: 320 320 320
+Encoding: 320 320 256
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 575 168 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 575 168 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lslash
-Encoding: 321 321 321
+Encoding: 321 321 257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21373,8 +21636,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lslash
-Encoding: 322 322 322
+Encoding: 322 322 258
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21561,74 +21825,82 @@ SplineSet
  639 364 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: Nacute
-Encoding: 323 323 323
+Encoding: 323 323 259
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 66 374 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 66 374 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nacute
-Encoding: 324 324 324
+Encoding: 324 324 260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -5.653 9 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -5.653 9 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncommaaccent
-Encoding: 325 325 325
+Encoding: 325 325 261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 66.7398 40 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 66.7398 40 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ncommaaccent
-Encoding: 326 326 326
+Encoding: 326 326 262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 105.74 40 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 105.74 40 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncaron
-Encoding: 327 327 327
+Encoding: 327 327 263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 127 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 127 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ncaron
-Encoding: 328 328 328
+Encoding: 328 328 264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 20 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 20 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: napostrophe
-Encoding: 329 329 329
+Encoding: 329 329 265
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 700 700 N 1 0 0 1 -542 0 2
-Refer: 110 110 N 1 0 0 1 159 0 2
-LCarets2: 1 0 
+Refer: 614 700 N 1 0 0 1 -542 0 2
+Refer: 79 110 N 1 0 0 1 159 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eng
-Encoding: 330 330 330
+Encoding: 330 330 266
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21660,8 +21932,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms lookup 0-1" Eng.alt
 EndChar
+
 StartChar: eng
-Encoding: 331 331 331
+Encoding: 331 331 267
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21694,62 +21967,69 @@ SplineSet
  1158 811 1158 811 1142 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omacron
-Encoding: 332 332 332
+Encoding: 332 332 268
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omacron
-Encoding: 333 333 333
+Encoding: 333 333 269
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Obreve
-Encoding: 334 334 334
+Encoding: 334 334 270
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: obreve
-Encoding: 335 335 335
+Encoding: 335 335 271
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ohungarumlaut
-Encoding: 336 336 336
+Encoding: 336 336 272
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ohungarumlaut
-Encoding: 337 337 337
+Encoding: 337 337 273
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 664 779 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: OE
-Encoding: 338 338 338
+Encoding: 338 338 274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21886,8 +22166,9 @@ SplineSet
  664 1233 l 2,20,21
 EndSplineSet
 EndChar
+
 StartChar: oe
-Encoding: 339 339 339
+Encoding: 339 339 275
 Width: 1233
 Flags: W
 TtInstrs:
@@ -22138,174 +22419,193 @@ SplineSet
  262 184 262 184 319 184 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: Racute
-Encoding: 340 340 340
+Encoding: 340 340 276
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 48 374 2
-Refer: 82 82 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 48 374 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: racute
-Encoding: 341 341 341
+Encoding: 341 341 277
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 164.347 9 2
-Refer: 114 114 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 116 180 N 1 0 0 1 164.347 9 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Rcommaaccent
-Encoding: 342 342 342
+Encoding: 342 342 278
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 153.74 40 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 153.74 40 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: rcommaaccent
-Encoding: 343 343 343
+Encoding: 343 343 279
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -102.76 40 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 -102.76 40 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rcaron
-Encoding: 344 344 344
+Encoding: 344 344 280
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 55 373 2
-LCarets2: 1 0 
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 55 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: rcaron
-Encoding: 345 345 345
+Encoding: 345 345 281
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 86 0 2
-LCarets2: 1 0 
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 86 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Sacute
-Encoding: 346 346 346
+Encoding: 346 346 282
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 66 374 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 66 374 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: sacute
-Encoding: 347 347 347
+Encoding: 347 347 283
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -5.653 9 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -5.653 9 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scircumflex
-Encoding: 348 348 348
+Encoding: 348 348 284
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 78 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 78 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scircumflex
-Encoding: 349 349 349
+Encoding: 349 349 285
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scedilla
-Encoding: 350 350 350
+Encoding: 350 350 286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scedilla
-Encoding: 351 351 351
+Encoding: 351 351 287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scaron
-Encoding: 352 352 352
+Encoding: 352 352 288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: scaron
-Encoding: 353 353 353
+Encoding: 353 353 289
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Tcommaaccent
-Encoding: 354 354 354
+Encoding: 354 354 290
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tcommaaccent
-Encoding: 355 355 355
+Encoding: 355 355 291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 181 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 181 0 2
 EndChar
+
 StartChar: Tcaron
-Encoding: 356 356 356
+Encoding: 356 356 292
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 79 373 2
-LCarets2: 1 0 
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 79 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: tcaron
-Encoding: 357 357 357
+Encoding: 357 357 293
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114113 -1 N 1 0 0 1 371 28 2
-LCarets2: 1 0 
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3087 -1 N 1 0 0 1 371 28 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tbar
-Encoding: 358 358 358
+Encoding: 358 358 294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22330,8 +22630,9 @@ SplineSet
  619 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tbar
-Encoding: 359 359 359
+Encoding: 359 359 295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22368,215 +22669,239 @@ SplineSet
  830 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Utilde
-Encoding: 360 360 360
+Encoding: 360 360 296
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 57 373 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 57 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: utilde
-Encoding: 361 361 361
+Encoding: 361 361 297
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Umacron
-Encoding: 362 362 362
+Encoding: 362 362 298
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: umacron
-Encoding: 363 363 363
+Encoding: 363 363 299
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ubreve
-Encoding: 364 364 364
+Encoding: 364 364 300
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ubreve
-Encoding: 365 365 365
+Encoding: 365 365 301
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uring
-Encoding: 366 366 366
+Encoding: 366 366 302
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 12 82 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 636 730 N 1 0 0 1 12 82 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uring
-Encoding: 367 367 367
+Encoding: 367 367 303
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 -10 5 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 636 730 N 1 0 0 1 -10 5 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uhungarumlaut
-Encoding: 368 368 368
+Encoding: 368 368 304
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uhungarumlaut
-Encoding: 369 369 369
+Encoding: 369 369 305
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 664 779 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uogonek
-Encoding: 370 370 370
+Encoding: 370 370 306
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 -54.1551 -15.6333 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 -54.1551 -15.6333 2
 EndChar
+
 StartChar: uogonek
-Encoding: 371 371 371
+Encoding: 371 371 307
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 393.345 0.366699 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 393.345 0.366699 2
 EndChar
+
 StartChar: Wcircumflex
-Encoding: 372 372 372
+Encoding: 372 372 308
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 71 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 71 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wcircumflex
-Encoding: 373 373 373
+Encoding: 373 373 309
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 25 9 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 25 9 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ycircumflex
-Encoding: 374 374 374
+Encoding: 374 374 310
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 58 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 58 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ycircumflex
-Encoding: 375 375 375
+Encoding: 375 375 311
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 13 9 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 13 9 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ydieresis
-Encoding: 376 376 376
+Encoding: 376 376 312
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 47 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Zacute
-Encoding: 377 377 377
+Encoding: 377 377 313
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 66 374 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 66 374 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zacute
-Encoding: 378 378 378
+Encoding: 378 378 314
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -5.653 9 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -5.653 9 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zdotaccent
-Encoding: 379 379 379
+Encoding: 379 379 315
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zdotaccent
-Encoding: 380 380 380
+Encoding: 380 380 316
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zcaron
-Encoding: 381 381 381
+Encoding: 381 381 317
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: zcaron
-Encoding: 382 382 382
+Encoding: 382 382 318
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: longs
-Encoding: 383 383 383
+Encoding: 383 383 319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22599,8 +22924,9 @@ SplineSet
  623 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0180
-Encoding: 384 384 384
+Encoding: 384 384 320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22641,8 +22967,9 @@ SplineSet
  524 209 524 209 600 209 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni0181
-Encoding: 385 385 385
+Encoding: 385 385 321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22683,16 +23010,18 @@ SplineSet
  612 678 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0182
-Encoding: 386 386 386
+Encoding: 386 386 322
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1041 1041 N 1 0 0 1 0 0 2
+Refer: 853 1041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0183
-Encoding: 387 387 387
+Encoding: 387 387 323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22723,8 +23052,9 @@ SplineSet
  778.371 395 778.371 395 809.86 557 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni0184
-Encoding: 388 388 388
+Encoding: 388 388 324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22751,8 +23081,9 @@ SplineSet
  59.8955 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0185
-Encoding: 389 389 389
+Encoding: 389 389 325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22784,8 +23115,9 @@ SplineSet
  525.39 961 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0186
-Encoding: 390 390 390
+Encoding: 390 390 326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22812,8 +23144,9 @@ SplineSet
  78.4502 7 78.4502 7 15.4482 43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0187
-Encoding: 391 391 391
+Encoding: 391 391 327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22842,8 +23175,9 @@ SplineSet
  655.658 236 655.658 236 675.009 236 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0188
-Encoding: 392 392 392
+Encoding: 392 392 328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22874,16 +23208,18 @@ SplineSet
  594.304 211 594.304 211 654.604 211 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0189
-Encoding: 393 393 393
+Encoding: 393 393 329
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni018A
-Encoding: 394 394 394
+Encoding: 394 394 330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22913,8 +23249,9 @@ SplineSet
  844.399 1227 844.399 1227 670.399 1227 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018B
-Encoding: 395 395 395
+Encoding: 395 395 331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22945,8 +23282,9 @@ SplineSet
  352.202 1494 l 25,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018C
-Encoding: 396 396 396
+Encoding: 396 396 332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22977,8 +23315,9 @@ SplineSet
  434.35 719 434.35 719 402.86 557 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni018D
-Encoding: 397 397 397
+Encoding: 397 397 333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23018,8 +23357,9 @@ SplineSet
  482.981 209 482.981 209 588.981 209 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni018E
-Encoding: 398 398 398
+Encoding: 398 398 334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23040,8 +23380,9 @@ SplineSet
  22.8955 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018F
-Encoding: 399 399 399
+Encoding: 399 399 335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23071,8 +23412,9 @@ SplineSet
  372.826 580 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni0190
-Encoding: 400 400 400
+Encoding: 400 400 336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23110,8 +23452,9 @@ SplineSet
  660.936 668 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0191
-Encoding: 401 401 401
+Encoding: 401 401 337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23138,8 +23481,9 @@ SplineSet
  1260.52 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: florin
-Encoding: 402 402 402
+Encoding: 402 402 338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23171,8 +23515,9 @@ SplineSet
  950.647 1332.37 950.647 1332.37 924.736 1218 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0193
-Encoding: 403 403 403
+Encoding: 403 403 339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23207,14 +23552,15 @@ SplineSet
  492.042 236 492.042 236 547.009 236 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0194
-Encoding: 404 404 404
+Encoding: 404 404 340
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
 SplineSet
-598.223 510 m 1,3,-1
+598.223 510 m 1025,3,-1
 462.506 762 m 1,0,0
  206.198 1493 l 1,7,-1
  527.798 1493 l 1,8,-1
@@ -23233,8 +23579,9 @@ SplineSet
  687.001 278.899 687.001 278.899 598.322 510 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0195
-Encoding: 405 405 405
+Encoding: 405 405 341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23271,8 +23618,9 @@ SplineSet
  1180.58 569 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0196
-Encoding: 406 406 406
+Encoding: 406 406 342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23295,8 +23643,9 @@ SplineSet
  371.385 237.674 371.385 237.674 414.699 462 c 10,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0197
-Encoding: 407 407 407
+Encoding: 407 407 343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23325,8 +23674,9 @@ SplineSet
  266.566 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0198
-Encoding: 408 408 408
+Encoding: 408 408 344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23352,8 +23702,9 @@ SplineSet
  961.108 1197.05 961.108 1197.05 824.688 1060 c 2,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0199
-Encoding: 409 409 409
+Encoding: 409 409 345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23382,8 +23733,9 @@ SplineSet
  234.452 1089 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019A
-Encoding: 410 410 410
+Encoding: 410 410 346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23414,8 +23766,9 @@ SplineSet
  685.141 753 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019B
-Encoding: 411 411 411
+Encoding: 411 411 347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23440,8 +23793,9 @@ SplineSet
  911.842 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019C
-Encoding: 412 412 412
+Encoding: 412 412 348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23477,8 +23831,9 @@ SplineSet
  427.016 54 427.016 54 426.29 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019D
-Encoding: 413 413 413
+Encoding: 413 413 349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23504,8 +23859,9 @@ SplineSet
  365.155 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019E
-Encoding: 414 414 414
+Encoding: 414 414 350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23530,8 +23886,9 @@ SplineSet
  1182.87 936 1182.87 936 1142.24 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019F
-Encoding: 415 415 415
+Encoding: 415 415 351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23560,26 +23917,29 @@ SplineSet
  764.53 449.395 764.53 449.395 813.631 651 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: Ohorn
-Encoding: 416 416 416
+Encoding: 416 416 352
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 -88 0 2
-Refer: 795 795 N 1 0 0 1 515.42 388 2
+Refer: 48 79 N 1 0 0 1 -88 0 2
+Refer: 680 795 N 1 0 0 1 515.42 388 2
 EndChar
+
 StartChar: ohorn
-Encoding: 417 417 417
+Encoding: 417 417 353
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 -89 0 2
-Refer: 795 795 N 1 0 0 1 407 0 2
+Refer: 80 111 N 1 0 0 1 -89 0 2
+Refer: 680 795 N 1 0 0 1 407 0 2
 EndChar
+
 StartChar: uni01A2
-Encoding: 418 418 418
+Encoding: 418 418 354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23609,8 +23969,9 @@ SplineSet
  337.378 906.926 337.378 906.926 305.902 745 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni01A3
-Encoding: 419 419 419
+Encoding: 419 419 355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23640,8 +24001,9 @@ SplineSet
  686.117 909 686.117 909 642.617 909 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni01A4
-Encoding: 420 420 420
+Encoding: 420 420 356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23675,8 +24037,9 @@ SplineSet
  419.317 1206 l 1,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni01A5
-Encoding: 421 421 421
+Encoding: 421 421 357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23714,8 +24077,9 @@ SplineSet
  715.32 -29 715.32 -29 613.538 -29 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni01A6
-Encoding: 422 422 422
+Encoding: 422 422 358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23750,8 +24114,9 @@ SplineSet
  501.768 1007 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A7
-Encoding: 423 423 423
+Encoding: 423 423 359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23788,8 +24153,9 @@ SplineSet
  950.931 740 950.931 740 711.408 655 c 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A8
-Encoding: 424 424 424
+Encoding: 424 424 360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23826,16 +24192,18 @@ SplineSet
  350.244 1085 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A9
-Encoding: 425 425 425
+Encoding: 425 425 361
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 931 931 N 1 0 0 1 0 0 2
+Refer: 758 931 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01AA
-Encoding: 426 426 426
+Encoding: 426 426 362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23874,8 +24242,9 @@ SplineSet
  476.581 1331 l 2,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni01AB
-Encoding: 427 427 427
+Encoding: 427 427 363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23910,8 +24279,9 @@ SplineSet
  969.519 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AC
-Encoding: 428 428 428
+Encoding: 428 428 364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23937,8 +24307,9 @@ SplineSet
  485.149 1237 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni01AD
-Encoding: 429 429 429
+Encoding: 429 429 365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23970,8 +24341,9 @@ SplineSet
  465.479 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AE
-Encoding: 430 430 430
+Encoding: 430 430 366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23994,26 +24366,29 @@ SplineSet
  306.658 -75.7082 306.658 -75.7082 318.94 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Uhorn
-Encoding: 431 431 431
+Encoding: 431 431 367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 -101 0 2
-Refer: 795 795 N 1 0 0 1 572 388 2
+Refer: 54 85 N 1 0 0 1 -101 0 2
+Refer: 680 795 N 1 0 0 1 572 388 2
 EndChar
+
 StartChar: uhorn
-Encoding: 432 432 432
+Encoding: 432 432 368
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 -152.5 0 2
-Refer: 795 795 N 1 0 0 1 408.5 0 2
+Refer: 86 117 N 1 0 0 1 -152.5 0 2
+Refer: 680 795 N 1 0 0 1 408.5 0 2
 EndChar
+
 StartChar: uni01B1
-Encoding: 433 433 433
+Encoding: 433 433 369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24046,8 +24421,9 @@ SplineSet
  1243.88 1249 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B2
-Encoding: 434 434 434
+Encoding: 434 434 370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24073,8 +24449,9 @@ SplineSet
  776.024 597.436 776.024 597.436 797.322 707 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B3
-Encoding: 435 435 435
+Encoding: 435 435 371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24097,8 +24474,9 @@ SplineSet
  1128.73 1239.31 1128.73 1239.31 986.729 1026 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B4
-Encoding: 436 436 436
+Encoding: 436 436 372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24125,8 +24503,9 @@ SplineSet
  1052.83 779.428 1052.83 779.428 989.554 664 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B5
-Encoding: 437 437 437
+Encoding: 437 437 373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24153,8 +24532,9 @@ SplineSet
  282.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B6
-Encoding: 438 438 438
+Encoding: 438 438 374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24181,8 +24561,9 @@ SplineSet
  289.853 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B7
-Encoding: 439 439 439
+Encoding: 439 439 375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24213,8 +24594,9 @@ SplineSet
  1192.36 574.886 1192.36 574.886 1163.23 425 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B8
-Encoding: 440 440 440
+Encoding: 440 440 376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24244,8 +24626,9 @@ SplineSet
  458.47 234 458.47 234 544.102 234 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B9
-Encoding: 441 441 441
+Encoding: 441 441 377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24276,8 +24659,9 @@ SplineSet
  943.771 452 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BA
-Encoding: 442 442 442
+Encoding: 442 442 378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24320,8 +24704,9 @@ SplineSet
  775 546 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BB
-Encoding: 443 443 443
+Encoding: 443 443 379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24360,8 +24745,9 @@ SplineSet
  336.81 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BC
-Encoding: 444 444 444
+Encoding: 444 444 380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24393,8 +24779,9 @@ SplineSet
  307.187 646 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BD
-Encoding: 445 445 445
+Encoding: 445 445 381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24425,8 +24812,9 @@ SplineSet
  641.771 452 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BE
-Encoding: 446 446 446
+Encoding: 446 446 382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24461,8 +24849,9 @@ SplineSet
  758.698 1078 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01BF
-Encoding: 447 447 447
+Encoding: 447 447 383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24490,8 +24879,9 @@ SplineSet
  432 414 432 414 376 145 c 17,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni01C0
-Encoding: 448 448 448
+Encoding: 448 448 384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24504,17 +24894,19 @@ SplineSet
  628.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C1
-Encoding: 449 449 449
+Encoding: 449 449 385
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 448 448 N 1 0 0 1 -229 0 2
-Refer: 448 448 N 1 0 0 1 229 0 2
+Refer: 384 448 N 1 0 0 1 -229 0 2
+Refer: 384 448 N 1 0 0 1 229 0 2
 EndChar
+
 StartChar: uni01C2
-Encoding: 450 450 450
+Encoding: 450 450 386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24543,396 +24935,442 @@ SplineSet
  628.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C3
-Encoding: 451 451 451
+Encoding: 451 451 387
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 0 0 2
+Refer: 2 33 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01C4
-Encoding: 452 452 452
+Encoding: 452 452 388
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C5
-Encoding: 453 453 453
+Encoding: 453 453 389
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C6
-Encoding: 454 454 454
+Encoding: 454 454 390
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C7
-Encoding: 455 455 455
+Encoding: 455 455 391
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C8
-Encoding: 456 456 456
+Encoding: 456 456 392
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C9
-Encoding: 457 457 457
+Encoding: 457 457 393
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CA
-Encoding: 458 458 458
+Encoding: 458 458 394
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CB
-Encoding: 459 459 459
+Encoding: 459 459 395
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CC
-Encoding: 460 460 460
+Encoding: 460 460 396
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CD
-Encoding: 461 461 461
+Encoding: 461 461 397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CE
-Encoding: 462 462 462
+Encoding: 462 462 398
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CF
-Encoding: 463 463 463
+Encoding: 463 463 399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D0
-Encoding: 464 464 464
+Encoding: 464 464 400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D1
-Encoding: 465 465 465
+Encoding: 465 465 401
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D2
-Encoding: 466 466 466
+Encoding: 466 466 402
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3091 -1 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D3
-Encoding: 467 467 467
+Encoding: 467 467 403
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 68 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 68 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D4
-Encoding: 468 468 468
+Encoding: 468 468 404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 15 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 15 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D5
-Encoding: 469 469 469
+Encoding: 469 469 405
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 1114114 -1 N 1 0 0 1 60.5 277 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 3088 -1 N 1 0 0 1 60.5 277 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01D6
-Encoding: 470 470 470
+Encoding: 470 470 406
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 35 315 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 35 315 2
 EndChar
+
 StartChar: uni01D7
-Encoding: 471 471 471
+Encoding: 471 471 407
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 78.0001 537 2
-Refer: 1114114 -1 N 1 0 0 1 54 245 2
-Refer: 85 85 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 78.0001 537 2
+Refer: 3088 -1 N 1 0 0 1 54 245 2
+Refer: 54 85 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01D8
-Encoding: 472 472 472
+Encoding: 472 472 408
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 120 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 654 769 N 1 0 0 1 120 415 2
 EndChar
+
 StartChar: uni01D9
-Encoding: 473 473 473
+Encoding: 473 473 409
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 54 245 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114120 -1 N 1 0 0 1 106.679 538 2
+Refer: 3088 -1 N 1 0 0 1 54 245 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 106.679 538 2
 EndChar
+
 StartChar: uni01DA
-Encoding: 474 474 474
+Encoding: 474 474 410
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 780 780 N 1 0 0 1 114 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 665 780 N 1 0 0 1 114 415 2
 EndChar
+
 StartChar: uni01DB
-Encoding: 475 475 475
+Encoding: 475 475 411
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 54 245 2
-Refer: 1114118 -1 N 1 0 0 1 138 538 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 54 245 2
+Refer: 3092 -1 N 1 0 0 1 138 538 2
 EndChar
+
 StartChar: uni01DC
-Encoding: 476 476 476
+Encoding: 476 476 412
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 768 768 N 1 0 0 1 114 415 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 653 768 N 1 0 0 1 114 415 2
 EndChar
+
 StartChar: uni01DD
-Encoding: 477 477 477
+Encoding: 477 477 413
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 2
+Refer: 516 601 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DE
-Encoding: 478 478 478
+Encoding: 478 478 414
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 1114114 -1 N 1 0 0 1 60.5 277 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 3088 -1 N 1 0 0 1 60.5 277 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DF
-Encoding: 479 479 479
+Encoding: 479 479 415
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 228 228 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 35 315 2
+Refer: 164 228 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 35 315 2
 EndChar
+
 StartChar: uni01E0
-Encoding: 480 480 480
+Encoding: 480 480 416
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 -96 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 -96 2
 EndChar
+
 StartChar: uni01E1
-Encoding: 481 481 481
+Encoding: 481 481 417
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 35 315 2
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 35 315 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E2
-Encoding: 482 482 482
+Encoding: 482 482 418
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 143 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 143 0 2
 EndChar
+
 StartChar: uni01E3
-Encoding: 483 483 483
+Encoding: 483 483 419
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcaron
-Encoding: 486 486 486
+Encoding: 486 486 420
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 185 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 185 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcaron
-Encoding: 487 487 487
+Encoding: 487 487 421
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E8
-Encoding: 488 488 488
+Encoding: 488 488 422
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 80 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 80 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E9
-Encoding: 489 489 489
+Encoding: 489 489 423
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 160 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 160 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EA
-Encoding: 490 490 490
+Encoding: 490 490 424
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 -11.5 -15.6333 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 -11.5 -15.6333 2
 EndChar
+
 StartChar: uni01EB
-Encoding: 491 491 491
+Encoding: 491 491 425
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 -11.5 -15.6333 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 637 731 N 1 0 0 1 -11.5 -15.6333 2
 EndChar
+
 StartChar: uni01EC
-Encoding: 492 492 492
+Encoding: 492 492 426
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 490 490 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 424 490 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01ED
-Encoding: 493 493 493
+Encoding: 493 493 427
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 491 491 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 425 491 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EE
-Encoding: 494 494 494
+Encoding: 494 494 428
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 47 373 2
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 47 373 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EF
-Encoding: 495 495 495
+Encoding: 495 495 429
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 573 658 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F4
-Encoding: 500 500 500
+Encoding: 500 500 430
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 185 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 185 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F5
-Encoding: 501 501 501
+Encoding: 501 501 431
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F6
-Encoding: 502 502 502
+Encoding: 502 502 432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24964,312 +25402,347 @@ SplineSet
  172.924 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01F8
-Encoding: 504 504 504
+Encoding: 504 504 433
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 91 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 91 373 2
 EndChar
+
 StartChar: uni01F9
-Encoding: 505 505 505
+Encoding: 505 505 434
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 768 768 N 1 0 0 1 -4 2 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 653 768 N 1 0 0 1 -4 2 2
 EndChar
+
 StartChar: AEacute
-Encoding: 508 508 508
+Encoding: 508 508 435
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 260 373 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 260 373 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aeacute
-Encoding: 509 509 509
+Encoding: 509 509 436
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Oslashacute
-Encoding: 510 510 510
+Encoding: 510 510 437
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 216 216 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 51 373 2
+Refer: 152 216 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: oslashacute
-Encoding: 511 511 511
+Encoding: 511 511 438
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 248 248 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 184 248 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0200
-Encoding: 512 512 512
+Encoding: 512 512 439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0201
-Encoding: 513 513 513
+Encoding: 513 513 440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0202
-Encoding: 514 514 514
+Encoding: 514 514 441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0203
-Encoding: 515 515 515
+Encoding: 515 515 442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0204
-Encoding: 516 516 516
+Encoding: 516 516 443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0205
-Encoding: 517 517 517
+Encoding: 517 517 444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0206
-Encoding: 518 518 518
+Encoding: 518 518 445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0207
-Encoding: 519 519 519
+Encoding: 519 519 446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0208
-Encoding: 520 520 520
+Encoding: 520 520 447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0209
-Encoding: 521 521 521
+Encoding: 521 521 448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020A
-Encoding: 522 522 522
+Encoding: 522 522 449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020B
-Encoding: 523 523 523
+Encoding: 523 523 450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020C
-Encoding: 524 524 524
+Encoding: 524 524 451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020D
-Encoding: 525 525 525
+Encoding: 525 525 452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020E
-Encoding: 526 526 526
+Encoding: 526 526 453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020F
-Encoding: 527 527 527
+Encoding: 527 527 454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0210
-Encoding: 528 528 528
+Encoding: 528 528 455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0211
-Encoding: 529 529 529
+Encoding: 529 529 456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 100 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 100 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0212
-Encoding: 530 530 530
+Encoding: 530 530 457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0213
-Encoding: 531 531 531
+Encoding: 531 531 458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 100 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 100 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0214
-Encoding: 532 532 532
+Encoding: 532 532 459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3100 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0215
-Encoding: 533 533 533
+Encoding: 533 533 460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 668 783 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0216
-Encoding: 534 534 534
+Encoding: 534 534 461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0217
-Encoding: 535 535 535
+Encoding: 535 535 462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 670 785 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scommaaccent
-Encoding: 536 536 536
+Encoding: 536 536 463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scommaaccent
-Encoding: 537 537 537
+Encoding: 537 537 464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021A
-Encoding: 538 538 538
+Encoding: 538 538 465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021B
-Encoding: 539 539 539
+Encoding: 539 539 466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 132 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 691 806 N 1 0 0 1 132 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021C
-Encoding: 540 540 540
+Encoding: 540 540 467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25325,8 +25798,9 @@ SplineSet
  1386 1219 1386 1219 1386 1170 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021D
-Encoding: 541 541 541
+Encoding: 541 541 468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25375,26 +25849,29 @@ SplineSet
  1270 914 1270 914 1270 871 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021E
-Encoding: 542 542 542
+Encoding: 542 542 469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 76 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 76 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021F
-Encoding: 543 543 543
+Encoding: 543 543 470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3094 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0221
-Encoding: 545 545 545
+Encoding: 545 545 471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25436,8 +25913,9 @@ SplineSet
  303.283 719 303.283 719 271.794 557 c 128,-1,39
 EndSplineSet
 EndChar
+
 StartChar: uni0224
-Encoding: 548 548 548
+Encoding: 548 548 472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25464,8 +25942,9 @@ SplineSet
  323.313 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0225
-Encoding: 549 549 549
+Encoding: 549 549 473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25492,137 +25971,152 @@ SplineSet
  336.062 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0226
-Encoding: 550 550 550
+Encoding: 550 550 474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0227
-Encoding: 551 551 551
+Encoding: 551 551 475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0228
-Encoding: 552 552 552
+Encoding: 552 552 476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0229
-Encoding: 553 553 553
+Encoding: 553 553 477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022A
-Encoding: 554 554 554
+Encoding: 554 554 478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 1114114 -1 N 1 0 0 1 60.5 277 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 3088 -1 N 1 0 0 1 60.5 277 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022B
-Encoding: 555 555 555
+Encoding: 555 555 479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 246 246 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 35 315 2
+Refer: 182 246 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 35 315 2
 EndChar
+
 StartChar: uni022C
-Encoding: 556 556 556
+Encoding: 556 556 480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 1114116 -1 N 1 0 0 1 38.5 277 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 3090 -1 N 1 0 0 1 38.5 277 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022D
-Encoding: 557 557 557
+Encoding: 557 557 481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 245 245 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 34.5 315 2
+Refer: 181 245 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 34.5 315 2
 EndChar
+
 StartChar: uni022E
-Encoding: 558 558 558
+Encoding: 558 558 482
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022F
-Encoding: 559 559 559
+Encoding: 559 559 483
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0230
-Encoding: 560 560 560
+Encoding: 560 560 484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 93.5 461 2
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 -96 2
+Refer: 623 713 N 1 0 0 1 93.5 461 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 -96 2
 EndChar
+
 StartChar: uni0231
-Encoding: 561 561 561
+Encoding: 561 561 485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 559 559 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 34.5 315 2
+Refer: 483 559 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 34.5 315 2
 EndChar
+
 StartChar: uni0232
-Encoding: 562 562 562
+Encoding: 562 562 486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0233
-Encoding: 563 563 563
+Encoding: 563 563 487
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0234
-Encoding: 564 564 564
+Encoding: 564 564 488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25653,8 +26147,9 @@ SplineSet
  612.347 212.699 612.347 212.699 652.056 200.316 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0235
-Encoding: 565 565 565
+Encoding: 565 565 489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25694,8 +26189,9 @@ SplineSet
  770.968 270 770.968 270 815.927 248 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0236
-Encoding: 566 566 566
+Encoding: 566 566 490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25731,8 +26227,9 @@ SplineSet
  646.985 438 l 2,5,6
 EndSplineSet
 EndChar
+
 StartChar: dotlessj
-Encoding: 567 567 567
+Encoding: 567 567 491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25755,8 +26252,9 @@ SplineSet
  733 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0238
-Encoding: 568 568 568
+Encoding: 568 568 492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25805,8 +26303,9 @@ SplineSet
  757.09 961 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0239
-Encoding: 569 569 569
+Encoding: 569 569 493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25855,8 +26354,9 @@ SplineSet
  475.91 157 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni023A
-Encoding: 570 570 570
+Encoding: 570 570 494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25892,8 +26392,9 @@ SplineSet
  606.588 612 l 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023B
-Encoding: 571 571 571
+Encoding: 571 571 495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25931,8 +26432,9 @@ SplineSet
  943.962 43 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023C
-Encoding: 572 572 572
+Encoding: 572 572 496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25969,8 +26471,9 @@ SplineSet
  461.676 541.899 461.676 541.899 459.307 525.606 c 1,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023D
-Encoding: 573 573 573
+Encoding: 573 573 497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25993,8 +26496,9 @@ SplineSet
  275.293 730 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023E
-Encoding: 574 574 574
+Encoding: 574 574 498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26023,8 +26527,9 @@ SplineSet
  835.493 1115.8 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023F
-Encoding: 575 575 575
+Encoding: 575 575 499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26068,8 +26573,9 @@ SplineSet
  1055.27 1116 1055.27 1116 1138.24 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0240
-Encoding: 576 576 576
+Encoding: 576 576 500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26094,8 +26600,9 @@ SplineSet
  342.671 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0241
-Encoding: 577 577 577
+Encoding: 577 577 501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26128,8 +26635,9 @@ SplineSet
  548.634 1213.45 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0243
-Encoding: 579 579 579
+Encoding: 579 579 502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26154,7 +26662,7 @@ SplineSet
  1106 377 1106 377 1068 283.5 c 128,-1,21
  1030 190 1030 190 961 127 c 1,22,23
  886 60 886 60 771 30 c 128,-1,24
- 656 3.8147e-06 656 3.8147e-06 461 0 c 2,25,-1
+ 656 3.8147e-006 656 3.8147e-006 461 0 c 2,25,-1
  -20 0 l 1,26,-1
  45.5652 338 l 1,27,-1
  -80 338 l 1,28,-1
@@ -26175,8 +26683,9 @@ SplineSet
  330.846 338 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0244
-Encoding: 580 580 580
+Encoding: 580 580 503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26211,8 +26720,9 @@ SplineSet
  346.116 474.358 346.116 474.358 340 403 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0245
-Encoding: 581 581 581
+Encoding: 581 581 504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26228,8 +26738,9 @@ SplineSet
  715 1251 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024C
-Encoding: 588 588 588
+Encoding: 588 588 505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26266,8 +26777,9 @@ SplineSet
  509 838 l 9,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024D
-Encoding: 589 589 589
+Encoding: 589 589 506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26299,8 +26811,9 @@ SplineSet
  1171.64 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0250
-Encoding: 592 592 592
+Encoding: 592 592 507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26338,8 +26851,9 @@ SplineSet
  38.8564 193 38.8564 193 94.4492 479 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0251
-Encoding: 593 593 593
+Encoding: 593 593 508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26370,8 +26884,9 @@ SplineSet
  444.101 719 444.101 719 412.611 557 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0252
-Encoding: 594 594 594
+Encoding: 594 594 509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26402,8 +26917,9 @@ SplineSet
  788.899 399 788.899 399 820.389 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0253
-Encoding: 595 595 595
+Encoding: 595 595 510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26441,8 +26957,9 @@ SplineSet
  748.468 395 748.468 395 779.958 557 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0254
-Encoding: 596 596 596
+Encoding: 596 596 511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26469,8 +26986,9 @@ SplineSet
  137.868 14 137.868 14 72.2266 57 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0255
-Encoding: 597 597 597
+Encoding: 597 597 512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26506,8 +27024,9 @@ SplineSet
  439.824 405.349 439.824 405.349 473.695 333.653 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0256
-Encoding: 598 598 598
+Encoding: 598 598 513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26544,8 +27063,9 @@ SplineSet
  734.819 1054 734.819 1054 759.741 961 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0257
-Encoding: 599 599 599
+Encoding: 599 599 514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26582,8 +27102,9 @@ SplineSet
  1077.75 1221.67 1077.75 1221.67 1051.77 1088 c 2,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0258
-Encoding: 600 600 600
+Encoding: 600 600 515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26613,8 +27134,9 @@ SplineSet
  432.04 801 432.04 801 407.492 685 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni0259
-Encoding: 601 601 601
+Encoding: 601 601 516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26644,8 +27166,9 @@ SplineSet
  358.508 433 l 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni025A
-Encoding: 602 602 602
+Encoding: 602 602 517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26687,8 +27210,9 @@ SplineSet
  903.405 736 l 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni025B
-Encoding: 603 603 603
+Encoding: 603 603 518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26726,8 +27250,9 @@ SplineSet
  269.57 550 269.57 550 426.041 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025C
-Encoding: 604 604 604
+Encoding: 604 604 519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26765,8 +27290,9 @@ SplineSet
  956.095 599 956.095 599 811.041 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025D
-Encoding: 605 605 605
+Encoding: 605 605 520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26815,8 +27341,9 @@ SplineSet
  655.346 590 655.346 590 581.041 573 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025E
-Encoding: 606 606 606
+Encoding: 606 606 521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26851,8 +27378,9 @@ SplineSet
  185.073 948 185.073 948 515.425 1099 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni025F
-Encoding: 607 607 607
+Encoding: 607 607 522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26881,8 +27409,9 @@ SplineSet
  790.714 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0260
-Encoding: 608 608 608
+Encoding: 608 608 523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26928,8 +27457,9 @@ SplineSet
  618.107 190 l 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0261
-Encoding: 609 609 609
+Encoding: 609 609 524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26966,8 +27496,9 @@ SplineSet
  725.966 887 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0262
-Encoding: 610 610 610
+Encoding: 610 610 525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26998,8 +27529,9 @@ SplineSet
  989.877 101 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0263
-Encoding: 611 611 611
+Encoding: 611 611 526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27023,8 +27555,9 @@ SplineSet
  732.499 95 732.499 95 616.76 369 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0264
-Encoding: 612 612 612
+Encoding: 612 612 527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27048,8 +27581,9 @@ SplineSet
  249.677 344 249.677 344 453.717 586 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0265
-Encoding: 613 613 613
+Encoding: 613 613 528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27074,8 +27608,9 @@ SplineSet
  136.288 182 136.288 182 176.913 391 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0266
-Encoding: 614 614 614
+Encoding: 614 614 529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27106,8 +27641,9 @@ SplineSet
  1096.81 936 1096.81 936 1056.18 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0267
-Encoding: 615 615 615
+Encoding: 615 615 530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27144,8 +27680,9 @@ SplineSet
  647.584 -91 647.584 -91 673.242 41 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0268
-Encoding: 616 616 616
+Encoding: 616 616 531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27178,8 +27715,9 @@ SplineSet
  250.479 1120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0269
-Encoding: 617 617 617
+Encoding: 617 617 532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27200,8 +27738,9 @@ SplineSet
  495.409 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026A
-Encoding: 618 618 618
+Encoding: 618 618 533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27222,8 +27761,9 @@ SplineSet
  829.117 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026B
-Encoding: 619 619 619
+Encoding: 619 619 534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27260,8 +27800,9 @@ SplineSet
  1066.36 747 1066.36 747 1150.8 811 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026C
-Encoding: 620 620 620
+Encoding: 620 620 535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27297,8 +27838,9 @@ SplineSet
  672.327 579.043 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026D
-Encoding: 621 621 621
+Encoding: 621 621 536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27319,8 +27861,9 @@ SplineSet
  259 -228 259 -228 308 23 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026E
-Encoding: 622 622 622
+Encoding: 622 622 537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27363,8 +27906,9 @@ SplineSet
  577.146 452 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026F
-Encoding: 623 623 623
+Encoding: 623 623 538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27400,8 +27944,9 @@ SplineSet
  462 54 462 54 461 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0270
-Encoding: 624 624 624
+Encoding: 624 624 539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27437,8 +27982,9 @@ SplineSet
  461 54 461 54 460 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0271
-Encoding: 625 625 625
+Encoding: 625 625 540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27480,8 +28026,9 @@ SplineSet
  813.248 1064.89 813.248 1064.89 813.861 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0272
-Encoding: 626 626 626
+Encoding: 626 626 541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27518,8 +28065,9 @@ SplineSet
  1277.17 909 1277.17 909 1233.05 682 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0273
-Encoding: 627 627 627
+Encoding: 627 627 542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27551,8 +28099,9 @@ SplineSet
  766.823 722 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0274
-Encoding: 628 628 628
+Encoding: 628 628 543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27571,8 +28120,9 @@ SplineSet
  228.853 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0275
-Encoding: 629 629 629
+Encoding: 629 629 544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27603,8 +28153,9 @@ SplineSet
  778.549 357.163 778.549 357.163 808.71 438 c 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0276
-Encoding: 630 630 630
+Encoding: 630 630 545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27640,8 +28191,9 @@ SplineSet
  677.95 1120 677.95 1120 683.95 1120 c 2,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0277
-Encoding: 631 631 631
+Encoding: 631 631 546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27676,8 +28228,9 @@ SplineSet
  1087.3 1176 1087.3 1176 1155.65 828 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0278
-Encoding: 632 632 632
+Encoding: 632 632 547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27724,8 +28277,9 @@ SplineSet
  853.383 849.886 853.383 849.886 822.174 871.425 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0279
-Encoding: 633 633 633
+Encoding: 633 633 548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27750,8 +28304,9 @@ SplineSet
  139.835 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027A
-Encoding: 634 634 634
+Encoding: 634 634 549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27776,8 +28331,9 @@ SplineSet
  97.6543 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027B
-Encoding: 635 635 635
+Encoding: 635 635 550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27810,8 +28366,9 @@ SplineSet
  69.6133 309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027C
-Encoding: 636 636 636
+Encoding: 636 636 551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27836,8 +28393,9 @@ SplineSet
  1133.57 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027D
-Encoding: 637 637 637
+Encoding: 637 637 552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27868,8 +28426,9 @@ SplineSet
  1133.57 811 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027E
-Encoding: 638 638 638
+Encoding: 638 638 553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27892,8 +28451,9 @@ SplineSet
  27.1475 0 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni027F
-Encoding: 639 639 639
+Encoding: 639 639 554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27916,8 +28476,9 @@ SplineSet
  27.1475 0 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0280
-Encoding: 640 640 640
+Encoding: 640 640 555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27955,8 +28516,9 @@ SplineSet
  478.923 894 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0281
-Encoding: 641 641 641
+Encoding: 641 641 556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27989,8 +28551,9 @@ SplineSet
  452.352 711 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0282
-Encoding: 642 642 642
+Encoding: 642 642 557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28033,8 +28596,9 @@ SplineSet
  1045.85 1116 1045.85 1116 1128.83 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0283
-Encoding: 643 643 643
+Encoding: 643 643 558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28059,8 +28623,9 @@ SplineSet
  687.98 0 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0284
-Encoding: 644 644 644
+Encoding: 644 644 559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28098,8 +28663,9 @@ SplineSet
  773.119 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0285
-Encoding: 645 645 645
+Encoding: 645 645 560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28124,8 +28690,9 @@ SplineSet
  288.804 -216.651 288.804 -216.651 324.98 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0286
-Encoding: 646 646 646
+Encoding: 646 646 561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28164,8 +28731,9 @@ SplineSet
  179.179 -199 l 2,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0287
-Encoding: 647 647 647
+Encoding: 647 647 562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28192,8 +28760,9 @@ SplineSet
  378.24 -318 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0288
-Encoding: 648 648 648
+Encoding: 648 648 563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28220,8 +28789,9 @@ SplineSet
  895.162 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0289
-Encoding: 649 649 649
+Encoding: 649 649 564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28258,8 +28828,9 @@ SplineSet
  730.948 339.766 730.948 339.766 755.971 438 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028A
-Encoding: 650 650 650
+Encoding: 650 650 565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28292,8 +28863,9 @@ SplineSet
  613.951 837 l 1,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni028B
-Encoding: 651 651 651
+Encoding: 651 651 566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28326,8 +28898,9 @@ SplineSet
  988.596 1115.01 988.596 1115.01 1067.98 1027 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028C
-Encoding: 652 652 652
+Encoding: 652 652 567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28343,8 +28916,9 @@ SplineSet
  -28.8525 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028D
-Encoding: 653 653 653
+Encoding: 653 653 568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28366,8 +28940,9 @@ SplineSet
  1124.15 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028E
-Encoding: 654 654 654
+Encoding: 654 654 569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28390,8 +28965,9 @@ SplineSet
  614.164 1241 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028F
-Encoding: 655 655 655
+Encoding: 655 655 570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28409,8 +28985,9 @@ SplineSet
  176.853 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0290
-Encoding: 656 656 656
+Encoding: 656 656 571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28436,8 +29013,9 @@ SplineSet
  220.256 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0291
-Encoding: 657 657 657
+Encoding: 657 657 572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28468,8 +29046,9 @@ SplineSet
  261.738 1120 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0292
-Encoding: 658 658 658
+Encoding: 658 658 573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28500,8 +29079,9 @@ SplineSet
  332.771 452 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0293
-Encoding: 659 659 659
+Encoding: 659 659 574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28541,8 +29121,9 @@ SplineSet
  342.771 452 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0294
-Encoding: 660 660 660
+Encoding: 660 660 575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28568,8 +29149,9 @@ SplineSet
  335.933 736 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0295
-Encoding: 661 661 661
+Encoding: 661 661 576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28595,8 +29177,9 @@ SplineSet
  880.933 736 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0296
-Encoding: 662 662 662
+Encoding: 662 662 577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28622,8 +29205,9 @@ SplineSet
  352.067 819 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0297
-Encoding: 663 663 663
+Encoding: 663 663 578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28652,8 +29236,9 @@ SplineSet
  396.931 132 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0298
-Encoding: 664 664 664
+Encoding: 664 664 579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28688,8 +29273,9 @@ SplineSet
  488.406 513 488.406 513 498.902 567 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0299
-Encoding: 665 665 665
+Encoding: 665 665 580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28725,8 +29311,9 @@ SplineSet
  995.023 627 995.023 627 911.581 599 c 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni029A
-Encoding: 666 666 666
+Encoding: 666 666 581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28761,8 +29348,9 @@ SplineSet
  1047.93 155 1047.93 155 717.575 4 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni029B
-Encoding: 667 667 667
+Encoding: 667 667 582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28799,8 +29387,9 @@ SplineSet
  855.502 101 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni029C
-Encoding: 668 668 668
+Encoding: 668 668 583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28821,8 +29410,9 @@ SplineSet
  228.853 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029D
-Encoding: 669 669 669
+Encoding: 669 669 584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28860,8 +29450,9 @@ SplineSet
  516.103 -115.687 516.103 -115.687 535.814 -66.9678 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni029E
-Encoding: 670 670 670
+Encoding: 670 670 585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28882,8 +29473,9 @@ SplineSet
  977.744 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029F
-Encoding: 671 671 671
+Encoding: 671 671 586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28898,8 +29490,9 @@ SplineSet
  344.853 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A0
-Encoding: 672 672 672
+Encoding: 672 672 587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28937,8 +29530,9 @@ SplineSet
  396.81 723 396.81 723 365.319 561 c 128,-1,33
 EndSplineSet
 EndChar
+
 StartChar: uni02A1
-Encoding: 673 673 673
+Encoding: 673 673 588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28974,8 +29568,9 @@ SplineSet
  355.934 736 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A2
-Encoding: 674 674 674
+Encoding: 674 674 589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29011,8 +29606,9 @@ SplineSet
  470.512 384 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A3
-Encoding: 675 675 675
+Encoding: 675 675 590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29054,8 +29650,9 @@ SplineSet
  673.728 901 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A4
-Encoding: 676 676 676
+Encoding: 676 676 591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29108,8 +29705,9 @@ SplineSet
  230.295 711 230.295 711 198.806 549 c 0,56,57
 EndSplineSet
 EndChar
+
 StartChar: uni02A5
-Encoding: 677 677 677
+Encoding: 677 677 592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29163,8 +29761,9 @@ SplineSet
  657.794 901 l 1,64,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A6
-Encoding: 678 678 678
+Encoding: 678 678 593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29221,8 +29820,9 @@ SplineSet
  547.795 225 l 1,48,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A7
-Encoding: 679 679 679
+Encoding: 679 679 594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29268,8 +29868,9 @@ SplineSet
  647.717 225 l 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A8
-Encoding: 680 680 680
+Encoding: 680 680 595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29326,8 +29927,9 @@ SplineSet
  627.307 758.115 627.307 758.115 699.653 895 c 1,62,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A9
-Encoding: 681 681 681
+Encoding: 681 681 596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29375,8 +29977,9 @@ SplineSet
  553.371 1283 553.371 1283 539.736 1218 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AA
-Encoding: 682 682 682
+Encoding: 682 682 597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29425,8 +30028,9 @@ SplineSet
  1150.52 1116 1150.52 1116 1197.49 1085 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AB
-Encoding: 683 683 683
+Encoding: 683 683 598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29456,8 +30060,9 @@ SplineSet
  115.744 216 115.744 216 164.533 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AC
-Encoding: 684 684 684
+Encoding: 684 684 599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29493,8 +30098,9 @@ SplineSet
  184.514 1312 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AD
-Encoding: 685 685 685
+Encoding: 685 685 600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29520,8 +30126,9 @@ SplineSet
  451.84 862 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AE
-Encoding: 686 686 686
+Encoding: 686 686 601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29553,8 +30160,9 @@ SplineSet
  715.362 1347.71 715.362 1347.71 676.756 1118 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AF
-Encoding: 687 687 687
+Encoding: 687 687 602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29592,8 +30200,9 @@ SplineSet
  638.579 1346.48 638.579 1346.48 598.321 1118 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B0
-Encoding: 688 688 688
+Encoding: 688 688 603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29618,8 +30227,9 @@ SplineSet
  921.105 1192 921.105 1192 898.363 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B1
-Encoding: 689 689 689
+Encoding: 689 689 604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29650,8 +30260,9 @@ SplineSet
  921.203 1192 921.203 1192 898.46 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B2
-Encoding: 690 690 690
+Encoding: 690 690 605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29677,8 +30288,9 @@ SplineSet
  919.488 1340 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B3
-Encoding: 691 691 691
+Encoding: 691 691 606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29703,8 +30315,9 @@ SplineSet
  917.756 1122 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B4
-Encoding: 692 692 692
+Encoding: 692 692 607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29729,8 +30342,9 @@ SplineSet
  315.244 842 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B5
-Encoding: 693 693 693
+Encoding: 693 693 608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29763,8 +30377,9 @@ SplineSet
  266.918 841 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B6
-Encoding: 694 694 694
+Encoding: 694 694 609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29797,8 +30412,9 @@ SplineSet
  509.522 1067 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B7
-Encoding: 695 695 695
+Encoding: 695 695 610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29820,8 +30436,9 @@ SplineSet
  283.035 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B8
-Encoding: 696 696 696
+Encoding: 696 696 611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29844,16 +30461,18 @@ SplineSet
  624.878 601 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B9
-Encoding: 697 697 697
+Encoding: 697 697 612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 884 884 N 1 0 0 1 0 0 2
+Refer: 720 884 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BB
-Encoding: 699 699 699
+Encoding: 699 699 613
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29926,8 +30545,9 @@ SplineSet
  733 903 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02BC
-Encoding: 700 700 700
+Encoding: 700 700 614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29942,15 +30562,17 @@ SplineSet
  594 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02BD
-Encoding: 701 701 701
+Encoding: 701 701 615
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 788 788 N 1 0 0 1 0 0 2
+Refer: 673 788 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BE
-Encoding: 702 702 702
+Encoding: 702 702 616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29969,8 +30591,9 @@ SplineSet
  631.536 1140 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02BF
-Encoding: 703 703 703
+Encoding: 703 703 617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29989,8 +30612,9 @@ SplineSet
  746.138 1140 746.138 1140 801.138 1140 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02C0
-Encoding: 704 704 704
+Encoding: 704 704 618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30016,8 +30640,9 @@ SplineSet
  437.432 1080 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02C1
-Encoding: 705 705 705
+Encoding: 705 705 619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30043,8 +30668,9 @@ SplineSet
  786.432 1080 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: circumflex
-Encoding: 710 710 710
+Encoding: 710 710 620
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30110,8 +30736,9 @@ SplineSet
  668 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: caron
-Encoding: 711 711 711
+Encoding: 711 711 621
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30177,8 +30804,9 @@ SplineSet
  838 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C8
-Encoding: 712 712 712
+Encoding: 712 712 622
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30212,16 +30840,18 @@ SplineSet
  765.24 1554 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C9
-Encoding: 713 713 713
+Encoding: 713 713 623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CC
-Encoding: 716 716 716
+Encoding: 716 716 624
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30255,32 +30885,36 @@ SplineSet
  765.24 390 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02CD
-Encoding: 717 717 717
+Encoding: 717 717 625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CE
-Encoding: 718 718 718
+Encoding: 718 718 626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni02CF
-Encoding: 719 719 719
+Encoding: 719 719 627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni02D0
-Encoding: 720 720 720
+Encoding: 720 720 628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30296,8 +30930,9 @@ SplineSet
  582.012 380 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D1
-Encoding: 721 721 721
+Encoding: 721 721 629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30309,24 +30944,27 @@ SplineSet
  579.067 740 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D2
-Encoding: 722 722 722
+Encoding: 722 722 630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 702 702 N 1 0 0 1 -85 -436 2
+Refer: 616 702 N 1 0 0 1 -85 -436 2
 EndChar
+
 StartChar: uni02D3
-Encoding: 723 723 723
+Encoding: 723 723 631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 -84.75 -436 2
+Refer: 617 703 N 1 0 0 1 -84.75 -436 2
 EndChar
+
 StartChar: uni02D6
-Encoding: 726 726 726
+Encoding: 726 726 632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30347,8 +30985,9 @@ SplineSet
  543 649 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D7
-Encoding: 727 727 727
+Encoding: 727 727 633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30361,26 +31000,29 @@ SplineSet
  825 469 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: breve
-Encoding: 728 728 728
+Encoding: 728 728 634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 659 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotaccent
-Encoding: 729 729 729
+Encoding: 729 729 635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 660 775 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ring
-Encoding: 730 730 730
+Encoding: 730 730 636
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30440,29 +31082,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-463 1534 m 0,0,1
+463 1534 m 256,0,1
  463 1652 463 1652 546 1735.5 c 128,-1,2
  629 1819 629 1819 748 1819 c 0,3,4
  866 1819 866 1819 949 1735.5 c 128,-1,5
- 1032 1652 1032 1652 1032 1534 c 0,6,7
+ 1032 1652 1032 1652 1032 1534 c 256,6,7
  1032 1416 1032 1416 949 1332.5 c 128,-1,8
  866 1249 866 1249 748 1249 c 0,9,10
  629 1249 629 1249 546 1332.5 c 128,-1,11
- 463 1416 463 1416 463 1534 c 0,0,1
+ 463 1416 463 1416 463 1534 c 256,0,1
 616 1534 m 0,12,13
  616 1479 616 1479 654.5 1441 c 128,-1,14
  693 1403 693 1403 748 1403 c 0,15,16
  802 1403 802 1403 840.5 1441.5 c 128,-1,17
- 879 1480 879 1480 879 1534 c 0,18,19
+ 879 1480 879 1480 879 1534 c 256,18,19
  879 1588 879 1588 840 1626.5 c 128,-1,20
  801 1665 801 1665 748 1665 c 0,21,22
  693 1665 693 1665 654.5 1626.5 c 128,-1,23
  616 1588 616 1588 616 1534 c 0,12,13
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ogonek
-Encoding: 731 731 731
+Encoding: 731 731 637
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30522,8 +31165,9 @@ SplineSet
  334 -69 334 -69 412 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tilde
-Encoding: 732 732 732
+Encoding: 732 732 638
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30703,18 +31347,20 @@ SplineSet
  844 1307 844 1307 811.5 1320 c 128,-1,28
  779 1333 779 1333 739 1364 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: hungarumlaut
-Encoding: 733 733 733
+Encoding: 733 733 639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 664 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02DE
-Encoding: 734 734 734
+Encoding: 734 734 640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30735,8 +31381,9 @@ SplineSet
  -287.062 883.291 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E0
-Encoding: 736 736 736
+Encoding: 736 736 641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30760,8 +31407,9 @@ SplineSet
  694 729 694 729 617 882 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02E1
-Encoding: 737 737 737
+Encoding: 737 737 642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30782,8 +31430,9 @@ SplineSet
  424 789 424 789 451 930 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E2
-Encoding: 738 738 738
+Encoding: 738 738 643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30820,8 +31469,9 @@ SplineSet
  858 1294 858 1294 911 1277 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E3
-Encoding: 739 739 739
+Encoding: 739 739 644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30842,8 +31492,9 @@ SplineSet
  1016 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E4
-Encoding: 740 740 740
+Encoding: 740 740 645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30869,8 +31520,9 @@ SplineSet
  786 1080 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni02E5
-Encoding: 741 741 741
+Encoding: 741 741 646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30885,8 +31537,9 @@ SplineSet
  1097 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E6
-Encoding: 742 742 742
+Encoding: 742 742 647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30903,8 +31556,9 @@ SplineSet
  1097 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E7
-Encoding: 743 743 743
+Encoding: 743 743 648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30921,8 +31575,9 @@ SplineSet
  1097 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E8
-Encoding: 744 744 744
+Encoding: 744 744 649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30939,8 +31594,9 @@ SplineSet
  1097 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E9
-Encoding: 745 745 745
+Encoding: 745 745 650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30955,56 +31611,63 @@ SplineSet
  821 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02EE
-Encoding: 750 750 750
+Encoding: 750 750 651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8221 8221 N 1 0 0 1 0 0 3
+Refer: 1874 8221 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni02F3
-Encoding: 755 755 755
+Encoding: 755 755 652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 690 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gravecomb
-Encoding: 768 768 768
+Encoding: 768 768 653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: acutecomb
-Encoding: 769 769 769
+Encoding: 769 769 654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0302
-Encoding: 770 770 770
+Encoding: 770 770 655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 620 710 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tildecomb
-Encoding: 771 771 771
+Encoding: 771 771 656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0304
-Encoding: 772 772 772
+Encoding: 772 772 657
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31039,16 +31702,18 @@ SplineSet
  459 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0305
-Encoding: 773 773 773
+Encoding: 773 773 658
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
+Refer: 1897 8254 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0306
-Encoding: 774 774 774
+Encoding: 774 774 659
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31103,8 +31768,9 @@ SplineSet
  446 1606 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307
-Encoding: 775 775 775
+Encoding: 775 775 660
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31152,16 +31818,18 @@ SplineSet
  643 1585 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0308
-Encoding: 776 776 776
+Encoding: 776 776 661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hookabovecomb
-Encoding: 777 777 777
+Encoding: 777 777 662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31184,16 +31852,18 @@ SplineSet
  856.884 1574 856.884 1574 852.607 1552 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni030A
-Encoding: 778 778 778
+Encoding: 778 778 663
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 0 2
+Refer: 636 730 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni030B
-Encoding: 779 779 779
+Encoding: 779 779 664
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31289,16 +31959,18 @@ SplineSet
  612 1638 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030C
-Encoding: 780 780 780
+Encoding: 780 780 665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 621 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni030D
-Encoding: 781 781 781
+Encoding: 781 781 666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31311,17 +31983,19 @@ SplineSet
  755.152 1706 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030E
-Encoding: 782 782 782
+Encoding: 782 782 667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 781 781 N 1 0 0 1 -285 0 2
-Refer: 781 781 N 1 0 0 1 285 0 2
+Refer: 666 781 N 1 0 0 1 -285 0 2
+Refer: 666 781 N 1 0 0 1 285 0 2
 EndChar
+
 StartChar: uni030F
-Encoding: 783 783 783
+Encoding: 783 783 668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31339,17 +32013,19 @@ SplineSet
  546.395 1638 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0310
-Encoding: 784 784 784
+Encoding: 784 784 669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 728 728 N 1 0 0 1 0 0 2
-Refer: 729 729 N 1 0 0 1 36 216 2
+Refer: 634 728 N 1 0 0 1 0 0 2
+Refer: 635 729 N 1 0 0 1 36 216 2
 EndChar
+
 StartChar: uni0311
-Encoding: 785 785 785
+Encoding: 785 785 670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31370,8 +32046,9 @@ SplineSet
  390.443 1309 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0312
-Encoding: 786 786 786
+Encoding: 786 786 671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31384,8 +32061,9 @@ SplineSet
  717 903 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0313
-Encoding: 787 787 787
+Encoding: 787 787 672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31401,8 +32079,9 @@ SplineSet
  529.164 1729 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0314
-Encoding: 788 788 788
+Encoding: 788 788 673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31418,8 +32097,9 @@ SplineSet
  803.164 1729 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0315
-Encoding: 789 789 789
+Encoding: 789 789 674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31432,24 +32112,27 @@ SplineSet
  702 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0316
-Encoding: 790 790 790
+Encoding: 790 790 675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 135 -1855 2
+Refer: 65 96 N 1 0 0 1 135 -1855 2
 EndChar
+
 StartChar: uni0317
-Encoding: 791 791 791
+Encoding: 791 791 676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -135 -1855 2
+Refer: 116 180 N 1 0 0 1 -135 -1855 2
 EndChar
+
 StartChar: uni0318
-Encoding: 792 792 792
+Encoding: 792 792 677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31466,8 +32149,9 @@ SplineSet
  493.033 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0319
-Encoding: 793 793 793
+Encoding: 793 793 678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31484,8 +32168,9 @@ SplineSet
  475.401 -252 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031A
-Encoding: 794 794 794
+Encoding: 794 794 679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31500,8 +32185,9 @@ SplineSet
  722.203 1713 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031B
-Encoding: 795 795 795
+Encoding: 795 795 680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31524,8 +32210,9 @@ SplineSet
  445.899 793 445.899 793 395.979 850 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031C
-Encoding: 796 796 796
+Encoding: 796 796 681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31543,8 +32230,9 @@ SplineSet
  436.319 -370 436.319 -370 509.079 -370 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031D
-Encoding: 797 797 797
+Encoding: 797 797 682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31561,8 +32249,9 @@ SplineSet
  250.333 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031E
-Encoding: 798 798 798
+Encoding: 798 798 683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31579,8 +32268,9 @@ SplineSet
  365.846 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031F
-Encoding: 799 799 799
+Encoding: 799 799 684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31601,8 +32291,9 @@ SplineSet
  408.033 -624.3 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0320
-Encoding: 800 800 800
+Encoding: 800 800 685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31615,8 +32306,9 @@ SplineSet
  320.631 -441 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0321
-Encoding: 801 801 801
+Encoding: 801 801 686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31635,8 +32327,9 @@ SplineSet
  1104.24 43 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0322
-Encoding: 802 802 802
+Encoding: 802 802 687
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31655,8 +32348,9 @@ SplineSet
  151.682 -208.808 151.682 -208.808 200.239 41 c 10,0,0
 EndSplineSet
 EndChar
+
 StartChar: dotbelowcomb
-Encoding: 803 803 803
+Encoding: 803 803 688
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31704,8 +32398,9 @@ SplineSet
  292.014 -216 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0324
-Encoding: 804 804 804
+Encoding: 804 804 689
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31794,8 +32489,9 @@ SplineSet
  114.014 -216 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0325
-Encoding: 805 805 805
+Encoding: 805 805 690
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31834,11 +32530,11 @@ Fore
 SplineSet
 640.817 -236.252 m 0,0,1
  640.817 -355.025 640.817 -355.025 542.361 -438 c 0,2,3
- 466.421 -502 466.421 -502 373.921 -502 c 0,4,5
+ 466.421 -502 466.421 -502 373.921 -502 c 256,4,5
  281.421 -502 281.421 -502 236.983 -446.3 c 128,-1,6
  192.546 -390.601 192.546 -390.601 192.546 -327.843 c 0,7,8
  192.546 -208.856 192.546 -208.856 290.911 -126.5 c 0,9,10
- 366.754 -63 366.754 -63 459.254 -63 c 0,11,12
+ 366.754 -63 366.754 -63 459.254 -63 c 256,11,12
  551.754 -63 551.754 -63 596.285 -118.276 c 128,-1,13
  640.817 -173.552 640.817 -173.552 640.817 -236.252 c 0,0,1
 399.079 -370 m 0,14,15
@@ -31850,8 +32546,9 @@ SplineSet
  327.202 -370 327.202 -370 399.079 -370 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0326
-Encoding: 806 806 806
+Encoding: 806 806 691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31864,8 +32561,9 @@ SplineSet
  284 -198 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0327
-Encoding: 807 807 807
+Encoding: 807 807 692
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31927,16 +32625,18 @@ SplineSet
  564 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0328
-Encoding: 808 808 808
+Encoding: 808 808 693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 -43.5 0 2
+Refer: 637 731 N 1 0 0 1 -43.5 0 2
 EndChar
+
 StartChar: uni0329
-Encoding: 809 809 809
+Encoding: 809 809 694
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31949,8 +32649,9 @@ SplineSet
  754.152 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032A
-Encoding: 810 810 810
+Encoding: 810 810 695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31967,8 +32668,9 @@ SplineSet
  967.849 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032B
-Encoding: 811 811 811
+Encoding: 811 811 696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31992,8 +32694,9 @@ SplineSet
  1053.01 -192 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni032C
-Encoding: 812 812 812
+Encoding: 812 812 697
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32036,8 +32739,9 @@ SplineSet
  497.726 -485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032D
-Encoding: 813 813 813
+Encoding: 813 813 698
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32080,8 +32784,9 @@ SplineSet
  329.812 -109 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032E
-Encoding: 814 814 814
+Encoding: 814 814 699
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32136,8 +32841,9 @@ SplineSet
  98.29 -194 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032F
-Encoding: 815 815 815
+Encoding: 815 815 700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32158,8 +32864,9 @@ SplineSet
  717.113 -455.176 717.113 -455.176 711.948 -489 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0330
-Encoding: 816 816 816
+Encoding: 816 816 701
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32300,8 +33007,9 @@ SplineSet
  430.726 -461 430.726 -461 390.726 -430 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0331
-Encoding: 817 817 817
+Encoding: 817 817 702
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32336,24 +33044,27 @@ SplineSet
  113.625 -218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0332
-Encoding: 818 818 818
+Encoding: 818 818 703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0333
-Encoding: 819 819 819
+Encoding: 819 819 704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8215 8215 N 1 0 0 1 0 0 2
+Refer: 1868 8215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0334
-Encoding: 820 820 820
+Encoding: 820 820 705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32380,8 +33091,9 @@ SplineSet
  1093.38 747 1093.38 747 1178.82 811 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0335
-Encoding: 821 821 821
+Encoding: 821 821 706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32394,8 +33106,9 @@ SplineSet
  173.146 438 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0336
-Encoding: 822 822 822
+Encoding: 822 822 707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32408,8 +33121,9 @@ SplineSet
  -18.8545 438 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0337
-Encoding: 823 823 823
+Encoding: 823 823 708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32422,8 +33136,9 @@ SplineSet
  32.5986 -117 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0338
-Encoding: 824 824 824
+Encoding: 824 824 709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32436,8 +33151,9 @@ SplineSet
  -1.64258 -63 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni0339
-Encoding: 825 825 825
+Encoding: 825 825 710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32455,8 +33171,9 @@ SplineSet
  289.079 -370 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033A
-Encoding: 826 826 826
+Encoding: 826 826 711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32473,8 +33190,9 @@ SplineSet
  265.151 -520 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033B
-Encoding: 827 827 827
+Encoding: 827 827 712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32492,8 +33210,9 @@ SplineSet
  709.549 -620 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033C
-Encoding: 828 828 828
+Encoding: 828 828 713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32517,8 +33236,9 @@ SplineSet
  179.998 -489 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033D
-Encoding: 829 829 829
+Encoding: 829 829 714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32539,8 +33259,9 @@ SplineSet
  590.439 1321.07 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033E
-Encoding: 830 830 830
+Encoding: 830 830 715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32571,33 +33292,37 @@ SplineSet
  702.209 1494.9 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033F
-Encoding: 831 831 831
+Encoding: 831 831 716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
-Refer: 8254 8254 N 1 0 0 1 0 -275 2
+Refer: 1897 8254 N 1 0 0 1 0 0 2
+Refer: 1897 8254 N 1 0 0 1 0 -275 2
 EndChar
+
 StartChar: uni0343
-Encoding: 835 835 835
+Encoding: 835 835 717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 787 787 N 1 0 0 1 0 0 2
+Refer: 672 787 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0358
-Encoding: 856 856 856
+Encoding: 856 856 718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 618 0 2
+Refer: 635 729 N 1 0 0 1 618 0 2
 EndChar
+
 StartChar: uni0361
-Encoding: 865 865 865
+Encoding: 865 865 719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32616,8 +33341,9 @@ SplineSet
  330.305 1796.91 330.305 1796.91 645.331 1803 c 24,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni0374
-Encoding: 884 884 884
+Encoding: 884 884 720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32630,8 +33356,9 @@ SplineSet
  451.6 1140 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0375
-Encoding: 885 885 885
+Encoding: 885 885 721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32644,24 +33371,27 @@ SplineSet
  781.4 72 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0376
-Encoding: 886 886 886
+Encoding: 886 886 722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 3
+Refer: 860 1048 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0377
-Encoding: 887 887 887
+Encoding: 887 887 723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 3
+Refer: 892 1080 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037A
-Encoding: 890 890 890
+Encoding: 890 890 724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32678,171 +33408,191 @@ SplineSet
  611.076 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni037B
-Encoding: 891 891 891
+Encoding: 891 891 725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 511 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037C
-Encoding: 892 892 892
+Encoding: 892 892 726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 165 -124 2
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 165 -124 2
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037D
-Encoding: 893 893 893
+Encoding: 893 893 727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -148 -124 2
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 -148 -124 2
+Refer: 511 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037E
-Encoding: 894 894 894
+Encoding: 894 894 728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 59 59 N 1 0 0 1 0 0 2
+Refer: 28 59 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni037F
-Encoding: 895 895 895
+Encoding: 895 895 729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 3
+Refer: 43 74 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: tonos
-Encoding: 900 900 900
+Encoding: 900 900 730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dieresistonos
-Encoding: 901 901 901
+Encoding: 901 901 731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 112 408 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 112 408 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alphatonos
-Encoding: 902 902 902
+Encoding: 902 902 732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -550 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: anoteleia
-Encoding: 903 903 903
+Encoding: 903 903 733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Epsilontonos
-Encoding: 904 904 904
+Encoding: 904 904 734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -820 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -820 0 2
 EndChar
+
 StartChar: Etatonos
-Encoding: 905 905 905
+Encoding: 905 905 735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -860 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -860 0 2
 EndChar
+
 StartChar: Iotatonos
-Encoding: 906 906 906
+Encoding: 906 906 736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -800 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: Omicrontonos
-Encoding: 908 908 908
+Encoding: 908 908 737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -640 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -640 0 2
 EndChar
+
 StartChar: Upsilontonos
-Encoding: 910 910 910
+Encoding: 910 910 738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -965 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -965 0 2
 EndChar
+
 StartChar: Omegatonos
-Encoding: 911 911 911
+Encoding: 911 911 739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -595 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -595 0 2
 EndChar
+
 StartChar: iotadieresistonos
-Encoding: 912 912 912
+Encoding: 912 912 740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 731 901 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alpha
-Encoding: 913 913 913
+Encoding: 913 913 741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Beta
-Encoding: 914 914 914
+Encoding: 914 914 742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gamma
-Encoding: 915 915 915
+Encoding: 915 915 743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 855 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0394
-Encoding: 916 916 916
+Encoding: 916 916 744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32859,32 +33609,36 @@ SplineSet
  750.434 260 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: Epsilon
-Encoding: 917 917 917
+Encoding: 917 917 745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zeta
-Encoding: 918 918 918
+Encoding: 918 918 746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eta
-Encoding: 919 919 919
+Encoding: 919 919 747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Theta
-Encoding: 920 920 920
+Encoding: 920 920 748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32915,24 +33669,27 @@ SplineSet
  17.6494 363 17.6494 363 91.9023 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: Iota
-Encoding: 921 921 921
+Encoding: 921 921 749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kappa
-Encoding: 922 922 922
+Encoding: 922 922 750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lambda
-Encoding: 923 923 923
+Encoding: 923 923 751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32948,24 +33705,27 @@ SplineSet
  182.896 0 l 17,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Mu
-Encoding: 924 924 924
+Encoding: 924 924 752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Nu
-Encoding: 925 925 925
+Encoding: 925 925 753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Xi
-Encoding: 926 926 926
+Encoding: 926 926 754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32988,32 +33748,36 @@ SplineSet
  840.313 664 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: Omicron
-Encoding: 927 927 927
+Encoding: 927 927 755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Pi
-Encoding: 928 928 928
+Encoding: 928 928 756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1055 1055 N 1 0 0 1 0 0 2
+Refer: 867 1055 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rho
-Encoding: 929 929 929
+Encoding: 929 929 757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Sigma
-Encoding: 931 931 931
+Encoding: 931 931 758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33034,24 +33798,27 @@ SplineSet
  499 747 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tau
-Encoding: 932 932 932
+Encoding: 932 932 759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilon
-Encoding: 933 933 933
+Encoding: 933 933 760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Phi
-Encoding: 934 934 934
+Encoding: 934 934 761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33094,16 +33861,18 @@ SplineSet
  407.116 537.729 407.116 537.729 426.216 526.395 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: Chi
-Encoding: 935 935 935
+Encoding: 935 935 762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Psi
-Encoding: 936 936 936
+Encoding: 936 936 763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33136,8 +33905,9 @@ SplineSet
  669.434 260 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: Omega
-Encoding: 937 937 937
+Encoding: 937 937 764
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33170,71 +33940,79 @@ SplineSet
  -10.8838 211 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Iotadieresis
-Encoding: 938 938 938
+Encoding: 938 938 765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 47 373 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 47 373 2
+Refer: 749 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilondieresis
-Encoding: 939 939 939
+Encoding: 939 939 766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 47 373 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 47 373 2
+Refer: 760 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alphatonos
-Encoding: 940 940 940
+Encoding: 940 940 767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: epsilontonos
-Encoding: 941 941 941
+Encoding: 941 941 768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: etatonos
-Encoding: 942 942 942
+Encoding: 942 942 769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotatonos
-Encoding: 943 943 943
+Encoding: 943 943 770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresistonos
-Encoding: 944 944 944
+Encoding: 944 944 771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 731 901 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alpha
-Encoding: 945 945 945
+Encoding: 945 945 772
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33269,8 +34047,9 @@ SplineSet
  700.638 589 l 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: beta
-Encoding: 946 946 946
+Encoding: 946 946 773
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33297,8 +34076,9 @@ SplineSet
  389.353 402 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: gamma
-Encoding: 947 947 947
+Encoding: 947 947 774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33322,8 +34102,9 @@ SplineSet
  472.671 957.354 472.671 957.354 488.56 808 c 2,3,-1
 EndSplineSet
 EndChar
+
 StartChar: delta
-Encoding: 948 948 948
+Encoding: 948 948 775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33363,8 +34144,9 @@ SplineSet
  749.019 909 749.019 909 643.019 909 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: epsilon
-Encoding: 949 949 949
+Encoding: 949 949 776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33410,8 +34192,9 @@ SplineSet
  658.005 487 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zeta
-Encoding: 950 950 950
+Encoding: 950 950 777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33437,8 +34220,9 @@ SplineSet
  510.331 952.546 510.331 952.546 428.975 534 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: eta
-Encoding: 951 951 951
+Encoding: 951 951 778
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33463,8 +34247,9 @@ SplineSet
  1182.87 936 1182.87 936 1142.24 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: theta
-Encoding: 952 952 952
+Encoding: 952 952 779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33493,8 +34278,9 @@ SplineSet
  698.558 -24.3203 698.558 -24.3203 460.558 -24.3203 c 24,21,22
 EndSplineSet
 EndChar
+
 StartChar: iota
-Encoding: 953 953 953
+Encoding: 953 953 780
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33515,16 +34301,18 @@ SplineSet
  871.853 1120 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: kappa
-Encoding: 954 954 954
+Encoding: 954 954 781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
+Refer: 894 1082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lambda
-Encoding: 955 955 955
+Encoding: 955 955 782
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33547,16 +34335,18 @@ SplineSet
  942.829 1393.65 942.829 1393.65 968.144 1220 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03BC
-Encoding: 956 956 956
+Encoding: 956 956 783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 181 181 N 1 0 0 1 0 0 2
+Refer: 117 181 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nu
-Encoding: 957 957 957
+Encoding: 957 957 784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33578,8 +34368,9 @@ SplineSet
  524 295 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: xi
-Encoding: 958 958 958
+Encoding: 958 958 785
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33610,16 +34401,18 @@ SplineSet
  691.429 -0.000976562 691.429 -0.000976562 632.175 0 c 0,5,-1
 EndSplineSet
 EndChar
+
 StartChar: omicron
-Encoding: 959 959 959
+Encoding: 959 959 786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: pi
-Encoding: 960 960 960
+Encoding: 960 960 787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33651,8 +34444,9 @@ SplineSet
  1231.71 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rho
-Encoding: 961 961 961
+Encoding: 961 961 788
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33680,8 +34474,9 @@ SplineSet
  857.483 399 857.483 399 888.974 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: sigma1
-Encoding: 962 962 962
+Encoding: 962 962 789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33712,8 +34507,9 @@ SplineSet
  579.772 231.78 579.772 231.78 722.467 225 c 24,22,23
 EndSplineSet
 EndChar
+
 StartChar: sigma
-Encoding: 963 963 963
+Encoding: 963 963 790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33741,8 +34537,9 @@ SplineSet
  605.207 866.814 605.207 866.814 563.827 887.362 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: tau
-Encoding: 964 964 964
+Encoding: 964 964 791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33765,8 +34562,9 @@ SplineSet
  244.853 1120 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: upsilon
-Encoding: 965 965 965
+Encoding: 965 965 792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33793,8 +34591,9 @@ SplineSet
  790 0 790 0 562 0 c 16,0,1
 EndSplineSet
 EndChar
+
 StartChar: phi
-Encoding: 966 966 966
+Encoding: 966 966 793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33824,8 +34623,9 @@ SplineSet
  921.905 867.855 921.905 867.855 883.286 864 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: chi
-Encoding: 967 967 967
+Encoding: 967 967 794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33858,8 +34658,9 @@ SplineSet
  633.274 -289.717 633.274 -289.717 587.891 -114 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: psi
-Encoding: 968 968 968
+Encoding: 968 968 795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33884,8 +34685,9 @@ SplineSet
  739.285 225 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: omega
-Encoding: 969 969 969
+Encoding: 969 969 796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33913,53 +34715,59 @@ SplineSet
  772.263 665 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: iotadieresis
-Encoding: 970 970 970
+Encoding: 970 970 797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresis
-Encoding: 971 971 971
+Encoding: 971 971 798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omicrontonos
-Encoding: 972 972 972
+Encoding: 972 972 799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilontonos
-Encoding: 973 973 973
+Encoding: 973 973 800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omegatonos
-Encoding: 974 974 974
+Encoding: 974 974 801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D0
-Encoding: 976 976 976
+Encoding: 976 976 802
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33988,8 +34796,9 @@ SplineSet
  849.067 590 849.067 590 682.534 685 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: theta1
-Encoding: 977 977 977
+Encoding: 977 977 803
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34018,8 +34827,9 @@ SplineSet
  820.829 572.934 820.829 572.934 840.048 668 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: Upsilon1
-Encoding: 978 978 978
+Encoding: 978 978 804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34044,26 +34854,29 @@ SplineSet
  918.36 1087.53 918.36 1087.53 926.909 1202.95 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D3
-Encoding: 979 979 979
+Encoding: 979 979 805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -1035 0 2
+Refer: 804 978 N 1 0 0 1 0 0 2
+Refer: 730 900 N 1 0 0 1 -1035 0 2
 EndChar
+
 StartChar: uni03D4
-Encoding: 980 980 980
+Encoding: 980 980 806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -29 373 2
-Refer: 978 978 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 -29 373 2
+Refer: 804 978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: phi1
-Encoding: 981 981 981
+Encoding: 981 981 807
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34098,8 +34911,9 @@ SplineSet
  870.292 848.707 870.292 848.707 823.063 874 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: omega1
-Encoding: 982 982 982
+Encoding: 982 982 808
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34128,8 +34942,9 @@ SplineSet
  421.2 895 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D7
-Encoding: 983 983 983
+Encoding: 983 983 809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34164,8 +34979,9 @@ SplineSet
  1058.78 195 1058.78 195 1127.19 261 c 25,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03D8
-Encoding: 984 984 984
+Encoding: 984 984 810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34194,8 +35010,9 @@ SplineSet
  818.579 32.4316 818.579 32.4316 654.73 -10 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D9
-Encoding: 985 985 985
+Encoding: 985 985 811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34224,8 +35041,9 @@ SplineSet
  838.111 24.8633 838.111 24.8633 690.788 -11 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DA
-Encoding: 986 986 986
+Encoding: 986 986 812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34254,8 +35072,9 @@ SplineSet
  463.664 236 463.664 236 575.664 236 c 8,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03DB
-Encoding: 987 987 987
+Encoding: 987 987 813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34284,16 +35103,18 @@ SplineSet
  733.265 895 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DC
-Encoding: 988 988 988
+Encoding: 988 988 814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 3
+Refer: 39 70 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03DD
-Encoding: 989 989 989
+Encoding: 989 989 815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34326,8 +35147,9 @@ SplineSet
  256.638 -54.2109 256.638 -54.2109 277.866 55 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DE
-Encoding: 990 990 990
+Encoding: 990 990 816
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34352,8 +35174,9 @@ SplineSet
  740.129 1368.79 740.129 1368.79 692.57 1159 c 26,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DF
-Encoding: 991 991 991
+Encoding: 991 991 817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34370,8 +35193,9 @@ SplineSet
  1145.48 924 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E0
-Encoding: 992 992 992
+Encoding: 992 992 818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34401,8 +35225,9 @@ SplineSet
  631.12 1273 631.12 1273 549.705 1240 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E1
-Encoding: 993 993 993
+Encoding: 993 993 819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34427,8 +35252,9 @@ SplineSet
  761.911 48 761.911 48 754.569 180 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03F0
-Encoding: 1008 1008 1008
+Encoding: 1008 1008 820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34461,8 +35287,9 @@ SplineSet
  119.947 417 119.947 417 275.441 507 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03F1
-Encoding: 1009 1009 1009
+Encoding: 1009 1009 821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34494,24 +35321,27 @@ SplineSet
  858.553 399 858.553 399 890.042 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03F2
-Encoding: 1010 1010 1010
+Encoding: 1010 1010 822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F3
-Encoding: 1011 1011 1011
+Encoding: 1011 1011 823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 3
+Refer: 75 106 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F4
-Encoding: 1012 1012 1012
+Encoding: 1012 1012 824
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34540,8 +35370,9 @@ SplineSet
  17.6494 363 17.6494 363 91.9023 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni03F5
-Encoding: 1013 1013 1013
+Encoding: 1013 1013 825
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34571,8 +35402,9 @@ SplineSet
  955.227 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F6
-Encoding: 1014 1014 1014
+Encoding: 1014 1014 826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34602,32 +35434,36 @@ SplineSet
  132.579 15.3008 132.579 15.3008 70.2266 57 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F7
-Encoding: 1015 1015 1015
+Encoding: 1015 1015 827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 222 222 N 1 0 0 1 0 0 3
+Refer: 158 222 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F8
-Encoding: 1016 1016 1016
+Encoding: 1016 1016 828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 254 254 N 1 0 0 1 0 0 3
+Refer: 190 254 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F9
-Encoding: 1017 1017 1017
+Encoding: 1017 1017 829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 3
+Refer: 36 67 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FA
-Encoding: 1018 1018 1018
+Encoding: 1018 1018 830
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34649,8 +35485,9 @@ SplineSet
  231.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FB
-Encoding: 1019 1019 1019
+Encoding: 1019 1019 831
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34672,8 +35509,9 @@ SplineSet
  226.537 1020 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FC
-Encoding: 1020 1020 1020
+Encoding: 1020 1020 832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34709,8 +35547,9 @@ SplineSet
  857.483 399 857.483 399 888.974 561 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03FD
-Encoding: 1021 1021 1021
+Encoding: 1021 1021 833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34737,44 +35576,49 @@ SplineSet
  78.4502 7 78.4502 7 15.4482 43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03FE
-Encoding: 1022 1022 1022
+Encoding: 1022 1022 834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1017 1017 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 166 0 2
+Refer: 829 1017 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 166 0 2
 EndChar
+
 StartChar: uni03FF
-Encoding: 1023 1023 1023
+Encoding: 1023 1023 835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -187 0 2
-Refer: 1021 1021 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 -187 0 2
+Refer: 833 1021 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0400
-Encoding: 1024 1024 1024
+Encoding: 1024 1024 836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 88 373 2
+Refer: 857 1045 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: uni0401
-Encoding: 1025 1025 1025
+Encoding: 1025 1025 837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 88 373 2
+Refer: 857 1045 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: uni0402
-Encoding: 1026 1026 1026
+Encoding: 1026 1026 838
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34815,17 +35659,19 @@ SplineSet
  1190 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0403
-Encoding: 1027 1027 1027
+Encoding: 1027 1027 839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 168 373 2
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 168 373 2
+Refer: 855 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0404
-Encoding: 1028 1028 1028
+Encoding: 1028 1028 840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34853,41 +35699,46 @@ SplineSet
  441 615 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0405
-Encoding: 1029 1029 1029
+Encoding: 1029 1029 841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0406
-Encoding: 1030 1030 1030
+Encoding: 1030 1030 842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0407
-Encoding: 1031 1031 1031
+Encoding: 1031 1031 843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1030 1030 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 88 373 2
+Refer: 842 1030 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 88 373 2
 EndChar
+
 StartChar: uni0408
-Encoding: 1032 1032 1032
+Encoding: 1032 1032 844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0409
-Encoding: 1033 1033 1033
+Encoding: 1033 1033 845
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34927,8 +35778,9 @@ SplineSet
  437 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040A
-Encoding: 1034 1034 1034
+Encoding: 1034 1034 846
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34964,8 +35816,9 @@ SplineSet
  437 0 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040B
-Encoding: 1035 1035 1035
+Encoding: 1035 1035 847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35000,35 +35853,39 @@ SplineSet
  268 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040C
-Encoding: 1036 1036 1036
+Encoding: 1036 1036 848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 31 373 2
-Refer: 1050 1050 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 31 373 2
+Refer: 862 1050 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040D
-Encoding: 1037 1037 1037
+Encoding: 1037 1037 849
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 129 373 2
+Refer: 860 1048 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 129 373 2
 EndChar
+
 StartChar: uni040E
-Encoding: 1038 1038 1038
+Encoding: 1038 1038 850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 871 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040F
-Encoding: 1039 1039 1039
+Encoding: 1039 1039 851
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35049,16 +35906,18 @@ SplineSet
  23 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0410
-Encoding: 1040 1040 1040
+Encoding: 1040 1040 852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0411
-Encoding: 1041 1041 1041
+Encoding: 1041 1041 853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35086,16 +35945,18 @@ SplineSet
  306.209 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0412
-Encoding: 1042 1042 1042
+Encoding: 1042 1042 854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0413
-Encoding: 1043 1043 1043
+Encoding: 1043 1043 855
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35110,8 +35971,9 @@ SplineSet
  717 1233 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0414
-Encoding: 1044 1044 1044
+Encoding: 1044 1044 856
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35140,16 +36002,18 @@ SplineSet
  -136 -322 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0415
-Encoding: 1045 1045 1045
+Encoding: 1045 1045 857
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0416
-Encoding: 1046 1046 1046
+Encoding: 1046 1046 858
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35178,16 +36042,18 @@ SplineSet
  -132 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0417
-Encoding: 1047 1047 1047
+Encoding: 1047 1047 859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0418
-Encoding: 1048 1048 1048
+Encoding: 1048 1048 860
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35206,25 +36072,28 @@ SplineSet
  1257 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0419
-Encoding: 1049 1049 1049
+Encoding: 1049 1049 861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 860 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041A
-Encoding: 1050 1050 1050
+Encoding: 1050 1050 862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041B
-Encoding: 1051 1051 1051
+Encoding: 1051 1051 863
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35249,32 +36118,36 @@ SplineSet
  616 1233 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni041C
-Encoding: 1052 1052 1052
+Encoding: 1052 1052 864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041D
-Encoding: 1053 1053 1053
+Encoding: 1053 1053 865
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041E
-Encoding: 1054 1054 1054
+Encoding: 1054 1054 866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041F
-Encoding: 1055 1055 1055
+Encoding: 1055 1055 867
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35291,32 +36164,36 @@ SplineSet
  427 1493 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0420
-Encoding: 1056 1056 1056
+Encoding: 1056 1056 868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0421
-Encoding: 1057 1057 1057
+Encoding: 1057 1057 869
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0422
-Encoding: 1058 1058 1058
+Encoding: 1058 1058 870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0423
-Encoding: 1059 1059 1059
+Encoding: 1059 1059 871
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35339,8 +36216,9 @@ SplineSet
  641 303 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0424
-Encoding: 1060 1060 1060
+Encoding: 1060 1060 872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35378,16 +36256,18 @@ SplineSet
  679 387 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0425
-Encoding: 1061 1061 1061
+Encoding: 1061 1061 873
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0426
-Encoding: 1062 1062 1062
+Encoding: 1062 1062 874
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35408,8 +36288,9 @@ SplineSet
  -34 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0427
-Encoding: 1063 1063 1063
+Encoding: 1063 1063 875
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35434,8 +36315,9 @@ SplineSet
  1278 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0428
-Encoding: 1064 1064 1064
+Encoding: 1064 1064 876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35456,8 +36338,9 @@ SplineSet
  1009 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0429
-Encoding: 1065 1065 1065
+Encoding: 1065 1065 877
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35482,8 +36365,9 @@ SplineSet
  866 0 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042A
-Encoding: 1066 1066 1066
+Encoding: 1066 1066 878
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35513,8 +36397,9 @@ SplineSet
  125 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042B
-Encoding: 1067 1067 1067
+Encoding: 1067 1067 879
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35546,8 +36431,9 @@ SplineSet
  793 0 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042C
-Encoding: 1068 1068 1068
+Encoding: 1068 1068 880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35575,8 +36461,9 @@ SplineSet
  -21 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042D
-Encoding: 1069 1069 1069
+Encoding: 1069 1069 881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35602,8 +36489,9 @@ SplineSet
  792 875 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni042E
-Encoding: 1070 1070 1070
+Encoding: 1070 1070 882
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35636,8 +36524,9 @@ SplineSet
  -105 0 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042F
-Encoding: 1071 1071 1071
+Encoding: 1071 1071 883
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35667,16 +36556,18 @@ SplineSet
  501 1009 501 1009 501 982 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni0430
-Encoding: 1072 1072 1072
+Encoding: 1072 1072 884
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0431
-Encoding: 1073 1073 1073
+Encoding: 1073 1073 885
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35718,8 +36609,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 0" uniF6C5
 EndChar
+
 StartChar: uni0432
-Encoding: 1074 1074 1074
+Encoding: 1074 1074 886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35754,8 +36646,9 @@ SplineSet
  438 698 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0433
-Encoding: 1075 1075 1075
+Encoding: 1075 1075 887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35770,8 +36663,9 @@ SplineSet
  579 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0434
-Encoding: 1076 1076 1076
+Encoding: 1076 1076 888
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35800,16 +36694,18 @@ SplineSet
  482 313 482 313 433 219 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0435
-Encoding: 1077 1077 1077
+Encoding: 1077 1077 889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0436
-Encoding: 1078 1078 1078
+Encoding: 1078 1078 890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35838,8 +36734,9 @@ SplineSet
  -95 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0437
-Encoding: 1079 1079 1079
+Encoding: 1079 1079 891
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35877,8 +36774,9 @@ SplineSet
  161 0 161 0 52 44 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0438
-Encoding: 1080 1080 1080
+Encoding: 1080 1080 892
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35897,25 +36795,28 @@ SplineSet
  43 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0439
-Encoding: 1081 1081 1081
+Encoding: 1081 1081 893
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 892 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043A
-Encoding: 1082 1082 1082
+Encoding: 1082 1082 894
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 2
+Refer: 248 312 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043B
-Encoding: 1083 1083 1083
+Encoding: 1083 1083 895
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35940,8 +36841,9 @@ SplineSet
  637 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043C
-Encoding: 1084 1084 1084
+Encoding: 1084 1084 896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35963,8 +36865,9 @@ SplineSet
  195 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043D
-Encoding: 1085 1085 1085
+Encoding: 1085 1085 897
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35985,16 +36888,18 @@ SplineSet
  1180 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043E
-Encoding: 1086 1086 1086
+Encoding: 1086 1086 898
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043F
-Encoding: 1087 1087 1087
+Encoding: 1087 1087 899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36011,24 +36916,27 @@ SplineSet
  1180 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0440
-Encoding: 1088 1088 1088
+Encoding: 1088 1088 900
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0441
-Encoding: 1089 1089 1089
+Encoding: 1089 1089 901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0442
-Encoding: 1090 1090 1090
+Encoding: 1090 1090 902
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36045,16 +36953,18 @@ SplineSet
  1180 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0443
-Encoding: 1091 1091 1091
+Encoding: 1091 1091 903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0444
-Encoding: 1092 1092 1092
+Encoding: 1092 1092 904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36093,16 +37003,18 @@ SplineSet
  667 209 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0445
-Encoding: 1093 1093 1093
+Encoding: 1093 1093 905
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0446
-Encoding: 1094 1094 1094
+Encoding: 1094 1094 906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36123,8 +37035,9 @@ SplineSet
  16 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0447
-Encoding: 1095 1095 1095
+Encoding: 1095 1095 907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36149,8 +37062,9 @@ SplineSet
  589 783 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0448
-Encoding: 1096 1096 1096
+Encoding: 1096 1096 908
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36171,8 +37085,9 @@ SplineSet
  1045 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0449
-Encoding: 1097 1097 1097
+Encoding: 1097 1097 909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36197,8 +37112,9 @@ SplineSet
  -23 0 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044A
-Encoding: 1098 1098 1098
+Encoding: 1098 1098 910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36227,8 +37143,9 @@ SplineSet
  516 219 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044B
-Encoding: 1099 1099 1099
+Encoding: 1099 1099 911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36260,8 +37177,9 @@ SplineSet
  799 0 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044C
-Encoding: 1100 1100 1100
+Encoding: 1100 1100 912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36288,8 +37206,9 @@ SplineSet
  537 1120 l 17,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044D
-Encoding: 1101 1101 1101
+Encoding: 1101 1101 913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36314,8 +37233,9 @@ SplineSet
  656 -29 656 -29 396 -29 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni044E
-Encoding: 1102 1102 1102
+Encoding: 1102 1102 914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36359,8 +37279,9 @@ SplineSet
  0 0 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044F
-Encoding: 1103 1103 1103
+Encoding: 1103 1103 915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36390,26 +37311,29 @@ SplineSet
  494 841 494 841 494 750 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0450
-Encoding: 1104 1104 1104
+Encoding: 1104 1104 916
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 39 0 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 39 0 2
+Refer: 889 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0451
-Encoding: 1105 1105 1105
+Encoding: 1105 1105 917
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 39 0 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 39 0 2
+Refer: 889 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0452
-Encoding: 1106 1106 1106
+Encoding: 1106 1106 918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36445,17 +37369,19 @@ SplineSet
  81 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0453
-Encoding: 1107 1107 1107
+Encoding: 1107 1107 919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 1075 1075 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 887 1075 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0454
-Encoding: 1108 1108 1108
+Encoding: 1108 1108 920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36485,41 +37411,46 @@ SplineSet
  1072 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0455
-Encoding: 1109 1109 1109
+Encoding: 1109 1109 921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0456
-Encoding: 1110 1110 1110
+Encoding: 1110 1110 922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0457
-Encoding: 1111 1111 1111
+Encoding: 1111 1111 923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 39 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 39 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0458
-Encoding: 1112 1112 1112
+Encoding: 1112 1112 924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0459
-Encoding: 1113 1113 1113
+Encoding: 1113 1113 925
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36558,8 +37489,9 @@ SplineSet
  640 901 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045A
-Encoding: 1114 1114 1114
+Encoding: 1114 1114 926
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36594,8 +37526,9 @@ SplineSet
  465 0 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045B
-Encoding: 1115 1115 1115
+Encoding: 1115 1115 927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36628,35 +37561,39 @@ SplineSet
  40 0 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045C
-Encoding: 1116 1116 1116
+Encoding: 1116 1116 928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 1082 1082 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 894 1082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045D
-Encoding: 1117 1117 1117
+Encoding: 1117 1117 929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 60 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 60 0 2
+Refer: 892 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045E
-Encoding: 1118 1118 1118
+Encoding: 1118 1118 930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 903 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045F
-Encoding: 1119 1119 1119
+Encoding: 1119 1119 931
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36677,8 +37614,9 @@ SplineSet
  90 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0462
-Encoding: 1122 1122 1122
+Encoding: 1122 1122 932
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36712,8 +37650,9 @@ SplineSet
  93 1124 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0463
-Encoding: 1123 1123 1123
+Encoding: 1123 1123 933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36747,72 +37686,83 @@ SplineSet
  566 479 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni046A
-Encoding: 1130 1130 1130
+Encoding: 1130 1130 934
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni046B
-Encoding: 1131 1131 1131
+Encoding: 1131 1131 935
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0472
-Encoding: 1138 1138 1138
+Encoding: 1138 1138 936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 415 415 N 1 0 0 1 0 0 3
+Refer: 351 415 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0473
-Encoding: 1139 1139 1139
+Encoding: 1139 1139 937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 3
+Refer: 544 629 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni048A
-Encoding: 1162 1162 1162
+Encoding: 1162 1162 938
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048B
-Encoding: 1163 1163 1163
+Encoding: 1163 1163 939
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048C
-Encoding: 1164 1164 1164
+Encoding: 1164 1164 940
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048D
-Encoding: 1165 1165 1165
+Encoding: 1165 1165 941
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048E
-Encoding: 1166 1166 1166
+Encoding: 1166 1166 942
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048F
-Encoding: 1167 1167 1167
+Encoding: 1167 1167 943
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0490
-Encoding: 1168 1168 1168
+Encoding: 1168 1168 944
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36829,8 +37779,9 @@ SplineSet
  716.671 1233 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0491
-Encoding: 1169 1169 1169
+Encoding: 1169 1169 945
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36847,8 +37798,9 @@ SplineSet
  549 901 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0492
-Encoding: 1170 1170 1170
+Encoding: 1170 1170 946
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36871,8 +37823,9 @@ SplineSet
  477 0 l 17,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0493
-Encoding: 1171 1171 1171
+Encoding: 1171 1171 947
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36895,8 +37848,9 @@ SplineSet
  493 458 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0494
-Encoding: 1172 1172 1172
+Encoding: 1172 1172 948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36928,8 +37882,9 @@ SplineSet
  662.051 952 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0495
-Encoding: 1173 1173 1173
+Encoding: 1173 1173 949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36960,8 +37915,9 @@ SplineSet
  638.375 645 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0496
-Encoding: 1174 1174 1174
+Encoding: 1174 1174 950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36994,8 +37950,9 @@ SplineSet
  -132 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0497
-Encoding: 1175 1175 1175
+Encoding: 1175 1175 951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37028,26 +37985,29 @@ SplineSet
  -95 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0498
-Encoding: 1176 1176 1176
+Encoding: 1176 1176 952
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1047 1047 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -54 0 2
+Refer: 859 1047 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -54 0 2
 EndChar
+
 StartChar: uni0499
-Encoding: 1177 1177 1177
+Encoding: 1177 1177 953
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1079 1079 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -70 0 2
+Refer: 891 1079 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -70 0 2
 EndChar
+
 StartChar: uni049A
-Encoding: 1178 1178 1178
+Encoding: 1178 1178 954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37072,8 +38032,9 @@ SplineSet
  1001 260 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049B
-Encoding: 1179 1179 1179
+Encoding: 1179 1179 955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37098,44 +38059,51 @@ SplineSet
  1105 209 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049C
-Encoding: 1180 1180 1180
+Encoding: 1180 1180 956
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049D
-Encoding: 1181 1181 1181
+Encoding: 1181 1181 957
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049E
-Encoding: 1182 1182 1182
+Encoding: 1182 1182 958
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049F
-Encoding: 1183 1183 1183
+Encoding: 1183 1183 959
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A0
-Encoding: 1184 1184 1184
+Encoding: 1184 1184 960
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A1
-Encoding: 1185 1185 1185
+Encoding: 1185 1185 961
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A2
-Encoding: 1186 1186 1186
+Encoding: 1186 1186 962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37160,8 +38128,9 @@ SplineSet
  940 0 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A3
-Encoding: 1187 1187 1187
+Encoding: 1187 1187 963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37186,8 +38155,9 @@ SplineSet
  927 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A4
-Encoding: 1188 1188 1188
+Encoding: 1188 1188 964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37210,8 +38180,9 @@ SplineSet
  -67 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A5
-Encoding: 1189 1189 1189
+Encoding: 1189 1189 965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37234,50 +38205,57 @@ SplineSet
  -31 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A6
-Encoding: 1190 1190 1190
+Encoding: 1190 1190 966
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A7
-Encoding: 1191 1191 1191
+Encoding: 1191 1191 967
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A8
-Encoding: 1192 1192 1192
+Encoding: 1192 1192 968
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A9
-Encoding: 1193 1193 1193
+Encoding: 1193 1193 969
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04AA
-Encoding: 1194 1194 1194
+Encoding: 1194 1194 970
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1057 1057 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 117 0 2
+Refer: 869 1057 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 117 0 2
 EndChar
+
 StartChar: uni04AB
-Encoding: 1195 1195 1195
+Encoding: 1195 1195 971
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1089 1089 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 72 0 2
+Refer: 901 1089 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 72 0 2
 EndChar
+
 StartChar: uni04AC
-Encoding: 1196 1196 1196
+Encoding: 1196 1196 972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37298,8 +38276,9 @@ SplineSet
  764 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AD
-Encoding: 1197 1197 1197
+Encoding: 1197 1197 973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37320,16 +38299,18 @@ SplineSet
  763 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AE
-Encoding: 1198 1198 1198
+Encoding: 1198 1198 974
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AF
-Encoding: 1199 1199 1199
+Encoding: 1199 1199 975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37347,8 +38328,9 @@ SplineSet
  142 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B0
-Encoding: 1200 1200 1200
+Encoding: 1200 1200 976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37374,8 +38356,9 @@ SplineSet
  145 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B1
-Encoding: 1201 1201 1201
+Encoding: 1201 1201 977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37401,8 +38384,9 @@ SplineSet
  142 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B2
-Encoding: 1202 1202 1202
+Encoding: 1202 1202 978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37427,8 +38411,9 @@ SplineSet
  1107 260 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B3
-Encoding: 1203 1203 1203
+Encoding: 1203 1203 979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37453,44 +38438,51 @@ SplineSet
  1072 209 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B4
-Encoding: 1204 1204 1204
+Encoding: 1204 1204 980
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B5
-Encoding: 1205 1205 1205
+Encoding: 1205 1205 981
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B6
-Encoding: 1206 1206 1206
+Encoding: 1206 1206 982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B7
-Encoding: 1207 1207 1207
+Encoding: 1207 1207 983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B8
-Encoding: 1208 1208 1208
+Encoding: 1208 1208 984
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B9
-Encoding: 1209 1209 1209
+Encoding: 1209 1209 985
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BA
-Encoding: 1210 1210 1210
+Encoding: 1210 1210 986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37520,66 +38512,75 @@ SplineSet
  101.002 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04BB
-Encoding: 1211 1211 1211
+Encoding: 1211 1211 987
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04BC
-Encoding: 1212 1212 1212
+Encoding: 1212 1212 988
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BD
-Encoding: 1213 1213 1213
+Encoding: 1213 1213 989
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BE
-Encoding: 1214 1214 1214
+Encoding: 1214 1214 990
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BF
-Encoding: 1215 1215 1215
+Encoding: 1215 1215 991
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C0
-Encoding: 1216 1216 1216
+Encoding: 1216 1216 992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C1
-Encoding: 1217 1217 1217
+Encoding: 1217 1217 993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 858 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C2
-Encoding: 1218 1218 1218
+Encoding: 1218 1218 994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 890 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C3
-Encoding: 1219 1219 1219
+Encoding: 1219 1219 995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37612,8 +38613,9 @@ SplineSet
  556.897 686.11 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C4
-Encoding: 1220 1220 1220
+Encoding: 1220 1220 996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37645,20 +38647,23 @@ SplineSet
  545.725 405 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C5
-Encoding: 1221 1221 1221
+Encoding: 1221 1221 997
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C6
-Encoding: 1222 1222 1222
+Encoding: 1222 1222 998
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C7
-Encoding: 1223 1223 1223
+Encoding: 1223 1223 999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37685,8 +38690,9 @@ SplineSet
  959.358 43 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C8
-Encoding: 1224 1224 1224
+Encoding: 1224 1224 1000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37713,20 +38719,23 @@ SplineSet
  1079.36 43 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C9
-Encoding: 1225 1225 1225
+Encoding: 1225 1225 1001
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CA
-Encoding: 1226 1226 1226
+Encoding: 1226 1226 1002
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CB
-Encoding: 1227 1227 1227
+Encoding: 1227 1227 1003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37760,8 +38769,9 @@ SplineSet
  886.539 260 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CC
-Encoding: 1228 1228 1228
+Encoding: 1228 1228 1004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37790,20 +38800,23 @@ SplineSet
  810.625 209 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CD
-Encoding: 1229 1229 1229
+Encoding: 1229 1229 1005
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CE
-Encoding: 1230 1230 1230
+Encoding: 1230 1230 1006
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CF
-Encoding: 1231 1231 1231
+Encoding: 1231 1231 1007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37816,342 +38829,381 @@ SplineSet
  873.998 1556 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04D0
-Encoding: 1232 1232 1232
+Encoding: 1232 1232 1008
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 1040 1040 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 852 1040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D1
-Encoding: 1233 1233 1233
+Encoding: 1233 1233 1009
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 884 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D2
-Encoding: 1234 1234 1234
+Encoding: 1234 1234 1010
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
-Refer: 1040 1040 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
+Refer: 852 1040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D3
-Encoding: 1235 1235 1235
+Encoding: 1235 1235 1011
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 31 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 31 0 2
+Refer: 884 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D4
-Encoding: 1236 1236 1236
+Encoding: 1236 1236 1012
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D5
-Encoding: 1237 1237 1237
+Encoding: 1237 1237 1013
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D6
-Encoding: 1238 1238 1238
+Encoding: 1238 1238 1014
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 18 0 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 18 0 2
+Refer: 857 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D7
-Encoding: 1239 1239 1239
+Encoding: 1239 1239 1015
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 14 0 2
+Refer: 889 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D8
-Encoding: 1240 1240 1240
+Encoding: 1240 1240 1016
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 399 399 N 1 0 0 1 0 0 2
+Refer: 335 399 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D9
-Encoding: 1241 1241 1241
+Encoding: 1241 1241 1017
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 477 477 N 1 0 0 1 0 0 2
+Refer: 413 477 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DA
-Encoding: 1242 1242 1242
+Encoding: 1242 1242 1018
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
-Refer: 1240 1240 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
+Refer: 1016 1240 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DB
-Encoding: 1243 1243 1243
+Encoding: 1243 1243 1019
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1241 1241 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1017 1241 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DC
-Encoding: 1244 1244 1244
+Encoding: 1244 1244 1020
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 198 373 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 198 373 2
+Refer: 858 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DD
-Encoding: 1245 1245 1245
+Encoding: 1245 1245 1021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 98 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 98 0 2
+Refer: 890 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DE
-Encoding: 1246 1246 1246
+Encoding: 1246 1246 1022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 19 373 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 19 373 2
+Refer: 859 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DF
-Encoding: 1247 1247 1247
+Encoding: 1247 1247 1023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 95 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 95 0 2
+Refer: 891 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E0
-Encoding: 1248 1248 1248
+Encoding: 1248 1248 1024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E1
-Encoding: 1249 1249 1249
+Encoding: 1249 1249 1025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 573 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E2
-Encoding: 1250 1250 1250
+Encoding: 1250 1250 1026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 860 1048 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E3
-Encoding: 1251 1251 1251
+Encoding: 1251 1251 1027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 892 1080 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E4
-Encoding: 1252 1252 1252
+Encoding: 1252 1252 1028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 860 1048 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04E5
-Encoding: 1253 1253 1253
+Encoding: 1253 1253 1029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -24 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -24 2
+Refer: 892 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E6
-Encoding: 1254 1254 1254
+Encoding: 1254 1254 1030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
-Refer: 1054 1054 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
+Refer: 866 1054 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E7
-Encoding: 1255 1255 1255
+Encoding: 1255 1255 1031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1086 1086 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 898 1086 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E8
-Encoding: 1256 1256 1256
+Encoding: 1256 1256 1032
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1012 1012 N 1 0 0 1 0 0 2
+Refer: 824 1012 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E9
-Encoding: 1257 1257 1257
+Encoding: 1257 1257 1033
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 2
+Refer: 544 629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EA
-Encoding: 1258 1258 1258
+Encoding: 1258 1258 1034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
-Refer: 1256 1256 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
+Refer: 1032 1256 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EB
-Encoding: 1259 1259 1259
+Encoding: 1259 1259 1035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1257 1257 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1033 1257 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EC
-Encoding: 1260 1260 1260
+Encoding: 1260 1260 1036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 138 373 2
-Refer: 1069 1069 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 138 373 2
+Refer: 881 1069 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04ED
-Encoding: 1261 1261 1261
+Encoding: 1261 1261 1037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 57 0 2
-Refer: 1101 1101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 57 0 2
+Refer: 913 1101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EE
-Encoding: 1262 1262 1262
+Encoding: 1262 1262 1038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 871 1059 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EF
-Encoding: 1263 1263 1263
+Encoding: 1263 1263 1039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 903 1091 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F0
-Encoding: 1264 1264 1264
+Encoding: 1264 1264 1040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
+Refer: 871 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F1
-Encoding: 1265 1265 1265
+Encoding: 1265 1265 1041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 903 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F2
-Encoding: 1266 1266 1266
+Encoding: 1266 1266 1042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
+Refer: 871 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F3
-Encoding: 1267 1267 1267
+Encoding: 1267 1267 1043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 664 779 N 1 0 0 1 0 0 2
+Refer: 903 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F4
-Encoding: 1268 1268 1268
+Encoding: 1268 1268 1044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 227 373 2
-Refer: 1063 1063 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 227 373 2
+Refer: 875 1063 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F5
-Encoding: 1269 1269 1269
+Encoding: 1269 1269 1045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 148 0 2
-Refer: 1095 1095 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 148 0 2
+Refer: 907 1095 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F6
-Encoding: 1270 1270 1270
+Encoding: 1270 1270 1046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38170,8 +39222,9 @@ SplineSet
  477 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F7
-Encoding: 1271 1271 1271
+Encoding: 1271 1271 1047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38190,170 +39243,195 @@ SplineSet
  513 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F8
-Encoding: 1272 1272 1272
+Encoding: 1272 1272 1048
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 77 373 2
-Refer: 1067 1067 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 77 373 2
+Refer: 879 1067 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F9
-Encoding: 1273 1273 1273
+Encoding: 1273 1273 1049
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 28 0 2
-Refer: 1099 1099 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 28 0 2
+Refer: 911 1099 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0500
-Encoding: 1280 1280 1280
+Encoding: 1280 1280 1050
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0501
-Encoding: 1281 1281 1281
+Encoding: 1281 1281 1051
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0502
-Encoding: 1282 1282 1282
+Encoding: 1282 1282 1052
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0503
-Encoding: 1283 1283 1283
+Encoding: 1283 1283 1053
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0504
-Encoding: 1284 1284 1284
+Encoding: 1284 1284 1054
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0505
-Encoding: 1285 1285 1285
+Encoding: 1285 1285 1055
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0506
-Encoding: 1286 1286 1286
+Encoding: 1286 1286 1056
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0507
-Encoding: 1287 1287 1287
+Encoding: 1287 1287 1057
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0508
-Encoding: 1288 1288 1288
+Encoding: 1288 1288 1058
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0509
-Encoding: 1289 1289 1289
+Encoding: 1289 1289 1059
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050A
-Encoding: 1290 1290 1290
+Encoding: 1290 1290 1060
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050B
-Encoding: 1291 1291 1291
+Encoding: 1291 1291 1061
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050C
-Encoding: 1292 1292 1292
+Encoding: 1292 1292 1062
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050D
-Encoding: 1293 1293 1293
+Encoding: 1293 1293 1063
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050E
-Encoding: 1294 1294 1294
+Encoding: 1294 1294 1064
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050F
-Encoding: 1295 1295 1295
+Encoding: 1295 1295 1065
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0510
-Encoding: 1296 1296 1296
+Encoding: 1296 1296 1066
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 400 400 N 1 0 0 1 0 0 3
+Refer: 336 400 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0511
-Encoding: 1297 1297 1297
+Encoding: 1297 1297 1067
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 3
+Refer: 776 949 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni051A
-Encoding: 1306 1306 1306
+Encoding: 1306 1306 1068
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051B
-Encoding: 1307 1307 1307
+Encoding: 1307 1307 1069
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051C
-Encoding: 1308 1308 1308
+Encoding: 1308 1308 1070
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051D
-Encoding: 1309 1309 1309
+Encoding: 1309 1309 1071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0531
-Encoding: 1329 1329 1329
+Encoding: 1329 1329 1072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38388,8 +39466,9 @@ SplineSet
  10 398 10 398 39 551 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0532
-Encoding: 1330 1330 1330
+Encoding: 1330 1330 1073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38420,8 +39499,9 @@ SplineSet
  1183 1095 1183 1095 1153 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0533
-Encoding: 1331 1331 1331
+Encoding: 1331 1331 1074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38462,8 +39542,9 @@ SplineSet
  807 1016 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0534
-Encoding: 1332 1332 1332
+Encoding: 1332 1332 1075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38494,8 +39575,9 @@ SplineSet
  68 942 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0535
-Encoding: 1333 1333 1333
+Encoding: 1333 1333 1076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38526,8 +39608,9 @@ SplineSet
  1082 551 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0536
-Encoding: 1334 1334 1334
+Encoding: 1334 1334 1077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38565,8 +39648,9 @@ SplineSet
  -40 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0537
-Encoding: 1335 1335 1335
+Encoding: 1335 1335 1078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38585,8 +39669,9 @@ SplineSet
  -33 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0538
-Encoding: 1336 1336 1336
+Encoding: 1336 1336 1079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38615,8 +39700,9 @@ SplineSet
  1183 1095 1183 1095 1153 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0539
-Encoding: 1337 1337 1337
+Encoding: 1337 1337 1080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38674,8 +39760,9 @@ SplineSet
  574 519 574 519 554 413 c 1,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni053A
-Encoding: 1338 1338 1338
+Encoding: 1338 1338 1081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38716,8 +39803,9 @@ SplineSet
  559 819 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni053B
-Encoding: 1339 1339 1339
+Encoding: 1339 1339 1082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38744,8 +39832,9 @@ SplineSet
  1119 714 1119 714 1089 561 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053C
-Encoding: 1340 1340 1340
+Encoding: 1340 1340 1083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38760,8 +39849,9 @@ SplineSet
  7 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053D
-Encoding: 1341 1341 1341
+Encoding: 1341 1341 1084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38798,8 +39888,9 @@ SplineSet
  790 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053E
-Encoding: 1342 1342 1342
+Encoding: 1342 1342 1085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38857,8 +39948,9 @@ SplineSet
  387 715 387 715 364 597 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni053F
-Encoding: 1343 1343 1343
+Encoding: 1343 1343 1086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38885,8 +39977,9 @@ SplineSet
  1198 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0540
-Encoding: 1344 1344 1344
+Encoding: 1344 1344 1087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38921,8 +40014,9 @@ SplineSet
  1054 236 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0541
-Encoding: 1345 1345 1345
+Encoding: 1345 1345 1088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38982,8 +40076,9 @@ SplineSet
  1213 1062 1213 1062 1179 885 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0542
-Encoding: 1346 1346 1346
+Encoding: 1346 1346 1089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39012,8 +40107,9 @@ SplineSet
  68 942 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0543
-Encoding: 1347 1347 1347
+Encoding: 1347 1347 1090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39054,8 +40150,9 @@ SplineSet
  455 602 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0544
-Encoding: 1348 1348 1348
+Encoding: 1348 1348 1091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39084,8 +40181,9 @@ SplineSet
  905 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0545
-Encoding: 1349 1349 1349
+Encoding: 1349 1349 1092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39141,8 +40239,9 @@ SplineSet
  1137 513 1137 513 1125 454 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0546
-Encoding: 1350 1350 1350
+Encoding: 1350 1350 1093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39171,8 +40270,9 @@ SplineSet
  1163 551 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0547
-Encoding: 1351 1351 1351
+Encoding: 1351 1351 1094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39226,8 +40326,9 @@ SplineSet
  376 701 376 701 358 606 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0548
-Encoding: 1352 1352 1352
+Encoding: 1352 1352 1095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39254,8 +40355,9 @@ SplineSet
  1191 1095 1191 1095 1161 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0549
-Encoding: 1353 1353 1353
+Encoding: 1353 1353 1096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39294,8 +40396,9 @@ SplineSet
  872 830 872 830 893 935 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054A
-Encoding: 1354 1354 1354
+Encoding: 1354 1354 1097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39325,8 +40428,9 @@ SplineSet
  681 442 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054B
-Encoding: 1355 1355 1355
+Encoding: 1355 1355 1098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39390,8 +40494,9 @@ SplineSet
  310 261 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni054C
-Encoding: 1356 1356 1356
+Encoding: 1356 1356 1099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39422,8 +40527,9 @@ SplineSet
  1118 1095 1118 1095 1088 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054D
-Encoding: 1357 1357 1357
+Encoding: 1357 1357 1100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39450,8 +40556,9 @@ SplineSet
  41 398 41 398 70 551 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054E
-Encoding: 1358 1358 1358
+Encoding: 1358 1358 1101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39480,8 +40587,9 @@ SplineSet
  1198 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054F
-Encoding: 1359 1359 1359
+Encoding: 1359 1359 1102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39542,8 +40650,9 @@ SplineSet
  353 447 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0550
-Encoding: 1360 1360 1360
+Encoding: 1360 1360 1103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39570,8 +40679,9 @@ SplineSet
  1191 1095 1191 1095 1161 942 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0551
-Encoding: 1361 1361 1361
+Encoding: 1361 1361 1104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39639,8 +40749,9 @@ SplineSet
  693 1518 693 1518 804 1518 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0552
-Encoding: 1362 1362 1362
+Encoding: 1362 1362 1105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39657,8 +40768,9 @@ SplineSet
  -33 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0553
-Encoding: 1363 1363 1363
+Encoding: 1363 1363 1106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39709,8 +40821,9 @@ SplineSet
  368 138 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0554
-Encoding: 1364 1364 1364
+Encoding: 1364 1364 1107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39761,16 +40874,18 @@ SplineSet
  841 1263 841 1263 783 1263 c 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0555
-Encoding: 1365 1365 1365
+Encoding: 1365 1365 1108
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 3
+Refer: 48 79 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0556
-Encoding: 1366 1366 1366
+Encoding: 1366 1366 1109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39831,16 +40946,18 @@ SplineSet
  590 1263 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uni0559
-Encoding: 1369 1369 1369
+Encoding: 1369 1369 1110
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 0 3
+Refer: 617 703 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni055A
-Encoding: 1370 1370 1370
+Encoding: 1370 1370 1111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39855,8 +40972,9 @@ SplineSet
  572 1495 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055B
-Encoding: 1371 1371 1371
+Encoding: 1371 1371 1112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39869,8 +40987,9 @@ SplineSet
  995 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055C
-Encoding: 1372 1372 1372
+Encoding: 1372 1372 1113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39897,8 +41016,9 @@ SplineSet
  873 1450 873 1450 786 1433 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni055D
-Encoding: 1373 1373 1373
+Encoding: 1373 1373 1114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39911,8 +41031,9 @@ SplineSet
  712 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055E
-Encoding: 1374 1374 1374
+Encoding: 1374 1374 1115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39955,8 +41076,9 @@ SplineSet
  232 1342 232 1342 209 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055F
-Encoding: 1375 1375 1375
+Encoding: 1375 1375 1116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39971,8 +41093,9 @@ SplineSet
  159 1265 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0561
-Encoding: 1377 1377 1377
+Encoding: 1377 1377 1117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40018,8 +41141,9 @@ SplineSet
  460 83 460 83 460 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0562
-Encoding: 1378 1378 1378
+Encoding: 1378 1378 1118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40048,8 +41172,9 @@ SplineSet
  1057 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0563
-Encoding: 1379 1379 1379
+Encoding: 1379 1379 1119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40094,8 +41219,9 @@ SplineSet
  412 642 412 642 396 561 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0564
-Encoding: 1380 1380 1380
+Encoding: 1380 1380 1120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40124,8 +41250,9 @@ SplineSet
  1103 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0565
-Encoding: 1381 1381 1381
+Encoding: 1381 1381 1121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40154,8 +41281,9 @@ SplineSet
  1159 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0566
-Encoding: 1382 1382 1382
+Encoding: 1382 1382 1122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40198,8 +41326,9 @@ SplineSet
  412 642 412 642 396 561 c 0,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni0567
-Encoding: 1383 1383 1383
+Encoding: 1383 1383 1123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40218,8 +41347,9 @@ SplineSet
  815 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0568
-Encoding: 1384 1384 1384
+Encoding: 1384 1384 1124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40246,8 +41376,9 @@ SplineSet
  974 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0569
-Encoding: 1385 1385 1385
+Encoding: 1385 1385 1125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40310,8 +41441,9 @@ SplineSet
  552 294 552 294 544 254 c 0,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni056A
-Encoding: 1386 1386 1386
+Encoding: 1386 1386 1126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40359,8 +41491,9 @@ SplineSet
  1083 895 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056B
-Encoding: 1387 1387 1387
+Encoding: 1387 1387 1127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40385,8 +41518,9 @@ SplineSet
  1138 938 1138 938 1097 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056C
-Encoding: 1388 1388 1388
+Encoding: 1388 1388 1128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40401,8 +41535,9 @@ SplineSet
  798 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056D
-Encoding: 1389 1389 1389
+Encoding: 1389 1389 1129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40455,8 +41590,9 @@ SplineSet
  126 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056E
-Encoding: 1390 1390 1390
+Encoding: 1390 1390 1130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40504,8 +41640,9 @@ SplineSet
  382 720 382 720 351 559 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni056F
-Encoding: 1391 1391 1391
+Encoding: 1391 1391 1131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40530,16 +41667,18 @@ SplineSet
  91 182 91 182 132 391 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0570
-Encoding: 1392 1392 1392
+Encoding: 1392 1392 1132
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 -4 0 3
+Refer: 73 104 N 1 0 0 1 -4 0 3
 EndChar
+
 StartChar: uni0571
-Encoding: 1393 1393 1393
+Encoding: 1393 1393 1133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40601,8 +41740,9 @@ SplineSet
  407 578 407 578 380 435 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni0572
-Encoding: 1394 1394 1394
+Encoding: 1394 1394 1134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40629,8 +41769,9 @@ SplineSet
  1020 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0573
-Encoding: 1395 1395 1395
+Encoding: 1395 1395 1135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40690,8 +41831,9 @@ SplineSet
  431 578 431 578 414 491 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni0574
-Encoding: 1396 1396 1396
+Encoding: 1396 1396 1136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40718,8 +41860,9 @@ SplineSet
  1214 1331 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0575
-Encoding: 1397 1397 1397
+Encoding: 1397 1397 1137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40742,8 +41885,9 @@ SplineSet
  910 43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0576
-Encoding: 1398 1398 1398
+Encoding: 1398 1398 1138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40770,8 +41914,9 @@ SplineSet
  117 182 117 182 158 393 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0577
-Encoding: 1399 1399 1399
+Encoding: 1399 1399 1139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40824,16 +41969,18 @@ SplineSet
  684 1145 684 1145 749 1145 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0578
-Encoding: 1400 1400 1400
+Encoding: 1400 1400 1140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 -4 0 3
+Refer: 79 110 N 1 0 0 1 -4 0 3
 EndChar
+
 StartChar: uni0579
-Encoding: 1401 1401 1401
+Encoding: 1401 1401 1141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40879,8 +42026,9 @@ SplineSet
  894 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057A
-Encoding: 1402 1402 1402
+Encoding: 1402 1402 1142
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40926,8 +42074,9 @@ SplineSet
  762 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057B
-Encoding: 1403 1403 1403
+Encoding: 1403 1403 1143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40996,8 +42145,9 @@ SplineSet
  766 917 766 917 718 917 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni057C
-Encoding: 1404 1404 1404
+Encoding: 1404 1404 1144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41039,16 +42189,18 @@ SplineSet
  695 909 695 909 643 909 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057D
-Encoding: 1405 1405 1405
+Encoding: 1405 1405 1145
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 6 0 3
+Refer: 86 117 N 1 0 0 1 6 0 3
 EndChar
+
 StartChar: uni057E
-Encoding: 1406 1406 1406
+Encoding: 1406 1406 1146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41075,8 +42227,9 @@ SplineSet
  987 -201 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057F
-Encoding: 1407 1407 1407
+Encoding: 1407 1407 1147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41121,8 +42274,9 @@ SplineSet
  1042 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0580
-Encoding: 1408 1408 1408
+Encoding: 1408 1408 1148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41147,16 +42301,18 @@ SplineSet
  1178 938 1178 938 1137 727 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0581
-Encoding: 1409 1409 1409
+Encoding: 1409 1409 1149
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 19 0 3
+Refer: 72 103 N 1 0 0 1 19 0 3
 EndChar
+
 StartChar: uni0582
-Encoding: 1410 1410 1410
+Encoding: 1410 1410 1150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41171,8 +42327,9 @@ SplineSet
  978 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0583
-Encoding: 1411 1411 1411
+Encoding: 1411 1411 1151
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41217,8 +42374,9 @@ SplineSet
  1041 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0584
-Encoding: 1412 1412 1412
+Encoding: 1412 1412 1152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41267,16 +42425,18 @@ SplineSet
  897 480 897 480 913 561 c 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni0585
-Encoding: 1413 1413 1413
+Encoding: 1413 1413 1153
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 3
+Refer: 80 111 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0586
-Encoding: 1414 1414 1414
+Encoding: 1414 1414 1154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41332,8 +42492,9 @@ SplineSet
  933 507 933 507 946 575 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni0587
-Encoding: 1415 1415 1415
+Encoding: 1415 1415 1155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41360,8 +42521,9 @@ SplineSet
  1082 225 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0589
-Encoding: 1417 1417 1417
+Encoding: 1417 1417 1156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41379,8 +42541,9 @@ SplineSet
  418 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni058A
-Encoding: 1418 1418 1418
+Encoding: 1418 1418 1157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41393,8 +42556,9 @@ SplineSet
  336 735 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E3F
-Encoding: 3647 3647 3647
+Encoding: 3647 3647 1158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41442,8 +42606,9 @@ SplineSet
  713 803 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0E81
-Encoding: 3713 3713 3713
+Encoding: 3713 3713 1159
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1353.71 1184 basechar 0
@@ -41469,8 +42634,9 @@ SplineSet
  465 184 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E82
-Encoding: 3714 3714 3714
+Encoding: 3714 3714 1160
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1127.64 0 basechar 0
@@ -41508,8 +42674,9 @@ SplineSet
  546 685 546 685 364 688 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E84
-Encoding: 3716 3716 3716
+Encoding: 3716 3716 1161
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1121.99 0 basechar 0
@@ -41539,8 +42706,9 @@ SplineSet
  1 -48 1 -48 78 349 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E87
-Encoding: 3719 3719 3719
+Encoding: 3719 3719 1162
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1067.18 -492 basechar 0
@@ -41571,8 +42739,9 @@ SplineSet
  549 1005 549 1005 486 1006 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0E88
-Encoding: 3720 3720 3720
+Encoding: 3720 3720 1163
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1118.61 0 basechar 0
@@ -41610,8 +42779,9 @@ SplineSet
  427 1178 427 1178 727 1178 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8A
-Encoding: 3722 3722 3722
+Encoding: 3722 3722 1164
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1068.04 -492 basechar 0
@@ -41654,8 +42824,9 @@ SplineSet
  562 630 562 630 339 630 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8D
-Encoding: 3725 3725 3725
+Encoding: 3725 3725 1165
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1124.44 0 basechar 0
@@ -41686,8 +42857,9 @@ SplineSet
  593 434 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E94
-Encoding: 3732 3732 3732
+Encoding: 3732 3732 1166
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1124.33 0 basechar 0
@@ -41717,8 +42889,9 @@ SplineSet
  708 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E95
-Encoding: 3733 3733 3733
+Encoding: 3733 3733 1167
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1120.75 0 basechar 0
@@ -41758,8 +42931,9 @@ SplineSet
  758 747 758 747 651 747 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E96
-Encoding: 3734 3734 3734
+Encoding: 3734 3734 1168
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1069.18 -492 basechar 0
@@ -41791,8 +42965,9 @@ SplineSet
  495 351 l 1,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E97
-Encoding: 3735 3735 3735
+Encoding: 3735 3735 1169
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1121.04 0 basechar 0
@@ -41831,8 +43006,9 @@ SplineSet
  130 808 130 808 166 992 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E99
-Encoding: 3737 3737 3737
+Encoding: 3737 3737 1170
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1122.69 0 basechar 0
@@ -41864,8 +43040,9 @@ SplineSet
  312 -29 312 -29 -41 -29 c 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9A
-Encoding: 3738 3738 3738
+Encoding: 3738 3738 1171
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1123.08 0 basechar 0
@@ -41894,8 +43071,9 @@ SplineSet
  12 -16 12 -16 77 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9B
-Encoding: 3739 3739 3739
+Encoding: 3739 3739 1172
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1083.42 0 basechar 0
@@ -41924,8 +43102,9 @@ SplineSet
  -28 -16 -28 -16 38 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9C
-Encoding: 3740 3740 3740
+Encoding: 3740 3740 1173
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1105.58 0 basechar 0
@@ -41981,8 +43160,9 @@ SplineSet
  885 -17 885 -17 741 -17 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni0E9D
-Encoding: 3741 3741 3741
+Encoding: 3741 3741 1174
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1391.66 1560 basechar 0
@@ -42023,8 +43203,9 @@ SplineSet
  1058 300 l 18,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9E
-Encoding: 3742 3742 3742
+Encoding: 3742 3742 1175
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1122.98 0 basechar 0
@@ -42064,8 +43245,9 @@ SplineSet
  242 216 242 216 364 216 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9F
-Encoding: 3743 3743 3743
+Encoding: 3743 3743 1176
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1391.66 1560 basechar 0
@@ -42105,8 +43287,9 @@ SplineSet
  202 216 202 216 324 216 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA1
-Encoding: 3745 3745 3745
+Encoding: 3745 3745 1177
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1126.97 0 basechar 0
@@ -42132,8 +43315,9 @@ SplineSet
  397 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA2
-Encoding: 3746 3746 3746
+Encoding: 3746 3746 1178
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1392.82 1560 basechar 0
@@ -42164,8 +43348,9 @@ SplineSet
  553 434 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA3
-Encoding: 3747 3747 3747
+Encoding: 3747 3747 1179
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1121.52 0 basechar 0
@@ -42201,8 +43386,9 @@ SplineSet
  818 200 818 200 843 328 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA5
-Encoding: 3749 3749 3749
+Encoding: 3749 3749 1180
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1121.52 0 basechar 0
@@ -42242,8 +43428,9 @@ SplineSet
  325 1165 325 1165 744 1164 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA7
-Encoding: 3751 3751 3751
+Encoding: 3751 3751 1181
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1124.15 0 basechar 0
@@ -42273,8 +43460,9 @@ SplineSet
  151 802 l 1,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0EAA
-Encoding: 3754 3754 3754
+Encoding: 3754 3754 1182
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1361.66 1312 basechar 0
@@ -42320,8 +43508,9 @@ SplineSet
  391 895 391 895 644 894 c 0,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni0EAB
-Encoding: 3755 3755 3755
+Encoding: 3755 3755 1183
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1120.93 0 basechar 0
@@ -42364,8 +43553,9 @@ SplineSet
  715 -25 715 -25 323 -24 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAD
-Encoding: 3757 3757 3757
+Encoding: 3757 3757 1184
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1121.52 0 basechar 0
@@ -42403,8 +43593,9 @@ SplineSet
  906 753 906 753 926 857 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: uni0EAE
-Encoding: 3758 3758 3758
+Encoding: 3758 3758 1185
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1111.8 0 basechar 0
@@ -42445,8 +43636,9 @@ SplineSet
  447 189 447 189 510 189 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAF
-Encoding: 3759 3759 3759
+Encoding: 3759 3759 1186
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42474,17 +43666,19 @@ SplineSet
  251 -259 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB0
-Encoding: 3760 3760 3760
+Encoding: 3760 3760 1187
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3761 3761 N 1 0 0 1 -249 -1282 2
-Refer: 3761 3761 N 1 0 0 1 -131 -674 2
+Refer: 1188 3761 N 1 0 0 1 -249 -1282 2
+Refer: 1188 3761 N 1 0 0 1 -131 -674 2
 EndChar
+
 StartChar: uni0EB1
-Encoding: 3761 3761 3761
+Encoding: 3761 3761 1188
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1450.71 1120 mark 0
@@ -42504,8 +43698,9 @@ SplineSet
  1418 1268 1418 1268 937 1270 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB2
-Encoding: 3762 3762 3762
+Encoding: 3762 3762 1189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42524,17 +43719,19 @@ SplineSet
  1360 1204 1360 1204 1273 758 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB3
-Encoding: 3763 3763 3763
+Encoding: 3763 3763 1190
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3789 3789 N 1 0 0 1 -1233 0 2
-Refer: 3762 3762 N 1 0 0 1 0 0 2
+Refer: 1204 3789 N 1 0 0 1 -1233 0 2
+Refer: 1189 3762 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0EB4
-Encoding: 3764 3764 3764
+Encoding: 3764 3764 1191
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1153.4 1200 mark 0
@@ -42554,8 +43751,9 @@ SplineSet
  287 1752 287 1752 254 1584 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB5
-Encoding: 3765 3765 3765
+Encoding: 3765 3765 1192
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.83 1200 mark 0
@@ -42578,8 +43776,9 @@ SplineSet
  172 1781 172 1781 138 1607 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB6
-Encoding: 3766 3766 3766
+Encoding: 3766 3766 1193
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1153.4 1200 mark 0
@@ -42608,8 +43807,9 @@ SplineSet
  753 1736 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB7
-Encoding: 3767 3767 3767
+Encoding: 3767 3767 1194
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.83 1200 mark 0
@@ -42641,8 +43841,9 @@ SplineSet
  754 1764 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB8
-Encoding: 3768 3768 3768
+Encoding: 3768 3768 1195
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -42665,8 +43866,9 @@ SplineSet
  569 -557 569 -557 589 -481 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0EB9
-Encoding: 3769 3769 3769
+Encoding: 3769 3769 1196
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -42695,8 +43897,9 @@ SplineSet
  152 -648 152 -648 185 -480 c 0,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni0EBB
-Encoding: 3771 3771 3771
+Encoding: 3771 3771 1197
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1166.33 1200 mark 0
@@ -42716,8 +43919,9 @@ SplineSet
  402 1836 402 1836 644 1836 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EBC
-Encoding: 3772 3772 3772
+Encoding: 3772 3772 1198
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1305 0 mark 0
@@ -42743,8 +43947,9 @@ SplineSet
  179 -454 179 -454 205 -454 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0EC8
-Encoding: 3784 3784 3784
+Encoding: 3784 3784 1199
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1167.11 1200 mark 0
@@ -42758,8 +43963,9 @@ SplineSet
  771 1729 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EC9
-Encoding: 3785 3785 3785
+Encoding: 3785 3785 1200
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1159.72 1200 mark 0
@@ -42780,8 +43986,9 @@ SplineSet
  1178 1274 1178 1274 466 1274 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECA
-Encoding: 3786 3786 3786
+Encoding: 3786 3786 1201
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1151.45 1200 mark 0
@@ -42819,8 +44026,9 @@ SplineSet
  121 1979 121 1979 470 1972 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECB
-Encoding: 3787 3787 3787
+Encoding: 3787 3787 1202
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1162.05 1200 mark 0
@@ -42842,17 +44050,19 @@ SplineSet
  292 1658 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECC
-Encoding: 3788 3788 3788
+Encoding: 3788 3788 1203
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1173.91 1200 mark 0
 LayerCount: 2
 Fore
-Refer: 3772 3772 N 1 0 0 1 364 1872 2
+Refer: 1198 3772 N 1 0 0 1 364 1872 2
 EndChar
+
 StartChar: uni0ECD
-Encoding: 3789 3789 3789
+Encoding: 3789 3789 1204
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1170.8 1200 mark 0
@@ -42871,8 +44081,9 @@ SplineSet
  566 1583 566 1583 557 1530 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni10D0
-Encoding: 4304 4304 4304
+Encoding: 4304 4304 1205
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42910,8 +44121,9 @@ SplineSet
  1131 549 1131 549 1122 505 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D1
-Encoding: 4305 4305 4305
+Encoding: 4305 4305 1206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42956,8 +44168,9 @@ SplineSet
  1101 606 1101 606 1087 534 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni10D2
-Encoding: 4306 4306 4306
+Encoding: 4306 4306 1207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43005,8 +44218,9 @@ SplineSet
  1114 140 1114 140 1102 79 c 0,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni10D3
-Encoding: 4307 4307 4307
+Encoding: 4307 4307 1208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43094,8 +44308,9 @@ SplineSet
  15 -229 l 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni10D4
-Encoding: 4308 4308 4308
+Encoding: 4308 4308 1209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43138,8 +44353,9 @@ SplineSet
  1073 8 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D5
-Encoding: 4309 4309 4309
+Encoding: 4309 4309 1210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43200,8 +44416,9 @@ SplineSet
  1071 -4 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D6
-Encoding: 4310 4310 4310
+Encoding: 4310 4310 1211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43257,8 +44474,9 @@ SplineSet
  1102 599 1102 599 1086 520 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni10D7
-Encoding: 4311 4311 4311
+Encoding: 4311 4311 1212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43314,8 +44532,9 @@ SplineSet
  1206 527 l 2,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni10D8
-Encoding: 4312 4312 4312
+Encoding: 4312 4312 1213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43360,8 +44579,9 @@ SplineSet
  1154 627 1154 627 1138 545 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D9
-Encoding: 4313 4313 4313
+Encoding: 4313 4313 1214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43414,8 +44634,9 @@ SplineSet
  1072 0 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DA
-Encoding: 4314 4314 4314
+Encoding: 4314 4314 1215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43468,8 +44689,9 @@ SplineSet
  758 853 758 853 707 853 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DB
-Encoding: 4315 4315 4315
+Encoding: 4315 4315 1216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43520,8 +44742,9 @@ SplineSet
  1077 471 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni10DC
-Encoding: 4316 4316 4316
+Encoding: 4316 4316 1217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43560,8 +44783,9 @@ SplineSet
  1109 625 1109 625 1092 538 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10DD
-Encoding: 4317 4317 4317
+Encoding: 4317 4317 1218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43617,8 +44841,9 @@ SplineSet
  1194 468 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DE
-Encoding: 4318 4318 4318
+Encoding: 4318 4318 1219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43668,8 +44893,9 @@ SplineSet
  1090 536 1090 536 1080 486 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DF
-Encoding: 4319 4319 4319
+Encoding: 4319 4319 1220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43714,8 +44940,9 @@ SplineSet
  1073 20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E0
-Encoding: 4320 4320 4320
+Encoding: 4320 4320 1221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43779,8 +45006,9 @@ SplineSet
  1145 468 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E1
-Encoding: 4321 4321 4321
+Encoding: 4321 4321 1222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43821,8 +45049,9 @@ SplineSet
  1101 573 1101 573 1092 525 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E2
-Encoding: 4322 4322 4322
+Encoding: 4322 4322 1223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43860,8 +45089,9 @@ SplineSet
  -36 192 -36 192 -9 332 c 0,13,14
 EndSplineSet
 EndChar
+
 StartChar: uni10E3
-Encoding: 4323 4323 4323
+Encoding: 4323 4323 1224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43927,8 +45157,9 @@ SplineSet
  1078 47 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E4
-Encoding: 4324 4324 4324
+Encoding: 4324 4324 1225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44012,8 +45243,9 @@ SplineSet
  1137 -22 l 2,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni10E5
-Encoding: 4325 4325 4325
+Encoding: 4325 4325 1226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44068,8 +45300,9 @@ SplineSet
  1046 102 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E6
-Encoding: 4326 4326 4326
+Encoding: 4326 4326 1227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44136,8 +45369,9 @@ SplineSet
  100 -152 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E7
-Encoding: 4327 4327 4327
+Encoding: 4327 4327 1228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44185,8 +45419,9 @@ SplineSet
  1073 -7 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E8
-Encoding: 4328 4328 4328
+Encoding: 4328 4328 1229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44250,8 +45485,9 @@ SplineSet
  1087 490 l 2,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10E9
-Encoding: 4329 4329 4329
+Encoding: 4329 4329 1230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44302,8 +45538,9 @@ SplineSet
  1102 599 1102 599 1091 546 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni10EA
-Encoding: 4330 4330 4330
+Encoding: 4330 4330 1231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44359,8 +45596,9 @@ SplineSet
  1209 673 1209 673 1205 649 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10EB
-Encoding: 4331 4331 4331
+Encoding: 4331 4331 1232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44394,8 +45632,9 @@ SplineSet
  1087 506 l 2,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni10EC
-Encoding: 4332 4332 4332
+Encoding: 4332 4332 1233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44472,8 +45711,9 @@ SplineSet
  186 1248 l 2,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10ED
-Encoding: 4333 4333 4333
+Encoding: 4333 4333 1234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44544,8 +45784,9 @@ SplineSet
  1037 61 1037 61 1029 18 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10EE
-Encoding: 4334 4334 4334
+Encoding: 4334 4334 1235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44579,8 +45820,9 @@ SplineSet
  1109 625 1109 625 1092 537 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EF
-Encoding: 4335 4335 4335
+Encoding: 4335 4335 1236
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44626,8 +45868,9 @@ SplineSet
  1067 70 1067 70 1057 18 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F0
-Encoding: 4336 4336 4336
+Encoding: 4336 4336 1237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44692,8 +45935,9 @@ SplineSet
  1063 401 1063 401 1059 381 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F1
-Encoding: 4337 4337 4337
+Encoding: 4337 4337 1238
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44771,8 +46015,9 @@ SplineSet
  1016 -43 1016 -43 1009 -79 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F2
-Encoding: 4338 4338 4338
+Encoding: 4338 4338 1239
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44811,8 +46056,9 @@ SplineSet
  63 22 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10F3
-Encoding: 4339 4339 4339
+Encoding: 4339 4339 1240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44853,8 +46099,9 @@ SplineSet
  1075 16 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F4
-Encoding: 4340 4340 4340
+Encoding: 4340 4340 1241
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44914,8 +46161,9 @@ SplineSet
  1028 20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F5
-Encoding: 4341 4341 4341
+Encoding: 4341 4341 1242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44960,8 +46208,9 @@ SplineSet
  1015 489 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F6
-Encoding: 4342 4342 4342
+Encoding: 4342 4342 1243
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45013,8 +46262,9 @@ SplineSet
  1223 422 l 2,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni10F7
-Encoding: 4343 4343 4343
+Encoding: 4343 4343 1244
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45056,8 +46306,9 @@ SplineSet
  1106 78 1106 78 1099 38 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F8
-Encoding: 4344 4344 4344
+Encoding: 4344 4344 1245
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45099,8 +46350,9 @@ SplineSet
  235 1044 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F9
-Encoding: 4345 4345 4345
+Encoding: 4345 4345 1246
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45134,8 +46386,9 @@ SplineSet
  126 574 126 574 136 625 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni10FA
-Encoding: 4346 4346 4346
+Encoding: 4346 4346 1247
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45176,8 +46429,9 @@ SplineSet
  563 -195 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10FB
-Encoding: 4347 4347 4347
+Encoding: 4347 4347 1248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45200,8 +46454,9 @@ SplineSet
  364 1007 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FC
-Encoding: 4348 4348 4348
+Encoding: 4348 4348 1249
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45230,524 +46485,611 @@ SplineSet
  643 1319 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni13A0
-Encoding: 5024 5024 5024
+Encoding: 5024 5024 1250
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A1
-Encoding: 5025 5025 5025
+Encoding: 5025 5025 1251
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A2
-Encoding: 5026 5026 5026
+Encoding: 5026 5026 1252
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A3
-Encoding: 5027 5027 5027
+Encoding: 5027 5027 1253
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A4
-Encoding: 5028 5028 5028
+Encoding: 5028 5028 1254
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A5
-Encoding: 5029 5029 5029
+Encoding: 5029 5029 1255
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A6
-Encoding: 5030 5030 5030
+Encoding: 5030 5030 1256
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A7
-Encoding: 5031 5031 5031
+Encoding: 5031 5031 1257
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A8
-Encoding: 5032 5032 5032
+Encoding: 5032 5032 1258
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A9
-Encoding: 5033 5033 5033
+Encoding: 5033 5033 1259
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AA
-Encoding: 5034 5034 5034
+Encoding: 5034 5034 1260
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AB
-Encoding: 5035 5035 5035
+Encoding: 5035 5035 1261
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AC
-Encoding: 5036 5036 5036
+Encoding: 5036 5036 1262
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AD
-Encoding: 5037 5037 5037
+Encoding: 5037 5037 1263
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AE
-Encoding: 5038 5038 5038
+Encoding: 5038 5038 1264
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AF
-Encoding: 5039 5039 5039
+Encoding: 5039 5039 1265
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B0
-Encoding: 5040 5040 5040
+Encoding: 5040 5040 1266
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B1
-Encoding: 5041 5041 5041
+Encoding: 5041 5041 1267
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B2
-Encoding: 5042 5042 5042
+Encoding: 5042 5042 1268
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B3
-Encoding: 5043 5043 5043
+Encoding: 5043 5043 1269
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B4
-Encoding: 5044 5044 5044
+Encoding: 5044 5044 1270
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B5
-Encoding: 5045 5045 5045
+Encoding: 5045 5045 1271
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B6
-Encoding: 5046 5046 5046
+Encoding: 5046 5046 1272
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B7
-Encoding: 5047 5047 5047
+Encoding: 5047 5047 1273
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B8
-Encoding: 5048 5048 5048
+Encoding: 5048 5048 1274
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B9
-Encoding: 5049 5049 5049
+Encoding: 5049 5049 1275
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BA
-Encoding: 5050 5050 5050
+Encoding: 5050 5050 1276
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BB
-Encoding: 5051 5051 5051
+Encoding: 5051 5051 1277
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BC
-Encoding: 5052 5052 5052
+Encoding: 5052 5052 1278
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BD
-Encoding: 5053 5053 5053
+Encoding: 5053 5053 1279
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BE
-Encoding: 5054 5054 5054
+Encoding: 5054 5054 1280
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BF
-Encoding: 5055 5055 5055
+Encoding: 5055 5055 1281
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C0
-Encoding: 5056 5056 5056
+Encoding: 5056 5056 1282
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C1
-Encoding: 5057 5057 5057
+Encoding: 5057 5057 1283
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C2
-Encoding: 5058 5058 5058
+Encoding: 5058 5058 1284
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C3
-Encoding: 5059 5059 5059
+Encoding: 5059 5059 1285
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C4
-Encoding: 5060 5060 5060
+Encoding: 5060 5060 1286
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C5
-Encoding: 5061 5061 5061
+Encoding: 5061 5061 1287
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C6
-Encoding: 5062 5062 5062
+Encoding: 5062 5062 1288
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C7
-Encoding: 5063 5063 5063
+Encoding: 5063 5063 1289
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C8
-Encoding: 5064 5064 5064
+Encoding: 5064 5064 1290
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C9
-Encoding: 5065 5065 5065
+Encoding: 5065 5065 1291
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CA
-Encoding: 5066 5066 5066
+Encoding: 5066 5066 1292
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CB
-Encoding: 5067 5067 5067
+Encoding: 5067 5067 1293
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CC
-Encoding: 5068 5068 5068
+Encoding: 5068 5068 1294
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CD
-Encoding: 5069 5069 5069
+Encoding: 5069 5069 1295
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CE
-Encoding: 5070 5070 5070
+Encoding: 5070 5070 1296
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CF
-Encoding: 5071 5071 5071
+Encoding: 5071 5071 1297
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D0
-Encoding: 5072 5072 5072
+Encoding: 5072 5072 1298
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D1
-Encoding: 5073 5073 5073
+Encoding: 5073 5073 1299
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D2
-Encoding: 5074 5074 5074
+Encoding: 5074 5074 1300
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D3
-Encoding: 5075 5075 5075
+Encoding: 5075 5075 1301
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D4
-Encoding: 5076 5076 5076
+Encoding: 5076 5076 1302
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D5
-Encoding: 5077 5077 5077
+Encoding: 5077 5077 1303
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D6
-Encoding: 5078 5078 5078
+Encoding: 5078 5078 1304
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D7
-Encoding: 5079 5079 5079
+Encoding: 5079 5079 1305
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D8
-Encoding: 5080 5080 5080
+Encoding: 5080 5080 1306
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D9
-Encoding: 5081 5081 5081
+Encoding: 5081 5081 1307
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DA
-Encoding: 5082 5082 5082
+Encoding: 5082 5082 1308
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DB
-Encoding: 5083 5083 5083
+Encoding: 5083 5083 1309
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DC
-Encoding: 5084 5084 5084
+Encoding: 5084 5084 1310
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DD
-Encoding: 5085 5085 5085
+Encoding: 5085 5085 1311
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DE
-Encoding: 5086 5086 5086
+Encoding: 5086 5086 1312
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DF
-Encoding: 5087 5087 5087
+Encoding: 5087 5087 1313
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E0
-Encoding: 5088 5088 5088
+Encoding: 5088 5088 1314
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E1
-Encoding: 5089 5089 5089
+Encoding: 5089 5089 1315
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E2
-Encoding: 5090 5090 5090
+Encoding: 5090 5090 1316
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E3
-Encoding: 5091 5091 5091
+Encoding: 5091 5091 1317
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E4
-Encoding: 5092 5092 5092
+Encoding: 5092 5092 1318
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E5
-Encoding: 5093 5093 5093
+Encoding: 5093 5093 1319
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E6
-Encoding: 5094 5094 5094
+Encoding: 5094 5094 1320
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E7
-Encoding: 5095 5095 5095
+Encoding: 5095 5095 1321
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E8
-Encoding: 5096 5096 5096
+Encoding: 5096 5096 1322
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E9
-Encoding: 5097 5097 5097
+Encoding: 5097 5097 1323
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EA
-Encoding: 5098 5098 5098
+Encoding: 5098 5098 1324
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EB
-Encoding: 5099 5099 5099
+Encoding: 5099 5099 1325
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EC
-Encoding: 5100 5100 5100
+Encoding: 5100 5100 1326
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13ED
-Encoding: 5101 5101 5101
+Encoding: 5101 5101 1327
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EE
-Encoding: 5102 5102 5102
+Encoding: 5102 5102 1328
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EF
-Encoding: 5103 5103 5103
+Encoding: 5103 5103 1329
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F0
-Encoding: 5104 5104 5104
+Encoding: 5104 5104 1330
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F1
-Encoding: 5105 5105 5105
+Encoding: 5105 5105 1331
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F2
-Encoding: 5106 5106 5106
+Encoding: 5106 5106 1332
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F3
-Encoding: 5107 5107 5107
+Encoding: 5107 5107 1333
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F4
-Encoding: 5108 5108 5108
+Encoding: 5108 5108 1334
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F5
-Encoding: 5109 5109 5109
+Encoding: 5109 5109 1335
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni1D02
-Encoding: 7426 7426 7426
+Encoding: 7426 7426 1336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45813,8 +47155,9 @@ SplineSet
  65 641 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D08
-Encoding: 7432 7432 7432
+Encoding: 7432 7432 1337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45852,8 +47195,9 @@ SplineSet
  963.43 575 963.43 575 806.959 552 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D09
-Encoding: 7433 7433 7433
+Encoding: 7433 7433 1338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45877,8 +47221,9 @@ SplineSet
  568 -541 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D14
-Encoding: 7444 7444 7444
+Encoding: 7444 7444 1339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45943,8 +47288,9 @@ SplineSet
  962 934 962 934 905 934 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: uni1D16
-Encoding: 7446 7446 7446
+Encoding: 7446 7446 1340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45963,8 +47309,9 @@ SplineSet
  206.658 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D17
-Encoding: 7447 7447 7447
+Encoding: 7447 7447 1341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45983,8 +47330,9 @@ SplineSet
  1242.66 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D1D
-Encoding: 7453 7453 7453
+Encoding: 7453 7453 1342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46009,8 +47357,9 @@ SplineSet
  978.098 0.5 978.098 0.5 770.098 0.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1E
-Encoding: 7454 7454 7454
+Encoding: 7454 7454 1343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46045,8 +47394,9 @@ SplineSet
  1020.77 -3.5 1020.77 -3.5 875.169 -3.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1F
-Encoding: 7455 7455 7455
+Encoding: 7455 7455 1344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46082,8 +47432,9 @@ SplineSet
  1201.53 476 1201.53 476 1141.19 464 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2C
-Encoding: 7468 7468 7468
+Encoding: 7468 7468 1345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46104,8 +47455,9 @@ SplineSet
  583 1504 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2D
-Encoding: 7469 7469 7469
+Encoding: 7469 7469 1346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46135,8 +47487,9 @@ SplineSet
  635 1358 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2E
-Encoding: 7470 7470 7470
+Encoding: 7470 7470 1347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46176,8 +47529,9 @@ SplineSet
  371 1505 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D30
-Encoding: 7472 7472 7472
+Encoding: 7472 7472 1348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46203,8 +47557,9 @@ SplineSet
  381 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D31
-Encoding: 7473 7473 7473
+Encoding: 7473 7473 1349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46225,8 +47580,9 @@ SplineSet
  829 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D32
-Encoding: 7474 7474 7474
+Encoding: 7474 7474 1350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46247,8 +47603,9 @@ SplineSet
  243 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D33
-Encoding: 7475 7475 7475
+Encoding: 7475 7475 1351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46281,8 +47638,9 @@ SplineSet
  706 810 706 810 720 819 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D34
-Encoding: 7476 7476 7476
+Encoding: 7476 7476 1352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46303,8 +47661,9 @@ SplineSet
  395 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D35
-Encoding: 7477 7477 7477
+Encoding: 7477 7477 1353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46325,8 +47684,9 @@ SplineSet
  389 1358 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D36
-Encoding: 7478 7478 7478
+Encoding: 7478 7478 1354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46349,8 +47709,9 @@ SplineSet
  323 681 323 681 262 709 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D37
-Encoding: 7479 7479 7479
+Encoding: 7479 7479 1355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46371,8 +47732,9 @@ SplineSet
  349 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D38
-Encoding: 7480 7480 7480
+Encoding: 7480 7480 1356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46387,8 +47749,9 @@ SplineSet
  243 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D39
-Encoding: 7481 7481 7481
+Encoding: 7481 7481 1357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46410,8 +47773,9 @@ SplineSet
  363 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3A
-Encoding: 7482 7482 7482
+Encoding: 7482 7482 1358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46430,8 +47794,9 @@ SplineSet
  385 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3B
-Encoding: 7483 7483 7483
+Encoding: 7483 7483 1359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46450,8 +47815,9 @@ SplineSet
  1011 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3C
-Encoding: 7484 7484 7484
+Encoding: 7484 7484 1360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46481,8 +47847,9 @@ SplineSet
  269 999 269 999 286 1085 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D3E
-Encoding: 7486 7486 7486
+Encoding: 7486 7486 1361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46510,8 +47877,9 @@ SplineSet
  387 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3F
-Encoding: 7487 7487 7487
+Encoding: 7487 7487 1362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46546,8 +47914,9 @@ SplineSet
  510 1365 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D40
-Encoding: 7488 7488 7488
+Encoding: 7488 7488 1363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46564,8 +47933,9 @@ SplineSet
  627 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D41
-Encoding: 7489 7489 7489
+Encoding: 7489 7489 1364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46590,8 +47960,9 @@ SplineSet
  264 917 264 917 276 977 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D42
-Encoding: 7490 7490 7490
+Encoding: 7490 7490 1365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46613,8 +47984,9 @@ SplineSet
  309 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D43
-Encoding: 7491 7491 7491
+Encoding: 7491 7491 1366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46656,8 +48028,9 @@ SplineSet
  956 1082 956 1082 945 1026 c 2,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D44
-Encoding: 7492 7492 7492
+Encoding: 7492 7492 1367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46699,8 +48072,9 @@ SplineSet
  277 880 277 880 288 936 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D45
-Encoding: 7493 7493 7493
+Encoding: 7493 7493 1368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46734,8 +48108,9 @@ SplineSet
  505 1071 505 1071 492.5 1006.5 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D46
-Encoding: 7494 7494 7494
+Encoding: 7494 7494 1369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46799,8 +48174,9 @@ SplineSet
  256 1026 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D47
-Encoding: 7495 7495 7495
+Encoding: 7495 7495 1370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46834,8 +48210,9 @@ SplineSet
  509 1206 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D48
-Encoding: 7496 7496 7496
+Encoding: 7496 7496 1371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46869,8 +48246,9 @@ SplineSet
  483 1071 483 1071 470.5 1006.5 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D49
-Encoding: 7497 7497 7497
+Encoding: 7497 7497 1372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46904,8 +48282,9 @@ SplineSet
  778 1052 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni1D4A
-Encoding: 7498 7498 7498
+Encoding: 7498 7498 1373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46939,8 +48318,9 @@ SplineSet
  455 910 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni1D4B
-Encoding: 7499 7499 7499
+Encoding: 7499 7499 1374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46982,8 +48362,9 @@ SplineSet
  398 976 398 976 496 989 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4C
-Encoding: 7500 7500 7500
+Encoding: 7500 7500 1375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47025,8 +48406,9 @@ SplineSet
  835 990 835 990 737 977 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4D
-Encoding: 7501 7501 7501
+Encoding: 7501 7501 1376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47068,8 +48450,9 @@ SplineSet
  901 715 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D4E
-Encoding: 7502 7502 7502
+Encoding: 7502 7502 1377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47093,8 +48476,9 @@ SplineSet
  617 365 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4F
-Encoding: 7503 7503 7503
+Encoding: 7503 7503 1378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47115,8 +48499,9 @@ SplineSet
  379 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D50
-Encoding: 7504 7504 7504
+Encoding: 7504 7504 1379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47155,8 +48540,9 @@ SplineSet
  708 1265 708 1265 709 1232 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D51
-Encoding: 7505 7505 7505
+Encoding: 7505 7505 1380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47189,8 +48575,9 @@ SplineSet
  948 1117 948 1117 940 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D52
-Encoding: 7506 7506 7506
+Encoding: 7506 7506 1381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47220,8 +48607,9 @@ SplineSet
  281 936 281 936 290 981 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni1D53
-Encoding: 7507 7507 7507
+Encoding: 7507 7507 1382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47250,8 +48638,9 @@ SplineSet
  323 676 323 676 280 700 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D54
-Encoding: 7508 7508 7508
+Encoding: 7508 7508 1383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47272,8 +48661,9 @@ SplineSet
  258 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D55
-Encoding: 7509 7509 7509
+Encoding: 7509 7509 1384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47294,8 +48684,9 @@ SplineSet
  975 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D56
-Encoding: 7510 7510 7510
+Encoding: 7510 7510 1385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47329,8 +48720,9 @@ SplineSet
  749 891 749 891 762 956 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D57
-Encoding: 7511 7511 7511
+Encoding: 7511 7511 1386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47358,8 +48750,9 @@ SplineSet
  756 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D58
-Encoding: 7512 7512 7512
+Encoding: 7512 7512 1387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47386,8 +48779,9 @@ SplineSet
  308 844 308 844 316 887 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D59
-Encoding: 7513 7513 7513
+Encoding: 7513 7513 1388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47414,8 +48808,9 @@ SplineSet
  796 668 796 668 665 668 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5A
-Encoding: 7514 7514 7514
+Encoding: 7514 7514 1389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47454,8 +48849,9 @@ SplineSet
  525 698 525 698 524 731 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5B
-Encoding: 7515 7515 7515
+Encoding: 7515 7515 1390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47471,40 +48867,45 @@ SplineSet
  1015 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D62
-Encoding: 7522 7522 7522
+Encoding: 7522 7522 1391
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8305 8305 N 1 0 0 1 0 -668 3
+Refer: 1907 8305 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D63
-Encoding: 7523 7523 7523
+Encoding: 7523 7523 1392
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 691 691 N 1 0 0 1 0 -668 3
+Refer: 606 691 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D64
-Encoding: 7524 7524 7524
+Encoding: 7524 7524 1393
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7512 7512 N 1 0 0 1 0 -668 3
+Refer: 1387 7512 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D65
-Encoding: 7525 7525 7525
+Encoding: 7525 7525 1394
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7515 7515 N 1 0 0 1 0 -668 3
+Refer: 1390 7515 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D77
-Encoding: 7543 7543 7543
+Encoding: 7543 7543 1395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47545,16 +48946,18 @@ SplineSet
  233.5 641 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D78
-Encoding: 7544 7544 7544
+Encoding: 7544 7544 1396
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7476 7476 N 1 0 0 1 0 0 2
+Refer: 1352 7476 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1D7B
-Encoding: 7547 7547 7547
+Encoding: 7547 7547 1397
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47583,8 +48986,9 @@ SplineSet
  315 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D85
-Encoding: 7557 7557 7557
+Encoding: 7557 7557 1398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47615,8 +49019,9 @@ SplineSet
  428.986 216 428.986 216 477.775 467 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9B
-Encoding: 7579 7579 7579
+Encoding: 7579 7579 1399
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47650,8 +49055,9 @@ SplineSet
  728 891 728 891 740.5 955.5 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D9C
-Encoding: 7580 7580 7580
+Encoding: 7580 7580 1400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47680,8 +49086,9 @@ SplineSet
  843 700 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9D
-Encoding: 7581 7581 7581
+Encoding: 7581 7581 1401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47721,8 +49128,9 @@ SplineSet
  516 878 516 878 529 855 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9E
-Encoding: 7582 7582 7582
+Encoding: 7582 7582 1402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47766,8 +49174,9 @@ SplineSet
  859 1284 l 2,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni1D9F
-Encoding: 7583 7583 7583
+Encoding: 7583 7583 1403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47808,8 +49217,9 @@ SplineSet
  830 1003 830 1003 739 989 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA0
-Encoding: 7584 7584 7584
+Encoding: 7584 7584 1404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47836,8 +49246,9 @@ SplineSet
  742 1386 742 1386 734 1350 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA1
-Encoding: 7585 7585 7585
+Encoding: 7585 7585 1405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47862,8 +49273,9 @@ SplineSet
  608 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA2
-Encoding: 7586 7586 7586
+Encoding: 7586 7586 1406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47902,8 +49314,9 @@ SplineSet
  678 1165 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni1DA3
-Encoding: 7587 7587 7587
+Encoding: 7587 7587 1407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47930,8 +49343,9 @@ SplineSet
  331 844 331 844 339 887 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA4
-Encoding: 7588 7588 7588
+Encoding: 7588 7588 1408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47963,8 +49377,9 @@ SplineSet
  381 1295 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA5
-Encoding: 7589 7589 7589
+Encoding: 7589 7589 1409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47987,8 +49402,9 @@ SplineSet
  536 1169 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA6
-Encoding: 7590 7590 7590
+Encoding: 7590 7590 1410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48009,8 +49425,9 @@ SplineSet
  745 1169 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA7
-Encoding: 7591 7591 7591
+Encoding: 7591 7591 1411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48039,8 +49456,9 @@ SplineSet
  360 913 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA8
-Encoding: 7592 7592 7592
+Encoding: 7592 7592 1412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48080,8 +49498,9 @@ SplineSet
  563 603 563 603 574 630 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni1DA9
-Encoding: 7593 7593 7593
+Encoding: 7593 7593 1413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48104,8 +49523,9 @@ SplineSet
  420 628 420 628 430 681 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAA
-Encoding: 7594 7594 7594
+Encoding: 7594 7594 1414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48135,8 +49555,9 @@ SplineSet
  466 877 466 877 476 930 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAB
-Encoding: 7595 7595 7595
+Encoding: 7595 7595 1415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48151,8 +49572,9 @@ SplineSet
  438 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAC
-Encoding: 7596 7596 7596
+Encoding: 7596 7596 1416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48197,8 +49619,9 @@ SplineSet
  731 1264 731 1264 732 1232 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAD
-Encoding: 7597 7597 7597
+Encoding: 7597 7597 1417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48237,8 +49660,9 @@ SplineSet
  547 698 547 698 546 731 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAE
-Encoding: 7598 7598 7598
+Encoding: 7598 7598 1418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48276,8 +49700,9 @@ SplineSet
  1011 1099 1011 1099 1001 1050 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAF
-Encoding: 7599 7599 7599
+Encoding: 7599 7599 1419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48312,8 +49737,9 @@ SplineSet
  706 1072 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB0
-Encoding: 7600 7600 7600
+Encoding: 7600 7600 1420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48332,8 +49758,9 @@ SplineSet
  365 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB1
-Encoding: 7601 7601 7601
+Encoding: 7601 7601 1421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48367,8 +49794,9 @@ SplineSet
  721 868 721 868 739 913 c 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB2
-Encoding: 7602 7602 7602
+Encoding: 7602 7602 1422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48415,8 +49843,9 @@ SplineSet
  762 1144 762 1144 742 1156 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB3
-Encoding: 7603 7603 7603
+Encoding: 7603 7603 1423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48464,8 +49893,9 @@ SplineSet
  876 1293 876 1293 930 1276 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB4
-Encoding: 7604 7604 7604
+Encoding: 7604 7604 1424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48490,8 +49920,9 @@ SplineSet
  669 668 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB5
-Encoding: 7605 7605 7605
+Encoding: 7605 7605 1425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48525,8 +49956,9 @@ SplineSet
  779 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB6
-Encoding: 7606 7606 7606
+Encoding: 7606 7606 1426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48565,8 +49997,9 @@ SplineSet
  692 858 692 858 706 913 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB7
-Encoding: 7607 7607 7607
+Encoding: 7607 7607 1427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48603,8 +50036,9 @@ SplineSet
  611 1137 l 1,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni1DB9
-Encoding: 7609 7609 7609
+Encoding: 7609 7609 1428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48641,8 +50075,9 @@ SplineSet
  843 1292 843 1292 895 1243 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBA
-Encoding: 7610 7610 7610
+Encoding: 7610 7610 1429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48658,8 +50093,9 @@ SplineSet
  218 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBB
-Encoding: 7611 7611 7611
+Encoding: 7611 7611 1430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48678,8 +50114,9 @@ SplineSet
  403 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBC
-Encoding: 7612 7612 7612
+Encoding: 7612 7612 1431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48707,8 +50144,9 @@ SplineSet
  357 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBD
-Encoding: 7613 7613 7613
+Encoding: 7613 7613 1432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48741,8 +50179,9 @@ SplineSet
  385 1295 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBE
-Encoding: 7614 7614 7614
+Encoding: 7614 7614 1433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48775,8 +50214,9 @@ SplineSet
  436 921 l 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBF
-Encoding: 7615 7615 7615
+Encoding: 7615 7615 1434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48809,3230 +50249,3588 @@ SplineSet
  679 654 679 654 529 654 c 24,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1E00
-Encoding: 7680 7680 7680
+Encoding: 7680 7680 1435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 690 805 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E01
-Encoding: 7681 7681 7681
+Encoding: 7681 7681 1436
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 690 805 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E02
-Encoding: 7682 7682 7682
+Encoding: 7682 7682 1437
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E03
-Encoding: 7683 7683 7683
+Encoding: 7683 7683 1438
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 100 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 100 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E04
-Encoding: 7684 7684 7684
+Encoding: 7684 7684 1439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E05
-Encoding: 7685 7685 7685
+Encoding: 7685 7685 1440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E06
-Encoding: 7686 7686 7686
+Encoding: 7686 7686 1441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E07
-Encoding: 7687 7687 7687
+Encoding: 7687 7687 1442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E08
-Encoding: 7688 7688 7688
+Encoding: 7688 7688 1443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 117 0 2
-Refer: 1114115 -1 N 1 0 0 1 137 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 117 0 2
+Refer: 3089 -1 N 1 0 0 1 137 373 2
 EndChar
+
 StartChar: uni1E09
-Encoding: 7689 7689 7689
+Encoding: 7689 7689 1444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 86 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 72 0 2
+Refer: 116 180 N 1 0 0 1 86 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 72 0 2
 EndChar
+
 StartChar: uni1E0A
-Encoding: 7690 7690 7690
+Encoding: 7690 7690 1445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0B
-Encoding: 7691 7691 7691
+Encoding: 7691 7691 1446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 -100 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 -100 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0C
-Encoding: 7692 7692 7692
+Encoding: 7692 7692 1447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0D
-Encoding: 7693 7693 7693
+Encoding: 7693 7693 1448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0E
-Encoding: 7694 7694 7694
+Encoding: 7694 7694 1449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0F
-Encoding: 7695 7695 7695
+Encoding: 7695 7695 1450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E10
-Encoding: 7696 7696 7696
+Encoding: 7696 7696 1451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -184.5 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -184.5 0 2
 EndChar
+
 StartChar: uni1E11
-Encoding: 7697 7697 7697
+Encoding: 7697 7697 1452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -121.5 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -121.5 0 2
 EndChar
+
 StartChar: uni1E12
-Encoding: 7698 7698 7698
+Encoding: 7698 7698 1453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E13
-Encoding: 7699 7699 7699
+Encoding: 7699 7699 1454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E18
-Encoding: 7704 7704 7704
+Encoding: 7704 7704 1455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E19
-Encoding: 7705 7705 7705
+Encoding: 7705 7705 1456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1A
-Encoding: 7706 7706 7706
+Encoding: 7706 7706 1457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1B
-Encoding: 7707 7707 7707
+Encoding: 7707 7707 1458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1C
-Encoding: 7708 7708 7708
+Encoding: 7708 7708 1459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 3097 -1 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1D
-Encoding: 7709 7709 7709
+Encoding: 7709 7709 1460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 659 774 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1E
-Encoding: 7710 7710 7710
+Encoding: 7710 7710 1461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 14 0 2
-Refer: 70 70 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 14 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1F
-Encoding: 7711 7711 7711
+Encoding: 7711 7711 1462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 102 102 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E20
-Encoding: 7712 7712 7712
+Encoding: 7712 7712 1463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E21
-Encoding: 7713 7713 7713
+Encoding: 7713 7713 1464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E22
-Encoding: 7714 7714 7714
+Encoding: 7714 7714 1465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E23
-Encoding: 7715 7715 7715
+Encoding: 7715 7715 1466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E24
-Encoding: 7716 7716 7716
+Encoding: 7716 7716 1467
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E25
-Encoding: 7717 7717 7717
+Encoding: 7717 7717 1468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E26
-Encoding: 7718 7718 7718
+Encoding: 7718 7718 1469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 3
-Refer: 1114114 -1 N 1 0 0 1 0.5 348 2
+Refer: 41 72 N 1 0 0 1 0 0 3
+Refer: 3088 -1 N 1 0 0 1 0.5 348 2
 EndChar
+
 StartChar: uni1E27
-Encoding: 7719 7719 7719
+Encoding: 7719 7719 1470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 7 328 2
+Refer: 73 104 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 7 328 2
 EndChar
+
 StartChar: uni1E28
-Encoding: 7720 7720 7720
+Encoding: 7720 7720 1471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -335 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -335 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E29
-Encoding: 7721 7721 7721
+Encoding: 7721 7721 1472
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -300 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 692 807 N 1 0 0 1 -300 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2A
-Encoding: 7722 7722 7722
+Encoding: 7722 7722 1473
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 699 814 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2B
-Encoding: 7723 7723 7723
+Encoding: 7723 7723 1474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 699 814 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2C
-Encoding: 7724 7724 7724
+Encoding: 7724 7724 1475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2D
-Encoding: 7725 7725 7725
+Encoding: 7725 7725 1476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E30
-Encoding: 7728 7728 7728
+Encoding: 7728 7728 1477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni1E31
-Encoding: 7729 7729 7729
+Encoding: 7729 7729 1478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 -121 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 -121 373 2
 EndChar
+
 StartChar: uni1E32
-Encoding: 7730 7730 7730
+Encoding: 7730 7730 1479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E33
-Encoding: 7731 7731 7731
+Encoding: 7731 7731 1480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E34
-Encoding: 7732 7732 7732
+Encoding: 7732 7732 1481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E35
-Encoding: 7733 7733 7733
+Encoding: 7733 7733 1482
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E36
-Encoding: 7734 7734 7734
+Encoding: 7734 7734 1483
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E37
-Encoding: 7735 7735 7735
+Encoding: 7735 7735 1484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E38
-Encoding: 7736 7736 7736
+Encoding: 7736 7736 1485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
-Refer: 7734 7734 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
+Refer: 1483 7734 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E39
-Encoding: 7737 7737 7737
+Encoding: 7737 7737 1486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
-Refer: 7735 7735 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
+Refer: 1484 7735 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3A
-Encoding: 7738 7738 7738
+Encoding: 7738 7738 1487
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3B
-Encoding: 7739 7739 7739
+Encoding: 7739 7739 1488
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3C
-Encoding: 7740 7740 7740
+Encoding: 7740 7740 1489
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3D
-Encoding: 7741 7741 7741
+Encoding: 7741 7741 1490
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3E
-Encoding: 7742 7742 7742
+Encoding: 7742 7742 1491
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 63 373 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 63 373 2
 EndChar
+
 StartChar: uni1E3F
-Encoding: 7743 7743 7743
+Encoding: 7743 7743 1492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E40
-Encoding: 7744 7744 7744
+Encoding: 7744 7744 1493
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E41
-Encoding: 7745 7745 7745
+Encoding: 7745 7745 1494
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 3
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E42
-Encoding: 7746 7746 7746
+Encoding: 7746 7746 1495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E43
-Encoding: 7747 7747 7747
+Encoding: 7747 7747 1496
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E44
-Encoding: 7748 7748 7748
+Encoding: 7748 7748 1497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E45
-Encoding: 7749 7749 7749
+Encoding: 7749 7749 1498
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E46
-Encoding: 7750 7750 7750
+Encoding: 7750 7750 1499
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E47
-Encoding: 7751 7751 7751
+Encoding: 7751 7751 1500
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E48
-Encoding: 7752 7752 7752
+Encoding: 7752 7752 1501
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E49
-Encoding: 7753 7753 7753
+Encoding: 7753 7753 1502
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4A
-Encoding: 7754 7754 7754
+Encoding: 7754 7754 1503
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4B
-Encoding: 7755 7755 7755
+Encoding: 7755 7755 1504
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4C
-Encoding: 7756 7756 7756
+Encoding: 7756 7756 1505
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 0 262 2
+Refer: 3089 -1 N 1 0 0 1 50 515 2
 EndChar
+
 StartChar: uni1E4D
-Encoding: 7757 7757 7757
+Encoding: 7757 7757 1506
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 72 403 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 654 769 N 1 0 0 1 72 403 2
+Refer: 638 732 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E54
-Encoding: 7764 7764 7764
+Encoding: 7764 7764 1507
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -137 380 2
+Refer: 49 80 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -137 380 2
 EndChar
+
 StartChar: uni1E55
-Encoding: 7765 7765 7765
+Encoding: 7765 7765 1508
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 3
-Refer: 769 769 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
+Refer: 654 769 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E56
-Encoding: 7766 7766 7766
+Encoding: 7766 7766 1509
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E57
-Encoding: 7767 7767 7767
+Encoding: 7767 7767 1510
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 112 112 N 1 0 0 1 0 0 3
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E58
-Encoding: 7768 7768 7768
+Encoding: 7768 7768 1511
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E59
-Encoding: 7769 7769 7769
+Encoding: 7769 7769 1512
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5A
-Encoding: 7770 7770 7770
+Encoding: 7770 7770 1513
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5B
-Encoding: 7771 7771 7771
+Encoding: 7771 7771 1514
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5C
-Encoding: 7772 7772 7772
+Encoding: 7772 7772 1515
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114128 -1 N 1 0 0 1 -50 0 2
-Refer: 7770 7770 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 -50 0 2
+Refer: 1513 7770 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5D
-Encoding: 7773 7773 7773
+Encoding: 7773 7773 1516
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 7771 7771 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
+Refer: 1514 7771 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5E
-Encoding: 7774 7774 7774
+Encoding: 7774 7774 1517
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5F
-Encoding: 7775 7775 7775
+Encoding: 7775 7775 1518
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E60
-Encoding: 7776 7776 7776
+Encoding: 7776 7776 1519
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E61
-Encoding: 7777 7777 7777
+Encoding: 7777 7777 1520
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 3
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E62
-Encoding: 7778 7778 7778
+Encoding: 7778 7778 1521
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E63
-Encoding: 7779 7779 7779
+Encoding: 7779 7779 1522
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E68
-Encoding: 7784 7784 7784
+Encoding: 7784 7784 1523
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E69
-Encoding: 7785 7785 7785
+Encoding: 7785 7785 1524
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6A
-Encoding: 7786 7786 7786
+Encoding: 7786 7786 1525
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6B
-Encoding: 7787 7787 7787
+Encoding: 7787 7787 1526
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6C
-Encoding: 7788 7788 7788
+Encoding: 7788 7788 1527
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6D
-Encoding: 7789 7789 7789
+Encoding: 7789 7789 1528
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6E
-Encoding: 7790 7790 7790
+Encoding: 7790 7790 1529
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6F
-Encoding: 7791 7791 7791
+Encoding: 7791 7791 1530
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E70
-Encoding: 7792 7792 7792
+Encoding: 7792 7792 1531
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E71
-Encoding: 7793 7793 7793
+Encoding: 7793 7793 1532
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E72
-Encoding: 7794 7794 7794
+Encoding: 7794 7794 1533
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 689 804 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E73
-Encoding: 7795 7795 7795
+Encoding: 7795 7795 1534
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 689 804 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E74
-Encoding: 7796 7796 7796
+Encoding: 7796 7796 1535
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E75
-Encoding: 7797 7797 7797
+Encoding: 7797 7797 1536
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 701 816 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E76
-Encoding: 7798 7798 7798
+Encoding: 7798 7798 1537
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E77
-Encoding: 7799 7799 7799
+Encoding: 7799 7799 1538
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 698 813 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E78
-Encoding: 7800 7800 7800
+Encoding: 7800 7800 1539
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 0 262 2
+Refer: 3089 -1 N 1 0 0 1 50 515 2
 EndChar
+
 StartChar: uni1E79
-Encoding: 7801 7801 7801
+Encoding: 7801 7801 1540
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 72 403 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 654 769 N 1 0 0 1 72 403 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7C
-Encoding: 7804 7804 7804
+Encoding: 7804 7804 1541
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 0 348 2
+Refer: 55 86 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 0 348 2
 EndChar
+
 StartChar: uni1E7D
-Encoding: 7805 7805 7805
+Encoding: 7805 7805 1542
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 0 -40 2
+Refer: 87 118 N 1 0 0 1 0 0 3
+Refer: 638 732 N 1 0 0 1 0 -40 2
 EndChar
+
 StartChar: uni1E7E
-Encoding: 7806 7806 7806
+Encoding: 7806 7806 1543
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 86 86 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7F
-Encoding: 7807 7807 7807
+Encoding: 7807 7807 1544
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 118 118 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wgrave
-Encoding: 7808 7808 7808
+Encoding: 7808 7808 1545
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: wgrave
-Encoding: 7809 7809 7809
+Encoding: 7809 7809 1546
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -24 9 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -24 9 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wacute
-Encoding: 7810 7810 7810
+Encoding: 7810 7810 1547
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: wacute
-Encoding: 7811 7811 7811
+Encoding: 7811 7811 1548
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 72 9 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 72 9 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wdieresis
-Encoding: 7812 7812 7812
+Encoding: 7812 7812 1549
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 53 303 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 53 303 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wdieresis
-Encoding: 7813 7813 7813
+Encoding: 7813 7813 1550
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 8 -68 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 8 -68 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E86
-Encoding: 7814 7814 7814
+Encoding: 7814 7814 1551
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E87
-Encoding: 7815 7815 7815
+Encoding: 7815 7815 1552
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E88
-Encoding: 7816 7816 7816
+Encoding: 7816 7816 1553
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E89
-Encoding: 7817 7817 7817
+Encoding: 7817 7817 1554
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8A
-Encoding: 7818 7818 7818
+Encoding: 7818 7818 1555
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8B
-Encoding: 7819 7819 7819
+Encoding: 7819 7819 1556
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8C
-Encoding: 7820 7820 7820
+Encoding: 7820 7820 1557
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 3
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 57 88 N 1 0 0 1 0 0 3
+Refer: 3088 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni1E8D
-Encoding: 7821 7821 7821
+Encoding: 7821 7821 1558
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0.5 -81 2
-Refer: 120 120 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 0.5 -81 2
+Refer: 89 120 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8E
-Encoding: 7822 7822 7822
+Encoding: 7822 7822 1559
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8F
-Encoding: 7823 7823 7823
+Encoding: 7823 7823 1560
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 660 775 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E90
-Encoding: 7824 7824 7824
+Encoding: 7824 7824 1561
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 3
-Refer: 1114119 -1 N 1 0 0 1 46 380 2
+Refer: 59 90 N 1 0 0 1 0 0 3
+Refer: 3093 -1 N 1 0 0 1 46 380 2
 EndChar
+
 StartChar: uni1E91
-Encoding: 7825 7825 7825
+Encoding: 7825 7825 1562
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 17 7 2
+Refer: 91 122 N 1 0 0 1 0 0 3
+Refer: 620 710 N 1 0 0 1 17 7 2
 EndChar
+
 StartChar: uni1E92
-Encoding: 7826 7826 7826
+Encoding: 7826 7826 1563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 20 0 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 20 0 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E93
-Encoding: 7827 7827 7827
+Encoding: 7827 7827 1564
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 39 0 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 39 0 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E94
-Encoding: 7828 7828 7828
+Encoding: 7828 7828 1565
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E95
-Encoding: 7829 7829 7829
+Encoding: 7829 7829 1566
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E96
-Encoding: 7830 7830 7830
+Encoding: 7830 7830 1567
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 702 817 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E97
-Encoding: 7831 7831 7831
+Encoding: 7831 7831 1568
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 -94 210 2
+Refer: 85 116 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 -94 210 2
 EndChar
+
 StartChar: uni1E98
-Encoding: 7832 7832 7832
+Encoding: 7832 7832 1569
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 0 20 2
+Refer: 88 119 N 1 0 0 1 0 0 3
+Refer: 636 730 N 1 0 0 1 0 20 2
 EndChar
+
 StartChar: uni1E99
-Encoding: 7833 7833 7833
+Encoding: 7833 7833 1570
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 12 20 2
+Refer: 90 121 N 1 0 0 1 0 0 3
+Refer: 636 730 N 1 0 0 1 12 20 2
 EndChar
+
 StartChar: uni1E9B
-Encoding: 7835 7835 7835
+Encoding: 7835 7835 1571
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 383 383 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
+Refer: 319 383 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E9F
-Encoding: 7839 7839 7839
+Encoding: 7839 7839 1572
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 948 948 N 1 0 0 1 0 0 2
+Refer: 775 948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA0
-Encoding: 7840 7840 7840
+Encoding: 7840 7840 1573
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 34 65 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA1
-Encoding: 7841 7841 7841
+Encoding: 7841 7841 1574
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EAC
-Encoding: 7852 7852 7852
+Encoding: 7852 7852 1575
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114119 -1 N 1 0 0 1 0 380 2
+Refer: 1573 7840 N 1 0 0 1 0 0 3
+Refer: 3093 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: uni1EAD
-Encoding: 7853 7853 7853
+Encoding: 7853 7853 1576
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -24.5 7 2
+Refer: 1574 7841 N 1 0 0 1 0 0 3
+Refer: 620 710 N 1 0 0 1 -24.5 7 2
 EndChar
+
 StartChar: uni1EB0
-Encoding: 7856 7856 7856
+Encoding: 7856 7856 1577
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 -128 2
-Refer: 1114118 -1 N 1 0 0 1 108 515 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 99.0377 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB1
-Encoding: 7857 7857 7857
+Encoding: 7857 7857 1578
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 66 316 2
-Refer: 259 259 N 1 0 0 1 0 0 3
+Refer: 653 768 N 1 0 0 1 41.9088 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB6
-Encoding: 7862 7862 7862
+Encoding: 7862 7862 1579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 1573 7840 N 1 0 0 1 0 0 3
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB7
-Encoding: 7863 7863 7863
+Encoding: 7863 7863 1580
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 728 728 N 1 0 0 1 -24.5 -52 2
+Refer: 1574 7841 N 1 0 0 1 0 0 3
+Refer: 634 728 N 1 0 0 1 -24.5 -52 2
 EndChar
+
 StartChar: uni1EB8
-Encoding: 7864 7864 7864
+Encoding: 7864 7864 1581
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 31 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 31 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB9
-Encoding: 7865 7865 7865
+Encoding: 7865 7865 1582
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 39 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 39 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBC
-Encoding: 7868 7868 7868
+Encoding: 7868 7868 1583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 112 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 112 373 2
 EndChar
+
 StartChar: uni1EBD
-Encoding: 7869 7869 7869
+Encoding: 7869 7869 1584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 -33 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 -33 2
 EndChar
+
 StartChar: uni1EC6
-Encoding: 7878 7878 7878
+Encoding: 7878 7878 1585
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7864 7864 N 1 0 0 1 0 0 3
-Refer: 1114119 -1 N 1 0 0 1 23.5 380 2
+Refer: 1581 7864 N 1 0 0 1 0 0 3
+Refer: 3093 -1 N 1 0 0 1 23.5 380 2
 EndChar
+
 StartChar: uni1EC7
-Encoding: 7879 7879 7879
+Encoding: 7879 7879 1586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7865 7865 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 34.5 7 2
+Refer: 1582 7865 N 1 0 0 1 0 0 3
+Refer: 620 710 N 1 0 0 1 34.5 7 2
 EndChar
+
 StartChar: uni1ECA
-Encoding: 7882 7882 7882
+Encoding: 7882 7882 1587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECB
-Encoding: 7883 7883 7883
+Encoding: 7883 7883 1588
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECC
-Encoding: 7884 7884 7884
+Encoding: 7884 7884 1589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECD
-Encoding: 7885 7885 7885
+Encoding: 7885 7885 1590
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ED8
-Encoding: 7896 7896 7896
+Encoding: 7896 7896 1591
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7884 7884 N 1 0 0 1 0 0 3
-Refer: 1114119 -1 N 1 0 0 1 -0.5 380 2
+Refer: 1589 7884 N 1 0 0 1 0 0 3
+Refer: 3093 -1 N 1 0 0 1 -0.5 380 2
 EndChar
+
 StartChar: uni1ED9
-Encoding: 7897 7897 7897
+Encoding: 7897 7897 1592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7885 7885 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -0.5 7 2
+Refer: 1590 7885 N 1 0 0 1 0 0 3
+Refer: 620 710 N 1 0 0 1 -0.5 7 2
 EndChar
+
 StartChar: uni1EDA
-Encoding: 7898 7898 7898
+Encoding: 7898 7898 1593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDB
-Encoding: 7899 7899 7899
+Encoding: 7899 7899 1594
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EDC
-Encoding: 7900 7900 7900
+Encoding: 7900 7900 1595
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDD
-Encoding: 7901 7901 7901
+Encoding: 7901 7901 1596
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE0
-Encoding: 7904 7904 7904
+Encoding: 7904 7904 1597
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EE1
-Encoding: 7905 7905 7905
+Encoding: 7905 7905 1598
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 638 732 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE2
-Encoding: 7906 7906 7906
+Encoding: 7906 7906 1599
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -111 0 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 -111 0 2
 EndChar
+
 StartChar: uni1EE3
-Encoding: 7907 7907 7907
+Encoding: 7907 7907 1600
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE4
-Encoding: 7908 7908 7908
+Encoding: 7908 7908 1601
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE5
-Encoding: 7909 7909 7909
+Encoding: 7909 7909 1602
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE8
-Encoding: 7912 7912 7912
+Encoding: 7912 7912 1603
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EE9
-Encoding: 7913 7913 7913
+Encoding: 7913 7913 1604
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEA
-Encoding: 7914 7914 7914
+Encoding: 7914 7914 1605
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEB
-Encoding: 7915 7915 7915
+Encoding: 7915 7915 1606
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEE
-Encoding: 7918 7918 7918
+Encoding: 7918 7918 1607
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEF
-Encoding: 7919 7919 7919
+Encoding: 7919 7919 1608
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 638 732 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EF0
-Encoding: 7920 7920 7920
+Encoding: 7920 7920 1609
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -138 0 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 -138 0 2
 EndChar
+
 StartChar: uni1EF1
-Encoding: 7921 7921 7921
+Encoding: 7921 7921 1610
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 688 803 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: Ygrave
-Encoding: 7922 7922 7922
+Encoding: 7922 7922 1611
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: ygrave
-Encoding: 7923 7923 7923
+Encoding: 7923 7923 1612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -36 9 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -36 9 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF4
-Encoding: 7924 7924 7924
+Encoding: 7924 7924 1613
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF5
-Encoding: 7925 7925 7925
+Encoding: 7925 7925 1614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 300 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 688 803 N 1 0 0 1 300 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF8
-Encoding: 7928 7928 7928
+Encoding: 7928 7928 1615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 48.9999 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 48.9999 373 2
 EndChar
+
 StartChar: uni1EF9
-Encoding: 7929 7929 7929
+Encoding: 7929 7929 1616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 -33 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 -33 2
 EndChar
+
 StartChar: uni1F00
-Encoding: 7936 7936 7936
+Encoding: 7936 7936 1617
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F01
-Encoding: 7937 7937 7937
+Encoding: 7937 7937 1618
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F02
-Encoding: 7938 7938 7938
+Encoding: 7938 7938 1619
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F03
-Encoding: 7939 7939 7939
+Encoding: 7939 7939 1620
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F04
-Encoding: 7940 7940 7940
+Encoding: 7940 7940 1621
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F05
-Encoding: 7941 7941 7941
+Encoding: 7941 7941 1622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F06
-Encoding: 7942 7942 7942
+Encoding: 7942 7942 1623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F07
-Encoding: 7943 7943 7943
+Encoding: 7943 7943 1624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F08
-Encoding: 7944 7944 7944
+Encoding: 7944 7944 1625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -440 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -440 0 2
 EndChar
+
 StartChar: uni1F09
-Encoding: 7945 7945 7945
+Encoding: 7945 7945 1626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -490 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -490 0 2
 EndChar
+
 StartChar: uni1F0A
-Encoding: 7946 7946 7946
+Encoding: 7946 7946 1627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -760 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -760 0 2
 EndChar
+
 StartChar: uni1F0B
-Encoding: 7947 7947 7947
+Encoding: 7947 7947 1628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -760 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -760 0 2
 EndChar
+
 StartChar: uni1F0C
-Encoding: 7948 7948 7948
+Encoding: 7948 7948 1629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -645 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -645 0 2
 EndChar
+
 StartChar: uni1F0D
-Encoding: 7949 7949 7949
+Encoding: 7949 7949 1630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -665 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -665 0 2
 EndChar
+
 StartChar: uni1F0E
-Encoding: 7950 7950 7950
+Encoding: 7950 7950 1631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -440 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -440 0 2
 EndChar
+
 StartChar: uni1F0F
-Encoding: 7951 7951 7951
+Encoding: 7951 7951 1632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -490 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -490 0 2
 EndChar
+
 StartChar: uni1F10
-Encoding: 7952 7952 7952
+Encoding: 7952 7952 1633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F11
-Encoding: 7953 7953 7953
+Encoding: 7953 7953 1634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F12
-Encoding: 7954 7954 7954
+Encoding: 7954 7954 1635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F13
-Encoding: 7955 7955 7955
+Encoding: 7955 7955 1636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F14
-Encoding: 7956 7956 7956
+Encoding: 7956 7956 1637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F15
-Encoding: 7957 7957 7957
+Encoding: 7957 7957 1638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F18
-Encoding: 7960 7960 7960
+Encoding: 7960 7960 1639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -695 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F19
-Encoding: 7961 7961 7961
+Encoding: 7961 7961 1640
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F1A
-Encoding: 7962 7962 7962
+Encoding: 7962 7962 1641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -965 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -965 0 2
 EndChar
+
 StartChar: uni1F1B
-Encoding: 7963 7963 7963
+Encoding: 7963 7963 1642
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -965 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -965 0 2
 EndChar
+
 StartChar: uni1F1C
-Encoding: 7964 7964 7964
+Encoding: 7964 7964 1643
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -910 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -910 0 2
 EndChar
+
 StartChar: uni1F1D
-Encoding: 7965 7965 7965
+Encoding: 7965 7965 1644
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -920 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -920 0 2
 EndChar
+
 StartChar: uni1F20
-Encoding: 7968 7968 7968
+Encoding: 7968 7968 1645
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F21
-Encoding: 7969 7969 7969
+Encoding: 7969 7969 1646
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F22
-Encoding: 7970 7970 7970
+Encoding: 7970 7970 1647
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F23
-Encoding: 7971 7971 7971
+Encoding: 7971 7971 1648
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F24
-Encoding: 7972 7972 7972
+Encoding: 7972 7972 1649
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F25
-Encoding: 7973 7973 7973
+Encoding: 7973 7973 1650
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F26
-Encoding: 7974 7974 7974
+Encoding: 7974 7974 1651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F27
-Encoding: 7975 7975 7975
+Encoding: 7975 7975 1652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F28
-Encoding: 7976 7976 7976
+Encoding: 7976 7976 1653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -745 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -745 0 2
 EndChar
+
 StartChar: uni1F29
-Encoding: 7977 7977 7977
+Encoding: 7977 7977 1654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -745 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -745 0 2
 EndChar
+
 StartChar: uni1F2A
-Encoding: 7978 7978 7978
+Encoding: 7978 7978 1655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -1020 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -1020 0 2
 EndChar
+
 StartChar: uni1F2B
-Encoding: 7979 7979 7979
+Encoding: 7979 7979 1656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -1020 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -1020 0 2
 EndChar
+
 StartChar: uni1F2C
-Encoding: 7980 7980 7980
+Encoding: 7980 7980 1657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -970 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -970 0 2
 EndChar
+
 StartChar: uni1F2D
-Encoding: 7981 7981 7981
+Encoding: 7981 7981 1658
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -970 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -970 0 2
 EndChar
+
 StartChar: uni1F2E
-Encoding: 7982 7982 7982
+Encoding: 7982 7982 1659
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -740 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -740 0 2
 EndChar
+
 StartChar: uni1F2F
-Encoding: 7983 7983 7983
+Encoding: 7983 7983 1660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -740 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -740 0 2
 EndChar
+
 StartChar: uni1F30
-Encoding: 7984 7984 7984
+Encoding: 7984 7984 1661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F31
-Encoding: 7985 7985 7985
+Encoding: 7985 7985 1662
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F32
-Encoding: 7986 7986 7986
+Encoding: 7986 7986 1663
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F33
-Encoding: 7987 7987 7987
+Encoding: 7987 7987 1664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F34
-Encoding: 7988 7988 7988
+Encoding: 7988 7988 1665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F35
-Encoding: 7989 7989 7989
+Encoding: 7989 7989 1666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F36
-Encoding: 7990 7990 7990
+Encoding: 7990 7990 1667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F37
-Encoding: 7991 7991 7991
+Encoding: 7991 7991 1668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F38
-Encoding: 7992 7992 7992
+Encoding: 7992 7992 1669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -695 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F39
-Encoding: 7993 7993 7993
+Encoding: 7993 7993 1670
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F3A
-Encoding: 7994 7994 7994
+Encoding: 7994 7994 1671
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -940 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -940 0 2
 EndChar
+
 StartChar: uni1F3B
-Encoding: 7995 7995 7995
+Encoding: 7995 7995 1672
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -960 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -960 0 2
 EndChar
+
 StartChar: uni1F3C
-Encoding: 7996 7996 7996
+Encoding: 7996 7996 1673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -900 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -900 0 2
 EndChar
+
 StartChar: uni1F3D
-Encoding: 7997 7997 7997
+Encoding: 7997 7997 1674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -910 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -910 0 2
 EndChar
+
 StartChar: uni1F3E
-Encoding: 7998 7998 7998
+Encoding: 7998 7998 1675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -695 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F3F
-Encoding: 7999 7999 7999
+Encoding: 7999 7999 1676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -695 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F40
-Encoding: 8000 8000 8000
+Encoding: 8000 8000 1677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F41
-Encoding: 8001 8001 8001
+Encoding: 8001 8001 1678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F42
-Encoding: 8002 8002 8002
+Encoding: 8002 8002 1679
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F43
-Encoding: 8003 8003 8003
+Encoding: 8003 8003 1680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F44
-Encoding: 8004 8004 8004
+Encoding: 8004 8004 1681
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F45
-Encoding: 8005 8005 8005
+Encoding: 8005 8005 1682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F48
-Encoding: 8008 8008 8008
+Encoding: 8008 8008 1683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -620 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -620 0 2
 EndChar
+
 StartChar: uni1F49
-Encoding: 8009 8009 8009
+Encoding: 8009 8009 1684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -695 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F4A
-Encoding: 8010 8010 8010
+Encoding: 8010 8010 1685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -945 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -945 0 2
 EndChar
+
 StartChar: uni1F4B
-Encoding: 8011 8011 8011
+Encoding: 8011 8011 1686
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -945 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -945 0 2
 EndChar
+
 StartChar: uni1F4C
-Encoding: 8012 8012 8012
+Encoding: 8012 8012 1687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -720 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -720 0 2
 EndChar
+
 StartChar: uni1F4D
-Encoding: 8013 8013 8013
+Encoding: 8013 8013 1688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -730 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -730 0 2
 EndChar
+
 StartChar: uni1F50
-Encoding: 8016 8016 8016
+Encoding: 8016 8016 1689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F51
-Encoding: 8017 8017 8017
+Encoding: 8017 8017 1690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F52
-Encoding: 8018 8018 8018
+Encoding: 8018 8018 1691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F53
-Encoding: 8019 8019 8019
+Encoding: 8019 8019 1692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F54
-Encoding: 8020 8020 8020
+Encoding: 8020 8020 1693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F55
-Encoding: 8021 8021 8021
+Encoding: 8021 8021 1694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F56
-Encoding: 8022 8022 8022
+Encoding: 8022 8022 1695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F57
-Encoding: 8023 8023 8023
+Encoding: 8023 8023 1696
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F59
-Encoding: 8025 8025 8025
+Encoding: 8025 8025 1697
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -845 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -845 0 2
 EndChar
+
 StartChar: uni1F5B
-Encoding: 8027 8027 8027
+Encoding: 8027 8027 1698
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -1050 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -1050 0 2
 EndChar
+
 StartChar: uni1F5D
-Encoding: 8029 8029 8029
+Encoding: 8029 8029 1699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -1075 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -1075 0 2
 EndChar
+
 StartChar: uni1F5F
-Encoding: 8031 8031 8031
+Encoding: 8031 8031 1700
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -855 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -855 0 2
 EndChar
+
 StartChar: uni1F60
-Encoding: 8032 8032 8032
+Encoding: 8032 8032 1701
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F61
-Encoding: 8033 8033 8033
+Encoding: 8033 8033 1702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F62
-Encoding: 8034 8034 8034
+Encoding: 8034 8034 1703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F63
-Encoding: 8035 8035 8035
+Encoding: 8035 8035 1704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F64
-Encoding: 8036 8036 8036
+Encoding: 8036 8036 1705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F65
-Encoding: 8037 8037 8037
+Encoding: 8037 8037 1706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F66
-Encoding: 8038 8038 8038
+Encoding: 8038 8038 1707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F67
-Encoding: 8039 8039 8039
+Encoding: 8039 8039 1708
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F68
-Encoding: 8040 8040 8040
+Encoding: 8040 8040 1709
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -600 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -600 0 2
 EndChar
+
 StartChar: uni1F69
-Encoding: 8041 8041 8041
+Encoding: 8041 8041 1710
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -670 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -670 0 2
 EndChar
+
 StartChar: uni1F6A
-Encoding: 8042 8042 8042
+Encoding: 8042 8042 1711
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -945 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -945 0 2
 EndChar
+
 StartChar: uni1F6B
-Encoding: 8043 8043 8043
+Encoding: 8043 8043 1712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -945 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -945 0 2
 EndChar
+
 StartChar: uni1F6C
-Encoding: 8044 8044 8044
+Encoding: 8044 8044 1713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -695 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F6D
-Encoding: 8045 8045 8045
+Encoding: 8045 8045 1714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -695 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -695 0 2
 EndChar
+
 StartChar: uni1F6E
-Encoding: 8046 8046 8046
+Encoding: 8046 8046 1715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -580 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -580 0 2
 EndChar
+
 StartChar: uni1F6F
-Encoding: 8047 8047 8047
+Encoding: 8047 8047 1716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -655 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -655 0 2
 EndChar
+
 StartChar: uni1F70
-Encoding: 8048 8048 8048
+Encoding: 8048 8048 1717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F71
-Encoding: 8049 8049 8049
+Encoding: 8049 8049 1718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 767 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F72
-Encoding: 8050 8050 8050
+Encoding: 8050 8050 1719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 776 949 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F73
-Encoding: 8051 8051 8051
+Encoding: 8051 8051 1720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 941 941 N 1 0 0 1 0 0 2
+Refer: 768 941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F74
-Encoding: 8052 8052 8052
+Encoding: 8052 8052 1721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F75
-Encoding: 8053 8053 8053
+Encoding: 8053 8053 1722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 769 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F76
-Encoding: 8054 8054 8054
+Encoding: 8054 8054 1723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F77
-Encoding: 8055 8055 8055
+Encoding: 8055 8055 1724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 943 943 N 1 0 0 1 0 0 2
+Refer: 770 943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F78
-Encoding: 8056 8056 8056
+Encoding: 8056 8056 1725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 786 959 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F79
-Encoding: 8057 8057 8057
+Encoding: 8057 8057 1726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 972 972 N 1 0 0 1 0 0 2
+Refer: 799 972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7A
-Encoding: 8058 8058 8058
+Encoding: 8058 8058 1727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7B
-Encoding: 8059 8059 8059
+Encoding: 8059 8059 1728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 973 973 N 1 0 0 1 0 0 2
+Refer: 800 973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7C
-Encoding: 8060 8060 8060
+Encoding: 8060 8060 1729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7D
-Encoding: 8061 8061 8061
+Encoding: 8061 8061 1730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 801 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F80
-Encoding: 8064 8064 8064
+Encoding: 8064 8064 1731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7936 7936 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1617 7936 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F81
-Encoding: 8065 8065 8065
+Encoding: 8065 8065 1732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7937 7937 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1618 7937 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F82
-Encoding: 8066 8066 8066
+Encoding: 8066 8066 1733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7938 7938 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1619 7938 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F83
-Encoding: 8067 8067 8067
+Encoding: 8067 8067 1734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7939 7939 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1620 7939 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F84
-Encoding: 8068 8068 8068
+Encoding: 8068 8068 1735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7940 7940 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
+Refer: 1621 7940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F85
-Encoding: 8069 8069 8069
+Encoding: 8069 8069 1736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7941 7941 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
+Refer: 1622 7941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F86
-Encoding: 8070 8070 8070
+Encoding: 8070 8070 1737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7942 7942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1623 7942 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F87
-Encoding: 8071 8071 8071
+Encoding: 8071 8071 1738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7943 7943 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1624 7943 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F88
-Encoding: 8072 8072 8072
+Encoding: 8072 8072 1739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7944 7944 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1625 7944 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F89
-Encoding: 8073 8073 8073
+Encoding: 8073 8073 1740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7945 7945 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1626 7945 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8A
-Encoding: 8074 8074 8074
+Encoding: 8074 8074 1741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7946 7946 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1627 7946 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8B
-Encoding: 8075 8075 8075
+Encoding: 8075 8075 1742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7947 7947 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1628 7947 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8C
-Encoding: 8076 8076 8076
+Encoding: 8076 8076 1743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7948 7948 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1629 7948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8D
-Encoding: 8077 8077 8077
+Encoding: 8077 8077 1744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7949 7949 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1630 7949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8E
-Encoding: 8078 8078 8078
+Encoding: 8078 8078 1745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7950 7950 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1631 7950 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8F
-Encoding: 8079 8079 8079
+Encoding: 8079 8079 1746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7951 7951 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1632 7951 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F90
-Encoding: 8080 8080 8080
+Encoding: 8080 8080 1747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7968 7968 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1645 7968 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F91
-Encoding: 8081 8081 8081
+Encoding: 8081 8081 1748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7969 7969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1646 7969 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F92
-Encoding: 8082 8082 8082
+Encoding: 8082 8082 1749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7970 7970 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1647 7970 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F93
-Encoding: 8083 8083 8083
+Encoding: 8083 8083 1750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7971 7971 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1648 7971 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F94
-Encoding: 8084 8084 8084
+Encoding: 8084 8084 1751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7972 7972 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
+Refer: 1649 7972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F95
-Encoding: 8085 8085 8085
+Encoding: 8085 8085 1752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7973 7973 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
+Refer: 1650 7973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F96
-Encoding: 8086 8086 8086
+Encoding: 8086 8086 1753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7974 7974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1651 7974 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F97
-Encoding: 8087 8087 8087
+Encoding: 8087 8087 1754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7975 7975 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1652 7975 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F98
-Encoding: 8088 8088 8088
+Encoding: 8088 8088 1755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7976 7976 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1653 7976 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F99
-Encoding: 8089 8089 8089
+Encoding: 8089 8089 1756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7977 7977 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1654 7977 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9A
-Encoding: 8090 8090 8090
+Encoding: 8090 8090 1757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7978 7978 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1655 7978 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9B
-Encoding: 8091 8091 8091
+Encoding: 8091 8091 1758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7979 7979 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1656 7979 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9C
-Encoding: 8092 8092 8092
+Encoding: 8092 8092 1759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7980 7980 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1657 7980 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9D
-Encoding: 8093 8093 8093
+Encoding: 8093 8093 1760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7981 7981 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1658 7981 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9E
-Encoding: 8094 8094 8094
+Encoding: 8094 8094 1761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7982 7982 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1659 7982 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9F
-Encoding: 8095 8095 8095
+Encoding: 8095 8095 1762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7983 7983 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1660 7983 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA0
-Encoding: 8096 8096 8096
+Encoding: 8096 8096 1763
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8032 8032 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1701 8032 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA1
-Encoding: 8097 8097 8097
+Encoding: 8097 8097 1764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8033 8033 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1702 8033 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA2
-Encoding: 8098 8098 8098
+Encoding: 8098 8098 1765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8034 8034 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1703 8034 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA3
-Encoding: 8099 8099 8099
+Encoding: 8099 8099 1766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8035 8035 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1704 8035 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA4
-Encoding: 8100 8100 8100
+Encoding: 8100 8100 1767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8036 8036 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
+Refer: 1705 8036 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA5
-Encoding: 8101 8101 8101
+Encoding: 8101 8101 1768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8037 8037 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
+Refer: 1706 8037 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA6
-Encoding: 8102 8102 8102
+Encoding: 8102 8102 1769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8038 8038 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1707 8038 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA7
-Encoding: 8103 8103 8103
+Encoding: 8103 8103 1770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8039 8039 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1708 8039 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA8
-Encoding: 8104 8104 8104
+Encoding: 8104 8104 1771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8040 8040 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1709 8040 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA9
-Encoding: 8105 8105 8105
+Encoding: 8105 8105 1772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8041 8041 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1710 8041 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAA
-Encoding: 8106 8106 8106
+Encoding: 8106 8106 1773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8042 8042 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1711 8042 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAB
-Encoding: 8107 8107 8107
+Encoding: 8107 8107 1774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8043 8043 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1712 8043 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAC
-Encoding: 8108 8108 8108
+Encoding: 8108 8108 1775
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8044 8044 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1713 8044 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAD
-Encoding: 8109 8109 8109
+Encoding: 8109 8109 1776
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8045 8045 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1714 8045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAE
-Encoding: 8110 8110 8110
+Encoding: 8110 8110 1777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8046 8046 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1715 8046 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAF
-Encoding: 8111 8111 8111
+Encoding: 8111 8111 1778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8047 8047 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1716 8047 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB0
-Encoding: 8112 8112 8112
+Encoding: 8112 8112 1779
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB1
-Encoding: 8113 8113 8113
+Encoding: 8113 8113 1780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB2
-Encoding: 8114 8114 8114
+Encoding: 8114 8114 1781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8048 8048 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1717 8048 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB3
-Encoding: 8115 8115 8115
+Encoding: 8115 8115 1782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB4
-Encoding: 8116 8116 8116
+Encoding: 8116 8116 1783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 767 940 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB6
-Encoding: 8118 8118 8118
+Encoding: 8118 8118 1784
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 772 945 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB7
-Encoding: 8119 8119 8119
+Encoding: 8119 8119 1785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8118 8118 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1784 8118 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB8
-Encoding: 8120 8120 8120
+Encoding: 8120 8120 1786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB9
-Encoding: 8121 8121 8121
+Encoding: 8121 8121 1787
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBA
-Encoding: 8122 8122 8122
+Encoding: 8122 8122 1788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -470 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -470 0 2
 EndChar
+
 StartChar: uni1FBB
-Encoding: 8123 8123 8123
+Encoding: 8123 8123 1789
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 902 902 N 1 0 0 1 0 0 2
+Refer: 732 902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBC
-Encoding: 8124 8124 8124
+Encoding: 8124 8124 1790
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 741 913 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBD
-Encoding: 8125 8125 8125
+Encoding: 8125 8125 1791
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBE
-Encoding: 8126 8126 8126
+Encoding: 8126 8126 1792
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBF
-Encoding: 8127 8127 8127
+Encoding: 8127 8127 1793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52048,491 +53846,547 @@ SplineSet
  909.983 1475 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1FC0
-Encoding: 8128 8128 8128
+Encoding: 8128 8128 1794
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 638 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC1
-Encoding: 8129 8129 8129
+Encoding: 8129 8129 1795
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 84 340 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 84 340 2
 EndChar
+
 StartChar: uni1FC2
-Encoding: 8130 8130 8130
+Encoding: 8130 8130 1796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8052 8052 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1721 8052 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC3
-Encoding: 8131 8131 8131
+Encoding: 8131 8131 1797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC4
-Encoding: 8132 8132 8132
+Encoding: 8132 8132 1798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 769 942 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC6
-Encoding: 8134 8134 8134
+Encoding: 8134 8134 1799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 778 951 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC7
-Encoding: 8135 8135 8135
+Encoding: 8135 8135 1800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8134 8134 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1799 8134 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC8
-Encoding: 8136 8136 8136
+Encoding: 8136 8136 1801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
+Refer: 745 917 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1FC9
-Encoding: 8137 8137 8137
+Encoding: 8137 8137 1802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 904 904 N 1 0 0 1 0 0 2
+Refer: 734 904 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCA
-Encoding: 8138 8138 8138
+Encoding: 8138 8138 1803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -730 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -730 0 2
 EndChar
+
 StartChar: uni1FCB
-Encoding: 8139 8139 8139
+Encoding: 8139 8139 1804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 905 905 N 1 0 0 1 0 0 2
+Refer: 735 905 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCC
-Encoding: 8140 8140 8140
+Encoding: 8140 8140 1805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 747 919 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCD
-Encoding: 8141 8141 8141
+Encoding: 8141 8141 1806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -310 0 2
-Refer: 8175 8175 N 1 0 0 1 310 0 2
+Refer: 1793 8127 N 1 0 0 1 -310 0 2
+Refer: 1837 8175 N 1 0 0 1 310 0 2
 EndChar
+
 StartChar: uni1FCE
-Encoding: 8142 8142 8142
+Encoding: 8142 8142 1807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -210 0 2
-Refer: 8189 8189 N 1 0 0 1 110 0 2
+Refer: 1793 8127 N 1 0 0 1 -210 0 2
+Refer: 1848 8189 N 1 0 0 1 110 0 2
 EndChar
+
 StartChar: uni1FCF
-Encoding: 8143 8143 8143
+Encoding: 8143 8143 1808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 77 410 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 77 410 2
 EndChar
+
 StartChar: uni1FD0
-Encoding: 8144 8144 8144
+Encoding: 8144 8144 1809
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD1
-Encoding: 8145 8145 8145
+Encoding: 8145 8145 1810
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD2
-Encoding: 8146 8146 8146
+Encoding: 8146 8146 1811
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1835 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD3
-Encoding: 8147 8147 8147
+Encoding: 8147 8147 1812
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 912 912 N 1 0 0 1 0 0 2
+Refer: 740 912 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD6
-Encoding: 8150 8150 8150
+Encoding: 8150 8150 1813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD7
-Encoding: 8151 8151 8151
+Encoding: 8151 8151 1814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 780 953 N 1 0 0 1 0 0 2
+Refer: 1795 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD8
-Encoding: 8152 8152 8152
+Encoding: 8152 8152 1815
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD9
-Encoding: 8153 8153 8153
+Encoding: 8153 8153 1816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDA
-Encoding: 8154 8154 8154
+Encoding: 8154 8154 1817
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -670 0 2
+Refer: 749 921 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -670 0 2
 EndChar
+
 StartChar: uni1FDB
-Encoding: 8155 8155 8155
+Encoding: 8155 8155 1818
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 906 906 N 1 0 0 1 0 0 2
+Refer: 736 906 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDD
-Encoding: 8157 8157 8157
+Encoding: 8157 8157 1819
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -320 0 2
-Refer: 8175 8175 N 1 0 0 1 320 0 2
+Refer: 1849 8190 N 1 0 0 1 -320 0 2
+Refer: 1837 8175 N 1 0 0 1 320 0 2
 EndChar
+
 StartChar: uni1FDE
-Encoding: 8158 8158 8158
+Encoding: 8158 8158 1820
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -250 0 2
-Refer: 8189 8189 N 1 0 0 1 130 0 2
+Refer: 1849 8190 N 1 0 0 1 -250 0 2
+Refer: 1848 8189 N 1 0 0 1 130 0 2
 EndChar
+
 StartChar: uni1FDF
-Encoding: 8159 8159 8159
+Encoding: 8159 8159 1821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 77 410 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 77 410 2
 EndChar
+
 StartChar: uni1FE0
-Encoding: 8160 8160 8160
+Encoding: 8160 8160 1822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 659 774 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE1
-Encoding: 8161 8161 8161
+Encoding: 8161 8161 1823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 657 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE2
-Encoding: 8162 8162 8162
+Encoding: 8162 8162 1824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1835 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE3
-Encoding: 8163 8163 8163
+Encoding: 8163 8163 1825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 944 944 N 1 0 0 1 0 0 2
+Refer: 771 944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE4
-Encoding: 8164 8164 8164
+Encoding: 8164 8164 1826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 788 961 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE5
-Encoding: 8165 8165 8165
+Encoding: 8165 8165 1827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 788 961 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE6
-Encoding: 8166 8166 8166
+Encoding: 8166 8166 1828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE7
-Encoding: 8167 8167 8167
+Encoding: 8167 8167 1829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 792 965 N 1 0 0 1 0 0 2
+Refer: 1795 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE8
-Encoding: 8168 8168 8168
+Encoding: 8168 8168 1830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE9
-Encoding: 8169 8169 8169
+Encoding: 8169 8169 1831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 3102 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEA
-Encoding: 8170 8170 8170
+Encoding: 8170 8170 1832
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -750 0 2
+Refer: 760 933 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -750 0 2
 EndChar
+
 StartChar: uni1FEB
-Encoding: 8171 8171 8171
+Encoding: 8171 8171 1833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 910 910 N 1 0 0 1 0 0 2
+Refer: 738 910 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEC
-Encoding: 8172 8172 8172
+Encoding: 8172 8172 1834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 929 929 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -715 0 2
+Refer: 757 929 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -715 0 2
 EndChar
+
 StartChar: uni1FED
-Encoding: 8173 8173 8173
+Encoding: 8173 8173 1835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 0 370 2
 EndChar
+
 StartChar: uni1FEE
-Encoding: 8174 8174 8174
+Encoding: 8174 8174 1836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 731 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEF
-Encoding: 8175 8175 8175
+Encoding: 8175 8175 1837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF2
-Encoding: 8178 8178 8178
+Encoding: 8178 8178 1838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8060 8060 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1729 8060 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF3
-Encoding: 8179 8179 8179
+Encoding: 8179 8179 1839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF4
-Encoding: 8180 8180 8180
+Encoding: 8180 8180 1840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 801 974 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF6
-Encoding: 8182 8182 8182
+Encoding: 8182 8182 1841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 796 969 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF7
-Encoding: 8183 8183 8183
+Encoding: 8183 8183 1842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8182 8182 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1841 8182 N 1 0 0 1 0 0 2
+Refer: 724 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF8
-Encoding: 8184 8184 8184
+Encoding: 8184 8184 1843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -655 0 2
+Refer: 755 927 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -655 0 2
 EndChar
+
 StartChar: uni1FF9
-Encoding: 8185 8185 8185
+Encoding: 8185 8185 1844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 908 908 N 1 0 0 1 0 0 2
+Refer: 737 908 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFA
-Encoding: 8186 8186 8186
+Encoding: 8186 8186 1845
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -645 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -645 0 2
 EndChar
+
 StartChar: uni1FFB
-Encoding: 8187 8187 8187
+Encoding: 8187 8187 1846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 911 911 N 1 0 0 1 0 0 2
+Refer: 739 911 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFC
-Encoding: 8188 8188 8188
+Encoding: 8188 8188 1847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFD
-Encoding: 8189 8189 8189
+Encoding: 8189 8189 1848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFE
-Encoding: 8190 8190 8190
+Encoding: 8190 8190 1849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52548,74 +54402,86 @@ SplineSet
  539.027 1218 539.027 1218 588.983 1475 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2000
-Encoding: 8192 8192 8192
+Encoding: 8192 8192 1850
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2001
-Encoding: 8193 8193 8193
+Encoding: 8193 8193 1851
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2002
-Encoding: 8194 8194 8194
+Encoding: 8194 8194 1852
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2003
-Encoding: 8195 8195 8195
+Encoding: 8195 8195 1853
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2004
-Encoding: 8196 8196 8196
+Encoding: 8196 8196 1854
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2005
-Encoding: 8197 8197 8197
+Encoding: 8197 8197 1855
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2006
-Encoding: 8198 8198 8198
+Encoding: 8198 8198 1856
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2007
-Encoding: 8199 8199 8199
+Encoding: 8199 8199 1857
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2008
-Encoding: 8200 8200 8200
+Encoding: 8200 8200 1858
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2009
-Encoding: 8201 8201 8201
+Encoding: 8201 8201 1859
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni200A
-Encoding: 8202 8202 8202
+Encoding: 8202 8202 1860
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2010
-Encoding: 8208 8208 8208
+Encoding: 8208 8208 1861
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52650,16 +54516,18 @@ SplineSet
  299 735 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2011
-Encoding: 8209 8209 8209
+Encoding: 8209 8209 1862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8208 8208 N 1 0 0 1 0 0 2
+Refer: 1861 8208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: figuredash
-Encoding: 8210 8210 8210
+Encoding: 8210 8210 1863
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52699,8 +54567,9 @@ SplineSet
  -10 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: endash
-Encoding: 8211 8211 8211
+Encoding: 8211 8211 1864
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52740,8 +54609,9 @@ SplineSet
  -10 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: emdash
-Encoding: 8212 8212 8212
+Encoding: 8212 8212 1865
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52781,8 +54651,9 @@ SplineSet
  -10 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2015
-Encoding: 8213 8213 8213
+Encoding: 8213 8213 1866
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52822,26 +54693,29 @@ SplineSet
  -10 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2016
-Encoding: 8214 8214 8214
+Encoding: 8214 8214 1867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 245 0 2
-Refer: 124 124 N 1 0 0 1 -245 0 2
+Refer: 93 124 N 1 0 0 1 245 0 2
+Refer: 93 124 N 1 0 0 1 -245 0 2
 EndChar
+
 StartChar: underscoredbl
-Encoding: 8215 8215 8215
+Encoding: 8215 8215 1868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
-Refer: 95 95 N 1 0 0 1 0 275 2
+Refer: 64 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 275 2
 EndChar
+
 StartChar: quoteleft
-Encoding: 8216 8216 8216
+Encoding: 8216 8216 1869
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52914,8 +54788,9 @@ SplineSet
  733 903 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quoteright
-Encoding: 8217 8217 8217
+Encoding: 8217 8217 1870
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52984,8 +54859,9 @@ SplineSet
  645 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotesinglbase
-Encoding: 8218 8218 8218
+Encoding: 8218 8218 1871
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53054,8 +54930,9 @@ SplineSet
  397 367 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotereversed
-Encoding: 8219 8219 8219
+Encoding: 8219 8219 1872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53070,8 +54947,9 @@ SplineSet
  864.915 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblleft
-Encoding: 8220 8220 8220
+Encoding: 8220 8220 1873
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53195,8 +55073,9 @@ SplineSet
  1028 903 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblright
-Encoding: 8221 8221 8221
+Encoding: 8221 8221 1874
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53316,8 +55195,9 @@ SplineSet
  373 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblbase
-Encoding: 8222 8222 8222
+Encoding: 8222 8222 1875
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53437,8 +55317,9 @@ SplineSet
  145 367 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni201F
-Encoding: 8223 8223 8223
+Encoding: 8223 8223 1876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53460,8 +55341,9 @@ SplineSet
  1111.92 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: dagger
-Encoding: 8224 8224 8224
+Encoding: 8224 8224 1877
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53574,8 +55456,9 @@ SplineSet
  633 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: daggerdbl
-Encoding: 8225 8225 8225
+Encoding: 8225 8225 1878
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53740,8 +55623,9 @@ SplineSet
  633 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bullet
-Encoding: 8226 8226 8226
+Encoding: 8226 8226 1879
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53784,8 +55668,9 @@ SplineSet
  256 688 256 688 256 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2023
-Encoding: 8227 8227 8227
+Encoding: 8227 8227 1880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53797,20 +55682,23 @@ SplineSet
  256 319 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: onedotenleader
-Encoding: 8228 8228 8228
+Encoding: 8228 8228 1881
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: twodotenleader
-Encoding: 8229 8229 8229
+Encoding: 8229 8229 1882
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: ellipsis
-Encoding: 8230 8230 8230
+Encoding: 8230 8230 1883
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53952,14 +55840,16 @@ SplineSet
  -16 367 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni202F
-Encoding: 8239 8239 8239
+Encoding: 8239 8239 1884
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: perthousand
-Encoding: 8240 8240 8240
+Encoding: 8240 8240 1885
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54081,7 +55971,7 @@ Fore
 SplineSet
 662 289 m 2,0,1
  662 409 662 409 744.5 492 c 128,-1,2
- 827 575 827 575 946 575 c 0,3,4
+ 827 575 827 575 946 575 c 256,3,4
  1065 575 1065 575 1149 491.5 c 128,-1,5
  1233 408 1233 408 1233 289 c 0,6,7
  1233 169 1233 169 1149 84.5 c 128,-1,8
@@ -54093,7 +55983,7 @@ SplineSet
  896 414 896 414 859.5 376.5 c 128,-1,15
  823 339 823 339 823 289 c 0,16,17
  823 237 823 237 859 199.5 c 128,-1,18
- 895 162 895 162 946 162 c 0,19,20
+ 895 162 895 162 946 162 c 256,19,20
  997 162 997 162 1034 199.5 c 128,-1,21
  1071 237 1071 237 1071 289 c 0,22,23
  1071 339 1071 339 1034 375.5 c 128,-1,24
@@ -54111,7 +56001,7 @@ SplineSet
  233 1270 233 1270 197.5 1234.5 c 128,-1,39
  162 1199 162 1199 162 1147 c 0,40,41
  162 1094 162 1094 198 1056 c 128,-1,42
- 234 1018 234 1018 285 1018 c 0,43,44
+ 234 1018 234 1018 285 1018 c 256,43,44
  336 1018 336 1018 373 1056.5 c 128,-1,45
  410 1095 410 1095 410 1147 c 0,46,47
  410 1196 410 1196 372.5 1233 c 128,-1,48
@@ -54129,7 +56019,7 @@ SplineSet
  279 414 279 414 243 378 c 128,-1,63
  207 342 207 342 207 291 c 0,64,65
  207 238 207 238 243 200 c 128,-1,66
- 279 162 279 162 330 162 c 0,67,68
+ 279 162 279 162 330 162 c 256,67,68
  381 162 381 162 418 200.5 c 128,-1,69
  455 239 455 239 455 291 c 0,70,71
  455 340 455 340 417.5 377 c 128,-1,72
@@ -54141,8 +56031,9 @@ SplineSet
  35 664 l 1,73,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2031
-Encoding: 8241 8241 8241
+Encoding: 8241 8241 1886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54228,8 +56119,9 @@ SplineSet
  1023 412 1023 412 978 414 c 1,88,89
 EndSplineSet
 EndChar
+
 StartChar: minute
-Encoding: 8242 8242 8242
+Encoding: 8242 8242 1887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54242,27 +56134,30 @@ SplineSet
  609 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: second
-Encoding: 8243 8243 8243
+Encoding: 8243 8243 1888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 -188 0 2
-Refer: 8242 8242 N 1 0 0 1 188 0 2
+Refer: 1887 8242 N 1 0 0 1 -188 0 2
+Refer: 1887 8242 N 1 0 0 1 188 0 2
 EndChar
+
 StartChar: uni2034
-Encoding: 8244 8244 8244
+Encoding: 8244 8244 1889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 0 0 2
-Refer: 8242 8242 N 1 0 0 1 -375 0 2
-Refer: 8242 8242 N 1 0 0 1 375 0 2
+Refer: 1887 8242 N 1 0 0 1 0 0 2
+Refer: 1887 8242 N 1 0 0 1 -375 0 2
+Refer: 1887 8242 N 1 0 0 1 375 0 2
 EndChar
+
 StartChar: uni2035
-Encoding: 8245 8245 8245
+Encoding: 8245 8245 1890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54275,27 +56170,30 @@ SplineSet
  1059.96 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2036
-Encoding: 8246 8246 8246
+Encoding: 8246 8246 1891
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 -190 0 2
-Refer: 8245 8245 N 1 0 0 1 190 0 2
+Refer: 1890 8245 N 1 0 0 1 -190 0 2
+Refer: 1890 8245 N 1 0 0 1 190 0 2
 EndChar
+
 StartChar: uni2037
-Encoding: 8247 8247 8247
+Encoding: 8247 8247 1892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 -375 0 2
-Refer: 8245 8245 N 1 0 0 1 5 0 2
-Refer: 8245 8245 N 1 0 0 1 375 0 2
+Refer: 1890 8245 N 1 0 0 1 -375 0 2
+Refer: 1890 8245 N 1 0 0 1 5 0 2
+Refer: 1890 8245 N 1 0 0 1 375 0 2
 EndChar
+
 StartChar: guilsinglleft
-Encoding: 8249 8249 8249
+Encoding: 8249 8249 1893
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54339,8 +56237,9 @@ SplineSet
  877 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: guilsinglright
-Encoding: 8250 8250 8250
+Encoding: 8250 8250 1894
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54384,18 +56283,20 @@ SplineSet
  496 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdbl
-Encoding: 8252 8252 8252
+Encoding: 8252 8252 1895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni203D
-Encoding: 8253 8253 8253
+Encoding: 8253 8253 1896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54432,16 +56333,18 @@ SplineSet
  292 0 l 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni203E
-Encoding: 8254 8254 8254
+Encoding: 8254 8254 1897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 1840 2
+Refer: 64 95 N 1 0 0 1 0 1840 2
 EndChar
+
 StartChar: uni203F
-Encoding: 8255 8255 8255
+Encoding: 8255 8255 1898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54460,8 +56363,9 @@ SplineSet
  1123 -231 1123 -231 1301 -161 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2045
-Encoding: 8261 8261 8261
+Encoding: 8261 8261 1899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54482,8 +56386,9 @@ SplineSet
  580 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2046
-Encoding: 8262 8262 8262
+Encoding: 8262 8262 1900
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54504,38 +56409,42 @@ SplineSet
  969 1556 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2047
-Encoding: 8263 8263 8263
+Encoding: 8263 8263 1901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 -308 0 2
-Refer: 1114127 -1 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3101 -1 N 1 0 0 1 -308 0 2
+Refer: 3101 -1 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2048
-Encoding: 8264 8264 8264
+Encoding: 8264 8264 1902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 -244.5 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3101 -1 N 1 0 0 1 -244.5 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2049
-Encoding: 8265 8265 8265
+Encoding: 8265 8265 1903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 1114127 -1 N 1 0 0 1 244.5 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 3101 -1 N 1 0 0 1 244.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni204B
-Encoding: 8267 8267 8267
+Encoding: 8267 8267 1904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54556,14 +56465,16 @@ SplineSet
  852 1493 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni205F
-Encoding: 8287 8287 8287
+Encoding: 8287 8287 1905
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2070
-Encoding: 8304 8304 8304
+Encoding: 8304 8304 1906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54606,8 +56517,9 @@ SplineSet
  1050 1388 1050 1388 1050 1269 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2071
-Encoding: 8305 8305 8305
+Encoding: 8305 8305 1907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54631,8 +56543,9 @@ SplineSet
  714 1600 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2074
-Encoding: 8308 8308 8308
+Encoding: 8308 8308 1908
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54753,8 +56666,9 @@ SplineSet
  768 1503 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2075
-Encoding: 8309 8309 8309
+Encoding: 8309 8309 1909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54785,8 +56699,9 @@ SplineSet
  474 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2076
-Encoding: 8310 8310 8310
+Encoding: 8310 8310 1910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54823,8 +56738,9 @@ SplineSet
  995.961 1503.01 995.961 1503.01 1050 1486 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2077
-Encoding: 8311 8311 8311
+Encoding: 8311 8311 1911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54840,8 +56756,9 @@ SplineSet
  367 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2078
-Encoding: 8312 8312 8312
+Encoding: 8312 8312 1912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54884,8 +56801,9 @@ SplineSet
  587 1318.99 587 1318.99 587 1268 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2079
-Encoding: 8313 8313 8313
+Encoding: 8313 8313 1913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54922,8 +56840,9 @@ SplineSet
  551 1273.01 551 1273.01 551 1189 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni207A
-Encoding: 8314 8314 8314
+Encoding: 8314 8314 1914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54944,8 +56863,9 @@ SplineSet
  692 1336 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207B
-Encoding: 8315 8315 8315
+Encoding: 8315 8315 1915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54958,8 +56878,9 @@ SplineSet
  270 1095 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207C
-Encoding: 8316 8316 8316
+Encoding: 8316 8316 1916
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54977,8 +56898,9 @@ SplineSet
  284 1221 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207D
-Encoding: 8317 8317 8317
+Encoding: 8317 8317 1917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54997,8 +56919,9 @@ SplineSet
  850 1538 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207E
-Encoding: 8318 8318 8318
+Encoding: 8318 8318 1918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55017,8 +56940,9 @@ SplineSet
  383 517 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207F
-Encoding: 8319 8319 8319
+Encoding: 8319 8319 1919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55043,232 +56967,261 @@ SplineSet
  943.459 1192 943.459 1192 920.717 1075 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2080
-Encoding: 8320 8320 8320
+Encoding: 8320 8320 1920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 0 -668 3
+Refer: 1906 8304 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2081
-Encoding: 8321 8321 8321
+Encoding: 8321 8321 1921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 0 -668 3
+Refer: 121 185 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2082
-Encoding: 8322 8322 8322
+Encoding: 8322 8322 1922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 0 -668 3
+Refer: 114 178 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2083
-Encoding: 8323 8323 8323
+Encoding: 8323 8323 1923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 0 -668 3
+Refer: 115 179 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2084
-Encoding: 8324 8324 8324
+Encoding: 8324 8324 1924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 0 -668 3
+Refer: 1908 8308 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2085
-Encoding: 8325 8325 8325
+Encoding: 8325 8325 1925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 0 -668 3
+Refer: 1909 8309 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2086
-Encoding: 8326 8326 8326
+Encoding: 8326 8326 1926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 0 -668 3
+Refer: 1910 8310 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2087
-Encoding: 8327 8327 8327
+Encoding: 8327 8327 1927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 0 -668 3
+Refer: 1911 8311 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2088
-Encoding: 8328 8328 8328
+Encoding: 8328 8328 1928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 0 -668 3
+Refer: 1912 8312 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2089
-Encoding: 8329 8329 8329
+Encoding: 8329 8329 1929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8313 8313 N 1 0 0 1 0 -668 3
+Refer: 1913 8313 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208A
-Encoding: 8330 8330 8330
+Encoding: 8330 8330 1930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8314 8314 N 1 0 0 1 0 -668 3
+Refer: 1914 8314 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208B
-Encoding: 8331 8331 8331
+Encoding: 8331 8331 1931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8315 8315 N 1 0 0 1 0 -668 3
+Refer: 1915 8315 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208C
-Encoding: 8332 8332 8332
+Encoding: 8332 8332 1932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8316 8316 N 1 0 0 1 0 -668 3
+Refer: 1916 8316 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208D
-Encoding: 8333 8333 8333
+Encoding: 8333 8333 1933
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8317 8317 N 1 0 0 1 0 -668 3
+Refer: 1917 8317 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208E
-Encoding: 8334 8334 8334
+Encoding: 8334 8334 1934
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8318 8318 N 1 0 0 1 0 -668 3
+Refer: 1918 8318 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2090
-Encoding: 8336 8336 8336
+Encoding: 8336 8336 1935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7491 7491 N 1 0 0 1 0 -668 3
+Refer: 1366 7491 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2091
-Encoding: 8337 8337 8337
+Encoding: 8337 8337 1936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7497 7497 N 1 0 0 1 0 -668 3
+Refer: 1372 7497 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2092
-Encoding: 8338 8338 8338
+Encoding: 8338 8338 1937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7506 7506 N 1 0 0 1 0 -668 3
+Refer: 1381 7506 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2093
-Encoding: 8339 8339 8339
+Encoding: 8339 8339 1938
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 739 739 N 1 0 0 1 0 -668 3
+Refer: 644 739 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2094
-Encoding: 8340 8340 8340
+Encoding: 8340 8340 1939
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7498 7498 N 1 0 0 1 0 -668 3
+Refer: 1373 7498 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2095
-Encoding: 8341 8341 8341
+Encoding: 8341 8341 1940
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 688 688 N 1 0 0 1 0 -668 3
+Refer: 603 688 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2096
-Encoding: 8342 8342 8342
+Encoding: 8342 8342 1941
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7503 7503 N 1 0 0 1 0 -668 3
+Refer: 1378 7503 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2097
-Encoding: 8343 8343 8343
+Encoding: 8343 8343 1942
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 737 737 N 1 0 0 1 0 -668 3
+Refer: 642 737 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2098
-Encoding: 8344 8344 8344
+Encoding: 8344 8344 1943
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7504 7504 N 1 0 0 1 0 -668 3
+Refer: 1379 7504 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2099
-Encoding: 8345 8345 8345
+Encoding: 8345 8345 1944
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8319 8319 N 1 0 0 1 0 -668 3
+Refer: 1919 8319 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209A
-Encoding: 8346 8346 8346
+Encoding: 8346 8346 1945
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7510 7510 N 1 0 0 1 0 -668 3
+Refer: 1385 7510 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209B
-Encoding: 8347 8347 8347
+Encoding: 8347 8347 1946
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 738 738 N 1 0 0 1 0 -668 3
+Refer: 643 738 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209C
-Encoding: 8348 8348 8348
+Encoding: 8348 8348 1947
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7511 7511 N 1 0 0 1 0 -668 3
+Refer: 1386 7511 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni20A0
-Encoding: 8352 8352 8352
+Encoding: 8352 8352 1948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55307,8 +57260,9 @@ SplineSet
  770 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: colonmonetary
-Encoding: 8353 8353 8353
+Encoding: 8353 8353 1949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55359,8 +57313,9 @@ SplineSet
  476 366 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uni20A2
-Encoding: 8354 8354 8354
+Encoding: 8354 8354 1950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55402,8 +57357,9 @@ SplineSet
  794 262 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: franc
-Encoding: 8355 8355 8355
+Encoding: 8355 8355 1951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55430,8 +57386,9 @@ SplineSet
  157 448 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lira
-Encoding: 8356 8356 8356
+Encoding: 8356 8356 1952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55470,8 +57427,9 @@ SplineSet
  584 450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A5
-Encoding: 8357 8357 8357
+Encoding: 8357 8357 1953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55515,8 +57473,9 @@ SplineSet
  358 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A6
-Encoding: 8358 8358 8358
+Encoding: 8358 8358 1954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55563,8 +57522,9 @@ SplineSet
  452.757 861 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: peseta
-Encoding: 8359 8359 8359
+Encoding: 8359 8359 1955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55644,8 +57604,9 @@ SplineSet
  637 864 l 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: uni20A8
-Encoding: 8360 8360 8360
+Encoding: 8360 8360 1956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55706,8 +57667,9 @@ SplineSet
  731 -5 731 -5 711 2 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A9
-Encoding: 8361 8361 8361
+Encoding: 8361 8361 1957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55771,8 +57733,9 @@ SplineSet
  324 1118 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AA
-Encoding: 8362 8362 8362
+Encoding: 8362 8362 1958
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55806,17 +57769,19 @@ SplineSet
  1082 -29 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dong
-Encoding: 8363 8363 8363
+Encoding: 8363 8363 1959
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 273 273 N 1 0 0 1 0 0 2
-Refer: 717 717 N 1 0 0 1 303 0 2
+Refer: 209 273 N 1 0 0 1 0 0 2
+Refer: 625 717 N 1 0 0 1 303 0 2
 EndChar
+
 StartChar: Euro
-Encoding: 8364 8364 8364
+Encoding: 8364 8364 1960
 Width: 1233
 Flags: W
 TtInstrs:
@@ -55980,8 +57945,9 @@ SplineSet
  260 1010 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20AD
-Encoding: 8365 8365 8365
+Encoding: 8365 8365 1961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56008,8 +57974,9 @@ SplineSet
  145 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AE
-Encoding: 8366 8366 8366
+Encoding: 8366 8366 1962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56042,8 +58009,9 @@ SplineSet
  737 572 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AF
-Encoding: 8367 8367 8367
+Encoding: 8367 8367 1963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56133,8 +58101,9 @@ SplineSet
  168 154 168 154 184 218 c 1,129,130
 EndSplineSet
 EndChar
+
 StartChar: uni20B0
-Encoding: 8368 8368 8368
+Encoding: 8368 8368 1964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56178,8 +58147,9 @@ SplineSet
  846 993 846 993 919 925 c 1,50,51
 EndSplineSet
 EndChar
+
 StartChar: uni20B1
-Encoding: 8369 8369 8369
+Encoding: 8369 8369 1965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56228,8 +58198,9 @@ SplineSet
  791.244 807 791.244 807 859.933 909 c 1,42,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B2
-Encoding: 8370 8370 8370
+Encoding: 8370 8370 1966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56271,8 +58242,9 @@ SplineSet
  693 1265 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B3
-Encoding: 8371 8371 8371
+Encoding: 8371 8371 1967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56314,8 +58286,9 @@ SplineSet
  590 896 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B4
-Encoding: 8372 8372 8372
+Encoding: 8372 8372 1968
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56363,8 +58336,9 @@ SplineSet
  371.148 438 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B5
-Encoding: 8373 8373 8373
+Encoding: 8373 8373 1969
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56400,8 +58374,9 @@ SplineSet
  581.988 261.051 581.988 261.051 637.824 245.899 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B8
-Encoding: 8376 8376 8376
+Encoding: 8376 8376 1970
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56423,8 +58398,9 @@ SplineSet
  619 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B9
-Encoding: 8377 8377 8377
+Encoding: 8377 8377 1971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56462,8 +58438,9 @@ SplineSet
  1291 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20BA
-Encoding: 8378 8378 8378
+Encoding: 8378 8378 1972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56499,8 +58476,9 @@ SplineSet
  1193 748 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20BD
-Encoding: 8381 8381 8381
+Encoding: 8381 8381 1973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56538,8 +58516,9 @@ SplineSet
  696 1245 l 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2102
-Encoding: 8450 8450 8450
+Encoding: 8450 8450 1974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56573,8 +58552,9 @@ SplineSet
  512 1282 l 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni2105
-Encoding: 8453 8453 8453
+Encoding: 8453 8453 1975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56630,8 +58610,9 @@ SplineSet
  948 890 948 890 1016 890 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni210D
-Encoding: 8461 8461 8461
+Encoding: 8461 8461 1976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56662,16 +58643,18 @@ SplineSet
  22 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210E
-Encoding: 8462 8462 8462
+Encoding: 8462 8462 1977
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni210F
-Encoding: 8463 8463 8463
+Encoding: 8463 8463 1978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56705,8 +58688,9 @@ SplineSet
  811 734 811 734 811 788 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2115
-Encoding: 8469 8469 8469
+Encoding: 8469 8469 1979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56730,8 +58714,9 @@ SplineSet
  50 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2116
-Encoding: 8470 8470 8470
+Encoding: 8470 8470 1980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56777,8 +58762,9 @@ SplineSet
  264 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2117
-Encoding: 8471 8471 8471
+Encoding: 8471 8471 1981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56838,8 +58824,9 @@ SplineSet
  543 970 l 1,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2119
-Encoding: 8473 8473 8473
+Encoding: 8473 8473 1982
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56875,8 +58862,9 @@ SplineSet
  932 1315 932 1315 871 1338 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211A
-Encoding: 8474 8474 8474
+Encoding: 8474 8474 1983
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56916,8 +58904,9 @@ SplineSet
  960 1248 960 1248 938 1270 c 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211D
-Encoding: 8477 8477 8477
+Encoding: 8477 8477 1984
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56967,8 +58956,9 @@ SplineSet
  110 1373 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: trademark
-Encoding: 8482 8482 8482
+Encoding: 8482 8482 1985
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57066,8 +59056,9 @@ SplineSet
  438 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2124
-Encoding: 8484 8484 8484
+Encoding: 8484 8484 1986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57091,32 +59082,36 @@ SplineSet
  33 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2126
-Encoding: 8486 8486 8486
+Encoding: 8486 8486 1987
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 764 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212A
-Encoding: 8490 8490 8490
+Encoding: 8490 8490 1988
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212B
-Encoding: 8491 8491 8491
+Encoding: 8491 8491 1989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 197 197 N 1 0 0 1 0 0 2
+Refer: 133 197 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: estimated
-Encoding: 8494 8494 8494
+Encoding: 8494 8494 1990
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57154,8 +59149,9 @@ SplineSet
  237 714 l 2,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2148
-Encoding: 8520 8520 8520
+Encoding: 8520 8520 1991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57184,176 +59180,193 @@ SplineSet
  597 1000 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2150
-Encoding: 8528 8528 8528
+Encoding: 8528 8528 1992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+Refer: 1911 8311 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2151
-Encoding: 8529 8529 8529
+Encoding: 8529 8529 1993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 8313 8313 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+Refer: 1913 8313 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: onethird
-Encoding: 8531 8531 8531
+Encoding: 8531 8531 1994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 115 179 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: twothirds
-Encoding: 8532 8532 8532
+Encoding: 8532 8532 1995
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 137 -938 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 115 179 N 1 0 0 1 137 -938 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2155
-Encoding: 8533 8533 8533
+Encoding: 8533 8533 1996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2156
-Encoding: 8534 8534 8534
+Encoding: 8534 8534 1997
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2157
-Encoding: 8535 8535 8535
+Encoding: 8535 8535 1998
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-Refer: 179 179 N 1 0 0 1 -228 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+Refer: 115 179 N 1 0 0 1 -228 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2158
-Encoding: 8536 8536 8536
+Encoding: 8536 8536 1999
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-Refer: 8308 8308 N 1 0 0 1 -228 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+Refer: 1908 8308 N 1 0 0 1 -228 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2159
-Encoding: 8537 8537 8537
+Encoding: 8537 8537 2000
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 1910 8310 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni215A
-Encoding: 8538 8538 8538
+Encoding: 8538 8538 2001
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 137 -938 2
-Refer: 8309 8309 N 1 0 0 1 -228 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1910 8310 N 1 0 0 1 137 -938 2
+Refer: 1909 8309 N 1 0 0 1 -228 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: oneeighth
-Encoding: 8539 8539 8539
+Encoding: 8539 8539 2002
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: threeeighths
-Encoding: 8540 8540 8540
+Encoding: 8540 8540 2003
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-Refer: 179 179 N 1 0 0 1 -228 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+Refer: 115 179 N 1 0 0 1 -228 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: fiveeighths
-Encoding: 8541 8541 8541
+Encoding: 8541 8541 2004
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-Refer: 8309 8309 N 1 0 0 1 -228 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+Refer: 1909 8309 N 1 0 0 1 -228 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: seveneighths
-Encoding: 8542 8542 8542
+Encoding: 8542 8542 2005
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-Refer: 8311 8311 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+Refer: 1911 8311 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni215F
-Encoding: 8543 8543 8543
+Encoding: 8543 8543 2006
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2189
-Encoding: 8585 8585 8585
+Encoding: 8585 8585 2007
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 8304 8304 N 1 0 0 1 -258 156 2
-Refer: 179 179 N 1 0 0 1 137 -938 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
+Refer: 1906 8304 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 137 -938 2
 EndChar
+
 StartChar: arrowleft
-Encoding: 8592 8592 8592
+Encoding: 8592 8592 2008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57372,8 +59385,9 @@ SplineSet
  66 490 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowup
-Encoding: 8593 8593 8593
+Encoding: 8593 8593 2009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57392,8 +59406,9 @@ SplineSet
  687.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowright
-Encoding: 8594 8594 8594
+Encoding: 8594 8594 2010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57412,8 +59427,9 @@ SplineSet
  1167 490 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdown
-Encoding: 8595 8595 8595
+Encoding: 8595 8595 2011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57432,8 +59448,9 @@ SplineSet
  545.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowboth
-Encoding: 8596 8596 8596
+Encoding: 8596 8596 2012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57458,8 +59475,9 @@ SplineSet
  347 449 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowupdn
-Encoding: 8597 8597 8597
+Encoding: 8597 8597 2013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57484,8 +59502,9 @@ SplineSet
  504.5 281 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2196
-Encoding: 8598 8598 8598
+Encoding: 8598 8598 2014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57504,8 +59523,9 @@ SplineSet
  154 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2197
-Encoding: 8599 8599 8599
+Encoding: 8599 8599 2015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57524,8 +59544,9 @@ SplineSet
  1079 777 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2198
-Encoding: 8600 8600 8600
+Encoding: 8600 8600 2016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57544,8 +59565,9 @@ SplineSet
  1078 87 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2199
-Encoding: 8601 8601 8601
+Encoding: 8601 8601 2017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57564,8 +59586,9 @@ SplineSet
  272 -30 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219A
-Encoding: 8602 8602 8602
+Encoding: 8602 8602 2018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57592,8 +59615,9 @@ SplineSet
  1011 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219B
-Encoding: 8603 8603 8603
+Encoding: 8603 8603 2019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57620,8 +59644,9 @@ SplineSet
  222 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219C
-Encoding: 8604 8604 8604
+Encoding: 8604 8604 2020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57662,8 +59687,9 @@ SplineSet
  246.641 552 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219D
-Encoding: 8605 8605 8605
+Encoding: 8605 8605 2021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57704,8 +59730,9 @@ SplineSet
  986.359 552 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219E
-Encoding: 8606 8606 8606
+Encoding: 8606 8606 2022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57732,8 +59759,9 @@ SplineSet
  677 673 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219F
-Encoding: 8607 8607 8607
+Encoding: 8607 8607 2023
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57760,8 +59788,9 @@ SplineSet
  504.5 490 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A0
-Encoding: 8608 8608 8608
+Encoding: 8608 8608 2024
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57788,8 +59817,9 @@ SplineSet
  556 673 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A1
-Encoding: 8609 8609 8609
+Encoding: 8609 8609 2025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57816,8 +59846,9 @@ SplineSet
  728.5 611 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A2
-Encoding: 8610 8610 8610
+Encoding: 8610 8610 2026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57841,8 +59872,9 @@ SplineSet
  925 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A3
-Encoding: 8611 8611 8611
+Encoding: 8611 8611 2027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57866,8 +59898,9 @@ SplineSet
  308 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A4
-Encoding: 8612 8612 8612
+Encoding: 8612 8612 2028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57890,8 +59923,9 @@ SplineSet
  973 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A5
-Encoding: 8613 8613 8613
+Encoding: 8613 8613 2029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57914,8 +59948,9 @@ SplineSet
  504.5 194 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A6
-Encoding: 8614 8614 8614
+Encoding: 8614 8614 2030
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57938,8 +59973,9 @@ SplineSet
  260 673 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A7
-Encoding: 8615 8615 8615
+Encoding: 8615 8615 2031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57962,8 +59998,9 @@ SplineSet
  728.5 907 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdnbse
-Encoding: 8616 8616 8616
+Encoding: 8616 8616 2032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57992,8 +60029,9 @@ SplineSet
  545.5 194 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A9
-Encoding: 8617 8617 8617
+Encoding: 8617 8617 2033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58028,8 +60066,9 @@ SplineSet
  871 673 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AA
-Encoding: 8618 8618 8618
+Encoding: 8618 8618 2034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58064,8 +60103,9 @@ SplineSet
  349.868 673.479 349.868 673.479 362 673 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AB
-Encoding: 8619 8619 8619
+Encoding: 8619 8619 2035
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58115,8 +60155,9 @@ SplineSet
  886.332 817.895 886.332 817.895 871 818 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21AC
-Encoding: 8620 8620 8620
+Encoding: 8620 8620 2036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58166,8 +60207,9 @@ SplineSet
  375.373 817.528 375.373 817.528 362 818 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21AD
-Encoding: 8621 8621 8621
+Encoding: 8621 8621 2037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58222,8 +60264,9 @@ SplineSet
  347 673 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AE
-Encoding: 8622 8622 8622
+Encoding: 8622 8622 2038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58256,8 +60299,9 @@ SplineSet
  886 449 l 17,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AF
-Encoding: 8623 8623 8623
+Encoding: 8623 8623 2039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58280,8 +60324,9 @@ SplineSet
  901.479 265.154 l 9,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B0
-Encoding: 8624 8624 8624
+Encoding: 8624 8624 2040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58302,8 +60347,9 @@ SplineSet
  464.5 937 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B1
-Encoding: 8625 8625 8625
+Encoding: 8625 8625 2041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58324,8 +60370,9 @@ SplineSet
  768.5 937 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B2
-Encoding: 8626 8626 8626
+Encoding: 8626 8626 2042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58346,8 +60393,9 @@ SplineSet
  464.5 444 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B3
-Encoding: 8627 8627 8627
+Encoding: 8627 8627 2043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58368,8 +60416,9 @@ SplineSet
  768.5 444 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B4
-Encoding: 8628 8628 8628
+Encoding: 8628 8628 2044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58390,8 +60439,9 @@ SplineSet
  603 281 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: carriagereturn
-Encoding: 8629 8629 8629
+Encoding: 8629 8629 2045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58412,8 +60462,9 @@ SplineSet
  344.5 444.003 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B6
-Encoding: 8630 8630 8630
+Encoding: 8630 8630 2046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58447,8 +60498,9 @@ SplineSet
  300.121 625 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B7
-Encoding: 8631 8631 8631
+Encoding: 8631 8631 2047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58482,8 +60534,9 @@ SplineSet
  932.879 625 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B8
-Encoding: 8632 8632 8632
+Encoding: 8632 8632 2048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58507,8 +60560,9 @@ SplineSet
  154 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B9
-Encoding: 8633 8633 8633
+Encoding: 8633 8633 2049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58546,8 +60600,9 @@ SplineSet
  973 433.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21BA
-Encoding: 8634 8634 8634
+Encoding: 8634 8634 2050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58588,8 +60643,9 @@ SplineSet
  991 860 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21BB
-Encoding: 8635 8635 8635
+Encoding: 8635 8635 2051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58630,8 +60686,9 @@ SplineSet
  203 860 203 860 242 860 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BC
-Encoding: 8636 8636 8636
+Encoding: 8636 8636 2052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58647,8 +60704,9 @@ SplineSet
  66 449 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BD
-Encoding: 8637 8637 8637
+Encoding: 8637 8637 2053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58664,8 +60722,9 @@ SplineSet
  66 673 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BE
-Encoding: 8638 8638 8638
+Encoding: 8638 8638 2054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58681,8 +60740,9 @@ SplineSet
  504.5 1101 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BF
-Encoding: 8639 8639 8639
+Encoding: 8639 8639 2055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58698,8 +60758,9 @@ SplineSet
  728.5 1101 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C0
-Encoding: 8640 8640 8640
+Encoding: 8640 8640 2056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58715,8 +60776,9 @@ SplineSet
  1167 449 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C1
-Encoding: 8641 8641 8641
+Encoding: 8641 8641 2057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58732,8 +60794,9 @@ SplineSet
  1167 673 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C2
-Encoding: 8642 8642 8642
+Encoding: 8642 8642 2058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58749,8 +60812,9 @@ SplineSet
  504.5 0 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C3
-Encoding: 8643 8643 8643
+Encoding: 8643 8643 2059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58766,8 +60830,9 @@ SplineSet
  728.5 0 l 25,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C4
-Encoding: 8644 8644 8644
+Encoding: 8644 8644 2060
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58797,8 +60862,9 @@ SplineSet
  66 261 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C5
-Encoding: 8645 8645 8645
+Encoding: 8645 8645 2061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58828,8 +60894,9 @@ SplineSet
  929.5 0 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C6
-Encoding: 8646 8646 8646
+Encoding: 8646 8646 2062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58859,8 +60926,9 @@ SplineSet
  1167 261 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C7
-Encoding: 8647 8647 8647
+Encoding: 8647 8647 2063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58887,8 +60955,9 @@ SplineSet
  237.002 573.997 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C8
-Encoding: 8648 8648 8648
+Encoding: 8648 8648 2064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58915,8 +60984,9 @@ SplineSet
  616.503 929.998 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C9
-Encoding: 8649 8649 8649
+Encoding: 8649 8649 2065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58943,8 +61013,9 @@ SplineSet
  995.998 573.997 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CA
-Encoding: 8650 8650 8650
+Encoding: 8650 8650 2066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58971,8 +61042,9 @@ SplineSet
  616.497 171.002 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CB
-Encoding: 8651 8651 8651
+Encoding: 8651 8651 2067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58996,8 +61068,9 @@ SplineSet
  66 704 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CC
-Encoding: 8652 8652 8652
+Encoding: 8652 8652 2068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59021,8 +61094,9 @@ SplineSet
  1167 704 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CD
-Encoding: 8653 8653 8653
+Encoding: 8653 8653 2069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59059,8 +61133,9 @@ SplineSet
  727 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CE
-Encoding: 8654 8654 8654
+Encoding: 8654 8654 2070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59105,8 +61180,9 @@ SplineSet
  307 489 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CF
-Encoding: 8655 8655 8655
+Encoding: 8655 8655 2071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59143,8 +61219,9 @@ SplineSet
  506 489 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblleft
-Encoding: 8656 8656 8656
+Encoding: 8656 8656 2072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59168,8 +61245,9 @@ SplineSet
  307 633.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblup
-Encoding: 8657 8657 8657
+Encoding: 8657 8657 2073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59193,8 +61271,9 @@ SplineSet
  544.499 860 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblright
-Encoding: 8658 8658 8658
+Encoding: 8658 8658 2074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59218,8 +61297,9 @@ SplineSet
  926 633.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdbldown
-Encoding: 8659 8659 8659
+Encoding: 8659 8659 2075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59243,8 +61323,9 @@ SplineSet
  688.501 241 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblboth
-Encoding: 8660 8660 8660
+Encoding: 8660 8660 2076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59276,8 +61357,9 @@ SplineSet
  307 488.999 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D5
-Encoding: 8661 8661 8661
+Encoding: 8661 8661 2077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59309,8 +61391,9 @@ SplineSet
  544.499 241 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D6
-Encoding: 8662 8662 8662
+Encoding: 8662 8662 2078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59334,8 +61417,9 @@ SplineSet
  398 708 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D7
-Encoding: 8663 8663 8663
+Encoding: 8663 8663 2079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59359,8 +61443,9 @@ SplineSet
  835 708 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D8
-Encoding: 8664 8664 8664
+Encoding: 8664 8664 2080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59384,8 +61469,9 @@ SplineSet
  921 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D9
-Encoding: 8665 8665 8665
+Encoding: 8665 8665 2081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59409,8 +61495,9 @@ SplineSet
  312 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DA
-Encoding: 8666 8666 8666
+Encoding: 8666 8666 2082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59435,8 +61522,9 @@ SplineSet
  286 612 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DB
-Encoding: 8667 8667 8667
+Encoding: 8667 8667 2083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59461,8 +61549,9 @@ SplineSet
  947 612 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DC
-Encoding: 8668 8668 8668
+Encoding: 8668 8668 2084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59491,8 +61580,9 @@ SplineSet
  347 673 l 17,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DD
-Encoding: 8669 8669 8669
+Encoding: 8669 8669 2085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59521,8 +61611,9 @@ SplineSet
  886 673 l 9,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DE
-Encoding: 8670 8670 8670
+Encoding: 8670 8670 2086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59557,8 +61648,9 @@ SplineSet
  728.5 158.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DF
-Encoding: 8671 8671 8671
+Encoding: 8671 8671 2087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59593,8 +61685,9 @@ SplineSet
  728.5 942.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E0
-Encoding: 8672 8672 8672
+Encoding: 8672 8672 2088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59623,8 +61716,9 @@ SplineSet
  980.001 449.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E1
-Encoding: 8673 8673 8673
+Encoding: 8673 8673 2089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59653,8 +61747,9 @@ SplineSet
  728.499 186.999 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E2
-Encoding: 8674 8674 8674
+Encoding: 8674 8674 2090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59683,8 +61778,9 @@ SplineSet
  252.999 449.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E3
-Encoding: 8675 8675 8675
+Encoding: 8675 8675 2091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59713,8 +61809,9 @@ SplineSet
  504.501 914.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E4
-Encoding: 8676 8676 8676
+Encoding: 8676 8676 2092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59737,8 +61834,9 @@ SplineSet
  260 662.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E5
-Encoding: 8677 8677 8677
+Encoding: 8677 8677 2093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59761,8 +61859,9 @@ SplineSet
  973 662.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E6
-Encoding: 8678 8678 8678
+Encoding: 8678 8678 2094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59786,8 +61885,9 @@ SplineSet
  408 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E7
-Encoding: 8679 8679 8679
+Encoding: 8679 8679 2095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59811,8 +61911,9 @@ SplineSet
  1039.5 759 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E8
-Encoding: 8680 8680 8680
+Encoding: 8680 8680 2096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59836,8 +61937,9 @@ SplineSet
  824.5 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E9
-Encoding: 8681 8681 8681
+Encoding: 8681 8681 2097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59861,8 +61963,9 @@ SplineSet
  193.5 403 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EA
-Encoding: 8682 8682 8682
+Encoding: 8682 8682 2098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59896,8 +61999,9 @@ SplineSet
  424.5 400 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EB
-Encoding: 8683 8683 8683
+Encoding: 8683 8683 2099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59929,8 +62033,9 @@ SplineSet
  424.495 280 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EC
-Encoding: 8684 8684 8684
+Encoding: 8684 8684 2100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59963,8 +62068,9 @@ SplineSet
  424.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21ED
-Encoding: 8685 8685 8685
+Encoding: 8685 8685 2101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60000,8 +62106,9 @@ SplineSet
  651.504 1007 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EE
-Encoding: 8686 8686 8686
+Encoding: 8686 8686 2102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60036,8 +62143,9 @@ SplineSet
  801.5 858 l 17,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EF
-Encoding: 8687 8687 8687
+Encoding: 8687 8687 2103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60080,8 +62188,9 @@ SplineSet
  801.5 858 l 17,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F0
-Encoding: 8688 8688 8688
+Encoding: 8688 8688 2104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60113,8 +62222,9 @@ SplineSet
  346 373.995 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F1
-Encoding: 8689 8689 8689
+Encoding: 8689 8689 2105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60140,8 +62250,9 @@ SplineSet
  268.26 777 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F2
-Encoding: 8690 8690 8690
+Encoding: 8690 8690 2106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60167,8 +62278,9 @@ SplineSet
  841.5 228.52 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F3
-Encoding: 8691 8691 8691
+Encoding: 8691 8691 2107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60198,8 +62310,9 @@ SplineSet
  424.5 759 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F4
-Encoding: 8692 8692 8692
+Encoding: 8692 8692 2108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60229,8 +62342,9 @@ SplineSet
  144.07 673 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni21F5
-Encoding: 8693 8693 8693
+Encoding: 8693 8693 2109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60260,8 +62374,9 @@ SplineSet
  303.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F6
-Encoding: 8694 8694 8694
+Encoding: 8694 8694 2110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60296,8 +62411,9 @@ SplineSet
  996 319 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F7
-Encoding: 8695 8695 8695
+Encoding: 8695 8695 2111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60324,8 +62440,9 @@ SplineSet
  828.5 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F8
-Encoding: 8696 8696 8696
+Encoding: 8696 8696 2112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60352,8 +62469,9 @@ SplineSet
  404.5 449 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F9
-Encoding: 8697 8697 8697
+Encoding: 8697 8697 2113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60386,8 +62504,9 @@ SplineSet
  886 673 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FA
-Encoding: 8698 8698 8698
+Encoding: 8698 8698 2114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60422,8 +62541,9 @@ SplineSet
  846 673 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FB
-Encoding: 8699 8699 8699
+Encoding: 8699 8699 2115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60458,8 +62578,9 @@ SplineSet
  387 673 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FC
-Encoding: 8700 8700 8700
+Encoding: 8700 8700 2116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60500,8 +62621,9 @@ SplineSet
  741.365 449 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FD
-Encoding: 8701 8701 8701
+Encoding: 8701 8701 2117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60521,8 +62643,9 @@ SplineSet
  408 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FE
-Encoding: 8702 8702 8702
+Encoding: 8702 8702 2118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60542,8 +62665,9 @@ SplineSet
  825 138 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FF
-Encoding: 8703 8703 8703
+Encoding: 8703 8703 2119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60570,8 +62694,9 @@ SplineSet
  924 746 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: universal
-Encoding: 8704 8704 8704
+Encoding: 8704 8704 2120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60592,8 +62717,9 @@ SplineSet
  436 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2201
-Encoding: 8705 8705 8705
+Encoding: 8705 8705 2121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60622,8 +62748,9 @@ SplineSet
  23 746 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: partialdiff
-Encoding: 8706 8706 8706
+Encoding: 8706 8706 2122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60658,8 +62785,9 @@ SplineSet
  366 408 366 408 366 331 c 0,33,34
 EndSplineSet
 EndChar
+
 StartChar: existential
-Encoding: 8707 8707 8707
+Encoding: 8707 8707 2123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60680,8 +62808,9 @@ SplineSet
  163 251 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2204
-Encoding: 8708 8708 8708
+Encoding: 8708 8708 2124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60719,8 +62848,9 @@ SplineSet
  605 631 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: emptyset
-Encoding: 8709 8709 8709
+Encoding: 8709 8709 2125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60771,8 +62901,9 @@ SplineSet
  943.354 809.282 943.354 809.282 927.939 833.822 c 1,49,-1
 EndSplineSet
 EndChar
+
 StartChar: Delta
-Encoding: 8710 8710 8710
+Encoding: 8710 8710 2126
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60866,8 +62997,9 @@ SplineSet
  487 1423 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: gradient
-Encoding: 8711 8711 8711
+Encoding: 8711 8711 2127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60884,8 +63016,9 @@ SplineSet
  487 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: element
-Encoding: 8712 8712 8712
+Encoding: 8712 8712 2128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60915,8 +63048,9 @@ SplineSet
  337.073 647 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: notelement
-Encoding: 8713 8713 8713
+Encoding: 8713 8713 2129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60962,8 +63096,9 @@ SplineSet
  853.5 1524 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220A
-Encoding: 8714 8714 8714
+Encoding: 8714 8714 2130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60991,8 +63126,9 @@ SplineSet
  360.148 791.86 360.148 791.86 341 753 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: suchthat
-Encoding: 8715 8715 8715
+Encoding: 8715 8715 2131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61022,8 +63158,9 @@ SplineSet
  895.927 877 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220C
-Encoding: 8716 8716 8716
+Encoding: 8716 8716 2132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61069,8 +63206,9 @@ SplineSet
  389.5 0 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220D
-Encoding: 8717 8717 8717
+Encoding: 8717 8717 2133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61098,8 +63236,9 @@ SplineSet
  872.852 492.141 872.852 492.141 892 531 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220E
-Encoding: 8718 8718 8718
+Encoding: 8718 8718 2134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61112,8 +63251,9 @@ SplineSet
  250 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: product
-Encoding: 8719 8719 8719
+Encoding: 8719 8719 2135
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61161,8 +63301,9 @@ SplineSet
  1081 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2210
-Encoding: 8720 8720 8720
+Encoding: 8720 8720 2136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61179,8 +63320,9 @@ SplineSet
  152 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: summation
-Encoding: 8721 8721 8721
+Encoding: 8721 8721 2137
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61245,8 +63387,9 @@ SplineSet
  621 569 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: minus
-Encoding: 8722 8722 8722
+Encoding: 8722 8722 2138
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61279,8 +63422,9 @@ SplineSet
  66 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2213
-Encoding: 8723 8723 8723
+Encoding: 8723 8723 2139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61306,40 +63450,45 @@ SplineSet
  1145 1046 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2215
-Encoding: 8725 8725 8725
+Encoding: 8725 8725 2140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 47 47 N 1 0 0 1 0 0 2
+Refer: 16 47 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: asteriskmath
-Encoding: 8727 8727 8727
+Encoding: 8727 8727 2141
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42 42 N 1 0 0 1 0 -411 2
+Refer: 11 42 N 1 0 0 1 0 -411 2
 EndChar
+
 StartChar: uni2218
-Encoding: 8728 8728 8728
+Encoding: 8728 8728 2142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 176 176 N 1 0 0 1 0 -482 2
+Refer: 112 176 N 1 0 0 1 0 -482 2
 EndChar
+
 StartChar: uni2219
-Encoding: 8729 8729 8729
+Encoding: 8729 8729 2143
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8226 8226 N 1 0 0 1 0 -55 2
+Refer: 1879 8226 N 1 0 0 1 0 -55 2
 EndChar
+
 StartChar: radical
-Encoding: 8730 8730 8730
+Encoding: 8730 8730 2144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61405,8 +63554,9 @@ SplineSet
  113 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221B
-Encoding: 8731 8731 8731
+Encoding: 8731 8731 2145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61456,8 +63606,9 @@ SplineSet
  113 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221C
-Encoding: 8732 8732 8732
+Encoding: 8732 8732 2146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61493,8 +63644,9 @@ SplineSet
  113 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: proportional
-Encoding: 8733 8733 8733
+Encoding: 8733 8733 2147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61530,8 +63682,9 @@ SplineSet
  1056 223 l 17,33,34
 EndSplineSet
 EndChar
+
 StartChar: infinity
-Encoding: 8734 8734 8734
+Encoding: 8734 8734 2148
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61600,7 +63753,7 @@ SplineSet
  962 422 962 422 999 480.5 c 128,-1,5
  1036 539 1036 539 1036 633 c 0,6,7
  1036 728 1036 728 1002.5 785 c 128,-1,8
- 969 842 969 842 913 842 c 0,9,10
+ 969 842 969 842 913 842 c 256,9,10
  857 842 857 842 808 787 c 128,-1,11
  759 732 759 732 725 629 c 1,0,1
 506 635 m 1,12,13
@@ -61631,8 +63784,9 @@ SplineSet
  566 936 566 936 616 831 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: orthogonal
-Encoding: 8735 8735 8735
+Encoding: 8735 8735 2149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61647,8 +63801,9 @@ SplineSet
  1145 250 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: angle
-Encoding: 8736 8736 8736
+Encoding: 8736 8736 2150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61663,16 +63818,18 @@ SplineSet
  1145 250 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2223
-Encoding: 8739 8739 8739
+Encoding: 8739 8739 2151
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 0 0 3
+Refer: 93 124 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: logicaland
-Encoding: 8743 8743 8743
+Encoding: 8743 8743 2152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61688,8 +63845,9 @@ SplineSet
  1049.5 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalor
-Encoding: 8744 8744 8744
+Encoding: 8744 8744 2153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61705,8 +63863,9 @@ SplineSet
  1049.5 1186 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: intersection
-Encoding: 8745 8745 8745
+Encoding: 8745 8745 2154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61729,8 +63888,9 @@ SplineSet
  182.5 602 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: union
-Encoding: 8746 8746 8746
+Encoding: 8746 8746 2155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61753,8 +63913,9 @@ SplineSet
  182.5 276 182.5 276 182.5 584 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integral
-Encoding: 8747 8747 8747
+Encoding: 8747 8747 2156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61777,8 +63938,9 @@ SplineSet
  491 -237 491 -237 491 -68 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni222C
-Encoding: 8748 8748 8748
+Encoding: 8748 8748 2157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61815,10 +63977,11 @@ SplineSet
  127.143 -237 127.143 -237 192 -237 c 0,34,35
  230 -237 230 -237 230 -68 c 2,36,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uni222D
-Encoding: 8749 8749 8749
+Encoding: 8749 8749 2158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61870,59 +64033,65 @@ SplineSet
  56 -237 56 -237 80 -237 c 0,34,35
  118 -237 118 -237 118 -68 c 2,36,-1
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
+
 StartChar: therefore
-Encoding: 8756 8756 8756
+Encoding: 8756 8756 2159
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
+Refer: 2274 8901 N 1 0 0 1 -1 292 2
+Refer: 2274 8901 N 1 0 0 1 -302 -425 2
+Refer: 2274 8901 N 1 0 0 1 308 -425 2
 EndChar
+
 StartChar: uni2235
-Encoding: 8757 8757 8757
+Encoding: 8757 8757 2160
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2274 8901 N 1 0 0 1 3 -425 2
+Refer: 2274 8901 N 1 0 0 1 -301 292 2
+Refer: 2274 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2236
-Encoding: 8758 8758 8758
+Encoding: 8758 8758 2161
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
+Refer: 2274 8901 N 1 0 0 1 3 -425 2
+Refer: 2274 8901 N 1 0 0 1 -1 292 2
 EndChar
+
 StartChar: uni2237
-Encoding: 8759 8759 8759
+Encoding: 8759 8759 2162
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2274 8901 N 1 0 0 1 -302 -425 2
+Refer: 2274 8901 N 1 0 0 1 -301 292 2
+Refer: 2274 8901 N 1 0 0 1 308 -425 2
+Refer: 2274 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2238
-Encoding: 8760 8760 8760
+Encoding: 8760 8760 2163
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 372 2
-Refer: 8722 8722 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 372 2
+Refer: 2138 8722 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2239
-Encoding: 8761 8761 8761
+Encoding: 8761 8761 2164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61945,30 +64114,33 @@ SplineSet
  74 760 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni223A
-Encoding: 8762 8762 8762
+Encoding: 8762 8762 2165
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 404 340 2
-Refer: 8901 8901 N 1 0 0 1 408 -476 2
-Refer: 8901 8901 N 1 0 0 1 -401 340 2
-Refer: 8901 8901 N 1 0 0 1 -402 -476 2
+Refer: 2138 8722 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 404 340 2
+Refer: 2274 8901 N 1 0 0 1 408 -476 2
+Refer: 2274 8901 N 1 0 0 1 -401 340 2
+Refer: 2274 8901 N 1 0 0 1 -402 -476 2
 EndChar
+
 StartChar: uni223B
-Encoding: 8763 8763 8763
+Encoding: 8763 8763 2166
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 382 2
-Refer: 8901 8901 N 1 0 0 1 1 -530 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 2 382 2
+Refer: 2274 8901 N 1 0 0 1 1 -530 2
 EndChar
+
 StartChar: similar
-Encoding: 8764 8764 8764
+Encoding: 8764 8764 2167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61995,8 +64167,9 @@ SplineSet
  1071.01 751.008 1071.01 751.008 1145 816 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni223D
-Encoding: 8765 8765 8765
+Encoding: 8765 8765 2168
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62023,8 +64196,9 @@ SplineSet
  88 816 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2241
-Encoding: 8769 8769 8769
+Encoding: 8769 8769 2169
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62053,8 +64227,9 @@ SplineSet
  483.5 579 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2242
-Encoding: 8770 8770 8770
+Encoding: 8770 8770 2170
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62086,8 +64261,9 @@ SplineSet
  88 987 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2243
-Encoding: 8771 8771 8771
+Encoding: 8771 8771 2171
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62119,8 +64295,9 @@ SplineSet
  88 532 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2244
-Encoding: 8772 8772 8772
+Encoding: 8772 8772 2172
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62158,8 +64335,9 @@ SplineSet
  1010 1222 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: congruent
-Encoding: 8773 8773 8773
+Encoding: 8773 8773 2173
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62196,8 +64374,9 @@ SplineSet
  88 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2246
-Encoding: 8774 8774 8774
+Encoding: 8774 8774 2174
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62245,8 +64424,9 @@ SplineSet
  975 760.5 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2247
-Encoding: 8775 8775 8775
+Encoding: 8775 8775 2175
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62293,8 +64473,9 @@ SplineSet
  254 60.25 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: approxequal
-Encoding: 8776 8776 8776
+Encoding: 8776 8776 2176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62432,8 +64613,9 @@ SplineSet
  1071 955 1071 955 1145 1020 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2249
-Encoding: 8777 8777 8777
+Encoding: 8777 8777 2177
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62478,8 +64660,9 @@ SplineSet
  540 765.991 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224A
-Encoding: 8778 8778 8778
+Encoding: 8778 8778 2178
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62530,8 +64713,9 @@ SplineSet
  88 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224B
-Encoding: 8779 8779 8779
+Encoding: 8779 8779 2179
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62596,8 +64780,9 @@ SplineSet
  1071.01 720.258 1071.01 720.258 1145 785.25 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224C
-Encoding: 8780 8780 8780
+Encoding: 8780 8780 2180
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62634,8 +64819,9 @@ SplineSet
  1145 297.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224D
-Encoding: 8781 8781 8781
+Encoding: 8781 8781 2181
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62657,8 +64843,9 @@ SplineSet
  416 554 416 554 616 554 c 129,-1,4
 EndSplineSet
 EndChar
+
 StartChar: uni224E
-Encoding: 8782 8782 8782
+Encoding: 8782 8782 2182
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62704,8 +64891,9 @@ SplineSet
  666 1016 666 1016 617 1013 c 24,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224F
-Encoding: 8783 8783 8783
+Encoding: 8783 8783 2183
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62737,47 +64925,52 @@ SplineSet
  88 532 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2250
-Encoding: 8784 8784 8784
+Encoding: 8784 8784 2184
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 553 2
-Refer: 61 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 553 2
+Refer: 30 61 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2251
-Encoding: 8785 8785 8785
+Encoding: 8785 8785 2185
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 553 2
-Refer: 8901 8901 N 1 0 0 1 1 -696 2
-Refer: 61 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 553 2
+Refer: 2274 8901 N 1 0 0 1 1 -696 2
+Refer: 30 61 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2252
-Encoding: 8786 8786 8786
+Encoding: 8786 8786 2186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 363 -696 2
-Refer: 8901 8901 N 1 0 0 1 -361 553 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 363 -696 2
+Refer: 2274 8901 N 1 0 0 1 -361 553 2
 EndChar
+
 StartChar: uni2253
-Encoding: 8787 8787 8787
+Encoding: 8787 8787 2187
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 364 553 2
-Refer: 8901 8901 N 1 0 0 1 -361 -696 2
-Refer: 61 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 364 553 2
+Refer: 2274 8901 N 1 0 0 1 -361 -696 2
+Refer: 30 61 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2254
-Encoding: 8788 8788 8788
+Encoding: 8788 8788 2188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62805,8 +64998,9 @@ SplineSet
  81 1030 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2255
-Encoding: 8789 8789 8789
+Encoding: 8789 8789 2189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62834,8 +65028,9 @@ SplineSet
  1152 1030 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2256
-Encoding: 8790 8790 8790
+Encoding: 8790 8790 2190
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62865,8 +65060,9 @@ SplineSet
  915 595 915 595 888 532 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2257
-Encoding: 8791 8791 8791
+Encoding: 8791 8791 2191
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62902,8 +65098,9 @@ SplineSet
  495.526 1672.36 495.526 1672.36 617 1666.87 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni2258
-Encoding: 8792 8792 8792
+Encoding: 8792 8792 2192
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62928,8 +65125,9 @@ SplineSet
  391.646 1465 391.646 1465 617.1 1465 c 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni2259
-Encoding: 8793 8793 8793
+Encoding: 8793 8793 2193
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62955,8 +65153,9 @@ SplineSet
  302 1085 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225A
-Encoding: 8794 8794 8794
+Encoding: 8794 8794 2194
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62982,8 +65181,9 @@ SplineSet
  302 1688 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225B
-Encoding: 8795 8795 8795
+Encoding: 8795 8795 2195
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63012,8 +65212,9 @@ SplineSet
  194 1609 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225C
-Encoding: 8796 8796 8796
+Encoding: 8796 8796 2196
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63040,8 +65241,9 @@ SplineSet
  561.06 1820.32 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225D
-Encoding: 8797 8797 8797
+Encoding: 8797 8797 2197
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63123,8 +65325,9 @@ SplineSet
  1116.52 1535.14 l 1,65,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225E
-Encoding: 8798 8798 8798
+Encoding: 8798 8798 2198
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63172,8 +65375,9 @@ SplineSet
  661.509 1585.12 661.509 1585.12 683.772 1535.64 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni225F
-Encoding: 8799 8799 8799
+Encoding: 8799 8799 2199
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63219,8 +65423,9 @@ SplineSet
  491.5 1268 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: notequal
-Encoding: 8800 8800 8800
+Encoding: 8800 8800 2200
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63312,10 +65517,11 @@ SplineSet
  78 752 l 1,19,-1
  78 987 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: equivalence
-Encoding: 8801 8801 8801
+Encoding: 8801 8801 2201
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63338,8 +65544,9 @@ SplineSet
  88 1221.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2262
-Encoding: 8802 8802 8802
+Encoding: 8802 8802 2202
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63376,8 +65583,9 @@ SplineSet
  638 986.75 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2263
-Encoding: 8803 8803 8803
+Encoding: 8803 8803 2203
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63405,8 +65613,9 @@ SplineSet
  88 141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lessequal
-Encoding: 8804 8804 8804
+Encoding: 8804 8804 2204
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63467,8 +65676,9 @@ SplineSet
  1145 238 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: greaterequal
-Encoding: 8805 8805 8805
+Encoding: 8805 8805 2205
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63529,8 +65739,9 @@ SplineSet
  88 238 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2266
-Encoding: 8806 8806 8806
+Encoding: 8806 8806 2206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63556,8 +65767,9 @@ SplineSet
  1145 343 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2267
-Encoding: 8807 8807 8807
+Encoding: 8807 8807 2207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63583,8 +65795,9 @@ SplineSet
  1145 343 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2268
-Encoding: 8808 8808 8808
+Encoding: 8808 8808 2208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63621,8 +65834,9 @@ SplineSet
  1145 1053 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2269
-Encoding: 8809 8809 8809
+Encoding: 8809 8809 2209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63659,8 +65873,9 @@ SplineSet
  88 1053 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni226D
-Encoding: 8813 8813 8813
+Encoding: 8813 8813 2210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63689,8 +65904,9 @@ SplineSet
  538 733.41 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226E
-Encoding: 8814 8814 8814
+Encoding: 8814 8814 2211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63719,8 +65935,9 @@ SplineSet
  595 728.83 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226F
-Encoding: 8815 8815 8815
+Encoding: 8815 8815 2212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63736,8 +65953,9 @@ SplineSet
  88 926 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2270
-Encoding: 8816 8816 8816
+Encoding: 8816 8816 2213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63774,8 +65992,9 @@ SplineSet
  954 1131.48 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2271
-Encoding: 8817 8817 8817
+Encoding: 8817 8817 2214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63812,8 +66031,9 @@ SplineSet
  210 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2272
-Encoding: 8818 8818 8818
+Encoding: 8818 8818 2215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63848,8 +66068,9 @@ SplineSet
  1145 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2273
-Encoding: 8819 8819 8819
+Encoding: 8819 8819 2216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63884,8 +66105,9 @@ SplineSet
  88 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2274
-Encoding: 8820 8820 8820
+Encoding: 8820 8820 2217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63932,8 +66154,9 @@ SplineSet
  631 802.633 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2275
-Encoding: 8821 8821 8821
+Encoding: 8821 8821 2218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63981,8 +66204,9 @@ SplineSet
  660 691.77 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2276
-Encoding: 8822 8822 8822
+Encoding: 8822 8822 2219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64006,8 +66230,9 @@ SplineSet
  1145 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2277
-Encoding: 8823 8823 8823
+Encoding: 8823 8823 2220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64031,8 +66256,9 @@ SplineSet
  88 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2278
-Encoding: 8824 8824 8824
+Encoding: 8824 8824 2221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64077,8 +66303,9 @@ SplineSet
  592.253 895.325 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2279
-Encoding: 8825 8825 8825
+Encoding: 8825 8825 2222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64115,8 +66342,9 @@ SplineSet
  88 1157 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227A
-Encoding: 8826 8826 8826
+Encoding: 8826 8826 2223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64134,8 +66362,9 @@ SplineSet
  1143 1023 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227B
-Encoding: 8827 8827 8827
+Encoding: 8827 8827 2224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64153,8 +66382,9 @@ SplineSet
  371.366 675 371.366 675 86 1023 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227C
-Encoding: 8828 8828 8828
+Encoding: 8828 8828 2225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64175,8 +66405,9 @@ SplineSet
  1145 1185 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227D
-Encoding: 8829 8829 8829
+Encoding: 8829 8829 2226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64197,8 +66428,9 @@ SplineSet
  360.511 910 360.511 910 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227E
-Encoding: 8830 8830 8830
+Encoding: 8830 8830 2227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64233,8 +66465,9 @@ SplineSet
  1145 1185 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227F
-Encoding: 8831 8831 8831
+Encoding: 8831 8831 2228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64269,8 +66502,9 @@ SplineSet
  360.511 910 360.511 910 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2280
-Encoding: 8832 8832 8832
+Encoding: 8832 8832 2229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64300,8 +66534,9 @@ SplineSet
  543.487 637.327 543.487 637.327 569.658 631.896 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2281
-Encoding: 8833 8833 8833
+Encoding: 8833 8833 2230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64331,8 +66566,9 @@ SplineSet
  685.513 644.673 685.513 644.673 659.343 650.104 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: propersubset
-Encoding: 8834 8834 8834
+Encoding: 8834 8834 2231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64355,8 +66591,9 @@ SplineSet
  371 1144 371 1144 575 1144 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: propersuperset
-Encoding: 8835 8835 8835
+Encoding: 8835 8835 2232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64379,8 +66616,9 @@ SplineSet
  658 1144 l 18,0,-1
 EndSplineSet
 EndChar
+
 StartChar: notsubset
-Encoding: 8836 8836 8836
+Encoding: 8836 8836 2233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64415,8 +66653,9 @@ SplineSet
  621 919 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2285
-Encoding: 8837 8837 8837
+Encoding: 8837 8837 2234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64451,8 +66690,9 @@ SplineSet
  612 364 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: reflexsubset
-Encoding: 8838 8838 8838
+Encoding: 8838 8838 2235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64480,8 +66720,9 @@ SplineSet
  371 1321 371 1321 575 1321 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: reflexsuperset
-Encoding: 8839 8839 8839
+Encoding: 8839 8839 2236
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64509,8 +66750,9 @@ SplineSet
  658 1321 l 18,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2288
-Encoding: 8840 8840 8840
+Encoding: 8840 8840 2237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64553,8 +66795,9 @@ SplineSet
  947.43 1321 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2289
-Encoding: 8841 8841 8841
+Encoding: 8841 8841 2238
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64597,8 +66840,9 @@ SplineSet
  647 540 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228A
-Encoding: 8842 8842 8842
+Encoding: 8842 8842 2239
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64634,8 +66878,9 @@ SplineSet
  1145 198 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228B
-Encoding: 8843 8843 8843
+Encoding: 8843 8843 2240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64670,8 +66915,9 @@ SplineSet
  658 1321 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni228D
-Encoding: 8845 8845 8845
+Encoding: 8845 8845 2241
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64699,8 +66945,9 @@ SplineSet
  90 246 90 246 90 582 c 2,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228E
-Encoding: 8846 8846 8846
+Encoding: 8846 8846 2242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64736,8 +66983,9 @@ SplineSet
  682 848 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228F
-Encoding: 8847 8847 8847
+Encoding: 8847 8847 2243
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64805,8 +67053,9 @@ SplineSet
  88 1196 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2290
-Encoding: 8848 8848 8848
+Encoding: 8848 8848 2244
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64874,8 +67123,9 @@ SplineSet
  1145 1196 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2291
-Encoding: 8849 8849 8849
+Encoding: 8849 8849 2245
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64972,8 +67222,9 @@ SplineSet
  88 1302 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2292
-Encoding: 8850 8850 8850
+Encoding: 8850 8850 2246
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65072,8 +67323,9 @@ SplineSet
  1145 1302 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2293
-Encoding: 8851 8851 8851
+Encoding: 8851 8851 2247
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65090,8 +67342,9 @@ SplineSet
  1172 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2294
-Encoding: 8852 8852 8852
+Encoding: 8852 8852 2248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65108,8 +67361,9 @@ SplineSet
  62 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circleplus
-Encoding: 8853 8853 8853
+Encoding: 8853 8853 2249
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65164,8 +67418,9 @@ SplineSet
  531 989 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2296
-Encoding: 8854 8854 8854
+Encoding: 8854 8854 2250
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65212,8 +67467,9 @@ SplineSet
  271 727 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: circlemultiply
-Encoding: 8855 8855 8855
+Encoding: 8855 8855 2251
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65268,8 +67524,9 @@ SplineSet
  311.737 827.348 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2298
-Encoding: 8856 8856 8856
+Encoding: 8856 8856 2252
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65316,8 +67573,9 @@ SplineSet
  433.359 338.03 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2299
-Encoding: 8857 8857 8857
+Encoding: 8857 8857 2253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65364,8 +67622,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229A
-Encoding: 8858 8858 8858
+Encoding: 8858 8858 2254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65427,8 +67686,9 @@ SplineSet
  660.46 749.92 660.46 749.92 616.22 749.92 c 128,-1,16
 EndSplineSet
 EndChar
+
 StartChar: uni229B
-Encoding: 8859 8859 8859
+Encoding: 8859 8859 2255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65487,8 +67747,9 @@ SplineSet
  993.659 519.289 l 1,63,64
 EndSplineSet
 EndChar
+
 StartChar: uni229C
-Encoding: 8860 8860 8860
+Encoding: 8860 8860 2256
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65540,8 +67801,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229D
-Encoding: 8861 8861 8861
+Encoding: 8861 8861 2257
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65588,8 +67850,9 @@ SplineSet
  399 727 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229E
-Encoding: 8862 8862 8862
+Encoding: 8862 8862 2258
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65620,8 +67883,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229F
-Encoding: 8863 8863 8863
+Encoding: 8863 8863 2259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65644,8 +67908,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A0
-Encoding: 8864 8864 8864
+Encoding: 8864 8864 2260
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65676,8 +67941,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A1
-Encoding: 8865 8865 8865
+Encoding: 8865 8865 2261
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65700,8 +67966,9 @@ SplineSet
  50 1210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A2
-Encoding: 8866 8866 8866
+Encoding: 8866 8866 2262
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65718,8 +67985,9 @@ SplineSet
  303 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A3
-Encoding: 8867 8867 8867
+Encoding: 8867 8867 2263
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65736,8 +68004,9 @@ SplineSet
  928 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A4
-Encoding: 8868 8868 8868
+Encoding: 8868 8868 2264
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65754,8 +68023,9 @@ SplineSet
  1165 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: perpendicular
-Encoding: 8869 8869 8869
+Encoding: 8869 8869 2265
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65772,8 +68042,9 @@ SplineSet
  66 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B2
-Encoding: 8882 8882 8882
+Encoding: 8882 8882 2266
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65792,8 +68063,9 @@ SplineSet
  908 841 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B3
-Encoding: 8883 8883 8883
+Encoding: 8883 8883 2267
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65812,8 +68084,9 @@ SplineSet
  88 926 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B4
-Encoding: 8884 8884 8884
+Encoding: 8884 8884 2268
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65838,8 +68111,9 @@ SplineSet
  908 881 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B5
-Encoding: 8885 8885 8885
+Encoding: 8885 8885 2269
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65864,8 +68138,9 @@ SplineSet
  88 530 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B8
-Encoding: 8888 8888 8888
+Encoding: 8888 8888 2270
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65894,8 +68169,9 @@ SplineSet
  679 478 679 478 659 524 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C2
-Encoding: 8898 8898 8898
+Encoding: 8898 8898 2271
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65918,8 +68194,9 @@ SplineSet
  1143 1272 1143 1272 1143 936 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C3
-Encoding: 8899 8899 8899
+Encoding: 8899 8899 2272
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65942,8 +68219,9 @@ SplineSet
  90 -190 90 -190 90 146 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C4
-Encoding: 8900 8900 8900
+Encoding: 8900 8900 2273
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65961,8 +68239,9 @@ SplineSet
  6 732 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dotmath
-Encoding: 8901 8901 8901
+Encoding: 8901 8901 2274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65995,8 +68274,9 @@ SplineSet
  449 895 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C6
-Encoding: 8902 8902 8902
+Encoding: 8902 8902 2275
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66015,8 +68295,9 @@ SplineSet
  225.841 832.462 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22CD
-Encoding: 8909 8909 8909
+Encoding: 8909 8909 2276
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66048,8 +68329,9 @@ SplineSet
  1145 532 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni22CE
-Encoding: 8910 8910 8910
+Encoding: 8910 8910 2277
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66065,8 +68347,9 @@ SplineSet
  1234 1284 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22CF
-Encoding: 8911 8911 8911
+Encoding: 8911 8911 2278
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66082,8 +68365,9 @@ SplineSet
  -2 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22D0
-Encoding: 8912 8912 8912
+Encoding: 8912 8912 2279
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66121,8 +68405,9 @@ SplineSet
  778 -46 l 18,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni22D1
-Encoding: 8913 8913 8913
+Encoding: 8913 8913 2280
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66160,8 +68445,9 @@ SplineSet
  455 1330 l 18,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni22DA
-Encoding: 8922 8922 8922
+Encoding: 8922 8922 2281
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66190,8 +68476,9 @@ SplineSet
  1145 635 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DB
-Encoding: 8923 8923 8923
+Encoding: 8923 8923 2282
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66220,8 +68507,9 @@ SplineSet
  88 635 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DC
-Encoding: 8924 8924 8924
+Encoding: 8924 8924 2283
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66242,8 +68530,9 @@ SplineSet
  1145 954 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DD
-Encoding: 8925 8925 8925
+Encoding: 8925 8925 2284
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66264,8 +68553,9 @@ SplineSet
  88 954 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DE
-Encoding: 8926 8926 8926
+Encoding: 8926 8926 2285
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66286,8 +68576,9 @@ SplineSet
  872.489 192 872.489 192 1145 -83 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DF
-Encoding: 8927 8927 8927
+Encoding: 8927 8927 2286
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66308,8 +68599,9 @@ SplineSet
  88 -83 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E0
-Encoding: 8928 8928 8928
+Encoding: 8928 8928 2287
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66346,8 +68638,9 @@ SplineSet
  554.343 831.099 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E1
-Encoding: 8929 8929 8929
+Encoding: 8929 8929 2288
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66380,8 +68673,9 @@ SplineSet
  305.621 965.391 305.621 965.391 88 1185 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E2
-Encoding: 8930 8930 8930
+Encoding: 8930 8930 2289
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66419,8 +68713,9 @@ SplineSet
  486.563 619 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E3
-Encoding: 8931 8931 8931
+Encoding: 8931 8931 2290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66458,8 +68753,9 @@ SplineSet
  891.723 1067 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E4
-Encoding: 8932 8932 8932
+Encoding: 8932 8932 2291
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66489,8 +68785,9 @@ SplineSet
  88 -20 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E5
-Encoding: 8933 8933 8933
+Encoding: 8933 8933 2292
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66520,8 +68817,9 @@ SplineSet
  1145 1302 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E6
-Encoding: 8934 8934 8934
+Encoding: 8934 8934 2293
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66557,8 +68855,9 @@ SplineSet
  1145 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E7
-Encoding: 8935 8935 8935
+Encoding: 8935 8935 2294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66595,8 +68894,9 @@ SplineSet
  88 948 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E8
-Encoding: 8936 8936 8936
+Encoding: 8936 8936 2295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66633,8 +68933,9 @@ SplineSet
  483.5 -95 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22E9
-Encoding: 8937 8937 8937
+Encoding: 8937 8937 2296
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66671,8 +68972,9 @@ SplineSet
  483.5 -95 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22EF
-Encoding: 8943 8943 8943
+Encoding: 8943 8943 2297
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66695,16 +68997,18 @@ SplineSet
  57 827 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2300
-Encoding: 8960 8960 8960
+Encoding: 8960 8960 2298
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8709 8709 N 1 0 0 1 0 0 2
+Refer: 2125 8709 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2301
-Encoding: 8961 8961 8961
+Encoding: 8961 8961 2299
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66721,8 +69025,9 @@ SplineSet
  684 634 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: house
-Encoding: 8962 8962 8962
+Encoding: 8962 8962 2300
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66742,8 +69047,9 @@ SplineSet
  298 187 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2303
-Encoding: 8963 8963 8963
+Encoding: 8963 8963 2301
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66758,8 +69064,9 @@ SplineSet
  616 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2304
-Encoding: 8964 8964 8964
+Encoding: 8964 8964 2302
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66774,8 +69081,9 @@ SplineSet
  616 -269.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2305
-Encoding: 8965 8965 8965
+Encoding: 8965 8965 2303
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66795,8 +69103,9 @@ SplineSet
  156 939.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2306
-Encoding: 8966 8966 8966
+Encoding: 8966 8966 2304
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66821,8 +69130,9 @@ SplineSet
  156 939.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2308
-Encoding: 8968 8968 8968
+Encoding: 8968 8968 2305
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66837,8 +69147,9 @@ SplineSet
  599.469 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2309
-Encoding: 8969 8969 8969
+Encoding: 8969 8969 2306
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66853,8 +69164,9 @@ SplineSet
  988.469 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230A
-Encoding: 8970 8970 8970
+Encoding: 8970 8970 2307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66869,8 +69181,9 @@ SplineSet
  244.531 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230B
-Encoding: 8971 8971 8971
+Encoding: 8971 8971 2308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66885,8 +69198,9 @@ SplineSet
  633.531 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230C
-Encoding: 8972 8972 8972
+Encoding: 8972 8972 2309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66904,8 +69218,9 @@ SplineSet
  534 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230D
-Encoding: 8973 8973 8973
+Encoding: 8973 8973 2310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66923,8 +69238,9 @@ SplineSet
  534 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230E
-Encoding: 8974 8974 8974
+Encoding: 8974 8974 2311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66942,8 +69258,9 @@ SplineSet
  754 850 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230F
-Encoding: 8975 8975 8975
+Encoding: 8975 8975 2312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66961,8 +69278,9 @@ SplineSet
  534 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: revlogicalnot
-Encoding: 8976 8976 8976
+Encoding: 8976 8976 2313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66977,8 +69295,9 @@ SplineSet
  1145 899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2311
-Encoding: 8977 8977 8977
+Encoding: 8977 8977 2314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66996,16 +69315,18 @@ SplineSet
  617 418.5 617 418.5 71 232.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2312
-Encoding: 8978 8978 8978
+Encoding: 8978 8978 2315
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9696 9696 N 1 0 0 1 0 -100 2
+Refer: 2659 9696 N 1 0 0 1 0 -100 2
 EndChar
+
 StartChar: uni2313
-Encoding: 8979 8979 8979
+Encoding: 8979 8979 2316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67025,8 +69346,9 @@ SplineSet
  242.347 734.534 242.347 734.534 192.232 591 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2314
-Encoding: 8980 8980 8980
+Encoding: 8980 8980 2317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67046,8 +69368,9 @@ SplineSet
  715.74 887.046 715.74 887.046 616 887.046 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2315
-Encoding: 8981 8981 8981
+Encoding: 8981 8981 2318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67077,8 +69400,9 @@ SplineSet
  518.878 1103.87 518.878 1103.87 674.11 1103.87 c 0,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2318
-Encoding: 8984 8984 8984
+Encoding: 8984 8984 2319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67164,8 +69488,9 @@ SplineSet
  423 583 l 1,85,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2319
-Encoding: 8985 8985 8985
+Encoding: 8985 8985 2320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67180,8 +69505,9 @@ SplineSet
  1145 362 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni231C
-Encoding: 8988 8988 8988
+Encoding: 8988 8988 2321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67196,8 +69522,9 @@ SplineSet
  949 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231D
-Encoding: 8989 8989 8989
+Encoding: 8989 8989 2322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67212,8 +69539,9 @@ SplineSet
  284 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231E
-Encoding: 8990 8990 8990
+Encoding: 8990 8990 2323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67228,8 +69556,9 @@ SplineSet
  949 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231F
-Encoding: 8991 8991 8991
+Encoding: 8991 8991 2324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67244,8 +69573,9 @@ SplineSet
  284 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: integraltp
-Encoding: 8992 8992 8992
+Encoding: 8992 8992 2325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67270,8 +69600,9 @@ SplineSet
  485 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integralbt
-Encoding: 8993 8993 8993
+Encoding: 8993 8993 2326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67296,8 +69627,9 @@ SplineSet
  741 1926 l 25,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2325
-Encoding: 8997 8997 8997
+Encoding: 8997 8997 2327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67319,8 +69651,9 @@ SplineSet
  720 1255 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2326
-Encoding: 8998 8998 8998
+Encoding: 8998 8998 2328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67355,8 +69688,9 @@ SplineSet
  547.019 440 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2327
-Encoding: 8999 8999 8999
+Encoding: 8999 8999 2329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67389,8 +69723,9 @@ SplineSet
  716.019 440 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2328
-Encoding: 9000 9000 9000
+Encoding: 9000 9000 2330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67788,8 +70123,9 @@ SplineSet
  402 535 l 2,509,510
 EndSplineSet
 EndChar
+
 StartChar: uni232B
-Encoding: 9003 9003 9003
+Encoding: 9003 9003 2331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67824,8 +70160,9 @@ SplineSet
  685.981 440 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2335
-Encoding: 9013 9013 9013
+Encoding: 9013 9013 2332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67840,8 +70177,9 @@ SplineSet
  616 -68 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2336
-Encoding: 9014 9014 9014
+Encoding: 9014 9014 2333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67862,8 +70200,9 @@ SplineSet
  1165 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2337
-Encoding: 9015 9015 9015
+Encoding: 9015 9015 2334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67881,8 +70220,9 @@ SplineSet
  256 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2338
-Encoding: 9016 9016 9016
+Encoding: 9016 9016 2335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67910,8 +70250,9 @@ SplineSet
  150 987 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2339
-Encoding: 9017 9017 9017
+Encoding: 9017 9017 2336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67944,8 +70285,9 @@ SplineSet
  150 762 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233A
-Encoding: 9018 9018 9018
+Encoding: 9018 9018 2337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67975,17 +70317,19 @@ SplineSet
  1083 875.764 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233B
-Encoding: 9019 9019 9019
+Encoding: 9019 9019 2338
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 0 2
+Refer: 2411 9109 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233C
-Encoding: 9020 9020 9020
+Encoding: 9020 9020 2339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68023,8 +70367,9 @@ SplineSet
  1227 1727 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233D
-Encoding: 9021 9021 9021
+Encoding: 9021 9021 2340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68059,17 +70404,19 @@ SplineSet
  778.695 1156.22 778.695 1156.22 717 1172.25 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233E
-Encoding: 9022 9022 9022
+Encoding: 9022 9022 2341
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114132 -1 N 1 0 0 1 0 0 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
+Refer: 3106 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233F
-Encoding: 9023 9023 9023
+Encoding: 9023 9023 2342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68090,8 +70437,9 @@ SplineSet
  899 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2340
-Encoding: 9024 9024 9024
+Encoding: 9024 9024 2343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68112,8 +70460,9 @@ SplineSet
  787 524 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2341
-Encoding: 9025 9025 9025
+Encoding: 9025 9025 2344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68134,8 +70483,9 @@ SplineSet
  1113 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2342
-Encoding: 9026 9026 9026
+Encoding: 9026 9026 2345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68156,8 +70506,9 @@ SplineSet
  120 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2343
-Encoding: 9027 9027 9027
+Encoding: 9027 9027 2346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68184,8 +70535,9 @@ SplineSet
  1083 480.07 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2344
-Encoding: 9028 9028 9028
+Encoding: 9028 9028 2347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68212,8 +70564,9 @@ SplineSet
  150 480.07 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2345
-Encoding: 9029 9029 9029
+Encoding: 9029 9029 2348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68240,8 +70593,9 @@ SplineSet
  66 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2346
-Encoding: 9030 9030 9030
+Encoding: 9030 9030 2349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68268,8 +70622,9 @@ SplineSet
  1167 690 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2347
-Encoding: 9031 9031 9031
+Encoding: 9031 9031 2350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68298,8 +70653,9 @@ SplineSet
  1083 873 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2348
-Encoding: 9032 9032 9032
+Encoding: 9032 9032 2351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68328,8 +70684,9 @@ SplineSet
  150 873 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2349
-Encoding: 9033 9033 9033
+Encoding: 9033 9033 2352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68364,8 +70721,9 @@ SplineSet
  568.604 1185.38 568.604 1185.38 521.161 1173.81 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234A
-Encoding: 9034 9034 9034
+Encoding: 9034 9034 2353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68387,8 +70745,9 @@ SplineSet
  66 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234B
-Encoding: 9035 9035 9035
+Encoding: 9035 9035 2354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68399,10 +70758,10 @@ SplineSet
  717 1493 l 1,2,-1
  797 1493 l 1,3,-1
  1200 0 l 1,4,-1
- 717 -3.28626e-14 l 1,5,-1
+ 717 -3.28626e-014 l 1,5,-1
  717 -350 l 1,6,-1
  515 -350 l 1,7,-1
- 515 -2.42861e-15 l 1,8,-1
+ 515 -2.42861e-015 l 1,8,-1
  33 0 l 1,9,-1
  436 1493 l 1,10,-1
  515 1493 l 1,11,-1
@@ -68417,8 +70776,9 @@ SplineSet
  717 260 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234C
-Encoding: 9036 9036 9036
+Encoding: 9036 9036 2355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68444,8 +70804,9 @@ SplineSet
  120 889.059 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234D
-Encoding: 9037 9037 9037
+Encoding: 9037 9037 2356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68474,8 +70835,9 @@ SplineSet
  120 91 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234E
-Encoding: 9038 9038 9038
+Encoding: 9038 9038 2357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68510,8 +70872,9 @@ SplineSet
  496 800 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni234F
-Encoding: 9039 9039 9039
+Encoding: 9039 9039 2358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68538,8 +70901,9 @@ SplineSet
  688 1550 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2350
-Encoding: 9040 9040 9040
+Encoding: 9040 9040 2359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68568,8 +70932,9 @@ SplineSet
  504.5 -90 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2351
-Encoding: 9041 9041 9041
+Encoding: 9041 9041 2360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68591,8 +70956,9 @@ SplineSet
  1165 1284 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2352
-Encoding: 9042 9042 9042
+Encoding: 9042 9042 2361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68603,10 +70969,10 @@ SplineSet
  717 1493 l 1,2,-1
  1200 1493 l 1,3,-1
  797 0 l 1,4,-1
- 717 -3.28626e-14 l 1,5,-1
+ 717 -3.28626e-014 l 1,5,-1
  717 -350 l 1,6,-1
  515 -350 l 1,7,-1
- 515 -2.42861e-15 l 1,8,-1
+ 515 -2.42861e-015 l 1,8,-1
  436 0 l 1,9,-1
  33 1493 l 1,10,-1
  515 1493 l 1,11,-1
@@ -68621,8 +70987,9 @@ SplineSet
  515 694.729 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2353
-Encoding: 9043 9043 9043
+Encoding: 9043 9043 2362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68648,8 +71015,9 @@ SplineSet
  120 603.941 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2354
-Encoding: 9044 9044 9044
+Encoding: 9044 9044 2363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68678,8 +71046,9 @@ SplineSet
  120 1402 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2355
-Encoding: 9045 9045 9045
+Encoding: 9045 9045 2364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68714,8 +71083,9 @@ SplineSet
  498 802 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni2356
-Encoding: 9046 9046 9046
+Encoding: 9046 9046 2365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68742,8 +71112,9 @@ SplineSet
  546 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2357
-Encoding: 9047 9047 9047
+Encoding: 9047 9047 2366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68772,17 +71143,19 @@ SplineSet
  504.5 1583 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2358
-Encoding: 9048 9048 9048
+Encoding: 9048 9048 2367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2359
-Encoding: 9049 9049 9049
+Encoding: 9049 9049 2368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68804,35 +71177,39 @@ SplineSet
  845 260 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni235A
-Encoding: 9050 9050 9050
+Encoding: 9050 9050 2369
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 9671 9671 N 1 0 0 1 0 200 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
+Refer: 2634 9671 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235B
-Encoding: 9051 9051 9051
+Encoding: 9051 9051 2370
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 0 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235C
-Encoding: 9052 9052 9052
+Encoding: 9052 9052 2371
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235D
-Encoding: 9053 9053 9053
+Encoding: 9053 9053 2372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68867,26 +71244,29 @@ SplineSet
  799 381 l 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni235E
-Encoding: 9054 9054 9054
+Encoding: 9054 9054 2373
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 2411 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235F
-Encoding: 9055 9055 9055
+Encoding: 9055 9055 2374
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9711 9711 N 1 0 0 1 0 200 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 2674 9711 N 1 0 0 1 0 200 2
+Refer: 2275 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2360
-Encoding: 9056 9056 9056
+Encoding: 9056 9056 2375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68914,8 +71294,9 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2361
-Encoding: 9057 9057 9057
+Encoding: 9057 9057 2376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68942,8 +71323,9 @@ SplineSet
  1165 1284 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2362
-Encoding: 9058 9058 9058
+Encoding: 9058 9058 2377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68970,35 +71352,39 @@ SplineSet
  496 0 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2363
-Encoding: 9059 9059 9059
+Encoding: 9059 9059 2378
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 0 -250 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 3107 -1 N 1 0 0 1 0 -250 2
+Refer: 2275 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2364
-Encoding: 9060 9060 9060
+Encoding: 9060 9060 2379
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 0 -200 2
-Refer: 1114132 -1 N 1 0 0 1 0 0 2
+Refer: 3107 -1 N 1 0 0 1 0 -200 2
+Refer: 3106 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2365
-Encoding: 9061 9061 9061
+Encoding: 9061 9061 2380
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 0 150 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3107 -1 N 1 0 0 1 0 150 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni2366
-Encoding: 9062 9062 9062
+Encoding: 9062 9062 2381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69025,8 +71411,9 @@ SplineSet
  717 297 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2367
-Encoding: 9063 9063 9063
+Encoding: 9063 9063 2382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69058,26 +71445,29 @@ SplineSet
  444 385 444 385 515 369 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2368
-Encoding: 9064 9064 9064
+Encoding: 9064 9064 2383
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 0 -200 2
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 3107 -1 N 1 0 0 1 0 -200 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2369
-Encoding: 9065 9065 9065
+Encoding: 9065 9065 2384
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 0 -200 2
-Refer: 62 62 N 1 0 0 1 0 0 2
+Refer: 3107 -1 N 1 0 0 1 0 -200 2
+Refer: 31 62 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni236A
-Encoding: 9066 9066 9066
+Encoding: 9066 9066 2385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69097,8 +71487,9 @@ SplineSet
  461 367 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236B
-Encoding: 9067 9067 9067
+Encoding: 9067 9067 2386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69135,8 +71526,9 @@ SplineSet
  695.285 603.412 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni236C
-Encoding: 9068 9068 9068
+Encoding: 9068 9068 2387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69177,8 +71569,9 @@ SplineSet
  796.971 428.37 796.971 428.37 807.533 575.439 c 1,41,42
 EndSplineSet
 EndChar
+
 StartChar: uni236D
-Encoding: 9069 9069 9069
+Encoding: 9069 9069 2388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69209,8 +71602,9 @@ SplineSet
  1072 857 1072 857 1145 921 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236E
-Encoding: 9070 9070 9070
+Encoding: 9070 9070 2389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69238,8 +71632,9 @@ SplineSet
  449 1063 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236F
-Encoding: 9071 9071 9071
+Encoding: 9071 9071 2390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69278,8 +71673,9 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2370
-Encoding: 9072 9072 9072
+Encoding: 9072 9072 2391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69327,8 +71723,9 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2371
-Encoding: 9073 9073 9073
+Encoding: 9073 9073 2392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69361,8 +71758,9 @@ SplineSet
  647 513 l 2,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni2372
-Encoding: 9074 9074 9074
+Encoding: 9074 9074 2393
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69393,8 +71791,9 @@ SplineSet
  599 765 l 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni2373
-Encoding: 9075 9075 9075
+Encoding: 9075 9075 2394
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69415,8 +71814,9 @@ SplineSet
  763 1120 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2374
-Encoding: 9076 9076 9076
+Encoding: 9076 9076 2395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69444,8 +71844,9 @@ SplineSet
  850 399 850 399 850 561 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni2375
-Encoding: 9077 9077 9077
+Encoding: 9077 9077 2396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69473,17 +71874,19 @@ SplineSet
  743 665 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2376
-Encoding: 9078 9078 9078
+Encoding: 9078 9078 2397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 9082 9082 N 1 0 0 1 0 0 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
+Refer: 2401 9082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2377
-Encoding: 9079 9079 9079
+Encoding: 9079 9079 2398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69518,26 +71921,29 @@ SplineSet
  1053 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2378
-Encoding: 9080 9080 9080
+Encoding: 9080 9080 2399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9075 9075 N 1 0 0 1 0 0 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
+Refer: 2394 9075 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2379
-Encoding: 9081 9081 9081
+Encoding: 9081 9081 2400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 9077 9077 N 1 0 0 1 0 0 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
+Refer: 2396 9077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237A
-Encoding: 9082 9082 9082
+Encoding: 9082 9082 2401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69572,8 +71978,9 @@ SplineSet
  695 589 l 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni237D
-Encoding: 9085 9085 9085
+Encoding: 9085 9085 2402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69594,8 +72001,9 @@ SplineSet
  474.625 -239 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2380
-Encoding: 9088 9088 9088
+Encoding: 9088 9088 2403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69640,8 +72048,9 @@ SplineSet
  616 -68 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2381
-Encoding: 9089 9089 9089
+Encoding: 9089 9089 2404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69699,8 +72108,9 @@ SplineSet
  601 958 601 958 601 798 c 2,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2382
-Encoding: 9090 9090 9090
+Encoding: 9090 9090 2405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69778,8 +72188,9 @@ SplineSet
  601 958 601 958 601 798 c 2,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2383
-Encoding: 9091 9091 9091
+Encoding: 9091 9091 2406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69847,8 +72258,9 @@ SplineSet
  898 958 898 958 898 798 c 2,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2388
-Encoding: 9096 9096 9096
+Encoding: 9096 9096 2407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69921,8 +72333,9 @@ SplineSet
  871.113 577.04 l 1,80,81
 EndSplineSet
 EndChar
+
 StartChar: uni2389
-Encoding: 9097 9097 9097
+Encoding: 9097 9097 2408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69974,8 +72387,9 @@ SplineSet
  494.559 251.411 494.559 251.411 532.544 243.474 c 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238A
-Encoding: 9098 9098 9098
+Encoding: 9098 9098 2409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70026,8 +72440,9 @@ SplineSet
  1021 719.981 1021 719.981 991.526 791.878 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238B
-Encoding: 9099 9099 9099
+Encoding: 9099 9099 2410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70074,8 +72489,9 @@ SplineSet
  70 528.7 70 528.7 70 640 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2395
-Encoding: 9109 9109 9109
+Encoding: 9109 9109 2411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70093,8 +72509,9 @@ SplineSet
  6 -234 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni239B
-Encoding: 9115 9115 9115
+Encoding: 9115 9115 2412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70111,8 +72528,9 @@ SplineSet
  523 -516 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239C
-Encoding: 9116 9116 9116
+Encoding: 9116 9116 2413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70125,8 +72543,9 @@ SplineSet
  232 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni239D
-Encoding: 9117 9117 9117
+Encoding: 9117 9117 2414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70143,8 +72562,9 @@ SplineSet
  523 1926 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239E
-Encoding: 9118 9118 9118
+Encoding: 9118 9118 2415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70161,8 +72581,9 @@ SplineSet
  710 -516 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239F
-Encoding: 9119 9119 9119
+Encoding: 9119 9119 2416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70175,8 +72596,9 @@ SplineSet
  1001 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A0
-Encoding: 9120 9120 9120
+Encoding: 9120 9120 2417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70193,8 +72615,9 @@ SplineSet
  710 1926 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A1
-Encoding: 9121 9121 9121
+Encoding: 9121 9121 2418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70209,8 +72632,9 @@ SplineSet
  523 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A2
-Encoding: 9122 9122 9122
+Encoding: 9122 9122 2419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70223,8 +72647,9 @@ SplineSet
  232 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A3
-Encoding: 9123 9123 9123
+Encoding: 9123 9123 2420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70239,8 +72664,9 @@ SplineSet
  523 1926 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A4
-Encoding: 9124 9124 9124
+Encoding: 9124 9124 2421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70255,8 +72681,9 @@ SplineSet
  709 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A5
-Encoding: 9125 9125 9125
+Encoding: 9125 9125 2422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70269,8 +72696,9 @@ SplineSet
  1000 1926 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A6
-Encoding: 9126 9126 9126
+Encoding: 9126 9126 2423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70285,8 +72713,9 @@ SplineSet
  709 1926 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A7
-Encoding: 9127 9127 9127
+Encoding: 9127 9127 2424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70305,8 +72734,9 @@ SplineSet
  758 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23A8
-Encoding: 9128 9128 9128
+Encoding: 9128 9128 2425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70332,8 +72762,9 @@ SplineSet
  617 738 617 738 557 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23A9
-Encoding: 9129 9129 9129
+Encoding: 9129 9129 2426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70352,8 +72783,9 @@ SplineSet
  758 1913 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AA
-Encoding: 9130 9130 9130
+Encoding: 9130 9130 2427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70366,8 +72798,9 @@ SplineSet
  758 -524 l 25,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23AB
-Encoding: 9131 9131 9131
+Encoding: 9131 9131 2428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70386,8 +72819,9 @@ SplineSet
  475 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AC
-Encoding: 9132 9132 9132
+Encoding: 9132 9132 2429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70413,8 +72847,9 @@ SplineSet
  618.663 673.465 618.663 673.465 676 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23AD
-Encoding: 9133 9133 9133
+Encoding: 9133 9133 2430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70433,8 +72868,9 @@ SplineSet
  475 1913 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AE
-Encoding: 9134 9134 9134
+Encoding: 9134 9134 2431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70447,8 +72883,9 @@ SplineSet
  485 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CE
-Encoding: 9166 9166 9166
+Encoding: 9166 9166 2432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70476,8 +72913,9 @@ SplineSet
  1067 1072 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CF
-Encoding: 9167 9167 9167
+Encoding: 9167 9167 2433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70494,8 +72932,9 @@ SplineSet
  1227 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2423
-Encoding: 9251 9251 9251
+Encoding: 9251 9251 2434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70512,8 +72951,9 @@ SplineSet
  313.214 -239 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF100000
-Encoding: 9472 9472 9472
+Encoding: 9472 9472 2435
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70526,8 +72966,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2501
-Encoding: 9473 9473 9473
+Encoding: 9473 9473 2436
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70540,8 +72981,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF110000
-Encoding: 9474 9474 9474
+Encoding: 9474 9474 2437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70554,8 +72996,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2503
-Encoding: 9475 9475 9475
+Encoding: 9475 9475 2438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70568,8 +73011,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2504
-Encoding: 9476 9476 9476
+Encoding: 9476 9476 2439
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70592,8 +73036,9 @@ SplineSet
  60 618 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2505
-Encoding: 9477 9477 9477
+Encoding: 9477 9477 2440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70616,8 +73061,9 @@ SplineSet
  60 532 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2506
-Encoding: 9478 9478 9478
+Encoding: 9478 9478 2441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70640,8 +73086,9 @@ SplineSet
  536 1193 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2507
-Encoding: 9479 9479 9479
+Encoding: 9479 9479 2442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70664,8 +73111,9 @@ SplineSet
  456 1193 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2508
-Encoding: 9480 9480 9480
+Encoding: 9480 9480 2443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70693,8 +73141,9 @@ SplineSet
  984 618 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2509
-Encoding: 9481 9481 9481
+Encoding: 9481 9481 2444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70722,8 +73171,9 @@ SplineSet
  984 532 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250A
-Encoding: 9482 9482 9482
+Encoding: 9482 9482 2445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70751,8 +73201,9 @@ SplineSet
  536 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250B
-Encoding: 9483 9483 9483
+Encoding: 9483 9483 2446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70780,8 +73231,9 @@ SplineSet
  456 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF010000
-Encoding: 9484 9484 9484
+Encoding: 9484 9484 2447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70796,8 +73248,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250D
-Encoding: 9485 9485 9485
+Encoding: 9485 9485 2448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70812,8 +73265,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250E
-Encoding: 9486 9486 9486
+Encoding: 9486 9486 2449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70828,8 +73282,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250F
-Encoding: 9487 9487 9487
+Encoding: 9487 9487 2450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70844,8 +73299,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF030000
-Encoding: 9488 9488 9488
+Encoding: 9488 9488 2451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70860,8 +73316,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2511
-Encoding: 9489 9489 9489
+Encoding: 9489 9489 2452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70876,8 +73333,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2512
-Encoding: 9490 9490 9490
+Encoding: 9490 9490 2453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70892,8 +73350,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2513
-Encoding: 9491 9491 9491
+Encoding: 9491 9491 2454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70908,8 +73367,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF020000
-Encoding: 9492 9492 9492
+Encoding: 9492 9492 2455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70924,8 +73384,9 @@ SplineSet
  536 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2515
-Encoding: 9493 9493 9493
+Encoding: 9493 9493 2456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70940,8 +73401,9 @@ SplineSet
  536 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2516
-Encoding: 9494 9494 9494
+Encoding: 9494 9494 2457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70956,8 +73418,9 @@ SplineSet
  456 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2517
-Encoding: 9495 9495 9495
+Encoding: 9495 9495 2458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70972,8 +73435,9 @@ SplineSet
  456 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF040000
-Encoding: 9496 9496 9496
+Encoding: 9496 9496 2459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70988,8 +73452,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2519
-Encoding: 9497 9497 9497
+Encoding: 9497 9497 2460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71004,8 +73469,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251A
-Encoding: 9498 9498 9498
+Encoding: 9498 9498 2461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71020,8 +73486,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251B
-Encoding: 9499 9499 9499
+Encoding: 9499 9499 2462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71036,8 +73503,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF080000
-Encoding: 9500 9500 9500
+Encoding: 9500 9500 2463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71054,8 +73522,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251D
-Encoding: 9501 9501 9501
+Encoding: 9501 9501 2464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71072,8 +73541,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251E
-Encoding: 9502 9502 9502
+Encoding: 9502 9502 2465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71092,8 +73562,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251F
-Encoding: 9503 9503 9503
+Encoding: 9503 9503 2466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71112,8 +73583,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2520
-Encoding: 9504 9504 9504
+Encoding: 9504 9504 2467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71130,8 +73602,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2521
-Encoding: 9505 9505 9505
+Encoding: 9505 9505 2468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71150,8 +73623,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2522
-Encoding: 9506 9506 9506
+Encoding: 9506 9506 2469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71170,8 +73644,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2523
-Encoding: 9507 9507 9507
+Encoding: 9507 9507 2470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71188,8 +73663,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF090000
-Encoding: 9508 9508 9508
+Encoding: 9508 9508 2471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71206,8 +73682,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2525
-Encoding: 9509 9509 9509
+Encoding: 9509 9509 2472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71224,8 +73701,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2526
-Encoding: 9510 9510 9510
+Encoding: 9510 9510 2473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71244,8 +73722,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2527
-Encoding: 9511 9511 9511
+Encoding: 9511 9511 2474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71264,8 +73743,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2528
-Encoding: 9512 9512 9512
+Encoding: 9512 9512 2475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71282,8 +73762,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2529
-Encoding: 9513 9513 9513
+Encoding: 9513 9513 2476
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71302,8 +73783,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252A
-Encoding: 9514 9514 9514
+Encoding: 9514 9514 2477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71322,8 +73804,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252B
-Encoding: 9515 9515 9515
+Encoding: 9515 9515 2478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71340,8 +73823,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF060000
-Encoding: 9516 9516 9516
+Encoding: 9516 9516 2479
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71358,8 +73842,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252D
-Encoding: 9517 9517 9517
+Encoding: 9517 9517 2480
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71378,8 +73863,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252E
-Encoding: 9518 9518 9518
+Encoding: 9518 9518 2481
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71398,8 +73884,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252F
-Encoding: 9519 9519 9519
+Encoding: 9519 9519 2482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71416,8 +73903,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2530
-Encoding: 9520 9520 9520
+Encoding: 9520 9520 2483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71434,8 +73922,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2531
-Encoding: 9521 9521 9521
+Encoding: 9521 9521 2484
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71454,8 +73943,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2532
-Encoding: 9522 9522 9522
+Encoding: 9522 9522 2485
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71474,8 +73964,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2533
-Encoding: 9523 9523 9523
+Encoding: 9523 9523 2486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71492,8 +73983,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF070000
-Encoding: 9524 9524 9524
+Encoding: 9524 9524 2487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71510,8 +74002,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2535
-Encoding: 9525 9525 9525
+Encoding: 9525 9525 2488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71530,8 +74023,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2536
-Encoding: 9526 9526 9526
+Encoding: 9526 9526 2489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71550,8 +74044,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2537
-Encoding: 9527 9527 9527
+Encoding: 9527 9527 2490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71568,8 +74063,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2538
-Encoding: 9528 9528 9528
+Encoding: 9528 9528 2491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71586,8 +74082,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2539
-Encoding: 9529 9529 9529
+Encoding: 9529 9529 2492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71606,8 +74103,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253A
-Encoding: 9530 9530 9530
+Encoding: 9530 9530 2493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71626,8 +74124,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253B
-Encoding: 9531 9531 9531
+Encoding: 9531 9531 2494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71644,8 +74143,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF050000
-Encoding: 9532 9532 9532
+Encoding: 9532 9532 2495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71666,8 +74166,9 @@ SplineSet
  696 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253D
-Encoding: 9533 9533 9533
+Encoding: 9533 9533 2496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71688,8 +74189,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253E
-Encoding: 9534 9534 9534
+Encoding: 9534 9534 2497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71710,8 +74212,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253F
-Encoding: 9535 9535 9535
+Encoding: 9535 9535 2498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71732,8 +74235,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2540
-Encoding: 9536 9536 9536
+Encoding: 9536 9536 2499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71754,8 +74258,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2541
-Encoding: 9537 9537 9537
+Encoding: 9537 9537 2500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71776,8 +74281,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2542
-Encoding: 9538 9538 9538
+Encoding: 9538 9538 2501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71798,8 +74304,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2543
-Encoding: 9539 9539 9539
+Encoding: 9539 9539 2502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71822,8 +74329,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2544
-Encoding: 9540 9540 9540
+Encoding: 9540 9540 2503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71846,8 +74354,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2545
-Encoding: 9541 9541 9541
+Encoding: 9541 9541 2504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71870,8 +74379,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2546
-Encoding: 9542 9542 9542
+Encoding: 9542 9542 2505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71894,8 +74404,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2547
-Encoding: 9543 9543 9543
+Encoding: 9543 9543 2506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71916,8 +74427,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2548
-Encoding: 9544 9544 9544
+Encoding: 9544 9544 2507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71938,8 +74450,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2549
-Encoding: 9545 9545 9545
+Encoding: 9545 9545 2508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71960,8 +74473,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254A
-Encoding: 9546 9546 9546
+Encoding: 9546 9546 2509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71982,8 +74496,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254B
-Encoding: 9547 9547 9547
+Encoding: 9547 9547 2510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72004,8 +74519,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254C
-Encoding: 9548 9548 9548
+Encoding: 9548 9548 2511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72023,8 +74539,9 @@ SplineSet
  677 618 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254D
-Encoding: 9549 9549 9549
+Encoding: 9549 9549 2512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72042,8 +74559,9 @@ SplineSet
  60 532 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254E
-Encoding: 9550 9550 9550
+Encoding: 9550 9550 2513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72061,8 +74579,9 @@ SplineSet
  536 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254F
-Encoding: 9551 9551 9551
+Encoding: 9551 9551 2514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72080,8 +74599,9 @@ SplineSet
  456 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF430000
-Encoding: 9552 9552 9552
+Encoding: 9552 9552 2515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72099,8 +74619,9 @@ SplineSet
  -20 446 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF240000
-Encoding: 9553 9553 9553
+Encoding: 9553 9553 2516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72118,8 +74639,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF510000
-Encoding: 9554 9554 9554
+Encoding: 9554 9554 2517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72138,8 +74660,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF520000
-Encoding: 9555 9555 9555
+Encoding: 9555 9555 2518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72158,8 +74681,9 @@ SplineSet
  376 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF390000
-Encoding: 9556 9556 9556
+Encoding: 9556 9556 2519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72181,8 +74705,9 @@ SplineSet
  696 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF220000
-Encoding: 9557 9557 9557
+Encoding: 9557 9557 2520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72201,8 +74726,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF210000
-Encoding: 9558 9558 9558
+Encoding: 9558 9558 2521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72221,8 +74747,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF250000
-Encoding: 9559 9559 9559
+Encoding: 9559 9559 2522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72244,8 +74771,9 @@ SplineSet
  376 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF500000
-Encoding: 9560 9560 9560
+Encoding: 9560 9560 2523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72264,8 +74792,9 @@ SplineSet
  536 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF490000
-Encoding: 9561 9561 9561
+Encoding: 9561 9561 2524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72284,8 +74813,9 @@ SplineSet
  376 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF380000
-Encoding: 9562 9562 9562
+Encoding: 9562 9562 2525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72307,8 +74837,9 @@ SplineSet
  376 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF280000
-Encoding: 9563 9563 9563
+Encoding: 9563 9563 2526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72327,8 +74858,9 @@ SplineSet
  -20 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF270000
-Encoding: 9564 9564 9564
+Encoding: 9564 9564 2527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72347,8 +74879,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF260000
-Encoding: 9565 9565 9565
+Encoding: 9565 9565 2528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72370,8 +74903,9 @@ SplineSet
  -20 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF360000
-Encoding: 9566 9566 9566
+Encoding: 9566 9566 2529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72392,8 +74926,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF370000
-Encoding: 9567 9567 9567
+Encoding: 9567 9567 2530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72415,8 +74950,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF420000
-Encoding: 9568 9568 9568
+Encoding: 9568 9568 2531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72443,8 +74979,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF190000
-Encoding: 9569 9569 9569
+Encoding: 9569 9569 2532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72465,8 +75002,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF200000
-Encoding: 9570 9570 9570
+Encoding: 9570 9570 2533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72488,8 +75026,9 @@ SplineSet
  696 -512 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF230000
-Encoding: 9571 9571 9571
+Encoding: 9571 9571 2534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72516,8 +75055,9 @@ SplineSet
  696 -512 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF470000
-Encoding: 9572 9572 9572
+Encoding: 9572 9572 2535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72539,8 +75079,9 @@ SplineSet
  -20 790 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF480000
-Encoding: 9573 9573 9573
+Encoding: 9573 9573 2536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72561,8 +75102,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF410000
-Encoding: 9574 9574 9574
+Encoding: 9574 9574 2537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72589,8 +75131,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF450000
-Encoding: 9575 9575 9575
+Encoding: 9575 9575 2538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72612,8 +75155,9 @@ SplineSet
  -20 790 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF460000
-Encoding: 9576 9576 9576
+Encoding: 9576 9576 2539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72634,8 +75178,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF400000
-Encoding: 9577 9577 9577
+Encoding: 9577 9577 2540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72662,8 +75207,9 @@ SplineSet
  696 790 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF540000
-Encoding: 9578 9578 9578
+Encoding: 9578 9578 2541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72692,8 +75238,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF530000
-Encoding: 9579 9579 9579
+Encoding: 9579 9579 2542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72722,8 +75269,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF440000
-Encoding: 9580 9580 9580
+Encoding: 9580 9580 2543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72759,8 +75307,9 @@ SplineSet
  696 790 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256D
-Encoding: 9581 9581 9581
+Encoding: 9581 9581 2544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72779,8 +75328,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256E
-Encoding: 9582 9582 9582
+Encoding: 9582 9582 2545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72799,8 +75349,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256F
-Encoding: 9583 9583 9583
+Encoding: 9583 9583 2546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72819,8 +75370,9 @@ SplineSet
  -20 618 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2570
-Encoding: 9584 9584 9584
+Encoding: 9584 9584 2547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72839,8 +75391,9 @@ SplineSet
  1253 618 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2571
-Encoding: 9585 9585 9585
+Encoding: 9585 9585 2548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72853,8 +75406,9 @@ SplineSet
  -89 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2572
-Encoding: 9586 9586 9586
+Encoding: 9586 9586 2549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72867,8 +75421,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2573
-Encoding: 9587 9587 9587
+Encoding: 9587 9587 2550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72889,8 +75444,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2574
-Encoding: 9588 9588 9588
+Encoding: 9588 9588 2551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72903,8 +75459,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2575
-Encoding: 9589 9589 9589
+Encoding: 9589 9589 2552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72917,8 +75474,9 @@ SplineSet
  536 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2576
-Encoding: 9590 9590 9590
+Encoding: 9590 9590 2553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72931,8 +75489,9 @@ SplineSet
  616 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2577
-Encoding: 9591 9591 9591
+Encoding: 9591 9591 2554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72945,8 +75504,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2578
-Encoding: 9592 9592 9592
+Encoding: 9592 9592 2555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72959,8 +75519,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2579
-Encoding: 9593 9593 9593
+Encoding: 9593 9593 2556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72973,8 +75534,9 @@ SplineSet
  456 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257A
-Encoding: 9594 9594 9594
+Encoding: 9594 9594 2557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72987,8 +75549,9 @@ SplineSet
  616 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257B
-Encoding: 9595 9595 9595
+Encoding: 9595 9595 2558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73001,8 +75564,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257C
-Encoding: 9596 9596 9596
+Encoding: 9596 9596 2559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73019,8 +75583,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257D
-Encoding: 9597 9597 9597
+Encoding: 9597 9597 2560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73037,8 +75602,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257E
-Encoding: 9598 9598 9598
+Encoding: 9598 9598 2561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73055,8 +75621,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257F
-Encoding: 9599 9599 9599
+Encoding: 9599 9599 2562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73073,16 +75640,18 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: upblock
-Encoding: 9600 9600 9600
+Encoding: 9600 9600 2563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9604 9604 N 1 0 0 1 0 1216 2
+Refer: 2567 9604 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2581
-Encoding: 9601 9601 9601
+Encoding: 9601 9601 2564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73095,8 +75664,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2582
-Encoding: 9602 9602 9602
+Encoding: 9602 9602 2565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73109,8 +75679,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2583
-Encoding: 9603 9603 9603
+Encoding: 9603 9603 2566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73123,8 +75694,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dnblock
-Encoding: 9604 9604 9604
+Encoding: 9604 9604 2567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73137,8 +75709,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2585
-Encoding: 9605 9605 9605
+Encoding: 9605 9605 2568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73151,8 +75724,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2586
-Encoding: 9606 9606 9606
+Encoding: 9606 9606 2569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73165,8 +75739,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2587
-Encoding: 9607 9607 9607
+Encoding: 9607 9607 2570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73179,8 +75754,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: block
-Encoding: 9608 9608 9608
+Encoding: 9608 9608 2571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73193,8 +75769,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2589
-Encoding: 9609 9609 9609
+Encoding: 9609 9609 2572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73207,8 +75784,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258A
-Encoding: 9610 9610 9610
+Encoding: 9610 9610 2573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73221,8 +75799,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258B
-Encoding: 9611 9611 9611
+Encoding: 9611 9611 2574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73235,8 +75814,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lfblock
-Encoding: 9612 9612 9612
+Encoding: 9612 9612 2575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73249,8 +75829,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258D
-Encoding: 9613 9613 9613
+Encoding: 9613 9613 2576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73263,8 +75844,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258E
-Encoding: 9614 9614 9614
+Encoding: 9614 9614 2577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73277,8 +75859,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258F
-Encoding: 9615 9615 9615
+Encoding: 9615 9615 2578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73291,16 +75874,18 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rtblock
-Encoding: 9616 9616 9616
+Encoding: 9616 9616 2579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9612 9612 N 1 0 0 1 637 0 2
+Refer: 2575 9612 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: ltshade
-Encoding: 9617 9617 9617
+Encoding: 9617 9617 2580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73388,8 +75973,9 @@ SplineSet
  0 1059 l 25,60,-1
 EndSplineSet
 EndChar
+
 StartChar: shade
-Encoding: 9618 9618 9618
+Encoding: 9618 9618 2581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73547,8 +76133,9 @@ SplineSet
  0 1661 l 1,116,-1
 EndSplineSet
 EndChar
+
 StartChar: dkshade
-Encoding: 9619 9619 9619
+Encoding: 9619 9619 2582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73632,24 +76219,27 @@ SplineSet
  770 1901 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2594
-Encoding: 9620 9620 9620
+Encoding: 9620 9620 2583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9601 9601 N 1 0 0 1 0 2114 2
+Refer: 2564 9601 N 1 0 0 1 0 2114 2
 EndChar
+
 StartChar: uni2595
-Encoding: 9621 9621 9621
+Encoding: 9621 9621 2584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9615 9615 N 1 0 0 1 1114 0 2
+Refer: 2578 9615 N 1 0 0 1 1114 0 2
 EndChar
+
 StartChar: uni2596
-Encoding: 9622 9622 9622
+Encoding: 9622 9622 2585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73662,24 +76252,27 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2597
-Encoding: 9623 9623 9623
+Encoding: 9623 9623 2586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 0 2
+Refer: 2585 9622 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: uni2598
-Encoding: 9624 9624 9624
+Encoding: 9624 9624 2587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 1216 2
+Refer: 2585 9622 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2599
-Encoding: 9625 9625 9625
+Encoding: 9625 9625 2588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73694,17 +76287,19 @@ SplineSet
  -20 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259A
-Encoding: 9626 9626 9626
+Encoding: 9626 9626 2589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9624 9624 N 1 0 0 1 0 0 2
-Refer: 9623 9623 N 1 0 0 1 0 0 2
+Refer: 2587 9624 N 1 0 0 1 0 0 2
+Refer: 2586 9623 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259B
-Encoding: 9627 9627 9627
+Encoding: 9627 9627 2590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73719,8 +76314,9 @@ SplineSet
  -20 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259C
-Encoding: 9628 9628 9628
+Encoding: 9628 9628 2591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73735,25 +76331,28 @@ SplineSet
  1254 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259D
-Encoding: 9629 9629 9629
+Encoding: 9629 9629 2592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 1216 2
+Refer: 2585 9622 N 1 0 0 1 637 1216 2
 EndChar
+
 StartChar: uni259E
-Encoding: 9630 9630 9630
+Encoding: 9630 9630 2593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 0 2
-Refer: 9629 9629 N 1 0 0 1 0 0 2
+Refer: 2585 9622 N 1 0 0 1 0 0 2
+Refer: 2592 9629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259F
-Encoding: 9631 9631 9631
+Encoding: 9631 9631 2594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73768,8 +76367,9 @@ SplineSet
  1254 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: filledbox
-Encoding: 9632 9632 9632
+Encoding: 9632 9632 2595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73782,8 +76382,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H22073
-Encoding: 9633 9633 9633
+Encoding: 9633 9633 2596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73801,8 +76402,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A2
-Encoding: 9634 9634 9634
+Encoding: 9634 9634 2597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73828,17 +76430,19 @@ SplineSet
  6 -78.5 6 -78.5 6 263.5 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A3
-Encoding: 9635 9635 9635
+Encoding: 9635 9635 2598
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9642 9642 N 1 0 0 1 0 0 2
-Refer: 9633 9633 N 1 0 0 1 0 0 2
+Refer: 2605 9642 N 1 0 0 1 0 0 2
+Refer: 2596 9633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni25A4
-Encoding: 9636 9636 9636
+Encoding: 9636 9636 2599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73876,8 +76480,9 @@ SplineSet
  120 922 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A5
-Encoding: 9637 9637 9637
+Encoding: 9637 9637 2600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73915,8 +76520,9 @@ SplineSet
  120 36 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A6
-Encoding: 9638 9638 9638
+Encoding: 9638 9638 2601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74054,8 +76660,9 @@ SplineSet
  6 -78.5 l 1,100,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A7
-Encoding: 9639 9639 9639
+Encoding: 9639 9639 2602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74103,8 +76710,9 @@ SplineSet
  120 182 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A8
-Encoding: 9640 9640 9640
+Encoding: 9640 9640 2603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74152,8 +76760,9 @@ SplineSet
  967 36 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A9
-Encoding: 9641 9641 9641
+Encoding: 9641 9641 2604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74303,8 +76912,9 @@ SplineSet
  6 -78.5 l 1,112,-1
 EndSplineSet
 EndChar
+
 StartChar: H18543
-Encoding: 9642 9642 9642
+Encoding: 9642 9642 2605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74317,8 +76927,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H18551
-Encoding: 9643 9643 9643
+Encoding: 9643 9643 2606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74336,8 +76947,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: filledrect
-Encoding: 9644 9644 9644
+Encoding: 9644 9644 2607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74350,8 +76962,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AD
-Encoding: 9645 9645 9645
+Encoding: 9645 9645 2608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74369,8 +76982,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AE
-Encoding: 9646 9646 9646
+Encoding: 9646 9646 2609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74383,8 +76997,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AF
-Encoding: 9647 9647 9647
+Encoding: 9647 9647 2610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74402,8 +77017,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B0
-Encoding: 9648 9648 9648
+Encoding: 9648 9648 2611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74416,8 +77032,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B1
-Encoding: 9649 9649 9649
+Encoding: 9649 9649 2612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74435,8 +77052,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagup
-Encoding: 9650 9650 9650
+Encoding: 9650 9650 2613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74448,8 +77066,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B3
-Encoding: 9651 9651 9651
+Encoding: 9651 9651 2614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74465,8 +77084,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B4
-Encoding: 9652 9652 9652
+Encoding: 9652 9652 2615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74478,8 +77098,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B5
-Encoding: 9653 9653 9653
+Encoding: 9653 9653 2616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74495,8 +77116,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B6
-Encoding: 9654 9654 9654
+Encoding: 9654 9654 2617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74508,8 +77130,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B7
-Encoding: 9655 9655 9655
+Encoding: 9655 9655 2618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74525,8 +77148,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B8
-Encoding: 9656 9656 9656
+Encoding: 9656 9656 2619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74538,8 +77162,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B9
-Encoding: 9657 9657 9657
+Encoding: 9657 9657 2620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74555,8 +77180,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagrt
-Encoding: 9658 9658 9658
+Encoding: 9658 9658 2621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74568,8 +77194,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BB
-Encoding: 9659 9659 9659
+Encoding: 9659 9659 2622
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74585,8 +77212,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagdn
-Encoding: 9660 9660 9660
+Encoding: 9660 9660 2623
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74598,8 +77226,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BD
-Encoding: 9661 9661 9661
+Encoding: 9661 9661 2624
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74615,8 +77244,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BE
-Encoding: 9662 9662 9662
+Encoding: 9662 9662 2625
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74628,8 +77258,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BF
-Encoding: 9663 9663 9663
+Encoding: 9663 9663 2626
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74645,8 +77276,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C0
-Encoding: 9664 9664 9664
+Encoding: 9664 9664 2627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74658,8 +77290,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C1
-Encoding: 9665 9665 9665
+Encoding: 9665 9665 2628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74675,8 +77308,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C2
-Encoding: 9666 9666 9666
+Encoding: 9666 9666 2629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74688,8 +77322,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C3
-Encoding: 9667 9667 9667
+Encoding: 9667 9667 2630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74705,8 +77340,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triaglf
-Encoding: 9668 9668 9668
+Encoding: 9668 9668 2631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74718,8 +77354,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C5
-Encoding: 9669 9669 9669
+Encoding: 9669 9669 2632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74735,8 +77372,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C6
-Encoding: 9670 9670 9670
+Encoding: 9670 9670 2633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74749,8 +77387,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C7
-Encoding: 9671 9671 9671
+Encoding: 9671 9671 2634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74768,8 +77407,9 @@ SplineSet
  6 532 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25C8
-Encoding: 9672 9672 9672
+Encoding: 9672 9672 2635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74792,8 +77432,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C9
-Encoding: 9673 9673 9673
+Encoding: 9673 9673 2636
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74828,8 +77469,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: lozenge
-Encoding: 9674 9674 9674
+Encoding: 9674 9674 2637
 Width: 1233
 Flags: W
 TtInstrs:
@@ -74883,8 +77525,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: circle
-Encoding: 9675 9675 9675
+Encoding: 9675 9675 2638
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74910,8 +77553,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni25CC
-Encoding: 9676 9676 9676
+Encoding: 9676 9676 2639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74975,8 +77619,9 @@ SplineSet
  179.04 642.4 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25CD
-Encoding: 9677 9677 9677
+Encoding: 9677 9677 2640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75022,8 +77667,9 @@ SplineSet
  1105 714 1105 714 1002 838 c 1,51,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25CE
-Encoding: 9678 9678 9678
+Encoding: 9678 9678 2641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75067,8 +77713,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: H18533
-Encoding: 9679 9679 9679
+Encoding: 9679 9679 2642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75085,8 +77732,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D0
-Encoding: 9680 9680 9680
+Encoding: 9680 9680 2643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75109,8 +77757,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D1
-Encoding: 9681 9681 9681
+Encoding: 9681 9681 2644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75133,8 +77782,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D2
-Encoding: 9682 9682 9682
+Encoding: 9682 9682 2645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75157,8 +77807,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D3
-Encoding: 9683 9683 9683
+Encoding: 9683 9683 2646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75181,8 +77832,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D4
-Encoding: 9684 9684 9684
+Encoding: 9684 9684 2647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75208,8 +77860,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D5
-Encoding: 9685 9685 9685
+Encoding: 9685 9685 2648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75231,8 +77884,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D6
-Encoding: 9686 9686 9686
+Encoding: 9686 9686 2649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75246,8 +77900,9 @@ SplineSet
  921.5 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25D7
-Encoding: 9687 9687 9687
+Encoding: 9687 9687 2650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75261,8 +77916,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: invbullet
-Encoding: 9688 9688 9688
+Encoding: 9688 9688 2651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75292,8 +77948,9 @@ SplineSet
  -20 -20 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: invcircle
-Encoding: 9689 9689 9689
+Encoding: 9689 9689 2652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75324,8 +77981,9 @@ SplineSet
  -20 -512 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DA
-Encoding: 9690 9690 9690
+Encoding: 9690 9690 2653
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75349,8 +78007,9 @@ SplineSet
  1104.9 813.293 1104.9 813.293 1104.9 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DB
-Encoding: 9691 9691 9691
+Encoding: 9691 9691 2654
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75374,8 +78033,9 @@ SplineSet
  128.1 250.631 128.1 250.631 128.1 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DC
-Encoding: 9692 9692 9692
+Encoding: 9692 9692 2655
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75390,8 +78050,9 @@ SplineSet
  311.45 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25DD
-Encoding: 9693 9693 9693
+Encoding: 9693 9693 2656
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75406,8 +78067,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DE
-Encoding: 9694 9694 9694
+Encoding: 9694 9694 2657
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75422,8 +78084,9 @@ SplineSet
  462.5 -84 462.5 -84 311.5 -84 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DF
-Encoding: 9695 9695 9695
+Encoding: 9695 9695 2658
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75438,8 +78101,9 @@ SplineSet
  921.45 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E0
-Encoding: 9696 9696 9696
+Encoding: 9696 9696 2659
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75458,8 +78122,9 @@ SplineSet
  1227 883 1227 883 1227 532 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E1
-Encoding: 9697 9697 9697
+Encoding: 9697 9697 2660
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75478,8 +78143,9 @@ SplineSet
  167.172 532 l 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E2
-Encoding: 9698 9698 9698
+Encoding: 9698 9698 2661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75491,8 +78157,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E3
-Encoding: 9699 9699 9699
+Encoding: 9699 9699 2662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75504,8 +78171,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E4
-Encoding: 9700 9700 9700
+Encoding: 9700 9700 2663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75517,8 +78185,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E5
-Encoding: 9701 9701 9701
+Encoding: 9701 9701 2664
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75530,8 +78199,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: openbullet
-Encoding: 9702 9702 9702
+Encoding: 9702 9702 2665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75573,8 +78243,9 @@ SplineSet
  256 688 256 688 256 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E7
-Encoding: 9703 9703 9703
+Encoding: 9703 9703 2666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75592,8 +78263,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E8
-Encoding: 9704 9704 9704
+Encoding: 9704 9704 2667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75611,8 +78283,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E9
-Encoding: 9705 9705 9705
+Encoding: 9705 9705 2668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75629,8 +78302,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EA
-Encoding: 9706 9706 9706
+Encoding: 9706 9706 2669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75647,8 +78321,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EB
-Encoding: 9707 9707 9707
+Encoding: 9707 9707 2670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75671,8 +78346,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EC
-Encoding: 9708 9708 9708
+Encoding: 9708 9708 2671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75697,8 +78373,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25ED
-Encoding: 9709 9709 9709
+Encoding: 9709 9709 2672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75714,8 +78391,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EE
-Encoding: 9710 9710 9710
+Encoding: 9710 9710 2673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75731,8 +78409,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EF
-Encoding: 9711 9711 9711
+Encoding: 9711 9711 2674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75758,8 +78437,9 @@ SplineSet
  -20 165 -20 165 -20 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25F0
-Encoding: 9712 9712 9712
+Encoding: 9712 9712 2675
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75784,8 +78464,9 @@ SplineSet
  120 35.5 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F1
-Encoding: 9713 9713 9713
+Encoding: 9713 9713 2676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75810,8 +78491,9 @@ SplineSet
  120 588.5 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F2
-Encoding: 9714 9714 9714
+Encoding: 9714 9714 2677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75836,8 +78518,9 @@ SplineSet
  120 35.5 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F3
-Encoding: 9715 9715 9715
+Encoding: 9715 9715 2678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75862,8 +78545,9 @@ SplineSet
  120 35.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F4
-Encoding: 9716 9716 9716
+Encoding: 9716 9716 2679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75894,8 +78578,9 @@ SplineSet
  130.784 474.5 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni25F5
-Encoding: 9717 9717 9717
+Encoding: 9717 9717 2680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75926,8 +78611,9 @@ SplineSet
  130.784 474.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F6
-Encoding: 9718 9718 9718
+Encoding: 9718 9718 2681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75958,8 +78644,9 @@ SplineSet
  673 43.0479 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F7
-Encoding: 9719 9719 9719
+Encoding: 9719 9719 2682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75990,8 +78677,9 @@ SplineSet
  1102.3 588.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F8
-Encoding: 9720 9720 9720
+Encoding: 9720 9720 2683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76007,8 +78695,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25F9
-Encoding: 9721 9721 9721
+Encoding: 9721 9721 2684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76024,8 +78713,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FA
-Encoding: 9722 9722 9722
+Encoding: 9722 9722 2685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76041,8 +78731,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FB
-Encoding: 9723 9723 9723
+Encoding: 9723 9723 2686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76060,8 +78751,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FC
-Encoding: 9724 9724 9724
+Encoding: 9724 9724 2687
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76074,8 +78766,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FD
-Encoding: 9725 9725 9725
+Encoding: 9725 9725 2688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76093,8 +78786,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FE
-Encoding: 9726 9726 9726
+Encoding: 9726 9726 2689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76107,8 +78801,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FF
-Encoding: 9727 9727 9727
+Encoding: 9727 9727 2690
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76124,8 +78819,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2600
-Encoding: 9728 9728 9728
+Encoding: 9728 9728 2691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76207,8 +78903,9 @@ SplineSet
  590 446 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2638
-Encoding: 9784 9784 9784
+Encoding: 9784 9784 2692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76298,8 +78995,9 @@ SplineSet
  563 548 l 1,106,107
 EndSplineSet
 EndChar
+
 StartChar: uni2639
-Encoding: 9785 9785 9785
+Encoding: 9785 9785 2693
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76342,8 +79040,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: smileface
-Encoding: 9786 9786 9786
+Encoding: 9786 9786 2694
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76386,8 +79085,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: invsmileface
-Encoding: 9787 9787 9787
+Encoding: 9787 9787 2695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76421,8 +79121,9 @@ SplineSet
  496 860 496 860 501 970 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: sun
-Encoding: 9788 9788 9788
+Encoding: 9788 9788 2696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76513,8 +79214,9 @@ SplineSet
  592 924 592 924 556 910 c 0,74,75
 EndSplineSet
 EndChar
+
 StartChar: uni263F
-Encoding: 9791 9791 9791
+Encoding: 9791 9791 2697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76567,8 +79269,9 @@ SplineSet
  744 1012 744 1012 635 1018 c 2,50,-1
 EndSplineSet
 EndChar
+
 StartChar: female
-Encoding: 9792 9792 9792
+Encoding: 9792 9792 2698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76605,8 +79308,9 @@ SplineSet
  397 443 397 443 284 548 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2641
-Encoding: 9793 9793 9793
+Encoding: 9793 9793 2699
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76643,8 +79347,9 @@ SplineSet
  397 798 397 798 550 811 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: male
-Encoding: 9794 9794 9794
+Encoding: 9794 9794 2700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76680,8 +79385,9 @@ SplineSet
  910 411 910 411 781 282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2643
-Encoding: 9795 9795 9795
+Encoding: 9795 9795 2701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76713,8 +79419,9 @@ SplineSet
  488 543 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2644
-Encoding: 9796 9796 9796
+Encoding: 9796 9796 2702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76749,8 +79456,9 @@ SplineSet
  274 1141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2645
-Encoding: 9797 9797 9797
+Encoding: 9797 9797 2703
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76803,8 +79511,9 @@ SplineSet
  679 553 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2646
-Encoding: 9798 9798 9798
+Encoding: 9798 9798 2704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76866,8 +79575,9 @@ SplineSet
  679 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2647
-Encoding: 9799 9799 9799
+Encoding: 9799 9799 2705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76899,8 +79609,9 @@ SplineSet
  352 1322 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: spade
-Encoding: 9824 9824 9824
+Encoding: 9824 9824 2706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76933,8 +79644,9 @@ SplineSet
  619 1359 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2661
-Encoding: 9825 9825 9825
+Encoding: 9825 9825 2707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76974,8 +79686,9 @@ SplineSet
  56 1112 56 1112 56 1053 c 2,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2662
-Encoding: 9826 9826 9826
+Encoding: 9826 9826 2708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76996,8 +79709,9 @@ SplineSet
  614 1293 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: club
-Encoding: 9827 9827 9827
+Encoding: 9827 9827 2709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77041,8 +79755,9 @@ SplineSet
  586 1359 586 1359 618 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2664
-Encoding: 9828 9828 9828
+Encoding: 9828 9828 2710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77095,8 +79810,9 @@ SplineSet
  592 176 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: heart
-Encoding: 9829 9829 9829
+Encoding: 9829 9829 2711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77119,8 +79835,9 @@ SplineSet
  244 1359 244 1359 315 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: diamond
-Encoding: 9830 9830 9830
+Encoding: 9830 9830 2712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77135,8 +79852,9 @@ SplineSet
  617 1359 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2667
-Encoding: 9831 9831 9831
+Encoding: 9831 9831 2713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77211,8 +79929,9 @@ SplineSet
  617 277 l 1,97,98
 EndSplineSet
 EndChar
+
 StartChar: uni2669
-Encoding: 9833 9833 9833
+Encoding: 9833 9833 2714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77235,8 +79954,9 @@ SplineSet
  789 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnote
-Encoding: 9834 9834 9834
+Encoding: 9834 9834 2715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77265,8 +79985,9 @@ SplineSet
  566 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnotedbl
-Encoding: 9835 9835 9835
+Encoding: 9835 9835 2716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77298,8 +80019,9 @@ SplineSet
  473 1445 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266C
-Encoding: 9836 9836 9836
+Encoding: 9836 9836 2717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77330,8 +80052,9 @@ SplineSet
  438 1189 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266D
-Encoding: 9837 9837 9837
+Encoding: 9837 9837 2718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77355,8 +80078,9 @@ SplineSet
  519 658 519 658 376 441 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266E
-Encoding: 9838 9838 9838
+Encoding: 9838 9838 2719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77386,8 +80110,9 @@ SplineSet
  483 870 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266F
-Encoding: 9839 9839 9839
+Encoding: 9839 9839 2720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77439,16 +80164,18 @@ SplineSet
  482 867 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27C2
-Encoding: 10178 10178 10178
+Encoding: 10178 10178 2721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8869 8869 N 1 0 0 1 0 0 2
+Refer: 2265 8869 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni27C5
-Encoding: 10181 10181 10181
+Encoding: 10181 10181 2722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77473,8 +80200,9 @@ SplineSet
  791 -334 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27C6
-Encoding: 10182 10182 10182
+Encoding: 10182 10182 2723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77499,8 +80227,9 @@ SplineSet
  80 -334 80 -334 71 -334 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27DC
-Encoding: 10204 10204 10204
+Encoding: 10204 10204 2724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77529,8 +80258,9 @@ SplineSet
  554 811 554 811 574 765 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E0
-Encoding: 10208 10208 10208
+Encoding: 10208 10208 2725
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77551,8 +80281,9 @@ SplineSet
  616 -233 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E6
-Encoding: 10214 10214 10214
+Encoding: 10214 10214 2726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77574,8 +80305,9 @@ SplineSet
  474 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E7
-Encoding: 10215 10215 10215
+Encoding: 10215 10215 2727
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77597,8 +80329,9 @@ SplineSet
  1113 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E8
-Encoding: 10216 10216 10216
+Encoding: 10216 10216 2728
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77613,8 +80346,9 @@ SplineSet
  337.983 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E9
-Encoding: 10217 10217 10217
+Encoding: 10217 10217 2729
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77629,26 +80363,29 @@ SplineSet
  895.017 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27EA
-Encoding: 10218 10218 10218
+Encoding: 10218 10218 2730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10216 10216 N 1 0 0 1 -250 0 2
-Refer: 10216 10216 N 1 0 0 1 250 0 2
+Refer: 2728 10216 N 1 0 0 1 -250 0 2
+Refer: 2728 10216 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni27EB
-Encoding: 10219 10219 10219
+Encoding: 10219 10219 2731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10217 10217 N 1 0 0 1 -250 0 2
-Refer: 10217 10217 N 1 0 0 1 250 0 2
+Refer: 2729 10217 N 1 0 0 1 -250 0 2
+Refer: 2729 10217 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni27F5
-Encoding: 10229 10229 10229
+Encoding: 10229 10229 2732
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77667,8 +80404,9 @@ SplineSet
  -100 632 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F6
-Encoding: 10230 10230 10230
+Encoding: 10230 10230 2733
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77687,8 +80425,9 @@ SplineSet
  1333 490 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F7
-Encoding: 10231 10231 10231
+Encoding: 10231 10231 2734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77713,1544 +80452,1801 @@ SplineSet
  -100 632 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2800
-Encoding: 10240 10240 10240
+Encoding: 10240 10240 2735
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2801
-Encoding: 10241 10241 10241
+Encoding: 10241 10241 2736
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2802
-Encoding: 10242 10242 10242
+Encoding: 10242 10242 2737
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2803
-Encoding: 10243 10243 10243
+Encoding: 10243 10243 2738
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2804
-Encoding: 10244 10244 10244
+Encoding: 10244 10244 2739
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2805
-Encoding: 10245 10245 10245
+Encoding: 10245 10245 2740
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2806
-Encoding: 10246 10246 10246
+Encoding: 10246 10246 2741
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2807
-Encoding: 10247 10247 10247
+Encoding: 10247 10247 2742
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2808
-Encoding: 10248 10248 10248
+Encoding: 10248 10248 2743
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2809
-Encoding: 10249 10249 10249
+Encoding: 10249 10249 2744
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280A
-Encoding: 10250 10250 10250
+Encoding: 10250 10250 2745
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280B
-Encoding: 10251 10251 10251
+Encoding: 10251 10251 2746
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280C
-Encoding: 10252 10252 10252
+Encoding: 10252 10252 2747
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280D
-Encoding: 10253 10253 10253
+Encoding: 10253 10253 2748
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280E
-Encoding: 10254 10254 10254
+Encoding: 10254 10254 2749
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280F
-Encoding: 10255 10255 10255
+Encoding: 10255 10255 2750
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2810
-Encoding: 10256 10256 10256
+Encoding: 10256 10256 2751
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2811
-Encoding: 10257 10257 10257
+Encoding: 10257 10257 2752
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2812
-Encoding: 10258 10258 10258
+Encoding: 10258 10258 2753
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2813
-Encoding: 10259 10259 10259
+Encoding: 10259 10259 2754
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2814
-Encoding: 10260 10260 10260
+Encoding: 10260 10260 2755
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2815
-Encoding: 10261 10261 10261
+Encoding: 10261 10261 2756
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2816
-Encoding: 10262 10262 10262
+Encoding: 10262 10262 2757
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2817
-Encoding: 10263 10263 10263
+Encoding: 10263 10263 2758
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2818
-Encoding: 10264 10264 10264
+Encoding: 10264 10264 2759
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2819
-Encoding: 10265 10265 10265
+Encoding: 10265 10265 2760
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281A
-Encoding: 10266 10266 10266
+Encoding: 10266 10266 2761
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281B
-Encoding: 10267 10267 10267
+Encoding: 10267 10267 2762
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281C
-Encoding: 10268 10268 10268
+Encoding: 10268 10268 2763
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281D
-Encoding: 10269 10269 10269
+Encoding: 10269 10269 2764
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281E
-Encoding: 10270 10270 10270
+Encoding: 10270 10270 2765
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281F
-Encoding: 10271 10271 10271
+Encoding: 10271 10271 2766
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2820
-Encoding: 10272 10272 10272
+Encoding: 10272 10272 2767
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2821
-Encoding: 10273 10273 10273
+Encoding: 10273 10273 2768
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2822
-Encoding: 10274 10274 10274
+Encoding: 10274 10274 2769
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2823
-Encoding: 10275 10275 10275
+Encoding: 10275 10275 2770
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2824
-Encoding: 10276 10276 10276
+Encoding: 10276 10276 2771
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2825
-Encoding: 10277 10277 10277
+Encoding: 10277 10277 2772
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2826
-Encoding: 10278 10278 10278
+Encoding: 10278 10278 2773
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2827
-Encoding: 10279 10279 10279
+Encoding: 10279 10279 2774
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2828
-Encoding: 10280 10280 10280
+Encoding: 10280 10280 2775
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2829
-Encoding: 10281 10281 10281
+Encoding: 10281 10281 2776
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282A
-Encoding: 10282 10282 10282
+Encoding: 10282 10282 2777
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282B
-Encoding: 10283 10283 10283
+Encoding: 10283 10283 2778
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282C
-Encoding: 10284 10284 10284
+Encoding: 10284 10284 2779
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282D
-Encoding: 10285 10285 10285
+Encoding: 10285 10285 2780
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282E
-Encoding: 10286 10286 10286
+Encoding: 10286 10286 2781
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282F
-Encoding: 10287 10287 10287
+Encoding: 10287 10287 2782
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2830
-Encoding: 10288 10288 10288
+Encoding: 10288 10288 2783
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2831
-Encoding: 10289 10289 10289
+Encoding: 10289 10289 2784
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2832
-Encoding: 10290 10290 10290
+Encoding: 10290 10290 2785
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2833
-Encoding: 10291 10291 10291
+Encoding: 10291 10291 2786
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2834
-Encoding: 10292 10292 10292
+Encoding: 10292 10292 2787
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2835
-Encoding: 10293 10293 10293
+Encoding: 10293 10293 2788
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2836
-Encoding: 10294 10294 10294
+Encoding: 10294 10294 2789
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2837
-Encoding: 10295 10295 10295
+Encoding: 10295 10295 2790
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2838
-Encoding: 10296 10296 10296
+Encoding: 10296 10296 2791
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2839
-Encoding: 10297 10297 10297
+Encoding: 10297 10297 2792
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283A
-Encoding: 10298 10298 10298
+Encoding: 10298 10298 2793
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283B
-Encoding: 10299 10299 10299
+Encoding: 10299 10299 2794
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283C
-Encoding: 10300 10300 10300
+Encoding: 10300 10300 2795
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283D
-Encoding: 10301 10301 10301
+Encoding: 10301 10301 2796
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283E
-Encoding: 10302 10302 10302
+Encoding: 10302 10302 2797
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283F
-Encoding: 10303 10303 10303
+Encoding: 10303 10303 2798
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2840
-Encoding: 10304 10304 10304
+Encoding: 10304 10304 2799
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2841
-Encoding: 10305 10305 10305
+Encoding: 10305 10305 2800
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2842
-Encoding: 10306 10306 10306
+Encoding: 10306 10306 2801
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2843
-Encoding: 10307 10307 10307
+Encoding: 10307 10307 2802
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2844
-Encoding: 10308 10308 10308
+Encoding: 10308 10308 2803
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2845
-Encoding: 10309 10309 10309
+Encoding: 10309 10309 2804
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2846
-Encoding: 10310 10310 10310
+Encoding: 10310 10310 2805
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2847
-Encoding: 10311 10311 10311
+Encoding: 10311 10311 2806
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2848
-Encoding: 10312 10312 10312
+Encoding: 10312 10312 2807
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2849
-Encoding: 10313 10313 10313
+Encoding: 10313 10313 2808
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284A
-Encoding: 10314 10314 10314
+Encoding: 10314 10314 2809
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284B
-Encoding: 10315 10315 10315
+Encoding: 10315 10315 2810
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284C
-Encoding: 10316 10316 10316
+Encoding: 10316 10316 2811
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284D
-Encoding: 10317 10317 10317
+Encoding: 10317 10317 2812
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284E
-Encoding: 10318 10318 10318
+Encoding: 10318 10318 2813
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284F
-Encoding: 10319 10319 10319
+Encoding: 10319 10319 2814
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2850
-Encoding: 10320 10320 10320
+Encoding: 10320 10320 2815
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2851
-Encoding: 10321 10321 10321
+Encoding: 10321 10321 2816
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2852
-Encoding: 10322 10322 10322
+Encoding: 10322 10322 2817
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2853
-Encoding: 10323 10323 10323
+Encoding: 10323 10323 2818
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2854
-Encoding: 10324 10324 10324
+Encoding: 10324 10324 2819
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2855
-Encoding: 10325 10325 10325
+Encoding: 10325 10325 2820
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2856
-Encoding: 10326 10326 10326
+Encoding: 10326 10326 2821
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2857
-Encoding: 10327 10327 10327
+Encoding: 10327 10327 2822
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2858
-Encoding: 10328 10328 10328
+Encoding: 10328 10328 2823
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2859
-Encoding: 10329 10329 10329
+Encoding: 10329 10329 2824
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285A
-Encoding: 10330 10330 10330
+Encoding: 10330 10330 2825
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285B
-Encoding: 10331 10331 10331
+Encoding: 10331 10331 2826
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285C
-Encoding: 10332 10332 10332
+Encoding: 10332 10332 2827
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285D
-Encoding: 10333 10333 10333
+Encoding: 10333 10333 2828
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285E
-Encoding: 10334 10334 10334
+Encoding: 10334 10334 2829
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285F
-Encoding: 10335 10335 10335
+Encoding: 10335 10335 2830
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2860
-Encoding: 10336 10336 10336
+Encoding: 10336 10336 2831
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2861
-Encoding: 10337 10337 10337
+Encoding: 10337 10337 2832
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2862
-Encoding: 10338 10338 10338
+Encoding: 10338 10338 2833
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2863
-Encoding: 10339 10339 10339
+Encoding: 10339 10339 2834
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2864
-Encoding: 10340 10340 10340
+Encoding: 10340 10340 2835
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2865
-Encoding: 10341 10341 10341
+Encoding: 10341 10341 2836
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2866
-Encoding: 10342 10342 10342
+Encoding: 10342 10342 2837
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2867
-Encoding: 10343 10343 10343
+Encoding: 10343 10343 2838
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2868
-Encoding: 10344 10344 10344
+Encoding: 10344 10344 2839
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2869
-Encoding: 10345 10345 10345
+Encoding: 10345 10345 2840
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286A
-Encoding: 10346 10346 10346
+Encoding: 10346 10346 2841
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286B
-Encoding: 10347 10347 10347
+Encoding: 10347 10347 2842
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286C
-Encoding: 10348 10348 10348
+Encoding: 10348 10348 2843
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286D
-Encoding: 10349 10349 10349
+Encoding: 10349 10349 2844
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286E
-Encoding: 10350 10350 10350
+Encoding: 10350 10350 2845
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286F
-Encoding: 10351 10351 10351
+Encoding: 10351 10351 2846
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2870
-Encoding: 10352 10352 10352
+Encoding: 10352 10352 2847
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2871
-Encoding: 10353 10353 10353
+Encoding: 10353 10353 2848
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2872
-Encoding: 10354 10354 10354
+Encoding: 10354 10354 2849
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2873
-Encoding: 10355 10355 10355
+Encoding: 10355 10355 2850
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2874
-Encoding: 10356 10356 10356
+Encoding: 10356 10356 2851
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2875
-Encoding: 10357 10357 10357
+Encoding: 10357 10357 2852
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2876
-Encoding: 10358 10358 10358
+Encoding: 10358 10358 2853
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2877
-Encoding: 10359 10359 10359
+Encoding: 10359 10359 2854
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2878
-Encoding: 10360 10360 10360
+Encoding: 10360 10360 2855
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2879
-Encoding: 10361 10361 10361
+Encoding: 10361 10361 2856
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287A
-Encoding: 10362 10362 10362
+Encoding: 10362 10362 2857
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287B
-Encoding: 10363 10363 10363
+Encoding: 10363 10363 2858
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287C
-Encoding: 10364 10364 10364
+Encoding: 10364 10364 2859
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287D
-Encoding: 10365 10365 10365
+Encoding: 10365 10365 2860
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287E
-Encoding: 10366 10366 10366
+Encoding: 10366 10366 2861
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287F
-Encoding: 10367 10367 10367
+Encoding: 10367 10367 2862
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2880
-Encoding: 10368 10368 10368
+Encoding: 10368 10368 2863
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2881
-Encoding: 10369 10369 10369
+Encoding: 10369 10369 2864
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2882
-Encoding: 10370 10370 10370
+Encoding: 10370 10370 2865
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2883
-Encoding: 10371 10371 10371
+Encoding: 10371 10371 2866
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2884
-Encoding: 10372 10372 10372
+Encoding: 10372 10372 2867
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2885
-Encoding: 10373 10373 10373
+Encoding: 10373 10373 2868
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2886
-Encoding: 10374 10374 10374
+Encoding: 10374 10374 2869
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2887
-Encoding: 10375 10375 10375
+Encoding: 10375 10375 2870
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2888
-Encoding: 10376 10376 10376
+Encoding: 10376 10376 2871
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2889
-Encoding: 10377 10377 10377
+Encoding: 10377 10377 2872
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288A
-Encoding: 10378 10378 10378
+Encoding: 10378 10378 2873
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288B
-Encoding: 10379 10379 10379
+Encoding: 10379 10379 2874
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288C
-Encoding: 10380 10380 10380
+Encoding: 10380 10380 2875
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288D
-Encoding: 10381 10381 10381
+Encoding: 10381 10381 2876
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288E
-Encoding: 10382 10382 10382
+Encoding: 10382 10382 2877
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288F
-Encoding: 10383 10383 10383
+Encoding: 10383 10383 2878
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2890
-Encoding: 10384 10384 10384
+Encoding: 10384 10384 2879
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2891
-Encoding: 10385 10385 10385
+Encoding: 10385 10385 2880
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2892
-Encoding: 10386 10386 10386
+Encoding: 10386 10386 2881
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2893
-Encoding: 10387 10387 10387
+Encoding: 10387 10387 2882
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2894
-Encoding: 10388 10388 10388
+Encoding: 10388 10388 2883
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2895
-Encoding: 10389 10389 10389
+Encoding: 10389 10389 2884
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2896
-Encoding: 10390 10390 10390
+Encoding: 10390 10390 2885
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2897
-Encoding: 10391 10391 10391
+Encoding: 10391 10391 2886
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2898
-Encoding: 10392 10392 10392
+Encoding: 10392 10392 2887
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2899
-Encoding: 10393 10393 10393
+Encoding: 10393 10393 2888
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289A
-Encoding: 10394 10394 10394
+Encoding: 10394 10394 2889
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289B
-Encoding: 10395 10395 10395
+Encoding: 10395 10395 2890
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289C
-Encoding: 10396 10396 10396
+Encoding: 10396 10396 2891
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289D
-Encoding: 10397 10397 10397
+Encoding: 10397 10397 2892
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289E
-Encoding: 10398 10398 10398
+Encoding: 10398 10398 2893
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289F
-Encoding: 10399 10399 10399
+Encoding: 10399 10399 2894
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A0
-Encoding: 10400 10400 10400
+Encoding: 10400 10400 2895
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A1
-Encoding: 10401 10401 10401
+Encoding: 10401 10401 2896
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A2
-Encoding: 10402 10402 10402
+Encoding: 10402 10402 2897
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A3
-Encoding: 10403 10403 10403
+Encoding: 10403 10403 2898
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A4
-Encoding: 10404 10404 10404
+Encoding: 10404 10404 2899
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A5
-Encoding: 10405 10405 10405
+Encoding: 10405 10405 2900
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A6
-Encoding: 10406 10406 10406
+Encoding: 10406 10406 2901
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A7
-Encoding: 10407 10407 10407
+Encoding: 10407 10407 2902
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A8
-Encoding: 10408 10408 10408
+Encoding: 10408 10408 2903
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A9
-Encoding: 10409 10409 10409
+Encoding: 10409 10409 2904
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AA
-Encoding: 10410 10410 10410
+Encoding: 10410 10410 2905
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AB
-Encoding: 10411 10411 10411
+Encoding: 10411 10411 2906
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AC
-Encoding: 10412 10412 10412
+Encoding: 10412 10412 2907
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AD
-Encoding: 10413 10413 10413
+Encoding: 10413 10413 2908
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AE
-Encoding: 10414 10414 10414
+Encoding: 10414 10414 2909
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AF
-Encoding: 10415 10415 10415
+Encoding: 10415 10415 2910
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B0
-Encoding: 10416 10416 10416
+Encoding: 10416 10416 2911
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B1
-Encoding: 10417 10417 10417
+Encoding: 10417 10417 2912
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B2
-Encoding: 10418 10418 10418
+Encoding: 10418 10418 2913
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B3
-Encoding: 10419 10419 10419
+Encoding: 10419 10419 2914
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B4
-Encoding: 10420 10420 10420
+Encoding: 10420 10420 2915
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B5
-Encoding: 10421 10421 10421
+Encoding: 10421 10421 2916
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B6
-Encoding: 10422 10422 10422
+Encoding: 10422 10422 2917
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B7
-Encoding: 10423 10423 10423
+Encoding: 10423 10423 2918
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B8
-Encoding: 10424 10424 10424
+Encoding: 10424 10424 2919
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B9
-Encoding: 10425 10425 10425
+Encoding: 10425 10425 2920
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BA
-Encoding: 10426 10426 10426
+Encoding: 10426 10426 2921
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BB
-Encoding: 10427 10427 10427
+Encoding: 10427 10427 2922
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BC
-Encoding: 10428 10428 10428
+Encoding: 10428 10428 2923
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BD
-Encoding: 10429 10429 10429
+Encoding: 10429 10429 2924
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BE
-Encoding: 10430 10430 10430
+Encoding: 10430 10430 2925
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BF
-Encoding: 10431 10431 10431
+Encoding: 10431 10431 2926
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C0
-Encoding: 10432 10432 10432
+Encoding: 10432 10432 2927
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C1
-Encoding: 10433 10433 10433
+Encoding: 10433 10433 2928
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C2
-Encoding: 10434 10434 10434
+Encoding: 10434 10434 2929
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C3
-Encoding: 10435 10435 10435
+Encoding: 10435 10435 2930
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C4
-Encoding: 10436 10436 10436
+Encoding: 10436 10436 2931
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C5
-Encoding: 10437 10437 10437
+Encoding: 10437 10437 2932
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C6
-Encoding: 10438 10438 10438
+Encoding: 10438 10438 2933
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C7
-Encoding: 10439 10439 10439
+Encoding: 10439 10439 2934
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C8
-Encoding: 10440 10440 10440
+Encoding: 10440 10440 2935
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C9
-Encoding: 10441 10441 10441
+Encoding: 10441 10441 2936
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CA
-Encoding: 10442 10442 10442
+Encoding: 10442 10442 2937
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CB
-Encoding: 10443 10443 10443
+Encoding: 10443 10443 2938
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CC
-Encoding: 10444 10444 10444
+Encoding: 10444 10444 2939
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CD
-Encoding: 10445 10445 10445
+Encoding: 10445 10445 2940
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CE
-Encoding: 10446 10446 10446
+Encoding: 10446 10446 2941
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CF
-Encoding: 10447 10447 10447
+Encoding: 10447 10447 2942
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D0
-Encoding: 10448 10448 10448
+Encoding: 10448 10448 2943
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D1
-Encoding: 10449 10449 10449
+Encoding: 10449 10449 2944
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D2
-Encoding: 10450 10450 10450
+Encoding: 10450 10450 2945
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D3
-Encoding: 10451 10451 10451
+Encoding: 10451 10451 2946
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D4
-Encoding: 10452 10452 10452
+Encoding: 10452 10452 2947
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D5
-Encoding: 10453 10453 10453
+Encoding: 10453 10453 2948
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D6
-Encoding: 10454 10454 10454
+Encoding: 10454 10454 2949
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D7
-Encoding: 10455 10455 10455
+Encoding: 10455 10455 2950
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D8
-Encoding: 10456 10456 10456
+Encoding: 10456 10456 2951
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D9
-Encoding: 10457 10457 10457
+Encoding: 10457 10457 2952
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DA
-Encoding: 10458 10458 10458
+Encoding: 10458 10458 2953
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DB
-Encoding: 10459 10459 10459
+Encoding: 10459 10459 2954
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DC
-Encoding: 10460 10460 10460
+Encoding: 10460 10460 2955
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DD
-Encoding: 10461 10461 10461
+Encoding: 10461 10461 2956
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DE
-Encoding: 10462 10462 10462
+Encoding: 10462 10462 2957
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DF
-Encoding: 10463 10463 10463
+Encoding: 10463 10463 2958
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E0
-Encoding: 10464 10464 10464
+Encoding: 10464 10464 2959
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E1
-Encoding: 10465 10465 10465
+Encoding: 10465 10465 2960
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E2
-Encoding: 10466 10466 10466
+Encoding: 10466 10466 2961
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E3
-Encoding: 10467 10467 10467
+Encoding: 10467 10467 2962
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E4
-Encoding: 10468 10468 10468
+Encoding: 10468 10468 2963
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E5
-Encoding: 10469 10469 10469
+Encoding: 10469 10469 2964
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E6
-Encoding: 10470 10470 10470
+Encoding: 10470 10470 2965
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E7
-Encoding: 10471 10471 10471
+Encoding: 10471 10471 2966
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E8
-Encoding: 10472 10472 10472
+Encoding: 10472 10472 2967
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E9
-Encoding: 10473 10473 10473
+Encoding: 10473 10473 2968
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EA
-Encoding: 10474 10474 10474
+Encoding: 10474 10474 2969
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EB
-Encoding: 10475 10475 10475
+Encoding: 10475 10475 2970
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EC
-Encoding: 10476 10476 10476
+Encoding: 10476 10476 2971
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28ED
-Encoding: 10477 10477 10477
+Encoding: 10477 10477 2972
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EE
-Encoding: 10478 10478 10478
+Encoding: 10478 10478 2973
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EF
-Encoding: 10479 10479 10479
+Encoding: 10479 10479 2974
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F0
-Encoding: 10480 10480 10480
+Encoding: 10480 10480 2975
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F1
-Encoding: 10481 10481 10481
+Encoding: 10481 10481 2976
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F2
-Encoding: 10482 10482 10482
+Encoding: 10482 10482 2977
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F3
-Encoding: 10483 10483 10483
+Encoding: 10483 10483 2978
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F4
-Encoding: 10484 10484 10484
+Encoding: 10484 10484 2979
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F5
-Encoding: 10485 10485 10485
+Encoding: 10485 10485 2980
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F6
-Encoding: 10486 10486 10486
+Encoding: 10486 10486 2981
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F7
-Encoding: 10487 10487 10487
+Encoding: 10487 10487 2982
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F8
-Encoding: 10488 10488 10488
+Encoding: 10488 10488 2983
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F9
-Encoding: 10489 10489 10489
+Encoding: 10489 10489 2984
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FA
-Encoding: 10490 10490 10490
+Encoding: 10490 10490 2985
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FB
-Encoding: 10491 10491 10491
+Encoding: 10491 10491 2986
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FC
-Encoding: 10492 10492 10492
+Encoding: 10492 10492 2987
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FD
-Encoding: 10493 10493 10493
+Encoding: 10493 10493 2988
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FE
-Encoding: 10494 10494 10494
+Encoding: 10494 10494 2989
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FF
-Encoding: 10495 10495 10495
+Encoding: 10495 10495 2990
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2987
-Encoding: 10631 10631 10631
+Encoding: 10631 10631 2991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79270,8 +82266,9 @@ SplineSet
  1000 1373 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2988
-Encoding: 10632 10632 10632
+Encoding: 10632 10632 2992
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79291,8 +82288,9 @@ SplineSet
  233 -89 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2997
-Encoding: 10647 10647 10647
+Encoding: 10647 10647 2993
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79309,8 +82307,9 @@ SplineSet
  694 -322 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2998
-Encoding: 10648 10648 10648
+Encoding: 10648 10648 2994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79327,8 +82326,9 @@ SplineSet
  539 1608 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29EB
-Encoding: 10731 10731 10731
+Encoding: 10731 10731 2995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79341,8 +82341,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FA
-Encoding: 10746 10746 10746
+Encoding: 10746 10746 2996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79371,8 +82372,9 @@ SplineSet
  748 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FB
-Encoding: 10747 10747 10747
+Encoding: 10747 10747 2997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79409,8 +82411,9 @@ SplineSet
  148 762 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2A00
-Encoding: 10752 10752 10752
+Encoding: 10752 10752 2998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79433,35 +82436,39 @@ SplineSet
  80 1547 80 1547 616 1547 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2A2F
-Encoding: 10799 10799 10799
+Encoding: 10799 10799 2999
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 215 215 N 1 0 0 1 0 0 2
+Refer: 151 215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6A
-Encoding: 10858 10858 10858
+Encoding: 10858 10858 3000
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 382 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 2 382 2
 EndChar
+
 StartChar: uni2A6B
-Encoding: 10859 10859 10859
+Encoding: 10859 10859 3001
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 242 382 2
-Refer: 8901 8901 N 1 0 0 1 -239 -530 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 242 382 2
+Refer: 2274 8901 N 1 0 0 1 -239 -530 2
 EndChar
+
 StartChar: uni2B05
-Encoding: 11013 11013 11013
+Encoding: 11013 11013 3002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79477,8 +82484,9 @@ SplineSet
  395 842 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B06
-Encoding: 11014 11014 11014
+Encoding: 11014 11014 3003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79494,8 +82502,9 @@ SplineSet
  759 921 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B07
-Encoding: 11015 11015 11015
+Encoding: 11015 11015 3004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79511,8 +82520,9 @@ SplineSet
  474 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B08
-Encoding: 11016 11016 11016
+Encoding: 11016 11016 3005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79528,8 +82538,9 @@ SplineSet
  874 756 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B09
-Encoding: 11017 11017 11017
+Encoding: 11017 11017 3006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79545,8 +82556,9 @@ SplineSet
  560 957 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0A
-Encoding: 11018 11018 11018
+Encoding: 11018 11018 3007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79562,8 +82574,9 @@ SplineSet
  773 342 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0B
-Encoding: 11019 11019 11019
+Encoding: 11019 11019 3008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79579,8 +82592,9 @@ SplineSet
  259 543 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0C
-Encoding: 11020 11020 11020
+Encoding: 11020 11020 3009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79599,8 +82613,9 @@ SplineSet
  395 842 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0D
-Encoding: 11021 11021 11021
+Encoding: 11021 11021 3010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79619,8 +82634,9 @@ SplineSet
  474 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B12
-Encoding: 11026 11026 11026
+Encoding: 11026 11026 3011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79638,8 +82654,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B13
-Encoding: 11027 11027 11027
+Encoding: 11027 11027 3012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79657,8 +82674,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B14
-Encoding: 11028 11028 11028
+Encoding: 11028 11028 3013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79675,8 +82693,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B15
-Encoding: 11029 11029 11029
+Encoding: 11029 11029 3014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79693,8 +82712,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B16
-Encoding: 11030 11030 11030
+Encoding: 11030 11030 3015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79711,8 +82731,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B17
-Encoding: 11031 11031 11031
+Encoding: 11031 11031 3016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79729,8 +82750,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B18
-Encoding: 11032 11032 11032
+Encoding: 11032 11032 3017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79747,8 +82769,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B19
-Encoding: 11033 11033 11033
+Encoding: 11033 11033 3018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79765,8 +82788,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B1A
-Encoding: 11034 11034 11034
+Encoding: 11034 11034 3019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79842,8 +82866,9 @@ SplineSet
  206 1142.5 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C64
-Encoding: 11364 11364 11364
+Encoding: 11364 11364 3020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79883,8 +82908,9 @@ SplineSet
  546 1245 l 1,32,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6D
-Encoding: 11373 11373 11373
+Encoding: 11373 11373 3021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79914,8 +82940,9 @@ SplineSet
  449 984 449 984 403 746 c 0,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni2C6E
-Encoding: 11374 11374 11374
+Encoding: 11374 11374 3022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79943,8 +82970,9 @@ SplineSet
  982.479 1196 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6F
-Encoding: 11375 11375 11375
+Encoding: 11375 11375 3023
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79965,8 +82993,9 @@ SplineSet
  797 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C70
-Encoding: 11376 11376 11376
+Encoding: 11376 11376 3024
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79996,8 +83025,9 @@ SplineSet
  797 507 797 507 843 745 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C75
-Encoding: 11381 11381 11381
+Encoding: 11381 11381 3025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80014,8 +83044,9 @@ SplineSet
  282 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C76
-Encoding: 11382 11382 11382
+Encoding: 11382 11382 3026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80032,8 +83063,9 @@ SplineSet
  1106 739 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C77
-Encoding: 11383 11383 11383
+Encoding: 11383 11383 3027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80061,8 +83093,9 @@ SplineSet
  914 868 914 868 875 864 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2C79
-Encoding: 11385 11385 11385
+Encoding: 11385 11385 3028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80093,8 +83126,9 @@ SplineSet
  1306 1340 1306 1340 1257 1088 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7A
-Encoding: 11386 11386 11386
+Encoding: 11386 11386 3029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80129,16 +83163,18 @@ SplineSet
  389 550 l 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C7C
-Encoding: 11388 11388 11388
+Encoding: 11388 11388 3030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 690 690 N 1 0 0 1 0 -668 3
+Refer: 605 690 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2C7D
-Encoding: 11389 11389 11389
+Encoding: 11389 11389 3031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80154,8 +83190,9 @@ SplineSet
  773 806 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7E
-Encoding: 11390 11390 11390
+Encoding: 11390 11390 3032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80199,8 +83236,9 @@ SplineSet
  506 664 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7F
-Encoding: 11391 11391 11391
+Encoding: 11391 11391 3033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80225,8 +83263,9 @@ SplineSet
  328 170 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18
-Encoding: 11800 11800 11800
+Encoding: 11800 11800 3034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80264,17 +83303,19 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" uni2E18.case
 EndChar
+
 StartChar: uni2E1F
-Encoding: 11807 11807 11807
+Encoding: 11807 11807 3035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 -530 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 -530 2
 EndChar
+
 StartChar: uni2E22
-Encoding: 11810 11810 11810
+Encoding: 11810 11810 3036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80289,8 +83330,9 @@ SplineSet
  580 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E23
-Encoding: 11811 11811 11811
+Encoding: 11811 11811 3037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80305,8 +83347,9 @@ SplineSet
  666 1366 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E24
-Encoding: 11812 11812 11812
+Encoding: 11812 11812 3038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80321,8 +83364,9 @@ SplineSet
  526 -80 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E25
-Encoding: 11813 11813 11813
+Encoding: 11813 11813 3039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80337,8 +83381,9 @@ SplineSet
  612 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E2E
-Encoding: 11822 11822 11822
+Encoding: 11822 11822 3040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80376,8 +83421,9 @@ SplineSet
  456 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA708
-Encoding: 42760 42760 42760
+Encoding: 42760 42760 3041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80395,8 +83441,9 @@ SplineSet
  633 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA709
-Encoding: 42761 42761 42761
+Encoding: 42761 42761 3042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80414,8 +83461,9 @@ SplineSet
  633 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70A
-Encoding: 42762 42762 42762
+Encoding: 42762 42762 3043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80433,8 +83481,9 @@ SplineSet
  633 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70B
-Encoding: 42763 42763 42763
+Encoding: 42763 42763 3044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80452,8 +83501,9 @@ SplineSet
  633 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70C
-Encoding: 42764 42764 42764
+Encoding: 42764 42764 3045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80471,8 +83521,9 @@ SplineSet
  909 1420 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70D
-Encoding: 42765 42765 42765
+Encoding: 42765 42765 3046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80490,8 +83541,9 @@ SplineSet
  324 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70E
-Encoding: 42766 42766 42766
+Encoding: 42766 42766 3047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80509,8 +83561,9 @@ SplineSet
  324 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70F
-Encoding: 42767 42767 42767
+Encoding: 42767 42767 3048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80528,8 +83581,9 @@ SplineSet
  324 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA710
-Encoding: 42768 42768 42768
+Encoding: 42768 42768 3049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80547,8 +83601,9 @@ SplineSet
  324 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA711
-Encoding: 42769 42769 42769
+Encoding: 42769 42769 3050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80566,8 +83621,9 @@ SplineSet
  600 1420 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA712
-Encoding: 42770 42770 42770
+Encoding: 42770 42770 3051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80582,8 +83638,9 @@ SplineSet
  412 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA713
-Encoding: 42771 42771 42771
+Encoding: 42771 42771 3052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80600,8 +83657,9 @@ SplineSet
  412 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA714
-Encoding: 42772 42772 42772
+Encoding: 42772 42772 3053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80618,8 +83676,9 @@ SplineSet
  412 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA715
-Encoding: 42773 42773 42773
+Encoding: 42773 42773 3054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80636,8 +83695,9 @@ SplineSet
  412 1420 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA716
-Encoding: 42774 42774 42774
+Encoding: 42774 42774 3055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80652,8 +83712,9 @@ SplineSet
  136 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71B
-Encoding: 42779 42779 42779
+Encoding: 42779 42779 3056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80672,8 +83733,9 @@ SplineSet
  654 1508 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71C
-Encoding: 42780 42780 42780
+Encoding: 42780 42780 3057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80692,8 +83754,9 @@ SplineSet
  579 664 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71D
-Encoding: 42781 42781 42781
+Encoding: 42781 42781 3058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80713,8 +83776,9 @@ SplineSet
  459 867 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71E
-Encoding: 42782 42782 42782
+Encoding: 42782 42782 3059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80734,16 +83798,18 @@ SplineSet
  545 1305 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71F
-Encoding: 42783 42783 42783
+Encoding: 42783 42783 3060
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42782 42782 N 1 0 0 1 -130 -668 2
+Refer: 3059 42782 N 1 0 0 1 -130 -668 2
 EndChar
+
 StartChar: uniA722
-Encoding: 42786 42786 42786
+Encoding: 42786 42786 3061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80763,8 +83829,9 @@ SplineSet
  872 0 872 0 182 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA723
-Encoding: 42787 42787 42787
+Encoding: 42787 42787 3062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80784,8 +83851,9 @@ SplineSet
  858 0 858 0 268 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA724
-Encoding: 42788 42788 42788
+Encoding: 42788 42788 3063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80800,8 +83868,9 @@ SplineSet
  540 1190 540 1190 498 976 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA725
-Encoding: 42789 42789 42789
+Encoding: 42789 42789 3064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80816,8 +83885,9 @@ SplineSet
  540 857 540 857 491 606 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA726
-Encoding: 42790 42790 42790
+Encoding: 42790 42790 3065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80844,8 +83914,9 @@ SplineSet
  962 58 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA727
-Encoding: 42791 42791 42791
+Encoding: 42791 42791 3066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80880,16 +83951,18 @@ SplineSet
  801 682 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA789
-Encoding: 42889 42889 42889
+Encoding: 42889 42889 3067
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 3
+Refer: 27 58 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78A
-Encoding: 42890 42890 42890
+Encoding: 42890 42890 3068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80907,8 +83980,9 @@ SplineSet
  859 649 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78B
-Encoding: 42891 42891 42891
+Encoding: 42891 42891 3069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80923,8 +83997,9 @@ SplineSet
  629 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78C
-Encoding: 42892 42892 42892
+Encoding: 42892 42892 3070
 Width: 1233
 Flags: W
 TtInstrs:
@@ -80956,16 +84031,18 @@ SplineSet
  797 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78D
-Encoding: 42893 42893 42893
+Encoding: 42893 42893 3071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1063 1063 N 1 0 0 1 0 0 3
+Refer: 875 1063 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78E
-Encoding: 42894 42894 42894
+Encoding: 42894 42894 3072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81001,8 +84078,9 @@ SplineSet
  408 799 408 799 393 816 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uniA790
-Encoding: 42896 42896 42896
+Encoding: 42896 42896 3073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81025,8 +84103,9 @@ SplineSet
  257 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA791
-Encoding: 42897 42897 42897
+Encoding: 42897 42897 3074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81059,8 +84138,9 @@ SplineSet
  1067.84 773.629 1067.84 773.629 1059 728 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7AA
-Encoding: 42922 42922 42922
+Encoding: 42922 42922 3075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81088,8 +84168,9 @@ SplineSet
  310.455 1495 310.455 1495 486 1495 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F8
-Encoding: 43000 43000 43000
+Encoding: 43000 43000 3076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81123,8 +84204,9 @@ SplineSet
  539 1287 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F9
-Encoding: 43001 43001 43001
+Encoding: 43001 43001 3077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81167,8 +84249,9 @@ SplineSet
  481 1177 481 1177 414 1177 c 0,35,36
 EndSplineSet
 EndChar
+
 StartChar: uniF6C5
-Encoding: 63173 63173 63173
+Encoding: 63173 63173 3078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81209,8 +84292,9 @@ SplineSet
  816 764 816 764 783 836.5 c 128,-1,38
 EndSplineSet
 EndChar
+
 StartChar: fi
-Encoding: 64257 64257 64257
+Encoding: 64257 64257 3079
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81413,11 +84497,12 @@ SplineSet
  684 1331 684 1331 655 1306.5 c 128,-1,25
  626 1282 626 1282 612 1219 c 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 3" f i
 EndChar
+
 StartChar: fl
-Encoding: 64258 64258 64258
+Encoding: 64258 64258 3080
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81586,35 +84671,40 @@ SplineSet
  684 1331 684 1331 655 1306.5 c 128,-1,21
  626 1282 626 1282 612 1219 c 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 3" f l
 EndChar
+
 StartChar: uniFFF9
-Encoding: 65529 65529 65529
+Encoding: 65529 65529 3081
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFA
-Encoding: 65530 65530 65530
+Encoding: 65530 65530 3082
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFB
-Encoding: 65531 65531 65531
+Encoding: 65531 65531 3083
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFC
-Encoding: 65532 65532 65532
+Encoding: 65532 65532 3084
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFD
-Encoding: 65533 65533 65533
+Encoding: 65533 65533 3085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81655,8 +84745,9 @@ SplineSet
  768 1898 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: u1D55A
-Encoding: 120154 120154 120154
+Encoding: 120154 120154 3086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81685,8 +84776,9 @@ SplineSet
  564 1000 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dlLtcaron
-Encoding: 1114113 -1 1114113
+Encoding: 1114113 -1 3087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81699,8 +84791,9 @@ SplineSet
  702 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Dieresis
-Encoding: 1114114 -1 1114114
+Encoding: 1114114 -1 3088
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81806,8 +84899,9 @@ SplineSet
  453 1526 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Acute
-Encoding: 1114115 -1 1114115
+Encoding: 1114115 -1 3089
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81919,8 +85013,9 @@ SplineSet
  811 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tilde
-Encoding: 1114116 -1 1114116
+Encoding: 1114116 -1 3090
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82101,8 +85196,9 @@ SplineSet
  769 1284 769 1284 731 1313 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: c6462
-Encoding: 1114117 -1 1114117
+Encoding: 1114117 -1 3091
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82163,8 +85259,9 @@ SplineSet
  88 212 88 212 88 426 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: Grave
-Encoding: 1114118 -1 1114118
+Encoding: 1114118 -1 3092
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82197,8 +85294,9 @@ SplineSet
  713 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Circumflex
-Encoding: 1114119 -1 1114119
+Encoding: 1114119 -1 3093
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82241,8 +85339,9 @@ SplineSet
  588 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Caron
-Encoding: 1114120 -1 1114120
+Encoding: 1114120 -1 3094
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82285,8 +85384,9 @@ SplineSet
  895 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: fractionslash
-Encoding: 1114121 -1 1114121
+Encoding: 1114121 -1 3095
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82326,8 +85426,9 @@ SplineSet
  84 500 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0311.case
-Encoding: 1114122 -1 1114122
+Encoding: 1114122 -1 3096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82347,8 +85448,9 @@ SplineSet
  454 1635 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0306.case
-Encoding: 1114123 -1 1114123
+Encoding: 1114123 -1 3097
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82397,8 +85499,9 @@ SplineSet
  508.128 1899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307.case
-Encoding: 1114124 -1 1114124
+Encoding: 1114124 -1 3098
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82433,8 +85536,9 @@ SplineSet
  703.128 1899 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030B.case
-Encoding: 1114125 -1 1114125
+Encoding: 1114125 -1 3099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82452,8 +85556,9 @@ SplineSet
  687.128 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030F.case
-Encoding: 1114126 -1 1114126
+Encoding: 1114126 -1 3100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82471,8 +85576,9 @@ SplineSet
  994.128 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: thinquestion
-Encoding: 1114127 -1 1114127
+Encoding: 1114127 -1 3101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82509,8 +85615,9 @@ SplineSet
  619 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0304.case
-Encoding: 1114128 -1 1114128
+Encoding: 1114128 -1 3102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82545,8 +85652,9 @@ SplineSet
  519.491 1870 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar
-Encoding: 1114129 -1 1114129
+Encoding: 1114129 -1 3103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82559,8 +85667,9 @@ SplineSet
  1102 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.wide
-Encoding: 1114130 -1 1114130
+Encoding: 1114130 -1 3104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82573,8 +85682,9 @@ SplineSet
  1227 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.small
-Encoding: 1114131 -1 1114131
+Encoding: 1114131 -1 3105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82587,8 +85697,9 @@ SplineSet
  1002 -234 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: jot
-Encoding: 1114132 -1 1114132
+Encoding: 1114132 -1 3106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82615,8 +85726,9 @@ SplineSet
  670.651 865.151 670.651 865.151 616.003 865.151 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: diaeresis.symbols
-Encoding: 1114133 -1 1114133
+Encoding: 1114133 -1 3107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82634,8 +85746,9 @@ SplineSet
  301 1585 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Eng.alt
-Encoding: 1114134 -1 1114134
+Encoding: 1114134 -1 3108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82660,8 +85773,9 @@ SplineSet
  294 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdown.case
-Encoding: 1114135 -1 1114135
+Encoding: 1114135 -1 3109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82776,8 +85890,9 @@ SplineSet
  604 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: questiondown.case
-Encoding: 1114136 -1 1114136
+Encoding: 1114136 -1 3110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82951,13 +86066,474 @@ SplineSet
  885 1210 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18.case
-Encoding: 1114137 -1 1114137
+Encoding: 1114137 -1 3111
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 11800 11800 N 1 0 0 1 0 373 3
+Refer: 3034 11800 N 1 0 0 1 0 373 3
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3112
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3113
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 202 59 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3114
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 523.409 589 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3115
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 466.909 314 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3116
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -324.091 584 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3117
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -295.591 299 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3118
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 605 547 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3119
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 582 236 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3120
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 117.261 759 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3121
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 119.705 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3122
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 N 1 0 0 1 197.538 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3123
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 N 1 0 0 1 139.409 466 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3124
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 269 637 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3125
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3126
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 146.39 759 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3127
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 82.2052 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3128
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3129
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 177 39 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3130
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 565.409 559 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3131
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 493.909 278 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3132
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -323.091 569 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3133
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -311.591 308 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3134
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 647 540 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3135
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 564 212 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3136
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 154.261 759 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3137
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 88.7052 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3138
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3139
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 29 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3140
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3141
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 152 4 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3142
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 120 344 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3143
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 17 29 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3144
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3145
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 126 14 2
+Refer: 90 121 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3146
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 192 344 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3147
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 157 39 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3148
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 518.409 549 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3149
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 654 769 S 1 0 0 1 445.909 283 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3150
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3092 -1 S 1 0 0 1 -360.091 564 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3151
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 768 S 1 0 0 1 -336.591 283 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3152
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 626 533 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3153
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 569 233 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3154
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 117.261 759 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3155
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 638 732 N 1 0 0 1 88.7052 453 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3156
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 114 344 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3157
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 662 777 S 1 0 0 1 87 54 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansMono-Oblique.sfd
+++ b/src/DejaVuSansMono-Oblique.sfd
@@ -10,13 +10,16 @@ UnderlinePosition: -85
 UnderlineWidth: 90
 Ascent: 1556
 Descent: 492
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 1 "Back"  1
-Layer: 1 1 "Fore"  0
+Layer: 0 1 "Back" 1
+Layer: 1 1 "Fore" 0
 FSType: 0
 OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
+CreationTime: 1470372098
+ModificationTime: 1492784294
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -37,11 +40,11 @@ HheadAOffset: 0
 HheadDescent: -483
 HheadDOffset: 0
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0"  {"'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0"  {"'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
-Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 3"  {"'dlig' Discretionary Ligatures in Latin lookup 3"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "'case' Case-Sensitive Forms"  {"'case' Case-Sensitive Forms" ("case" ) } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark positioning in Lao"  {"'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 0" { "'locl' Localized Forms in Cyrillic lookup 0"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0" { "'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
+Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 3" { "'dlig' Discretionary Ligatures in Latin lookup 3"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "'case' Case-Sensitive Forms" { "'case' Case-Sensitive Forms" ("case") } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark positioning in Lao" { "'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
 DEI: 91125
 TtTable: prep
 PUSHW_1
@@ -1685,12 +1688,14 @@ ShortTable: maxp 16
   3
   1
 EndShort
-LangName: 1033 "" "" "" "DejaVu Sans Mono Oblique" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License" 
+LangName: 1033 "" "" "" "DejaVu Sans Mono Oblique" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License"
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
+WinInfo: 7776 27 8
 GridOrder2: 1
 Grid
 1 740 m 25,0,-1
@@ -1700,50 +1705,50 @@ Grid
  1 894 l 25,1,-1
  -139 1034 l 25,0,0
 1 1510 m 9,0,-1
- -139 1650 l 17,0,0
+ -139 1650 l 1041,0,0
 1 1202 m 9,1,-1
- -139 1342 l 17,0,0
+ -139 1342 l 1041,0,0
 1 1818 m 9,1,-1
- -139 1958 l 17,0,0
+ -139 1958 l 1041,0,0
 1 1048 m 9,1,-1
- -139 1188 l 17,0,0
+ -139 1188 l 1041,0,0
 1 1664 m 9,1,-1
- -139 1804 l 17,0,0
+ -139 1804 l 1041,0,0
 1 1356 m 9,1,-1
- -139 1496 l 17,0,0
+ -139 1496 l 1041,0,0
 -139 -352 m 9,0,0
  1 -492 l 25,1,-1
- 141 -632 l 17
+ 141 -632 l 1041
 -139 -198 m 25,0,0
  1 -338 l 25,1,-1
  -139 -198 l 25,0,0
 1 278 m 9,0,-1
- -139 418 l 17,0,0
+ -139 418 l 1041,0,0
 1 -30 m 9,1,-1
- -139 110 l 17,0,0
+ -139 110 l 1041,0,0
 1 586 m 9,1,-1
- -139 726 l 17,0,0
+ -139 726 l 1041,0,0
 1 -184 m 9,1,-1
- -139 -44 l 17,0,0
+ -139 -44 l 1041,0,0
 1 432 m 9,1,-1
- -139 572 l 17,0,0
+ -139 572 l 1041,0,0
 1 124 m 9,1,-1
- -139 264 l 17,0,0
+ -139 264 l 1041,0,0
 1232 -409 m 25,0,0
  1372 -549 l 25,1,-1
  1232 -409 l 25,0,0
 1372 67 m 9,0,-1
- 1232 207 l 17,0,0
+ 1232 207 l 1041,0,0
 1372 -241 m 9,1,-1
- 1232 -101 l 17,0,0
+ 1232 -101 l 1041,0,0
 1372 375 m 9,1,-1
- 1232 515 l 17,0,0
+ 1232 515 l 1041,0,0
 1372 -395 m 9,1,-1
- 1232 -255 l 17,0,0
+ 1232 -255 l 1041,0,0
 1372 221 m 9,1,-1
- 1232 361 l 17,0,0
+ 1232 361 l 1041,0,0
 1372 -87 m 9,1,-1
- 1232 53 l 17,0,0
+ 1232 53 l 1041,0,0
 1232 669 m 25,0,0
  1372 529 l 25,1,-1
  1232 669 l 25,0,0
@@ -1751,56 +1756,56 @@ Grid
  1372 683 l 25,1,-1
  1232 823 l 25,0,0
 1372 1299 m 9,0,-1
- 1232 1439 l 17,0,0
+ 1232 1439 l 1041,0,0
 1372 991 m 9,1,-1
- 1232 1131 l 17,0,0
+ 1232 1131 l 1041,0,0
 1372 1607 m 9,1,-1
- 1232 1747 l 17,0,0
+ 1232 1747 l 1041,0,0
 1372 837 m 9,1,-1
- 1232 977 l 17,0,0
+ 1232 977 l 1041,0,0
 1372 1453 m 9,1,-1
- 1232 1593 l 17,0,0
+ 1232 1593 l 1041,0,0
 1372 1145 m 9,1,-1
- 1232 1285 l 17,0,0
+ 1232 1285 l 1041,0,0
 1372 1761 m 9,1,-1
  1232 1901 l 25,0,0
- 1092 2041 l 17,0,0
+ 1092 2041 l 1041,0,0
 1373 -632 m 9,1,-1
- 1233 -492 l 17,0,0
+ 1233 -492 l 1041,0,0
 1079 -492 m 25,0,0
  1219 -632 l 25,1,-1
  1079 -492 l 25,0,0
 603 -632 m 9,0,-1
- 463 -492 l 17,0,0
+ 463 -492 l 1041,0,0
 911 -632 m 9,1,-1
- 771 -492 l 17,0,0
+ 771 -492 l 1041,0,0
 295 -632 m 9,1,-1
- 155 -492 l 17,0,0
+ 155 -492 l 1041,0,0
 1065 -632 m 9,1,-1
- 925 -492 l 17,0,0
+ 925 -492 l 1041,0,0
 449 -632 m 9,1,-1
- 309 -492 l 17,0,0
+ 309 -492 l 1041,0,0
 757 -632 m 9,1,-1
- 617 -492 l 17,0,0
+ 617 -492 l 1041,0,0
 1386 1901 m 9,1,-1
- 1246 2041 l 17,0,0
+ 1246 2041 l 1041,0,0
 938 2041 m 25,0,0
  1078 1901 l 25,1,-1
  938 2041 l 25,0,0
 462 1901 m 9,0,-1
- 322 2041 l 17,0,0
+ 322 2041 l 1041,0,0
 770 1901 m 9,1,-1
- 630 2041 l 17,0,0
+ 630 2041 l 1041,0,0
 154 1901 m 9,1,-1
- 14 2041 l 17,0,0
+ 14 2041 l 1041,0,0
 924 1901 m 9,1,-1
- 784 2041 l 17,0,0
+ 784 2041 l 1041,0,0
 308 1901 m 9,1,-1
- 168 2041 l 17,0,0
+ 168 2041 l 1041,0,0
 616 1901 m 9,1,-1
- 476 2041 l 17,0,0
+ 476 2041 l 1041,0,0
 0 1901 m 9,1,-1
- -140 2041 l 17,0,0
+ -140 2041 l 1041,0,0
 -140 2041 m 1,1,-1
  1373 2041 l 1,2,-1
  1373 -632 l 1,3,-1
@@ -1812,8 +1817,9 @@ Grid
  0 -492 l 1,8,-1
  0 1901 l 1,5,-1
 EndSplineSet
-AnchorClass2: "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" 
-BeginChars: 1114137 0
+AnchorClass2: "lao-below" "'mark' Mark positioning in Lao" "lao-above" "'mark' Mark positioning in Lao"
+BeginChars: 1114137 3157
+
 StartChar: .notdef
 Encoding: 0 -1 0
 Width: 1233
@@ -1861,14 +1867,16 @@ SplineSet
  219 -248 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: space
-Encoding: 32 32 32
+Encoding: 32 32 1
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclam
-Encoding: 33 33 33
+Encoding: 33 33 2
 Width: 1233
 Flags: W
 TtInstrs:
@@ -1979,8 +1987,9 @@ SplineSet
  420 254 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedbl
-Encoding: 34 34 34
+Encoding: 34 34 3
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2029,8 +2038,9 @@ SplineSet
  512 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: numbersign
-Encoding: 35 35 35
+Encoding: 35 35 4
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2154,8 +2164,9 @@ SplineSet
  676 1470 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dollar
-Encoding: 36 36 36
+Encoding: 36 36 5
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2313,8 +2324,9 @@ SplineSet
  455 -301 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: percent
-Encoding: 37 37 37
+Encoding: 37 37 6
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2412,7 +2424,7 @@ SplineSet
  696 241 696 241 748.5 188 c 128,-1,2
  801 135 801 135 879 135 c 0,3,4
  956 135 956 135 1009.5 188.5 c 128,-1,5
- 1063 242 1063 242 1063 319 c 0,6,7
+ 1063 242 1063 242 1063 319 c 256,6,7
  1063 396 1063 396 1009 450 c 128,-1,8
  955 504 955 504 879 504 c 0,9,10
  801 504 801 504 748.5 451 c 128,-1,11
@@ -2437,26 +2449,27 @@ SplineSet
  168 1033 168 1033 220.5 980.5 c 128,-1,33
  273 928 273 928 352 928 c 0,34,35
  429 928 429 928 483 981.5 c 128,-1,36
- 537 1035 537 1035 537 1112 c 0,37,38
+ 537 1035 537 1035 537 1112 c 256,37,38
  537 1189 537 1189 483 1242.5 c 128,-1,39
- 429 1296 429 1296 352 1296 c 0,40,41
+ 429 1296 429 1296 352 1296 c 256,40,41
  275 1296 275 1296 221.5 1243 c 128,-1,42
  168 1190 168 1190 168 1112 c 0,31,32
-33 1112 m 0,43,44
+33 1112 m 256,43,44
  33 1247 33 1247 125 1339.5 c 128,-1,45
  217 1432 217 1432 352 1432 c 0,46,47
  416 1432 416 1432 474.5 1408 c 128,-1,48
- 533 1384 533 1384 578 1339 c 0,49,50
+ 533 1384 533 1384 578 1339 c 256,49,50
  623 1294 623 1294 647.5 1235.5 c 128,-1,51
  672 1177 672 1177 672 1112 c 0,52,53
  672 978 672 978 579 885.5 c 128,-1,54
  486 793 486 793 352 793 c 0,55,56
  217 793 217 793 125 885 c 128,-1,57
- 33 977 33 977 33 1112 c 0,43,44
+ 33 977 33 977 33 1112 c 256,43,44
 EndSplineSet
 EndChar
+
 StartChar: ampersand
-Encoding: 38 38 38
+Encoding: 38 38 7
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2682,8 +2695,9 @@ SplineSet
  432 795 l 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: quotesingle
-Encoding: 39 39 39
+Encoding: 39 39 8
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2716,8 +2730,9 @@ SplineSet
  702 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: parenleft
-Encoding: 40 40 40
+Encoding: 40 40 9
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2768,8 +2783,9 @@ SplineSet
  1042 1554 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: parenright
-Encoding: 41 41 41
+Encoding: 41 41 10
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2822,8 +2838,9 @@ SplineSet
  150 -270 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: asterisk
-Encoding: 42 42 42
+Encoding: 42 42 11
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2930,8 +2947,9 @@ SplineSet
  1067 1247 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: plus
-Encoding: 43 43 43
+Encoding: 43 43 12
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2993,8 +3011,9 @@ SplineSet
  700 1171 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: comma
-Encoding: 44 44 44
+Encoding: 44 44 13
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3064,8 +3083,9 @@ SplineSet
  416 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: hyphen
-Encoding: 45 45 45
+Encoding: 45 45 14
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3100,8 +3120,9 @@ SplineSet
  336 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: period
-Encoding: 46 46 46
+Encoding: 46 46 15
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3163,8 +3184,9 @@ SplineSet
  414 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: slash
-Encoding: 47 47 47
+Encoding: 47 47 16
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3210,8 +3232,9 @@ SplineSet
  16 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zero
-Encoding: 48 48 48
+Encoding: 48 48 17
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3413,15 +3436,15 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-481 750 m 0,0,1
+481 750 m 256,0,1
  481 805 481 805 521 845 c 128,-1,2
- 561 885 561 885 616 885 c 0,3,4
+ 561 885 561 885 616 885 c 256,3,4
  671 885 671 885 710.5 845 c 128,-1,5
  750 805 750 805 750 750 c 0,6,7
  750 694 750 694 711 655 c 128,-1,8
  672 616 672 616 616 616 c 0,9,10
  561 616 561 616 521 655.5 c 128,-1,11
- 481 695 481 695 481 750 c 0,0,1
+ 481 695 481 695 481 750 c 256,0,1
 1135 1020 m 0,12,13
  1135 829 1135 829 1077.5 607.5 c 128,-1,14
  1020 386 1020 386 936 248 c 0,15,16
@@ -3430,7 +3453,7 @@ SplineSet
  286 -29 286 -29 192 94 c 128,-1,20
  98 217 98 217 98 473 c 0,21,22
  98 665 98 665 155 884.5 c 128,-1,23
- 212 1104 212 1104 297 1245 c 0,24,25
+ 212 1104 212 1104 297 1245 c 256,24,25
  382 1386 382 1386 492.5 1453 c 128,-1,26
  603 1520 603 1520 750 1520 c 0,27,28
  945 1520 945 1520 1040 1397 c 128,-1,29
@@ -3450,8 +3473,9 @@ SplineSet
  402 135 402 135 506 135 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: one
-Encoding: 49 49 49
+Encoding: 49 49 18
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3557,8 +3581,9 @@ SplineSet
  156 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: two
-Encoding: 50 50 50
+Encoding: 50 50 19
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3682,8 +3707,9 @@ SplineSet
  268 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: three
-Encoding: 51 51 51
+Encoding: 51 51 20
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3797,8 +3823,9 @@ SplineSet
  923 832 923 832 762 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: four
-Encoding: 52 52 52
+Encoding: 52 52 21
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3939,8 +3966,9 @@ SplineSet
  846 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: five
-Encoding: 53 53 53
+Encoding: 53 53 22
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4081,8 +4109,9 @@ SplineSet
  352 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: six
-Encoding: 54 54 54
+Encoding: 54 54 23
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4182,8 +4211,9 @@ SplineSet
  1065 1489 1065 1489 1128 1460 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: seven
-Encoding: 55 55 55
+Encoding: 55 55 24
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4254,8 +4284,9 @@ SplineSet
  276 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: eight
-Encoding: 56 56 56
+Encoding: 56 56 25
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4341,7 +4372,7 @@ SplineSet
  215 1263 215 1263 363 1391.5 c 128,-1,17
  511 1520 511 1520 725 1520 c 0,18,19
  903 1520 903 1520 1014.5 1429 c 128,-1,20
- 1126 1338 1126 1338 1126 1194 c 0,21,22
+ 1126 1338 1126 1338 1126 1194 c 256,21,22
  1126 1050 1126 1050 1029 936.5 c 128,-1,23
  932 823 932 823 772 782 c 1,24,25
  898 752 898 752 962 669 c 128,-1,26
@@ -4363,8 +4394,9 @@ SplineSet
  806 1364 806 1364 707 1364 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: nine
-Encoding: 57 57 57
+Encoding: 57 57 26
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4456,8 +4488,9 @@ SplineSet
  127 1 127 1 63 31 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: colon
-Encoding: 58 58 58
+Encoding: 58 58 27
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4556,8 +4589,9 @@ SplineSet
  403 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: semicolon
-Encoding: 59 59 59
+Encoding: 59 59 28
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4669,8 +4703,9 @@ SplineSet
  551 1063 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: less
-Encoding: 60 60 60
+Encoding: 60 60 29
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4721,8 +4756,9 @@ SplineSet
  1145 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equal
-Encoding: 61 61 61
+Encoding: 61 61 30
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4769,8 +4805,9 @@ SplineSet
  88 930 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: greater
-Encoding: 62 62 62
+Encoding: 62 62 31
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4821,8 +4858,9 @@ SplineSet
  88 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: question
-Encoding: 63 63 63
+Encoding: 63 63 32
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4987,8 +5025,9 @@ SplineSet
  383 254 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: at
-Encoding: 64 64 64
+Encoding: 64 64 33
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5156,8 +5195,9 @@ SplineSet
  1059 135 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: A
-Encoding: 65 65 65
+Encoding: 65 65 34
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5298,8 +5338,9 @@ SplineSet
  639 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: B
-Encoding: 66 66 66
+Encoding: 66 66 35
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5443,7 +5484,7 @@ SplineSet
 313 1493 m 1,18,-1
  756 1493 l 2,19,20
  959 1493 959 1493 1063 1413.5 c 128,-1,21
- 1167 1334 1167 1334 1167 1180 c 0,22,23
+ 1167 1334 1167 1334 1167 1180 c 256,22,23
  1167 1026 1167 1026 1075 922.5 c 128,-1,24
  983 819 983 819 827 799 c 1,25,26
  952 776 952 776 1018.5 697 c 128,-1,27
@@ -5454,8 +5495,9 @@ SplineSet
  313 1493 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: C
-Encoding: 67 67 67
+Encoding: 67 67 36
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5538,8 +5580,9 @@ SplineSet
  944 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: D
-Encoding: 68 68 68
+Encoding: 68 68 37
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5649,8 +5692,9 @@ SplineSet
  586 1493 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: E
-Encoding: 69 69 69
+Encoding: 69 69 38
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5761,8 +5805,9 @@ SplineSet
  344 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: F
-Encoding: 70 70 70
+Encoding: 70 70 39
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5866,8 +5911,9 @@ SplineSet
  383 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: G
-Encoding: 71 71 71
+Encoding: 71 71 40
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6005,8 +6051,9 @@ SplineSet
  969 96 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: H
-Encoding: 72 72 72
+Encoding: 72 72 41
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6152,8 +6199,9 @@ SplineSet
  283 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: I
-Encoding: 73 73 73
+Encoding: 73 73 42
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6239,8 +6287,9 @@ SplineSet
  346 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: J
-Encoding: 74 74 74
+Encoding: 74 74 43
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6350,8 +6399,9 @@ SplineSet
  74 17 74 17 -25 61 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: K
-Encoding: 75 75 75
+Encoding: 75 75 44
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6480,8 +6530,9 @@ SplineSet
  283 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: L
-Encoding: 76 76 76
+Encoding: 76 76 45
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6554,8 +6605,9 @@ SplineSet
  369 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: M
-Encoding: 77 77 77
+Encoding: 77 77 46
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6759,8 +6811,9 @@ SplineSet
  229 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: N
-Encoding: 78 78 78
+Encoding: 78 78 47
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6914,8 +6967,9 @@ SplineSet
  285 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: O
-Encoding: 79 79 79
+Encoding: 79 79 48
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6988,8 +7042,9 @@ SplineSet
  1151 1275 1151 1275 1151 1020 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: P
-Encoding: 80 80 80
+Encoding: 80 80 49
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7121,8 +7176,9 @@ SplineSet
  342 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Q
-Encoding: 81 81 81
+Encoding: 81 81 50
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7217,8 +7273,9 @@ SplineSet
  392 135 392 135 502 135 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: R
-Encoding: 82 82 82
+Encoding: 82 82 51
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7406,8 +7463,9 @@ SplineSet
  473 1327 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: S
-Encoding: 83 83 83
+Encoding: 83 83 52
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7625,8 +7683,9 @@ SplineSet
  1052 1480 1052 1480 1147 1442 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: T
-Encoding: 84 84 84
+Encoding: 84 84 53
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7709,8 +7768,9 @@ SplineSet
  193 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: U
-Encoding: 85 85 85
+Encoding: 85 85 54
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7869,8 +7929,9 @@ SplineSet
  97 480 97 480 115 573 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: V
-Encoding: 86 86 86
+Encoding: 86 86 55
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7962,8 +8023,9 @@ SplineSet
  510 190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: W
-Encoding: 87 87 87
+Encoding: 87 87 56
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8218,8 +8280,9 @@ SplineSet
  145 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: X
-Encoding: 88 88 88
+Encoding: 88 88 57
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8368,8 +8431,9 @@ SplineSet
  242 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Y
-Encoding: 89 89 89
+Encoding: 89 89 58
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8491,8 +8555,9 @@ SplineSet
  195 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Z
-Encoding: 90 90 90
+Encoding: 90 90 59
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8570,8 +8635,9 @@ SplineSet
  305 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketleft
-Encoding: 91 91 91
+Encoding: 91 91 60
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8661,8 +8727,9 @@ SplineSet
  621 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: backslash
-Encoding: 92 92 92
+Encoding: 92 92 61
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8725,8 +8792,9 @@ SplineSet
  725 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketright
-Encoding: 93 93 93
+Encoding: 93 93 62
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8812,8 +8880,9 @@ SplineSet
  928 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciicircum
-Encoding: 94 94 94
+Encoding: 94 94 63
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8855,8 +8924,9 @@ SplineSet
  705 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underscore
-Encoding: 95 95 95
+Encoding: 95 95 64
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8886,8 +8956,9 @@ SplineSet
  1233 -403 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: grave
-Encoding: 96 96 96
+Encoding: 96 96 65
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8946,8 +9017,9 @@ SplineSet
  651 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: a
-Encoding: 97 97 97
+Encoding: 97 97 66
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9233,8 +9305,9 @@ SplineSet
  1075 702 1075 702 1063 639 c 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: b
-Encoding: 98 98 98
+Encoding: 98 98 67
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9415,8 +9488,9 @@ SplineSet
  434 977 l 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: c
-Encoding: 99 99 99
+Encoding: 99 99 68
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9501,8 +9575,9 @@ SplineSet
  940 51 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: d
-Encoding: 100 100 100
+Encoding: 100 100 69
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9683,8 +9758,9 @@ SplineSet
  913 1060 913 1060 954 977 c 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: e
-Encoding: 101 101 101
+Encoding: 101 101 70
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9815,8 +9891,9 @@ SplineSet
  961 57 l 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: f
-Encoding: 102 102 102
+Encoding: 102 102 71
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9951,8 +10028,9 @@ SplineSet
  1245 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: g
-Encoding: 103 103 103
+Encoding: 103 103 72
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10163,8 +10241,9 @@ SplineSet
  942 72 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: h
-Encoding: 104 104 104
+Encoding: 104 104 73
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10341,8 +10420,9 @@ SplineSet
  1085 746 1085 746 1075 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: i
-Encoding: 105 105 105
+Encoding: 105 105 74
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10472,8 +10552,9 @@ SplineSet
  729 1556 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: j
-Encoding: 106 106 106
+Encoding: 106 106 75
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10615,8 +10696,9 @@ SplineSet
  803 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: k
-Encoding: 107 107 107
+Encoding: 107 107 76
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10762,8 +10844,9 @@ SplineSet
  393 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: l
-Encoding: 108 108 108
+Encoding: 108 108 77
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10883,8 +10966,9 @@ SplineSet
  600 408 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: m
-Encoding: 109 109 109
+Encoding: 109 109 78
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11134,8 +11218,9 @@ SplineSet
  738 1072 738 1072 748 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: n
-Encoding: 110 110 110
+Encoding: 110 110 79
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11312,8 +11397,9 @@ SplineSet
  1085 746 1085 746 1075 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: o
-Encoding: 111 111 111
+Encoding: 111 111 80
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11378,8 +11464,9 @@ SplineSet
  576 1147 576 1147 713 1147 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: p
-Encoding: 112 112 112
+Encoding: 112 112 81
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11561,8 +11648,9 @@ SplineSet
  466 127 466 127 569 127 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: q
-Encoding: 113 113 113
+Encoding: 113 113 82
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11716,8 +11804,9 @@ SplineSet
  767 991 767 991 668 991 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: r
-Encoding: 114 114 114
+Encoding: 114 114 83
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11846,8 +11935,9 @@ SplineSet
  1184 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: s
-Encoding: 115 115 115
+Encoding: 115 115 84
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12102,8 +12192,9 @@ SplineSet
  1004 1114 1004 1114 1077 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: t
-Encoding: 116 116 116
+Encoding: 116 116 85
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12248,8 +12339,9 @@ SplineSet
  768 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: u
-Encoding: 117 117 117
+Encoding: 117 117 86
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12425,8 +12517,9 @@ SplineSet
  134 378 134 378 143 426 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: v
-Encoding: 118 118 118
+Encoding: 118 118 87
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12518,8 +12611,9 @@ SplineSet
  182 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: w
-Encoding: 119 119 119
+Encoding: 119 119 88
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12784,8 +12878,9 @@ SplineSet
  92 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: x
-Encoding: 120 120 120
+Encoding: 120 120 89
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12934,8 +13029,9 @@ SplineSet
  1208 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: y
-Encoding: 121 121 121
+Encoding: 121 121 90
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13088,8 +13184,9 @@ SplineSet
  786 360 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: z
-Encoding: 122 122 122
+Encoding: 122 122 91
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13165,8 +13262,9 @@ SplineSet
  319 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceleft
-Encoding: 123 123 123
+Encoding: 123 123 92
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13389,8 +13487,9 @@ SplineSet
  1176 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bar
-Encoding: 124 124 124
+Encoding: 124 124 93
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13423,8 +13522,9 @@ SplineSet
  702 1565 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceright
-Encoding: 125 125 125
+Encoding: 125 125 94
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13647,8 +13747,9 @@ SplineSet
  -14 -334 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciitilde
-Encoding: 126 126 126
+Encoding: 126 126 95
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13715,14 +13816,16 @@ SplineSet
  1071 718 1071 718 1145 780 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: nonbreakingspace
-Encoding: 160 160 160
+Encoding: 160 160 96
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclamdown
-Encoding: 161 161 161
+Encoding: 161 161 97
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13842,8 +13945,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" exclamdown.case
 EndChar
+
 StartChar: cent
-Encoding: 162 162 162
+Encoding: 162 162 98
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13969,8 +14073,9 @@ SplineSet
  432 139 432 139 541 127 c 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: sterling
-Encoding: 163 163 163
+Encoding: 163 163 99
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14134,8 +14239,9 @@ SplineSet
  1157 1491 1157 1491 1229 1462 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: currency
-Encoding: 164 164 164
+Encoding: 164 164 100
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14308,8 +14414,9 @@ SplineSet
  793 954 793 954 844 924 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: yen
-Encoding: 165 165 165
+Encoding: 165 165 101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14507,8 +14614,9 @@ SplineSet
  1036 524 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: brokenbar
-Encoding: 166 166 166
+Encoding: 166 166 102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14556,8 +14664,9 @@ SplineSet
  702 408 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: section
-Encoding: 167 167 167
+Encoding: 167 167 103
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14733,8 +14842,9 @@ SplineSet
  678 401 l 1,53,54
 EndSplineSet
 EndChar
+
 StartChar: dieresis
-Encoding: 168 168 168
+Encoding: 168 168 104
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14851,10 +14961,11 @@ SplineSet
  827 1350 l 1,7,-1
  866 1552 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: copyright
-Encoding: 169 169 169
+Encoding: 169 169 105
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14951,7 +15062,7 @@ SplineSet
  812 1094 812 1094 864 1071 c 1,0,-1
 616 1255 m 0,26,27
  510 1255 510 1255 419.5 1218 c 128,-1,28
- 329 1181 329 1181 254 1106 c 0,29,30
+ 329 1181 329 1181 254 1106 c 256,29,30
  179 1031 179 1031 140.5 939 c 128,-1,31
  102 847 102 847 102 741 c 0,32,33
  102 637 102 637 140.5 545.5 c 128,-1,34
@@ -14959,11 +15070,11 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,37
  511 227 511 227 616 227 c 0,38,39
  722 227 722 227 812.5 265 c 128,-1,40
- 903 303 903 303 979 379 c 0,41,42
+ 903 303 903 303 979 379 c 256,41,42
  1055 455 1055 455 1092.5 545.5 c 128,-1,43
  1130 636 1130 636 1130 741 c 0,44,45
  1130 847 1130 847 1092 939 c 128,-1,46
- 1054 1031 1054 1031 979 1106 c 0,47,48
+ 1054 1031 1054 1031 979 1106 c 256,47,48
  904 1181 904 1181 813.5 1218 c 128,-1,49
  723 1255 723 1255 616 1255 c 0,26,27
 616 1358 m 0,50,51
@@ -14972,11 +15083,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,55
  1233 867 1233 867 1233 741 c 0,56,57
  1233 616 1233 616 1187.5 507 c 128,-1,58
- 1142 398 1142 398 1051 307 c 0,59,60
+ 1142 398 1142 398 1051 307 c 256,59,60
  960 216 960 216 851 170.5 c 128,-1,61
  742 125 742 125 616 125 c 0,62,63
  491 125 491 125 382 170.5 c 128,-1,64
- 273 216 273 216 182 307 c 0,65,66
+ 273 216 273 216 182 307 c 256,65,66
  91 398 91 398 45.5 507 c 128,-1,67
  0 616 0 616 0 741 c 0,68,69
  0 867 0 867 46 977 c 128,-1,70
@@ -14985,8 +15096,9 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,50,51
 EndSplineSet
 EndChar
+
 StartChar: ordfeminine
-Encoding: 170 170 170
+Encoding: 170 170 106
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15145,8 +15257,9 @@ SplineSet
  246 592 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotleft
-Encoding: 171 171 171
+Encoding: 171 171 107
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15223,8 +15336,9 @@ SplineSet
  639 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalnot
-Encoding: 172 172 172
+Encoding: 172 172 108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15265,8 +15379,9 @@ SplineSet
  88 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: sfthyphen
-Encoding: 173 173 173
+Encoding: 173 173 109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15301,8 +15416,9 @@ SplineSet
  336 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: registered
-Encoding: 174 174 174
+Encoding: 174 174 110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15474,11 +15590,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,34
  1233 867 1233 867 1233 741 c 0,35,36
  1233 616 1233 616 1187.5 507 c 128,-1,37
- 1142 398 1142 398 1051 307 c 0,38,39
+ 1142 398 1142 398 1051 307 c 256,38,39
  960 216 960 216 851 170.5 c 128,-1,40
  742 125 742 125 616 125 c 0,41,42
  491 125 491 125 382 170.5 c 128,-1,43
- 273 216 273 216 182 307 c 0,44,45
+ 273 216 273 216 182 307 c 256,44,45
  91 398 91 398 45.5 507 c 128,-1,46
  0 616 0 616 0 741 c 0,47,48
  0 867 0 867 46 977 c 128,-1,49
@@ -15487,7 +15603,7 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,29,30
 616 1255 m 0,53,54
  510 1255 510 1255 419.5 1218 c 128,-1,55
- 329 1181 329 1181 254 1106 c 0,56,57
+ 329 1181 329 1181 254 1106 c 256,56,57
  179 1031 179 1031 140.5 939 c 128,-1,58
  102 847 102 847 102 741 c 0,59,60
  102 637 102 637 140.5 545.5 c 128,-1,61
@@ -15495,17 +15611,18 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,64
  511 227 511 227 616 227 c 0,65,66
  722 227 722 227 812.5 265 c 128,-1,67
- 903 303 903 303 979 379 c 0,68,69
+ 903 303 903 303 979 379 c 256,68,69
  1055 455 1055 455 1092.5 545.5 c 128,-1,70
  1130 636 1130 636 1130 741 c 0,71,72
  1130 847 1130 847 1092 939 c 128,-1,73
- 1054 1031 1054 1031 979 1106 c 0,74,75
+ 1054 1031 1054 1031 979 1106 c 256,74,75
  904 1181 904 1181 813.5 1218 c 128,-1,76
  723 1255 723 1255 616 1255 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: macron
-Encoding: 175 175 175
+Encoding: 175 175 111
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15541,10 +15658,11 @@ SplineSet
  440 1378 l 1,3,-1
  469 1526 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: degree
-Encoding: 176 176 176
+Encoding: 176 176 112
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15595,19 +15713,20 @@ SplineSet
  299 1065 299 1065 299 1200 c 0,12,13
  299 1334 299 1334 391 1427 c 128,-1,14
  483 1520 483 1520 616 1520 c 0,0,1
-616 1391 m 0,15,16
+616 1391 m 256,15,16
  537 1391 537 1391 481.5 1335.5 c 128,-1,17
- 426 1280 426 1280 426 1200 c 0,18,19
+ 426 1280 426 1280 426 1200 c 256,18,19
  426 1120 426 1120 480.5 1066 c 128,-1,20
  535 1012 535 1012 614 1012 c 0,21,22
  694 1012 694 1012 750.5 1067 c 128,-1,23
  807 1122 807 1122 807 1200 c 0,24,25
  807 1279 807 1279 751 1335 c 128,-1,26
- 695 1391 695 1391 616 1391 c 0,15,16
+ 695 1391 695 1391 616 1391 c 256,15,16
 EndSplineSet
 EndChar
+
 StartChar: plusminus
-Encoding: 177 177 177
+Encoding: 177 177 113
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15681,8 +15800,9 @@ SplineSet
  700 1171 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: twosuperior
-Encoding: 178 178 178
+Encoding: 178 178 114
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15818,8 +15938,9 @@ SplineSet
  492 782 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: threesuperior
-Encoding: 179 179 179
+Encoding: 179 179 115
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15931,8 +16052,9 @@ SplineSet
  869 1134 869 1134 772 1116 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: acute
-Encoding: 180 180 180
+Encoding: 180 180 116
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15987,10 +16109,11 @@ SplineSet
  575 1262 l 1,3,-1
  907 1638 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: mu
-Encoding: 181 181 181
+Encoding: 181 181 117
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16197,8 +16320,9 @@ SplineSet
  -39 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: paragraph
-Encoding: 182 182 182
+Encoding: 182 182 118
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16324,8 +16448,9 @@ SplineSet
  471 1493 471 1493 735 1493 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: periodcentered
-Encoding: 183 183 183
+Encoding: 183 183 119
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16387,17 +16512,19 @@ SplineSet
  512 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: cedilla
-Encoding: 184 184 184
+Encoding: 184 184 120
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 691 807 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: onesuperior
-Encoding: 185 185 185
+Encoding: 185 185 121
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16507,8 +16634,9 @@ SplineSet
  369 778 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ordmasculine
-Encoding: 186 186 186
+Encoding: 186 186 122
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16600,8 +16728,9 @@ SplineSet
  246 592 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotright
-Encoding: 187 187 187
+Encoding: 187 187 123
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16678,40 +16807,44 @@ SplineSet
  549 141 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: onequarter
-Encoding: 188 188 188
+Encoding: 188 188 124
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1908 8308 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: onehalf
-Encoding: 189 189 189
+Encoding: 189 189 125
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 154 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 154 -938 2
 EndChar
+
 StartChar: threequarters
-Encoding: 190 190 190
+Encoding: 190 190 126
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 137 -938 2
-Refer: 179 179 N 1 0 0 1 -227 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 1908 8308 N 1 0 0 1 137 -938 2
+Refer: 115 179 N 1 0 0 1 -227 156 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: questiondown
-Encoding: 191 191 191
+Encoding: 191 191 127
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16879,53 +17012,59 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" questiondown.case
 EndChar
+
 StartChar: Agrave
-Encoding: 192 192 192
+Encoding: 192 192 128
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Aacute
-Encoding: 193 193 193
+Encoding: 193 193 129
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Acircumflex
-Encoding: 194 194 194
+Encoding: 194 194 130
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Atilde
-Encoding: 195 195 195
+Encoding: 195 195 131
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Adieresis
-Encoding: 196 196 196
+Encoding: 196 196 132
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
 EndChar
+
 StartChar: Aring
-Encoding: 197 197 197
+Encoding: 197 197 133
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17081,7 +17220,7 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-924 1626 m 0,0,1
+924 1626 m 256,0,1
  924 1689 924 1689 879.5 1733.5 c 128,-1,2
  835 1778 835 1778 772 1778 c 0,3,4
  708 1778 708 1778 664.5 1734.5 c 128,-1,5
@@ -17089,7 +17228,7 @@ SplineSet
  621 1563 621 1563 664.5 1519 c 128,-1,8
  708 1475 708 1475 772 1475 c 0,9,10
  835 1475 835 1475 879.5 1519 c 128,-1,11
- 924 1563 924 1563 924 1626 c 0,0,1
+ 924 1563 924 1563 924 1626 c 256,0,1
 735 1325 m 1,12,-1
  371 551 l 1,13,-1
  801 551 l 1,14,-1
@@ -17112,8 +17251,9 @@ SplineSet
  600 1415 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: AE
-Encoding: 198 198 198
+Encoding: 198 198 134
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17282,90 +17422,100 @@ SplineSet
  647 1323 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: Ccedilla
-Encoding: 199 199 199
+Encoding: 199 199 135
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: Egrave
-Encoding: 200 200 200
+Encoding: 200 200 136
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 96 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 96 373 2
 EndChar
+
 StartChar: Eacute
-Encoding: 201 201 201
+Encoding: 201 201 137
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 96 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 96 373 2
 EndChar
+
 StartChar: Ecircumflex
-Encoding: 202 202 202
+Encoding: 202 202 138
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 96 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 96 373 2
 EndChar
+
 StartChar: Edieresis
-Encoding: 203 203 203
+Encoding: 203 203 139
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 96 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 96 373 2
 EndChar
+
 StartChar: Igrave
-Encoding: 204 204 204
+Encoding: 204 204 140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 57 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Iacute
-Encoding: 205 205 205
+Encoding: 205 205 141
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 57 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Icircumflex
-Encoding: 206 206 206
+Encoding: 206 206 142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 57 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Idieresis
-Encoding: 207 207 207
+Encoding: 207 207 143
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eth
-Encoding: 208 208 208
+Encoding: 208 208 144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17510,62 +17660,69 @@ SplineSet
  586 1493 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: Ntilde
-Encoding: 209 209 209
+Encoding: 209 209 145
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 47 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 47 373 2
 EndChar
+
 StartChar: Ograve
-Encoding: 210 210 210
+Encoding: 210 210 146
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 43 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 43 373 2
 EndChar
+
 StartChar: Oacute
-Encoding: 211 211 211
+Encoding: 211 211 147
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 43 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 43 373 2
 EndChar
+
 StartChar: Ocircumflex
-Encoding: 212 212 212
+Encoding: 212 212 148
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 43 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 43 373 2
 EndChar
+
 StartChar: Otilde
-Encoding: 213 213 213
+Encoding: 213 213 149
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 43 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 43 373 2
 EndChar
+
 StartChar: Odieresis
-Encoding: 214 214 214
+Encoding: 214 214 150
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
 EndChar
+
 StartChar: multiply
-Encoding: 215 215 215
+Encoding: 215 215 151
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17634,8 +17791,9 @@ SplineSet
  150 293 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Oslash
-Encoding: 216 216 216
+Encoding: 216 216 152
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17799,54 +17957,60 @@ SplineSet
  1094 1337 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: Ugrave
-Encoding: 217 217 217
+Encoding: 217 217 153
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 55 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 55 373 2
 EndChar
+
 StartChar: Uacute
-Encoding: 218 218 218
+Encoding: 218 218 154
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 55 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 55 373 2
 EndChar
+
 StartChar: Ucircumflex
-Encoding: 219 219 219
+Encoding: 219 219 155
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 55 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 55 373 2
 EndChar
+
 StartChar: Udieresis
-Encoding: 220 220 220
+Encoding: 220 220 156
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 55 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 55 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Yacute
-Encoding: 221 221 221
+Encoding: 221 221 157
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 57 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Thorn
-Encoding: 222 222 222
+Encoding: 222 222 158
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18015,8 +18179,9 @@ SplineSet
  461 1059 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: germandbls
-Encoding: 223 223 223
+Encoding: 223 223 159
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18234,62 +18399,69 @@ SplineSet
  276 1137 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: agrave
-Encoding: 224 224 224
+Encoding: 224 224 160
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: aacute
-Encoding: 225 225 225
+Encoding: 225 225 161
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: acircumflex
-Encoding: 226 226 226
+Encoding: 226 226 162
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: atilde
-Encoding: 227 227 227
+Encoding: 227 227 163
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: adieresis
-Encoding: 228 228 228
+Encoding: 228 228 164
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: aring
-Encoding: 229 229 229
+Encoding: 229 229 165
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 4 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 635 730 N 1 0 0 1 4 0 2
 EndChar
+
 StartChar: ae
-Encoding: 230 230 230
+Encoding: 230 230 166
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18695,91 +18867,101 @@ SplineSet
  1163 514 l 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: ccedilla
-Encoding: 231 231 231
+Encoding: 231 231 167
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 104 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 104 0 2
 EndChar
+
 StartChar: egrave
-Encoding: 232 232 232
+Encoding: 232 232 168
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eacute
-Encoding: 233 233 233
+Encoding: 233 233 169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ecircumflex
-Encoding: 234 234 234
+Encoding: 234 234 170
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: edieresis
-Encoding: 235 235 235
+Encoding: 235 235 171
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: igrave
-Encoding: 236 236 236
+Encoding: 236 236 172
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 -29 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -29 0 2
 EndChar
+
 StartChar: iacute
-Encoding: 237 237 237
+Encoding: 237 237 173
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 -29 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -29 0 2
 EndChar
+
 StartChar: icircumflex
-Encoding: 238 238 238
+Encoding: 238 238 174
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 -29 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 -29 0 2
 EndChar
+
 StartChar: idieresis
-Encoding: 239 239 239
+Encoding: 239 239 175
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 -29 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -29 0 2
 EndChar
+
 StartChar: eth
-Encoding: 240 240 240
+Encoding: 240 240 176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18959,62 +19141,69 @@ SplineSet
  893 870 893 870 874 907 c 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: ntilde
-Encoding: 241 241 241
+Encoding: 241 241 177
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ograve
-Encoding: 242 242 242
+Encoding: 242 242 178
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: oacute
-Encoding: 243 243 243
+Encoding: 243 243 179
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ocircumflex
-Encoding: 244 244 244
+Encoding: 244 244 180
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: otilde
-Encoding: 245 245 245
+Encoding: 245 245 181
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: odieresis
-Encoding: 246 246 246
+Encoding: 246 246 182
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: divide
-Encoding: 247 247 247
+Encoding: 247 247 183
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19078,8 +19267,9 @@ SplineSet
  88 727 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: oslash
-Encoding: 248 248 248
+Encoding: 248 248 184
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19237,53 +19427,59 @@ SplineSet
  852 938 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: ugrave
-Encoding: 249 249 249
+Encoding: 249 249 185
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 -4 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -4 0 2
 EndChar
+
 StartChar: uacute
-Encoding: 250 250 250
+Encoding: 250 250 186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 -4 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -4 0 2
 EndChar
+
 StartChar: ucircumflex
-Encoding: 251 251 251
+Encoding: 251 251 187
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 -4 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 -4 0 2
 EndChar
+
 StartChar: udieresis
-Encoding: 252 252 252
+Encoding: 252 252 188
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 -4 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -4 0 2
 EndChar
+
 StartChar: yacute
-Encoding: 253 253 253
+Encoding: 253 253 189
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: thorn
-Encoding: 254 254 254
+Encoding: 254 254 190
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19464,173 +19660,192 @@ SplineSet
  466 127 466 127 569 127 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: ydieresis
-Encoding: 255 255 255
+Encoding: 255 255 191
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Amacron
-Encoding: 256 256 256
+Encoding: 256 256 192
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: amacron
-Encoding: 257 257 257
+Encoding: 257 257 193
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Abreve
-Encoding: 258 258 258
+Encoding: 258 258 194
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: abreve
-Encoding: 259 259 259
+Encoding: 259 259 195
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Aogonek
-Encoding: 260 260 260
+Encoding: 260 260 196
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 470 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 470 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aogonek
-Encoding: 261 261 261
+Encoding: 261 261 197
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 366 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 366 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cacute
-Encoding: 262 262 262
+Encoding: 262 262 198
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 174 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 174 373 2
 EndChar
+
 StartChar: cacute
-Encoding: 263 263 263
+Encoding: 263 263 199
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ccircumflex
-Encoding: 264 264 264
+Encoding: 264 264 200
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 215 373 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 215 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ccircumflex
-Encoding: 265 265 265
+Encoding: 265 265 201
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 90 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 90 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cdotaccent
-Encoding: 266 266 266
+Encoding: 266 266 202
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 75 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 75 0 2
 EndChar
+
 StartChar: cdotaccent
-Encoding: 267 267 267
+Encoding: 267 267 203
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 75 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 75 0 2
 EndChar
+
 StartChar: Ccaron
-Encoding: 268 268 268
+Encoding: 268 268 204
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 174 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 174 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ccaron
-Encoding: 269 269 269
+Encoding: 269 269 205
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcaron
-Encoding: 270 270 270
+Encoding: 270 270 206
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 42 373 2
-LCarets2: 1 0 
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 42 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dcaron
-Encoding: 271 271 271
+Encoding: 271 271 207
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 0.895604 0 0 0.992021 671.027 -72.9309 2
-Refer: 100 100 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 0.895604 0 0 0.992021 671.027 -72.9309 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcroat
-Encoding: 272 272 272
+Encoding: 272 272 208
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dcroat
-Encoding: 273 273 273
+Encoding: 273 273 209
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19888,187 +20103,208 @@ SplineSet
  913 1060 913 1060 954 977 c 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: Emacron
-Encoding: 274 274 274
+Encoding: 274 274 210
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: emacron
-Encoding: 275 275 275
+Encoding: 275 275 211
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 35 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 35 0 2
 EndChar
+
 StartChar: Ebreve
-Encoding: 276 276 276
+Encoding: 276 276 212
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: ebreve
-Encoding: 277 277 277
+Encoding: 277 277 213
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: Edotaccent
-Encoding: 278 278 278
+Encoding: 278 278 214
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: edotaccent
-Encoding: 279 279 279
+Encoding: 279 279 215
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: Eogonek
-Encoding: 280 280 280
+Encoding: 280 280 216
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 360 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 360 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eogonek
-Encoding: 281 281 281
+Encoding: 281 281 217
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 285 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 285 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ecaron
-Encoding: 282 282 282
+Encoding: 282 282 218
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 144 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 144 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecaron
-Encoding: 283 283 283
+Encoding: 283 283 219
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 55 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 55 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gcircumflex
-Encoding: 284 284 284
+Encoding: 284 284 220
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 57 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 57 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcircumflex
-Encoding: 285 285 285
+Encoding: 285 285 221
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gbreve
-Encoding: 286 286 286
+Encoding: 286 286 222
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: gbreve
-Encoding: 287 287 287
+Encoding: 287 287 223
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gdotaccent
-Encoding: 288 288 288
+Encoding: 288 288 224
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: gdotaccent
-Encoding: 289 289 289
+Encoding: 289 289 225
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcommaaccent
-Encoding: 290 290 290
+Encoding: 290 290 226
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 127.949 -31 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 127.949 -31 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcommaaccent
-Encoding: 291 291 291
+Encoding: 291 291 227
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 786 786 N 1 0 0 1 80.6538 302 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 670 786 N 1 0 0 1 80.6538 302 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hcircumflex
-Encoding: 292 292 292
+Encoding: 292 292 228
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 75 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 75 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hcircumflex
-Encoding: 293 293 293
+Encoding: 293 293 229
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 -212 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 -212 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hbar
-Encoding: 294 294 294
+Encoding: 294 294 230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20102,8 +20338,9 @@ SplineSet
  409 1105 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: hbar
-Encoding: 295 295 295
+Encoding: 295 295 231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20138,88 +20375,98 @@ SplineSet
  1053 788.5 1053 788.5 1034.5 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Itilde
-Encoding: 296 296 296
+Encoding: 296 296 232
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 57 373 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 57 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: itilde
-Encoding: 297 297 297
+Encoding: 297 297 233
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -29 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 -29 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Imacron
-Encoding: 298 298 298
+Encoding: 298 298 234
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: imacron
-Encoding: 299 299 299
+Encoding: 299 299 235
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ibreve
-Encoding: 300 300 300
+Encoding: 300 300 236
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ibreve
-Encoding: 301 301 301
+Encoding: 301 301 237
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iogonek
-Encoding: 302 302 302
+Encoding: 302 302 238
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 36.2852 0 2
-Refer: 731 731 N 1 0 0 1 108.285 -0.000325203 2
+Refer: 42 73 N 1 0 0 1 36.2852 0 2
+Refer: 636 731 N 1 0 0 1 108.285 -0.000325203 2
 EndChar
+
 StartChar: iogonek
-Encoding: 303 303 303
+Encoding: 303 303 239
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 4.1662 0 2
-Refer: 731 731 N 1 0 0 1 112.163 0.000650167 2
+Refer: 74 105 N 1 0 0 1 4.1662 0 2
+Refer: 636 731 N 1 0 0 1 112.163 0.000650167 2
 EndChar
+
 StartChar: Idotaccent
-Encoding: 304 304 304
+Encoding: 304 304 240
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotlessi
-Encoding: 305 305 305
+Encoding: 305 305 241
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20307,8 +20554,9 @@ SplineSet
  358 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: IJ
-Encoding: 306 306 306
+Encoding: 306 306 242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20344,8 +20592,9 @@ SplineSet
  283.416 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ij
-Encoding: 307 307 307
+Encoding: 307 307 243
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20387,42 +20636,47 @@ SplineSet
  1325 1553 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: Jcircumflex
-Encoding: 308 308 308
+Encoding: 308 308 244
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 135 373 2
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 135 373 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: jcircumflex
-Encoding: 309 309 309
+Encoding: 309 309 245
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -29 0 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 -29 0 2
+Refer: 490 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kcommaaccent
-Encoding: 310 310 310
+Encoding: 310 310 246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 104.449 -2 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 104.449 -2 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kcommaaccent
-Encoding: 311 311 311
+Encoding: 311 311 247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 142.449 -2 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 142.449 -2 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kgreenlandic
-Encoding: 312 312 312
+Encoding: 312 312 248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20443,85 +20697,94 @@ SplineSet
  345 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Lacute
-Encoding: 313 313 313
+Encoding: 313 313 249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 55 374 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 55 374 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lacute
-Encoding: 314 314 314
+Encoding: 314 314 250
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 55 375 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 55 375 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lcommaaccent
-Encoding: 315 315 315
+Encoding: 315 315 251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 108.449 -2 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 108.449 -2 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lcommaaccent
-Encoding: 316 316 316
+Encoding: 316 316 252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 177.449 -2 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 177.449 -2 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lcaron
-Encoding: 317 317 317
+Encoding: 317 317 253
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 167 -146 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 1 0 0 1 167 -146 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lcaron
-Encoding: 318 318 318
+Encoding: 318 318 254
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 297 -70 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3087 -1 N 1 0 0 1 297 -70 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ldot
-Encoding: 319 319 319
+Encoding: 319 319 255
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 355.299 143.5 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 355.299 143.5 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ldot
-Encoding: 320 320 320
+Encoding: 320 320 256
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 571 142 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 571 142 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lslash
-Encoding: 321 321 321
+Encoding: 321 321 257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20647,8 +20910,9 @@ SplineSet
  371 1491 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lslash
-Encoding: 322 322 322
+Encoding: 322 322 258
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20811,74 +21075,82 @@ SplineSet
  600 408 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: Nacute
-Encoding: 323 323 323
+Encoding: 323 323 259
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 73 380 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 73 380 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nacute
-Encoding: 324 324 324
+Encoding: 324 324 260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -7.392 7 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -7.392 7 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncommaaccent
-Encoding: 325 325 325
+Encoding: 325 325 261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 39.9494 -2 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 39.9494 -2 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ncommaaccent
-Encoding: 326 326 326
+Encoding: 326 326 262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 80.9494 -2 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 80.9494 -2 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncaron
-Encoding: 327 327 327
+Encoding: 327 327 263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 132 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 132 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ncaron
-Encoding: 328 328 328
+Encoding: 328 328 264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 48 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 48 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: napostrophe
-Encoding: 329 329 329
+Encoding: 329 329 265
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 700 700 N 1 0 0 1 -439 0 2
-Refer: 110 110 N 1 0 0 1 123 0 2
-LCarets2: 1 0 
+Refer: 613 700 N 1 0 0 1 -439 0 2
+Refer: 79 110 N 1 0 0 1 123 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eng
-Encoding: 330 330 330
+Encoding: 330 330 266
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20910,8 +21182,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Latin lookup 0-1" Eng.alt
 EndChar
+
 StartChar: eng
-Encoding: 331 331 331
+Encoding: 331 331 267
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -20944,62 +21217,69 @@ SplineSet
  1134 788 1134 788 1116 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omacron
-Encoding: 332 332 332
+Encoding: 332 332 268
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omacron
-Encoding: 333 333 333
+Encoding: 333 333 269
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Obreve
-Encoding: 334 334 334
+Encoding: 334 334 270
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: obreve
-Encoding: 335 335 335
+Encoding: 335 335 271
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ohungarumlaut
-Encoding: 336 336 336
+Encoding: 336 336 272
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ohungarumlaut
-Encoding: 337 337 337
+Encoding: 337 337 273
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 663 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: OE
-Encoding: 338 338 338
+Encoding: 338 338 274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21137,8 +21417,9 @@ SplineSet
  702 1323 l 2,20,21
 EndSplineSet
 EndChar
+
 StartChar: oe
-Encoding: 339 339 339
+Encoding: 339 339 275
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21402,172 +21683,191 @@ SplineSet
  242 123 242 123 311 123 c 0,57,58
 EndSplineSet
 EndChar
+
 StartChar: Racute
-Encoding: 340 340 340
+Encoding: 340 340 276
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 55 374 2
-Refer: 82 82 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3089 -1 N 1 0 0 1 55 374 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: racute
-Encoding: 341 341 341
+Encoding: 341 341 277
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 207.608 7 2
-Refer: 114 114 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 116 180 N 1 0 0 1 207.608 7 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Rcommaaccent
-Encoding: 342 342 342
+Encoding: 342 342 278
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 124.949 -2 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 124.949 -2 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: rcommaaccent
-Encoding: 343 343 343
+Encoding: 343 343 279
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -122.051 -2 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 -122.051 -2 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rcaron
-Encoding: 344 344 344
+Encoding: 344 344 280
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 66 373 2
-LCarets2: 1 0 
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 66 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: rcaron
-Encoding: 345 345 345
+Encoding: 345 345 281
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Sacute
-Encoding: 346 346 346
+Encoding: 346 346 282
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 73 380 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 73 380 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: sacute
-Encoding: 347 347 347
+Encoding: 347 347 283
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -7.392 7 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -7.392 7 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scircumflex
-Encoding: 348 348 348
+Encoding: 348 348 284
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 111 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 111 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scircumflex
-Encoding: 349 349 349
+Encoding: 349 349 285
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 69.4907 28 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 69.4907 28 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scedilla
-Encoding: 350 350 350
+Encoding: 350 350 286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scedilla
-Encoding: 351 351 351
+Encoding: 351 351 287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scaron
-Encoding: 352 352 352
+Encoding: 352 352 288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: scaron
-Encoding: 353 353 353
+Encoding: 353 353 289
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Tcommaaccent
-Encoding: 354 354 354
+Encoding: 354 354 290
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tcommaaccent
-Encoding: 355 355 355
+Encoding: 355 355 291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 121 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 121 0 2
 EndChar
+
 StartChar: Tcaron
-Encoding: 356 356 356
+Encoding: 356 356 292
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 96 373 2
-LCarets2: 1 0 
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 96 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: tcaron
-Encoding: 357 357 357
+Encoding: 357 357 293
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114113 -1 N 1 0 0 1 343 41.9999 2
-LCarets2: 1 0 
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3087 -1 N 1 0 0 1 343 41.9999 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tbar
-Encoding: 358 358 358
+Encoding: 358 358 294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21592,8 +21892,9 @@ SplineSet
  192 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tbar
-Encoding: 359 359 359
+Encoding: 359 359 295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21630,215 +21931,239 @@ SplineSet
  754 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Utilde
-Encoding: 360 360 360
+Encoding: 360 360 296
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 55 373 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 55 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: utilde
-Encoding: 361 361 361
+Encoding: 361 361 297
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -4 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 -4 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Umacron
-Encoding: 362 362 362
+Encoding: 362 362 298
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: umacron
-Encoding: 363 363 363
+Encoding: 363 363 299
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ubreve
-Encoding: 364 364 364
+Encoding: 364 364 300
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ubreve
-Encoding: 365 365 365
+Encoding: 365 365 301
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uring
-Encoding: 366 366 366
+Encoding: 366 366 302
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 -18 31 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 635 730 N 1 0 0 1 -18 31 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uring
-Encoding: 367 367 367
+Encoding: 367 367 303
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 -40 -135 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 635 730 N 1 0 0 1 -40 -135 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uhungarumlaut
-Encoding: 368 368 368
+Encoding: 368 368 304
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uhungarumlaut
-Encoding: 369 369 369
+Encoding: 369 369 305
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 663 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uogonek
-Encoding: 370 370 370
+Encoding: 370 370 306
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 -34.222 -15.8333 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 -34.222 -15.8333 2
 EndChar
+
 StartChar: uogonek
-Encoding: 371 371 371
+Encoding: 371 371 307
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 414.278 -1.8333 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 414.278 -1.8333 2
 EndChar
+
 StartChar: Wcircumflex
-Encoding: 372 372 372
+Encoding: 372 372 308
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 74 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 74 380 2
 EndChar
+
 StartChar: wcircumflex
-Encoding: 373 373 373
+Encoding: 373 373 309
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 20 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 20 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ycircumflex
-Encoding: 374 374 374
+Encoding: 374 374 310
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 82 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3092 -1 N 1 0 0 1 82 380 2
 EndChar
+
 StartChar: ycircumflex
-Encoding: 375 375 375
+Encoding: 375 375 311
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 20 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 20 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ydieresis
-Encoding: 376 376 376
+Encoding: 376 376 312
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: Zacute
-Encoding: 377 377 377
+Encoding: 377 377 313
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 73 380 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 73 380 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zacute
-Encoding: 378 378 378
+Encoding: 378 378 314
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -7.392 7 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 -7.392 7 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zdotaccent
-Encoding: 379 379 379
+Encoding: 379 379 315
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: zdotaccent
-Encoding: 380 380 380
+Encoding: 380 380 316
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zcaron
-Encoding: 381 381 381
+Encoding: 381 381 317
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
 EndChar
+
 StartChar: zcaron
-Encoding: 382 382 382
+Encoding: 382 382 318
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: longs
-Encoding: 383 383 383
+Encoding: 383 383 319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21861,8 +22186,9 @@ SplineSet
  557 0 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0180
-Encoding: 384 384 384
+Encoding: 384 384 320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21907,8 +22233,9 @@ SplineSet
  439 127 439 127 539 127 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni0181
-Encoding: 385 385 385
+Encoding: 385 385 321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21951,16 +22278,18 @@ SplineSet
  532.988 713 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0182
-Encoding: 386 386 386
+Encoding: 386 386 322
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1041 1041 N 1 0 0 1 0 0 2
+Refer: 852 1041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0183
-Encoding: 387 387 387
+Encoding: 387 387 323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -21993,8 +22322,9 @@ SplineSet
  836.652 345 836.652 345 878.249 559 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0184
-Encoding: 388 388 388
+Encoding: 388 388 324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22021,8 +22351,9 @@ SplineSet
  442.366 877 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0185
-Encoding: 389 389 389
+Encoding: 389 389 325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22054,8 +22385,9 @@ SplineSet
  479.5 977 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0186
-Encoding: 390 390 390
+Encoding: 390 390 326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22082,8 +22414,9 @@ SplineSet
  73.4219 12 73.4219 12 4.3916 53 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0187
-Encoding: 391 391 391
+Encoding: 391 391 327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22115,8 +22448,9 @@ SplineSet
  847.826 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0188
-Encoding: 392 392 392
+Encoding: 392 392 328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22148,16 +22482,18 @@ SplineSet
  835.693 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0189
-Encoding: 393 393 393
+Encoding: 393 393 329
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni018A
-Encoding: 394 394 394
+Encoding: 394 394 330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22188,8 +22524,9 @@ SplineSet
  442.162 166 l 2,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni018B
-Encoding: 395 395 395
+Encoding: 395 395 331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22217,8 +22554,9 @@ SplineSet
  347.838 1327 l 129,-1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018C
-Encoding: 396 396 396
+Encoding: 396 396 332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22251,8 +22589,9 @@ SplineSet
  442 1372 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018D
-Encoding: 397 397 397
+Encoding: 397 397 333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22295,8 +22634,9 @@ SplineSet
  889 84 889 84 840 51 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni018E
-Encoding: 398 398 398
+Encoding: 398 398 334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22317,8 +22657,9 @@ SplineSet
  1247.1 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018F
-Encoding: 399 399 399
+Encoding: 399 399 335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22348,8 +22689,9 @@ SplineSet
  825.695 393.392 825.695 393.392 883.522 644 c 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0190
-Encoding: 400 400 400
+Encoding: 400 400 336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22387,8 +22729,9 @@ SplineSet
  295.818 760 295.818 760 450.399 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0191
-Encoding: 401 401 401
+Encoding: 401 401 337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22413,8 +22756,9 @@ SplineSet
  566.508 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: florin
-Encoding: 402 402 402
+Encoding: 402 402 338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22451,8 +22795,9 @@ SplineSet
  1255.63 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0193
-Encoding: 403 403 403
+Encoding: 403 403 339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22489,8 +22834,9 @@ SplineSet
  920.933 123 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0194
-Encoding: 404 404 404
+Encoding: 404 404 340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22514,8 +22860,9 @@ SplineSet
  767.67 200 767.67 200 607.012 495 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0195
-Encoding: 405 405 405
+Encoding: 405 405 341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22551,8 +22898,9 @@ SplineSet
  782.866 922.002 782.866 922.002 738.547 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0196
-Encoding: 406 406 406
+Encoding: 406 406 342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22575,8 +22923,9 @@ SplineSet
  626.061 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0197
-Encoding: 407 407 407
+Encoding: 407 407 343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22607,8 +22956,9 @@ SplineSet
  346.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0198
-Encoding: 408 408 408
+Encoding: 408 408 344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22635,8 +22985,9 @@ SplineSet
  731 1180 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0199
-Encoding: 409 409 409
+Encoding: 409 409 345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22665,8 +23016,9 @@ SplineSet
  279.541 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019A
-Encoding: 410 410 410
+Encoding: 410 410 346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22697,8 +23049,9 @@ SplineSet
  565.621 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019B
-Encoding: 411 411 411
+Encoding: 411 411 347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22723,8 +23076,9 @@ SplineSet
  669.556 1213.1 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019C
-Encoding: 412 412 412
+Encoding: 412 412 348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22760,8 +23114,9 @@ SplineSet
  461.878 43 461.878 43 447.679 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019D
-Encoding: 413 413 413
+Encoding: 413 413 349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22785,8 +23140,9 @@ SplineSet
  376.508 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019E
-Encoding: 414 414 414
+Encoding: 414 414 350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22811,8 +23167,9 @@ SplineSet
  1160.53 922 1160.53 922 1116.21 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019F
-Encoding: 415 415 415
+Encoding: 415 415 351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22841,26 +23198,29 @@ SplineSet
  310.028 644 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: Ohorn
-Encoding: 416 416 416
+Encoding: 416 416 352
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 -123 0 2
-Refer: 795 795 N 1 0 0 1 466.64 420 2
+Refer: 48 79 N 1 0 0 1 -123 0 2
+Refer: 679 795 N 1 0 0 1 466.64 420 2
 EndChar
+
 StartChar: ohorn
-Encoding: 417 417 417
+Encoding: 417 417 353
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 -105.5 0 2
-Refer: 795 795 N 1 0 0 1 387.5 0 2
+Refer: 80 111 N 1 0 0 1 -105.5 0 2
+Refer: 679 795 N 1 0 0 1 387.5 0 2
 EndChar
+
 StartChar: uni01A2
-Encoding: 418 418 418
+Encoding: 418 418 354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22890,8 +23250,9 @@ SplineSet
  784.486 1215 l 1,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni01A3
-Encoding: 419 419 419
+Encoding: 419 419 355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22922,8 +23283,9 @@ SplineSet
  316.175 639.325 316.175 639.325 300.562 559 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni01A4
-Encoding: 420 420 420
+Encoding: 420 420 356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22956,8 +23318,9 @@ SplineSet
  673.04 766 l 2,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni01A5
-Encoding: 421 421 421
+Encoding: 421 421 357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22994,8 +23357,9 @@ SplineSet
  467.137 977 l 1,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni01A6
-Encoding: 422 422 422
+Encoding: 422 422 358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23030,8 +23394,9 @@ SplineSet
  433.18 1063 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A7
-Encoding: 423 423 423
+Encoding: 423 423 359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23068,8 +23433,9 @@ SplineSet
  360.386 1442 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A8
-Encoding: 424 424 424
+Encoding: 424 424 360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23106,16 +23472,18 @@ SplineSet
  371.467 1081 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A9
-Encoding: 425 425 425
+Encoding: 425 425 361
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 931 931 N 1 0 0 1 0 0 2
+Refer: 757 931 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01AA
-Encoding: 426 426 426
+Encoding: 426 426 362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23147,8 +23515,9 @@ SplineSet
  874.825 1130 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AB
-Encoding: 427 427 427
+Encoding: 427 427 363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23184,8 +23553,9 @@ SplineSet
  795.162 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AC
-Encoding: 428 428 428
+Encoding: 428 428 364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23208,8 +23578,9 @@ SplineSet
  565.838 1327 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AD
-Encoding: 429 429 429
+Encoding: 429 429 365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23242,8 +23613,9 @@ SplineSet
  680.479 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AE
-Encoding: 430 430 430
+Encoding: 430 430 366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23267,26 +23639,29 @@ SplineSet
  560.319 -74.6762 560.319 -74.6762 560.319 -117.301 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: Uhorn
-Encoding: 431 431 431
+Encoding: 431 431 367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 -138.5 0 2
-Refer: 795 795 N 1 0 0 1 504.14 420 2
+Refer: 54 85 N 1 0 0 1 -138.5 0 2
+Refer: 679 795 N 1 0 0 1 504.14 420 2
 EndChar
+
 StartChar: uhorn
-Encoding: 432 432 432
+Encoding: 432 432 368
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 -156 0 2
-Refer: 795 795 N 1 0 0 1 380 0 2
+Refer: 86 117 N 1 0 0 1 -156 0 2
+Refer: 679 795 N 1 0 0 1 380 0 2
 EndChar
+
 StartChar: uni01B1
-Encoding: 433 433 433
+Encoding: 433 433 369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23319,8 +23694,9 @@ SplineSet
  1300.9 1460 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B2
-Encoding: 434 434 434
+Encoding: 434 434 370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23345,8 +23721,9 @@ SplineSet
  629.471 0 629.471 0 360.396 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B3
-Encoding: 435 435 435
+Encoding: 435 435 371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23372,8 +23749,9 @@ SplineSet
  1055.18 1284.87 1055.18 1284.87 951.136 1140 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B4
-Encoding: 436 436 436
+Encoding: 436 436 372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23401,8 +23779,9 @@ SplineSet
  533.139 -104 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B5
-Encoding: 437 437 437
+Encoding: 437 437 373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23430,8 +23809,9 @@ SplineSet
  323.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B6
-Encoding: 438 438 438
+Encoding: 438 438 374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23459,8 +23839,9 @@ SplineSet
  331.047 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B7
-Encoding: 439 439 439
+Encoding: 439 439 375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23491,8 +23872,9 @@ SplineSet
  169.672 435 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B8
-Encoding: 440 440 440
+Encoding: 440 440 376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23523,8 +23905,9 @@ SplineSet
  919.949 292.378 919.949 292.378 947.672 435 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B9
-Encoding: 441 441 441
+Encoding: 441 441 377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23555,8 +23938,9 @@ SplineSet
  570.094 476 570.094 476 676.094 476 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni01BA
-Encoding: 442 442 442
+Encoding: 442 442 378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23589,8 +23973,9 @@ SplineSet
  168 -274 168 -274 472 -274 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BB
-Encoding: 443 443 443
+Encoding: 443 443 379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23623,8 +24008,9 @@ SplineSet
  292.485 1421 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BC
-Encoding: 444 444 444
+Encoding: 444 444 380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23654,8 +24040,9 @@ SplineSet
  361.771 142 361.771 142 501.219 142 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BD
-Encoding: 445 445 445
+Encoding: 445 445 381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23683,8 +24070,9 @@ SplineSet
  176.531 -266 176.531 -266 399.816 -266 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BE
-Encoding: 446 446 446
+Encoding: 446 446 382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23716,8 +24104,9 @@ SplineSet
  766.604 306.321 766.604 306.321 793.392 439 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BF
-Encoding: 447 447 447
+Encoding: 447 447 383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23745,8 +24134,9 @@ SplineSet
  314 397 314 397 249 60 c 17,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni01C0
-Encoding: 448 448 448
+Encoding: 448 448 384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23759,17 +24149,19 @@ SplineSet
  660.604 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C1
-Encoding: 449 449 449
+Encoding: 449 449 385
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 448 448 N 1 0 0 1 202 0 2
-Refer: 448 448 N 1 0 0 1 -202 0 2
+Refer: 384 448 N 1 0 0 1 202 0 2
+Refer: 384 448 N 1 0 0 1 -202 0 2
 EndChar
+
 StartChar: uni01C2
-Encoding: 450 450 450
+Encoding: 450 450 386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23798,384 +24190,429 @@ SplineSet
  660.604 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C3
-Encoding: 451 451 451
+Encoding: 451 451 387
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 0 0 2
+Refer: 2 33 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01C4
-Encoding: 452 452 452
+Encoding: 452 452 388
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C5
-Encoding: 453 453 453
+Encoding: 453 453 389
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C6
-Encoding: 454 454 454
+Encoding: 454 454 390
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C7
-Encoding: 455 455 455
+Encoding: 455 455 391
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C8
-Encoding: 456 456 456
+Encoding: 456 456 392
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C9
-Encoding: 457 457 457
+Encoding: 457 457 393
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CA
-Encoding: 458 458 458
+Encoding: 458 458 394
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CB
-Encoding: 459 459 459
+Encoding: 459 459 395
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CC
-Encoding: 460 460 460
+Encoding: 460 460 396
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CD
-Encoding: 461 461 461
+Encoding: 461 461 397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CE
-Encoding: 462 462 462
+Encoding: 462 462 398
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 30 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 30 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CF
-Encoding: 463 463 463
+Encoding: 463 463 399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 92 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 92 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D0
-Encoding: 464 464 464
+Encoding: 464 464 400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D1
-Encoding: 465 465 465
+Encoding: 465 465 401
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 92 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 92 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D2
-Encoding: 466 466 466
+Encoding: 466 466 402
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 50 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 50 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D3
-Encoding: 467 467 467
+Encoding: 467 467 403
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 78 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 78 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D4
-Encoding: 468 468 468
+Encoding: 468 468 404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 20 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 20 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D5
-Encoding: 469 469 469
+Encoding: 469 469 405
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 50 249 2
-Refer: 713 713 N 1 0 0 1 72 426 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 50 249 2
+Refer: 622 713 N 1 0 0 1 72 426 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01D6
-Encoding: 470 470 470
+Encoding: 470 470 406
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 37 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 37 316 2
 EndChar
+
 StartChar: uni01D7
-Encoding: 471 471 471
+Encoding: 471 471 407
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 96 515 2
-Refer: 1114114 -1 N 1 0 0 1 50 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 96 515 2
+Refer: 3088 -1 N 1 0 0 1 50 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01D8
-Encoding: 472 472 472
+Encoding: 472 472 408
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 72 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 653 769 N 1 0 0 1 72 316 2
 EndChar
+
 StartChar: uni01D9
-Encoding: 473 473 473
+Encoding: 473 473 409
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 50 249 2
-Refer: 1114119 -1 N 1 0 0 1 104.5 515 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 50 249 2
+Refer: 3093 -1 N 1 0 0 1 104.5 515 2
 EndChar
+
 StartChar: uni01DA
-Encoding: 474 474 474
+Encoding: 474 474 410
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 780 780 N 1 0 0 1 84 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 664 780 N 1 0 0 1 84 316 2
 EndChar
+
 StartChar: uni01DB
-Encoding: 475 475 475
+Encoding: 475 475 411
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 50 249 2
-Refer: 1114117 -1 N 1 0 0 1 110 515 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 50 249 2
+Refer: 3091 -1 N 1 0 0 1 110 515 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DC
-Encoding: 476 476 476
+Encoding: 476 476 412
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 252 252 N 1 0 0 1 0 0 2
-Refer: 768 768 N 1 0 0 1 66 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
+Refer: 652 768 N 1 0 0 1 66 316 2
 EndChar
+
 StartChar: uni01DD
-Encoding: 477 477 477
+Encoding: 477 477 413
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 2
+Refer: 515 601 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DF
-Encoding: 479 479 479
+Encoding: 479 479 414
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 228 228 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 77 316 2
+Refer: 164 228 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 77 316 2
 EndChar
+
 StartChar: uni01E0
-Encoding: 480 480 480
+Encoding: 480 480 415
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 72 426 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 -19.5 -124 2
+Refer: 622 713 N 1 0 0 1 72 426 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 -19.5 -124 2
 EndChar
+
 StartChar: uni01E1
-Encoding: 481 481 481
+Encoding: 481 481 416
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 77 316 2
-Refer: 551 551 N 1 0 0 1 0 0 3
+Refer: 111 175 N 1 0 0 1 77 316 2
+Refer: 474 551 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01E2
-Encoding: 482 482 482
+Encoding: 482 482 417
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 170 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 170 0 2
 EndChar
+
 StartChar: uni01E3
-Encoding: 483 483 483
+Encoding: 483 483 418
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcaron
-Encoding: 486 486 486
+Encoding: 486 486 419
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcaron
-Encoding: 487 487 487
+Encoding: 487 487 420
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E8
-Encoding: 488 488 488
+Encoding: 488 488 421
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E9
-Encoding: 489 489 489
+Encoding: 489 489 422
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EA
-Encoding: 490 490 490
+Encoding: 490 490 423
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 28.5 -15.8333 2
 EndChar
+
 StartChar: uni01EB
-Encoding: 491 491 491
+Encoding: 491 491 424
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 636 731 N 1 0 0 1 28.5 -15.8333 2
 EndChar
+
 StartChar: uni01EC
-Encoding: 492 492 492
+Encoding: 492 492 425
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 490 490 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 423 490 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01ED
-Encoding: 493 493 493
+Encoding: 493 493 426
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 491 491 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 424 491 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EE
-Encoding: 494 494 494
+Encoding: 494 494 427
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 57 373 2
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 57 373 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EF
-Encoding: 495 495 495
+Encoding: 495 495 428
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
+Refer: 572 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F4
-Encoding: 500 500 500
+Encoding: 500 500 429
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 57 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 57 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F5
-Encoding: 501 501 501
+Encoding: 501 501 430
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F6
-Encoding: 502 502 502
+Encoding: 502 502 431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24206,311 +24643,346 @@ SplineSet
  714.704 135 714.704 135 761.005 135 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01F8
-Encoding: 504 504 504
+Encoding: 504 504 432
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 69.9999 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 69.9999 373 2
 EndChar
+
 StartChar: uni01F9
-Encoding: 505 505 505
+Encoding: 505 505 433
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: AEacute
-Encoding: 508 508 508
+Encoding: 508 508 434
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 298 373 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 298 373 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aeacute
-Encoding: 509 509 509
+Encoding: 509 509 435
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Oslashacute
-Encoding: 510 510 510
+Encoding: 510 510 436
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 43 373 2
-Refer: 216 216 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 43 373 2
+Refer: 152 216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: oslashacute
-Encoding: 511 511 511
+Encoding: 511 511 437
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 248 248 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 184 248 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0200
-Encoding: 512 512 512
+Encoding: 512 512 438
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0201
-Encoding: 513 513 513
+Encoding: 513 513 439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0202
-Encoding: 514 514 514
+Encoding: 514 514 440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0203
-Encoding: 515 515 515
+Encoding: 515 515 441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0204
-Encoding: 516 516 516
+Encoding: 516 516 442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0205
-Encoding: 517 517 517
+Encoding: 517 517 443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni0206
-Encoding: 518 518 518
+Encoding: 518 518 444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0207
-Encoding: 519 519 519
+Encoding: 519 519 445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni0208
-Encoding: 520 520 520
+Encoding: 520 520 446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0209
-Encoding: 521 521 521
+Encoding: 521 521 447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020A
-Encoding: 522 522 522
+Encoding: 522 522 448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020B
-Encoding: 523 523 523
+Encoding: 523 523 449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020C
-Encoding: 524 524 524
+Encoding: 524 524 450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020D
-Encoding: 525 525 525
+Encoding: 525 525 451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020E
-Encoding: 526 526 526
+Encoding: 526 526 452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020F
-Encoding: 527 527 527
+Encoding: 527 527 453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0210
-Encoding: 528 528 528
+Encoding: 528 528 454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni0211
-Encoding: 529 529 529
+Encoding: 529 529 455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 150 0 2
 EndChar
+
 StartChar: uni0212
-Encoding: 530 530 530
+Encoding: 530 530 456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni0213
-Encoding: 531 531 531
+Encoding: 531 531 457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 150 0 2
 EndChar
+
 StartChar: uni0214
-Encoding: 532 532 532
+Encoding: 532 532 458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3099 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0215
-Encoding: 533 533 533
+Encoding: 533 533 459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 783 783 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 667 783 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0216
-Encoding: 534 534 534
+Encoding: 534 534 460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3095 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0217
-Encoding: 535 535 535
+Encoding: 535 535 461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 785 785 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 669 785 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scommaaccent
-Encoding: 536 536 536
+Encoding: 536 536 462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scommaaccent
-Encoding: 537 537 537
+Encoding: 537 537 463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 54 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 54 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021A
-Encoding: 538 538 538
+Encoding: 538 538 464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021B
-Encoding: 539 539 539
+Encoding: 539 539 465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 154 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 690 806 N 1 0 0 1 154 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021C
-Encoding: 540 540 540
+Encoding: 540 540 466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24560,8 +25032,9 @@ SplineSet
  1323 1348 1323 1348 1323 1200 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021D
-Encoding: 541 541 541
+Encoding: 541 541 467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24611,26 +25084,29 @@ SplineSet
  883 463 883 463 880 461 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021E
-Encoding: 542 542 542
+Encoding: 542 542 468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 75 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 75 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021F
-Encoding: 543 543 543
+Encoding: 543 543 469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3093 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0221
-Encoding: 545 545 545
+Encoding: 545 545 470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24674,8 +25150,9 @@ SplineSet
  186.127 773 186.127 773 144.53 559 c 128,-1,42
 EndSplineSet
 EndChar
+
 StartChar: uni0224
-Encoding: 548 548 548
+Encoding: 548 548 471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24704,8 +25181,9 @@ SplineSet
  364.508 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0225
-Encoding: 549 549 549
+Encoding: 549 549 472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24734,137 +25212,152 @@ SplineSet
  377.45 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0226
-Encoding: 550 550 550
+Encoding: 550 550 473
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0227
-Encoding: 551 551 551
+Encoding: 551 551 474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0228
-Encoding: 552 552 552
+Encoding: 552 552 475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni0229
-Encoding: 553 553 553
+Encoding: 553 553 476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni022A
-Encoding: 554 554 554
+Encoding: 554 554 477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 72 426 2
-Refer: 1114114 -1 N 1 0 0 1 50 249 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 622 713 N 1 0 0 1 72 426 2
+Refer: 3088 -1 N 1 0 0 1 50 249 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022B
-Encoding: 555 555 555
+Encoding: 555 555 478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 246 246 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 37 316 2
+Refer: 182 246 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 37 316 2
 EndChar
+
 StartChar: uni022C
-Encoding: 556 556 556
+Encoding: 556 556 479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 72 426 2
-Refer: 1114116 -1 N 1 0 0 1 27.5 245 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 622 713 N 1 0 0 1 72 426 2
+Refer: 3090 -1 N 1 0 0 1 27.5 245 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022D
-Encoding: 557 557 557
+Encoding: 557 557 480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 245 245 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 40.5 316 2
+Refer: 181 245 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 40.5 316 2
 EndChar
+
 StartChar: uni022E
-Encoding: 558 558 558
+Encoding: 558 558 481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022F
-Encoding: 559 559 559
+Encoding: 559 559 482
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0230
-Encoding: 560 560 560
+Encoding: 560 560 483
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 72 426 2
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 -124 2
+Refer: 622 713 N 1 0 0 1 72 426 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 -124 2
 EndChar
+
 StartChar: uni0231
-Encoding: 561 561 561
+Encoding: 561 561 484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 559 559 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 37 316 2
+Refer: 482 559 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 37 316 2
 EndChar
+
 StartChar: uni0232
-Encoding: 562 562 562
+Encoding: 562 562 485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0233
-Encoding: 563 563 563
+Encoding: 563 563 486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0234
-Encoding: 564 564 564
+Encoding: 564 564 487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24893,8 +25386,9 @@ SplineSet
  569.95 -29 569.95 -29 524.255 -12 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0235
-Encoding: 565 565 565
+Encoding: 565 565 488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24934,8 +25428,9 @@ SplineSet
  696.824 406 l 2,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0236
-Encoding: 566 566 566
+Encoding: 566 566 489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24970,8 +25465,9 @@ SplineSet
  567.543 406 l 2,5,6
 EndSplineSet
 EndChar
+
 StartChar: dotlessj
-Encoding: 567 567 567
+Encoding: 567 567 490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24992,8 +25488,9 @@ SplineSet
  473 -151 473 -151 498 -20 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0238
-Encoding: 568 568 568
+Encoding: 568 568 491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25042,8 +25539,9 @@ SplineSet
  713.2 977 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0239
-Encoding: 569 569 569
+Encoding: 569 569 492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25092,8 +25590,9 @@ SplineSet
  519.8 141 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni023A
-Encoding: 570 570 570
+Encoding: 570 570 493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25126,8 +25625,9 @@ SplineSet
  753.884 995.274 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023B
-Encoding: 571 571 571
+Encoding: 571 571 494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25166,8 +25666,9 @@ SplineSet
  938.586 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023C
-Encoding: 572 572 572
+Encoding: 572 572 495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25205,8 +25706,9 @@ SplineSet
  963.615 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023D
-Encoding: 573 573 573
+Encoding: 573 573 496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25229,8 +25731,9 @@ SplineSet
  433.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023E
-Encoding: 574 574 574
+Encoding: 574 574 497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25259,8 +25762,9 @@ SplineSet
  502.766 686.702 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023F
-Encoding: 575 575 575
+Encoding: 575 575 498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25305,8 +25809,9 @@ SplineSet
  1046.27 1114 1046.27 1114 1119.85 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0240
-Encoding: 576 576 576
+Encoding: 576 576 499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25334,8 +25839,9 @@ SplineSet
  384.254 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0241
-Encoding: 577 577 577
+Encoding: 577 577 500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25365,8 +25871,9 @@ SplineSet
  486.588 1327 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0243
-Encoding: 579 579 579
+Encoding: 579 579 501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25389,7 +25896,7 @@ SplineSet
  952 776 952 776 1018.5 697 c 128,-1,18
  1085 618 1085 618 1085 494 c 0,19,20
  1085 260 1085 260 925.5 130 c 128,-1,21
- 766 3.05176e-05 766 3.05176e-05 475 0 c 2,22,-1
+ 766 3.05176e-005 766 3.05176e-005 475 0 c 2,22,-1
  23 0 l 1,23,-1
  94.0918 366 l 1,24,-1
  -66 366 l 1,25,-1
@@ -25410,8 +25917,9 @@ SplineSet
  297.122 366 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0244
-Encoding: 580 580 580
+Encoding: 580 580 502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25445,8 +25953,9 @@ SplineSet
  284 413 284 413 279 319 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0245
-Encoding: 581 581 581
+Encoding: 581 581 503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25462,8 +25971,9 @@ SplineSet
  723 1303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024C
-Encoding: 588 588 588
+Encoding: 588 588 504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25500,8 +26010,9 @@ SplineSet
  944 728 944 728 766 705 c 1,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni024D
-Encoding: 589 589 589
+Encoding: 589 589 505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25529,8 +26040,9 @@ SplineSet
  1184 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0250
-Encoding: 592 592 592
+Encoding: 592 592 506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25571,8 +26083,9 @@ SplineSet
  109.376 332 109.376 332 137.949 479 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0251
-Encoding: 593 593 593
+Encoding: 593 593 507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25603,8 +26116,9 @@ SplineSet
  392.598 773 392.598 773 351 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0252
-Encoding: 594 594 594
+Encoding: 594 594 508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25635,8 +26149,9 @@ SplineSet
  840.402 345 840.402 345 882 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0253
-Encoding: 595 595 595
+Encoding: 595 595 509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25674,8 +26189,9 @@ SplineSet
  383.524 977.125 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0254
-Encoding: 596 596 596
+Encoding: 596 596 510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25702,8 +26218,9 @@ SplineSet
  281.079 1061 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0255
-Encoding: 597 597 597
+Encoding: 597 597 511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25737,8 +26254,9 @@ SplineSet
  540.529 -37 540.529 -37 472.526 -19.8467 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0256
-Encoding: 598 598 598
+Encoding: 598 598 512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25775,8 +26293,9 @@ SplineSet
  825.552 1060 825.552 1060 844.643 977 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0257
-Encoding: 599 599 599
+Encoding: 599 599 513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25814,8 +26333,9 @@ SplineSet
  790.943 1002 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0258
-Encoding: 600 600 600
+Encoding: 600 600 514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25846,8 +26366,9 @@ SplineSet
  361.122 822 361.122 822 325.633 660 c 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0259
-Encoding: 601 601 601
+Encoding: 601 601 515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25878,8 +26399,9 @@ SplineSet
  286.367 458 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni025A
-Encoding: 602 602 602
+Encoding: 602 602 516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25921,8 +26443,9 @@ SplineSet
  830.204 783.108 l 1,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni025B
-Encoding: 603 603 603
+Encoding: 603 603 517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25960,8 +26483,9 @@ SplineSet
  321.179 584 321.179 584 457.65 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025C
-Encoding: 604 604 604
+Encoding: 604 604 518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -25999,8 +26523,9 @@ SplineSet
  915.51 632 915.51 632 791.65 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025D
-Encoding: 605 605 605
+Encoding: 605 605 519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26050,8 +26575,9 @@ SplineSet
  619.884 631.999 619.884 631.999 525.775 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025E
-Encoding: 606 606 606
+Encoding: 606 606 520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26086,8 +26612,9 @@ SplineSet
  253.55 953 253.55 953 557.18 1099 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni025F
-Encoding: 607 607 607
+Encoding: 607 607 521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26116,8 +26643,9 @@ SplineSet
  1144.54 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0260
-Encoding: 608 608 608
+Encoding: 608 608 522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26162,8 +26690,9 @@ SplineSet
  713.172 362.999 713.172 362.999 753.214 569 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0261
-Encoding: 609 609 609
+Encoding: 609 609 523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26200,8 +26729,9 @@ SplineSet
  1024.29 72 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0262
-Encoding: 610 610 610
+Encoding: 610 610 524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26231,8 +26761,9 @@ SplineSet
  781.527 156 781.527 156 865.804 178 c 128,-1,12
 EndSplineSet
 EndChar
+
 StartChar: uni0263
-Encoding: 611 611 611
+Encoding: 611 611 525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26256,8 +26787,9 @@ SplineSet
  776.773 120 776.773 120 637.308 452 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0264
-Encoding: 612 612 612
+Encoding: 612 612 526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26281,8 +26813,9 @@ SplineSet
  673.865 286 673.865 286 585.175 440 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0265
-Encoding: 613 613 613
+Encoding: 613 613 527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26307,8 +26840,9 @@ SplineSet
  159.731 196 159.731 196 204.051 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0266
-Encoding: 614 614 614
+Encoding: 614 614 528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26341,8 +26875,9 @@ SplineSet
  409.169 961.5 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0267
-Encoding: 615 615 615
+Encoding: 615 615 529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26385,8 +26920,9 @@ SplineSet
  450.572 961.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0268
-Encoding: 616 616 616
+Encoding: 616 616 530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26418,8 +26954,9 @@ SplineSet
  303.979 1120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0269
-Encoding: 617 617 617
+Encoding: 617 617 531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26440,8 +26977,9 @@ SplineSet
  925.647 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni026A
-Encoding: 618 618 618
+Encoding: 618 618 532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26462,8 +27000,9 @@ SplineSet
  268.353 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026B
-Encoding: 619 619 619
+Encoding: 619 619 533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26500,8 +27039,9 @@ SplineSet
  585.121 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026C
-Encoding: 620 620 620
+Encoding: 620 620 534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26537,8 +27077,9 @@ SplineSet
  481.785 786 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni026D
-Encoding: 621 621 621
+Encoding: 621 621 535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26559,8 +27100,9 @@ SplineSet
  544 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026E
-Encoding: 622 622 622
+Encoding: 622 622 536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26603,8 +27145,9 @@ SplineSet
  392.696 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026F
-Encoding: 623 623 623
+Encoding: 623 623 537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26640,8 +27183,9 @@ SplineSet
  492 41 492 41 478 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0270
-Encoding: 624 624 624
+Encoding: 624 624 538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26677,8 +27221,9 @@ SplineSet
  492 41 492 41 478 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0271
-Encoding: 625 625 625
+Encoding: 625 625 539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26723,8 +27268,9 @@ SplineSet
  781.396 1077 781.396 1077 795.592 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0272
-Encoding: 626 626 626
+Encoding: 626 626 540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26755,8 +27301,9 @@ SplineSet
  415.038 -20 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0273
-Encoding: 627 627 627
+Encoding: 627 627 541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26787,8 +27334,9 @@ SplineSet
  628.441 -234 628.441 -234 670.038 -20 c 2,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0274
-Encoding: 628 628 628
+Encoding: 628 628 542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26807,8 +27355,9 @@ SplineSet
  255.478 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0275
-Encoding: 629 629 629
+Encoding: 629 629 543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26837,8 +27386,9 @@ SplineSet
  833.266 315.092 833.266 315.092 873.492 447 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0276
-Encoding: 630 630 630
+Encoding: 630 630 544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26870,8 +27420,9 @@ SplineSet
  679.459 990 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0277
-Encoding: 631 631 631
+Encoding: 631 631 545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26912,8 +27463,9 @@ SplineSet
  230.521 724 230.521 724 252.656 780 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0278
-Encoding: 632 632 632
+Encoding: 632 632 546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26960,8 +27512,9 @@ SplineSet
  374.34 162.672 374.34 162.672 449.12 138.621 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0279
-Encoding: 633 633 633
+Encoding: 633 633 547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26984,8 +27537,9 @@ SplineSet
  215.704 172 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027A
-Encoding: 634 634 634
+Encoding: 634 634 548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27008,8 +27562,9 @@ SplineSet
  174.302 172 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027B
-Encoding: 635 635 635
+Encoding: 635 635 549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27042,8 +27597,9 @@ SplineSet
  139.483 172 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027C
-Encoding: 636 636 636
+Encoding: 636 636 550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27066,8 +27622,9 @@ SplineSet
  1058.7 948 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027D
-Encoding: 637 637 637
+Encoding: 637 637 551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27100,8 +27657,9 @@ SplineSet
  1059.2 948 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027E
-Encoding: 638 638 638
+Encoding: 638 638 552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27124,8 +27682,9 @@ SplineSet
  553.059 741 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027F
-Encoding: 639 639 639
+Encoding: 639 639 553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27148,8 +27707,9 @@ SplineSet
  786.268 953 786.268 953 745.059 741 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0280
-Encoding: 640 640 640
+Encoding: 640 640 554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27182,8 +27742,9 @@ SplineSet
  385.724 965 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0281
-Encoding: 641 641 641
+Encoding: 641 641 555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27216,8 +27777,9 @@ SplineSet
  228.276 155 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0282
-Encoding: 642 642 642
+Encoding: 642 642 556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27264,8 +27826,9 @@ SplineSet
  1055.55 1117 1055.55 1117 1125.72 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0283
-Encoding: 643 643 643
+Encoding: 643 643 557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27290,8 +27853,9 @@ SplineSet
  321.047 -173 321.047 -173 350.787 -20 c 0,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0284
-Encoding: 644 644 644
+Encoding: 644 644 558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27328,8 +27892,9 @@ SplineSet
  1086.41 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0285
-Encoding: 645 645 645
+Encoding: 645 645 559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27354,8 +27919,9 @@ SplineSet
  832.354 678 832.354 678 696.677 -20 c 0,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0286
-Encoding: 646 646 646
+Encoding: 646 646 560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27387,8 +27953,9 @@ SplineSet
  655.175 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0287
-Encoding: 647 647 647
+Encoding: 647 647 561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27415,8 +27982,9 @@ SplineSet
  522.188 -318 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0288
-Encoding: 648 648 648
+Encoding: 648 648 562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27443,8 +28011,9 @@ SplineSet
  893.519 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0289
-Encoding: 649 649 649
+Encoding: 649 649 563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27481,8 +28050,9 @@ SplineSet
  841.119 311.231 841.119 311.231 876.416 452 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028A
-Encoding: 650 650 650
+Encoding: 650 650 564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27515,8 +28085,9 @@ SplineSet
  174.891 956 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028B
-Encoding: 651 651 651
+Encoding: 651 651 565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27546,8 +28117,9 @@ SplineSet
  723.474 974 723.474 974 679.806 986 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028C
-Encoding: 652 652 652
+Encoding: 652 652 566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27563,8 +28135,9 @@ SplineSet
  1052.65 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028D
-Encoding: 653 653 653
+Encoding: 653 653 567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27586,8 +28159,9 @@ SplineSet
  1108.85 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028E
-Encoding: 654 654 654
+Encoding: 654 654 568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27610,8 +28184,9 @@ SplineSet
  651.165 1224 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028F
-Encoding: 655 655 655
+Encoding: 655 655 569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27629,8 +28204,9 @@ SplineSet
  213.672 1149 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0290
-Encoding: 656 656 656
+Encoding: 656 656 570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27657,8 +28233,9 @@ SplineSet
  362.881 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0291
-Encoding: 657 657 657
+Encoding: 657 657 571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27688,8 +28265,9 @@ SplineSet
  697.014 290.209 697.014 290.209 633.565 147 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni0292
-Encoding: 658 658 658
+Encoding: 658 658 572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27720,8 +28298,9 @@ SplineSet
  635.047 476 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0293
-Encoding: 659 659 659
+Encoding: 659 659 573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27759,8 +28338,9 @@ SplineSet
  670.367 -186 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0294
-Encoding: 660 660 660
+Encoding: 660 660 574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27786,8 +28366,9 @@ SplineSet
  450.082 798 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0295
-Encoding: 661 661 661
+Encoding: 661 661 575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27813,8 +28394,9 @@ SplineSet
  790.082 798 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0296
-Encoding: 662 662 662
+Encoding: 662 662 576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27840,8 +28422,9 @@ SplineSet
  441.918 756 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0297
-Encoding: 663 663 663
+Encoding: 663 663 577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27870,8 +28453,9 @@ SplineSet
  296.633 1086 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0298
-Encoding: 664 664 664
+Encoding: 664 664 578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27906,8 +28490,9 @@ SplineSet
  493.767 520 493.767 520 502.902 567 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0299
-Encoding: 665 665 665
+Encoding: 665 665 579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27943,8 +28528,9 @@ SplineSet
  320.672 1149 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029A
-Encoding: 666 666 666
+Encoding: 666 666 580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27979,8 +28565,9 @@ SplineSet
  814.371 1145 814.371 1145 888.68 1099 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni029B
-Encoding: 667 667 667
+Encoding: 667 667 581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28020,8 +28607,9 @@ SplineSet
  538.623 156 538.623 156 601.566 178 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029C
-Encoding: 668 668 668
+Encoding: 668 668 582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28042,8 +28630,9 @@ SplineSet
  255.478 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029D
-Encoding: 669 669 669
+Encoding: 669 669 583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28076,8 +28665,9 @@ SplineSet
  496.545 -199.079 496.545 -199.079 514.69 -154.325 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029E
-Encoding: 670 670 670
+Encoding: 670 670 584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28097,8 +28687,9 @@ SplineSet
  962.272 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029F
-Encoding: 671 671 671
+Encoding: 671 671 585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28113,8 +28704,9 @@ SplineSet
  356.478 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A0
-Encoding: 672 672 672
+Encoding: 672 672 586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28151,8 +28743,9 @@ SplineSet
  266.862 762 266.862 762 227.403 559 c 128,-1,36
 EndSplineSet
 EndChar
+
 StartChar: uni02A1
-Encoding: 673 673 673
+Encoding: 673 673 587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28186,8 +28779,9 @@ SplineSet
  450.082 798 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A2
-Encoding: 674 674 674
+Encoding: 674 674 588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28221,8 +28815,9 @@ SplineSet
  518.494 440 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A3
-Encoding: 675 675 675
+Encoding: 675 675 589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28264,8 +28859,9 @@ SplineSet
  695.023 973 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A4
-Encoding: 676 676 676
+Encoding: 676 676 590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28319,8 +28915,9 @@ SplineSet
  707.279 973 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A5
-Encoding: 677 677 677
+Encoding: 677 677 591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28373,8 +28970,9 @@ SplineSet
  895.972 290.209 895.972 290.209 846.768 147 c 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A6
-Encoding: 678 678 678
+Encoding: 678 678 592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28429,8 +29027,9 @@ SplineSet
  1078.58 1117 1078.58 1117 1118.35 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A7
-Encoding: 679 679 679
+Encoding: 679 679 593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28474,8 +29073,9 @@ SplineSet
  595.109 154 l 1,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni02A8
-Encoding: 680 680 680
+Encoding: 680 680 594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28528,8 +29128,9 @@ SplineSet
  491.231 154 l 1,57,58
 EndSplineSet
 EndChar
+
 StartChar: uni02A9
-Encoding: 681 681 681
+Encoding: 681 681 595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28578,8 +29179,9 @@ SplineSet
  1161.77 908.004 1161.77 908.004 1116.68 676 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AA
-Encoding: 682 682 682
+Encoding: 682 682 596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28622,8 +29224,9 @@ SplineSet
  357.208 676.569 357.208 676.569 372.763 788 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AB
-Encoding: 683 683 683
+Encoding: 683 683 597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28647,8 +29250,9 @@ SplineSet
  395.279 973 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AC
-Encoding: 684 684 684
+Encoding: 684 684 598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28684,8 +29288,9 @@ SplineSet
  273.406 1311.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AD
-Encoding: 685 685 685
+Encoding: 685 685 599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28711,8 +29316,9 @@ SplineSet
  253.603 1311 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AE
-Encoding: 686 686 686
+Encoding: 686 686 600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28747,8 +29353,9 @@ SplineSet
  575.11 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AF
-Encoding: 687 687 687
+Encoding: 687 687 601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28791,8 +29398,9 @@ SplineSet
  677.075 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B0
-Encoding: 688 688 688
+Encoding: 688 688 602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28817,8 +29425,9 @@ SplineSet
  926.121 1160.48 926.121 1160.48 900.867 1030.56 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B1
-Encoding: 689 689 689
+Encoding: 689 689 603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28851,8 +29460,9 @@ SplineSet
  455.233 1180.38 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B2
-Encoding: 690 690 690
+Encoding: 690 690 604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28876,8 +29486,9 @@ SplineSet
  738.863 1523.36 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B3
-Encoding: 691 691 691
+Encoding: 691 691 605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28900,8 +29511,9 @@ SplineSet
  863.905 1182.88 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B4
-Encoding: 692 692 692
+Encoding: 692 692 606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28924,8 +29536,9 @@ SplineSet
  369.095 748.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B5
-Encoding: 693 693 693
+Encoding: 693 693 607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28958,8 +29571,9 @@ SplineSet
  318.361 748.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B6
-Encoding: 694 694 694
+Encoding: 694 694 608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28992,8 +29606,9 @@ SplineSet
  377.429 738.8 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B7
-Encoding: 695 695 695
+Encoding: 695 695 609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29015,8 +29630,9 @@ SplineSet
  204.013 1279.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B8
-Encoding: 696 696 696
+Encoding: 696 696 610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29039,16 +29655,18 @@ SplineSet
  600.798 593.76 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B9
-Encoding: 697 697 697
+Encoding: 697 697 611
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 884 884 N 1 0 0 1 0 0 2
+Refer: 719 884 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BB
-Encoding: 699 699 699
+Encoding: 699 699 612
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29122,8 +29740,9 @@ SplineSet
  715 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02BC
-Encoding: 700 700 700
+Encoding: 700 700 613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29138,15 +29757,17 @@ SplineSet
  618.245 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02BD
-Encoding: 701 701 701
+Encoding: 701 701 614
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 788 788 N 1 0 0 1 0 0 2
+Refer: 672 788 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BE
-Encoding: 702 702 702
+Encoding: 702 702 615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29165,8 +29786,9 @@ SplineSet
  729.546 1007 729.546 1007 614.546 1007 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02BF
-Encoding: 703 703 703
+Encoding: 703 703 616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29185,8 +29807,9 @@ SplineSet
  830.402 1068 830.402 1068 818.546 1007 c 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02C0
-Encoding: 704 704 704
+Encoding: 704 704 617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29212,8 +29835,9 @@ SplineSet
  511.371 1340.88 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C1
-Encoding: 705 705 705
+Encoding: 705 705 618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29239,8 +29863,9 @@ SplineSet
  725.571 1340.88 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circumflex
-Encoding: 710 710 710
+Encoding: 710 710 619
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29328,8 +29953,9 @@ SplineSet
  717 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: caron
-Encoding: 711 711 711
+Encoding: 711 711 620
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29399,8 +30025,9 @@ SplineSet
  782 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C8
-Encoding: 712 712 712
+Encoding: 712 712 621
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29434,16 +30061,18 @@ SplineSet
  738.44 1554 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C9
-Encoding: 713 713 713
+Encoding: 713 713 622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CC
-Encoding: 716 716 716
+Encoding: 716 716 623
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29477,32 +30106,36 @@ SplineSet
  738.44 252 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02CD
-Encoding: 717 717 717
+Encoding: 717 717 624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CE
-Encoding: 718 718 718
+Encoding: 718 718 625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni02CF
-Encoding: 719 719 719
+Encoding: 719 719 626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni02D0
-Encoding: 720 720 720
+Encoding: 720 720 627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29518,8 +30151,9 @@ SplineSet
  577.76 330.199 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D1
-Encoding: 721 721 721
+Encoding: 721 721 628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29531,24 +30165,27 @@ SplineSet
  584.408 728.801 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D2
-Encoding: 722 722 722
+Encoding: 722 722 629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 702 702 N 1 0 0 1 -96.5652 -497 2
+Refer: 615 702 N 1 0 0 1 -96.5652 -497 2
 EndChar
+
 StartChar: uni02D3
-Encoding: 723 723 723
+Encoding: 723 723 630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 -97 -497 2
+Refer: 616 703 N 1 0 0 1 -97 -497 2
 EndChar
+
 StartChar: uni02D6
-Encoding: 726 726 726
+Encoding: 726 726 631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29569,8 +30206,9 @@ SplineSet
  557 629 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D7
-Encoding: 727 727 727
+Encoding: 727 727 632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29583,26 +30221,29 @@ SplineSet
  827 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: breve
-Encoding: 728 728 728
+Encoding: 728 728 633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 658 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotaccent
-Encoding: 729 729 729
+Encoding: 729 729 634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 659 775 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ring
-Encoding: 730 730 730
+Encoding: 730 730 635
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29704,27 +30345,28 @@ Fore
 SplineSet
 930 1595 m 0,0,1
  930 1659 930 1659 886 1703 c 128,-1,2
- 842 1747 842 1747 778 1747 c 0,3,4
+ 842 1747 842 1747 778 1747 c 256,3,4
  714 1747 714 1747 670.5 1703.5 c 128,-1,5
  627 1660 627 1660 627 1595 c 0,6,7
  627 1531 627 1531 670.5 1487.5 c 128,-1,8
- 714 1444 714 1444 778 1444 c 0,9,10
+ 714 1444 714 1444 778 1444 c 256,9,10
  842 1444 842 1444 886 1488 c 128,-1,11
  930 1532 930 1532 930 1595 c 0,0,1
 1053 1595 m 0,12,13
  1053 1480 1053 1480 973 1400.5 c 128,-1,14
- 893 1321 893 1321 778 1321 c 0,15,16
+ 893 1321 893 1321 778 1321 c 256,15,16
  663 1321 663 1321 583.5 1400.5 c 128,-1,17
  504 1480 504 1480 504 1595 c 0,18,19
  504 1711 504 1711 583.5 1790.5 c 128,-1,20
- 663 1870 663 1870 778 1870 c 0,21,22
+ 663 1870 663 1870 778 1870 c 256,21,22
  893 1870 893 1870 973 1790.5 c 128,-1,23
  1053 1711 1053 1711 1053 1595 c 0,12,13
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ogonek
-Encoding: 731 731 731
+Encoding: 731 731 636
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29783,8 +30425,9 @@ SplineSet
  306 -69 306 -69 383 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tilde
-Encoding: 732 732 732
+Encoding: 732 732 637
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30011,19 +30654,21 @@ SplineSet
  847 1307 847 1307 814 1321.5 c 128,-1,27
  781 1336 781 1336 741 1376 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: hungarumlaut
-Encoding: 733 733 733
+Encoding: 733 733 638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 663 779 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni02DE
-Encoding: 734 734 734
+Encoding: 734 734 639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30044,8 +30689,9 @@ SplineSet
  -329.035 868 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E0
-Encoding: 736 736 736
+Encoding: 736 736 640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30069,8 +30715,9 @@ SplineSet
  721 735 721 735 628 921 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni02E1
-Encoding: 737 737 737
+Encoding: 737 737 641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30093,8 +30740,9 @@ SplineSet
  603 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02E2
-Encoding: 738 738 738
+Encoding: 738 738 642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30131,8 +30779,9 @@ SplineSet
  861 1310 861 1310 906 1293 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E3
-Encoding: 739 739 739
+Encoding: 739 739 643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30153,8 +30802,9 @@ SplineSet
  1006 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E4
-Encoding: 740 740 740
+Encoding: 740 740 644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30180,8 +30830,9 @@ SplineSet
  726 1115 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E5
-Encoding: 741 741 741
+Encoding: 741 741 645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30196,8 +30847,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E6
-Encoding: 742 742 742
+Encoding: 742 742 646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30214,8 +30866,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E7
-Encoding: 743 743 743
+Encoding: 743 743 647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30232,8 +30885,9 @@ SplineSet
  810 752 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E8
-Encoding: 744 744 744
+Encoding: 744 744 648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30250,8 +30904,9 @@ SplineSet
  750 444 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E9
-Encoding: 745 745 745
+Encoding: 745 745 649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30266,56 +30921,63 @@ SplineSet
  690 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02EE
-Encoding: 750 750 750
+Encoding: 750 750 650
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8221 8221 N 1 0 0 1 0 0 3
+Refer: 1874 8221 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni02F3
-Encoding: 755 755 755
+Encoding: 755 755 651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 689 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gravecomb
-Encoding: 768 768 768
+Encoding: 768 768 652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: acutecomb
-Encoding: 769 769 769
+Encoding: 769 769 653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0302
-Encoding: 770 770 770
+Encoding: 770 770 654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 619 710 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tildecomb
-Encoding: 771 771 771
+Encoding: 771 771 655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0304
-Encoding: 772 772 772
+Encoding: 772 772 656
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30352,16 +31014,18 @@ SplineSet
  469 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0305
-Encoding: 773 773 773
+Encoding: 773 773 657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
+Refer: 1897 8254 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0306
-Encoding: 774 774 774
+Encoding: 774 774 658
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30423,8 +31087,9 @@ SplineSet
  470 1600 470 1600 472 1608 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307
-Encoding: 775 775 775
+Encoding: 775 775 659
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30475,16 +31140,18 @@ SplineSet
  672 1552 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0308
-Encoding: 776 776 776
+Encoding: 776 776 660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hookabovecomb
-Encoding: 777 777 777
+Encoding: 777 777 661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30506,16 +31173,18 @@ SplineSet
  540.985 1734 540.985 1734 630.985 1734 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni030A
-Encoding: 778 778 778
+Encoding: 778 778 662
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 0 2
+Refer: 635 730 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni030B
-Encoding: 779 779 779
+Encoding: 779 779 663
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30607,16 +31276,18 @@ SplineSet
  1028 1638 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030C
-Encoding: 780 780 780
+Encoding: 780 780 664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 620 711 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni030D
-Encoding: 781 781 781
+Encoding: 781 781 665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30629,17 +31300,19 @@ SplineSet
  725.152 1706 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030E
-Encoding: 782 782 782
+Encoding: 782 782 666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 781 781 N 1 0 0 1 -204 0 2
-Refer: 781 781 N 1 0 0 1 204 0 2
+Refer: 665 781 N 1 0 0 1 -204 0 2
+Refer: 665 781 N 1 0 0 1 204 0 2
 EndChar
+
 StartChar: uni030F
-Encoding: 783 783 783
+Encoding: 783 783 667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30657,17 +31330,19 @@ SplineSet
  896.395 1638 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0310
-Encoding: 784 784 784
+Encoding: 784 784 668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 728 728 N 1 0 0 1 0 0 2
-Refer: 729 729 N 1 0 0 1 48 204 2
+Refer: 633 728 N 1 0 0 1 0 0 2
+Refer: 634 729 N 1 0 0 1 48 204 2
 EndChar
+
 StartChar: uni0311
-Encoding: 785 785 785
+Encoding: 785 785 669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30687,8 +31362,9 @@ SplineSet
  415.776 1321 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0312
-Encoding: 786 786 786
+Encoding: 786 786 670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30701,8 +31377,9 @@ SplineSet
  708 967 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0313
-Encoding: 787 787 787
+Encoding: 787 787 671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30718,8 +31395,9 @@ SplineSet
  737.542 1475 l 146,-1,13
 EndSplineSet
 EndChar
+
 StartChar: uni0314
-Encoding: 788 788 788
+Encoding: 788 788 672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30735,8 +31413,9 @@ SplineSet
  446.086 1218 446.086 1218 496.042 1475 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0315
-Encoding: 789 789 789
+Encoding: 789 789 673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30749,24 +31428,27 @@ SplineSet
  720 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0316
-Encoding: 790 790 790
+Encoding: 790 790 674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni0317
-Encoding: 791 791 791
+Encoding: 791 791 675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni0318
-Encoding: 792 792 792
+Encoding: 792 792 676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30783,8 +31465,9 @@ SplineSet
  587 -454 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0319
-Encoding: 793 793 793
+Encoding: 793 793 677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30801,8 +31484,9 @@ SplineSet
  641.16 -590 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031A
-Encoding: 794 794 794
+Encoding: 794 794 678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30817,8 +31501,9 @@ SplineSet
  746.688 1768 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031B
-Encoding: 795 795 795
+Encoding: 795 795 679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30841,8 +31526,9 @@ SplineSet
  455.05 817 455.05 817 403.741 872 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031C
-Encoding: 796 796 796
+Encoding: 796 796 680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30861,8 +31547,9 @@ SplineSet
  452.471 -404 452.471 -404 503.471 -404 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031D
-Encoding: 797 797 797
+Encoding: 797 797 681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30879,8 +31566,9 @@ SplineSet
  703.6 -454 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031E
-Encoding: 798 798 798
+Encoding: 798 798 682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30897,8 +31585,9 @@ SplineSet
  594.561 -413 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031F
-Encoding: 799 799 799
+Encoding: 799 799 683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30919,8 +31608,9 @@ SplineSet
  551.16 -590 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0320
-Encoding: 800 800 800
+Encoding: 800 800 684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30933,8 +31623,9 @@ SplineSet
  358.282 -413 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0321
-Encoding: 801 801 801
+Encoding: 801 801 685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30953,8 +31644,9 @@ SplineSet
  966 128 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0322
-Encoding: 802 802 802
+Encoding: 802 802 686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30973,8 +31665,9 @@ SplineSet
  109 128 l 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: dotbelowcomb
-Encoding: 803 803 803
+Encoding: 803 803 687
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31023,8 +31716,9 @@ SplineSet
  328.375 -209 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0324
-Encoding: 804 804 804
+Encoding: 804 804 688
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31106,8 +31800,9 @@ SplineSet
  526.68 -210 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0325
-Encoding: 805 805 805
+Encoding: 805 805 689
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31146,26 +31841,27 @@ Fore
 SplineSet
 641.817 -236.252 m 0,0,1
  641.817 -355.025 641.817 -355.025 543.361 -438 c 0,2,3
- 467.421 -502 467.421 -502 374.921 -502 c 0,4,5
+ 467.421 -502 467.421 -502 374.921 -502 c 256,4,5
  282.421 -502 282.421 -502 237.983 -446.3 c 128,-1,6
  193.546 -390.601 193.546 -390.601 193.546 -327.843 c 0,7,8
  193.546 -208.856 193.546 -208.856 291.911 -126.5 c 0,9,10
- 367.754 -63 367.754 -63 460.254 -63 c 0,11,12
+ 367.754 -63 367.754 -63 460.254 -63 c 256,11,12
  552.754 -63 552.754 -63 597.285 -118.276 c 128,-1,13
  641.817 -173.552 641.817 -173.552 641.817 -236.252 c 0,0,1
-393.471 -404 m 0,14,15
+393.471 -404 m 256,14,15
  444.471 -404 444.471 -404 493.06 -363.318 c 128,-1,16
  541.65 -322.636 541.65 -322.636 541.65 -257.569 c 0,17,18
  541.65 -222.996 541.65 -222.996 516.677 -191.998 c 128,-1,19
- 491.705 -161 491.705 -161 440.705 -161 c 0,20,21
+ 491.705 -161 491.705 -161 440.705 -161 c 256,20,21
  389.705 -161 389.705 -161 341.611 -201.266 c 128,-1,22
  293.517 -241.533 293.517 -241.533 293.517 -308.259 c 0,23,24
  293.517 -343.236 293.517 -343.236 317.994 -373.618 c 128,-1,25
- 342.471 -404 342.471 -404 393.471 -404 c 0,14,15
+ 342.471 -404 342.471 -404 393.471 -404 c 256,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0326
-Encoding: 806 806 806
+Encoding: 806 806 690
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31178,8 +31874,9 @@ SplineSet
  335 -197 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0327
-Encoding: 807 807 807
+Encoding: 807 807 691
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31242,16 +31939,18 @@ SplineSet
  555 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0328
-Encoding: 808 808 808
+Encoding: 808 808 692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 10 0 2
+Refer: 636 731 N 1 0 0 1 10 0 2
 EndChar
+
 StartChar: uni0329
-Encoding: 809 809 809
+Encoding: 809 809 693
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31264,8 +31963,9 @@ SplineSet
  727.652 -209 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032A
-Encoding: 810 810 810
+Encoding: 810 810 694
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31282,8 +31982,9 @@ SplineSet
  924.072 -209 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032B
-Encoding: 811 811 811
+Encoding: 811 811 695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31304,8 +32005,9 @@ SplineSet
  648.176 -455 648.176 -455 604.551 -372.975 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni032C
-Encoding: 812 812 812
+Encoding: 812 812 696
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31351,8 +32053,9 @@ SplineSet
  451.726 -485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032D
-Encoding: 813 813 813
+Encoding: 813 813 697
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31398,8 +32101,9 @@ SplineSet
  377.812 -109 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032E
-Encoding: 814 814 814
+Encoding: 814 814 698
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31461,8 +32165,9 @@ SplineSet
  118.124 -208 118.124 -208 120.124 -200 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni032F
-Encoding: 815 815 815
+Encoding: 815 815 699
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31483,8 +32188,9 @@ SplineSet
  695.174 -455.639 695.174 -455.639 691.726 -485 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0330
-Encoding: 816 816 816
+Encoding: 816 816 700
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31666,8 +32372,9 @@ SplineSet
  428.726 -458 428.726 -458 388.726 -418 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0331
-Encoding: 817 817 817
+Encoding: 817 817 701
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31704,24 +32411,27 @@ SplineSet
  132.875 -209 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0332
-Encoding: 818 818 818
+Encoding: 818 818 702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0333
-Encoding: 819 819 819
+Encoding: 819 819 703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8215 8215 N 1 0 0 1 0 0 2
+Refer: 1868 8215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0334
-Encoding: 820 820 820
+Encoding: 820 820 704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31748,8 +32458,9 @@ SplineSet
  1086.94 718 1086.94 718 1172.99 780 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0335
-Encoding: 821 821 821
+Encoding: 821 821 705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31762,8 +32473,9 @@ SplineSet
  1062 616 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0336
-Encoding: 822 822 822
+Encoding: 822 822 706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31776,8 +32488,9 @@ SplineSet
  0 452 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0337
-Encoding: 823 823 823
+Encoding: 823 823 707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31790,8 +32503,9 @@ SplineSet
  11.875 -96 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0338
-Encoding: 824 824 824
+Encoding: 824 824 708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31804,8 +32518,9 @@ SplineSet
  -47.3232 -70 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0339
-Encoding: 825 825 825
+Encoding: 825 825 709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31824,8 +32539,9 @@ SplineSet
  283.471 -404 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033A
-Encoding: 826 826 826
+Encoding: 826 826 710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31842,8 +32558,9 @@ SplineSet
  308.928 -384 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033B
-Encoding: 827 827 827
+Encoding: 827 827 711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31861,8 +32578,9 @@ SplineSet
  727.981 -623 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033C
-Encoding: 828 828 828
+Encoding: 828 828 712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31883,8 +32601,9 @@ SplineSet
  584.824 -168 584.824 -168 628.449 -250.025 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni033D
-Encoding: 829 829 829
+Encoding: 829 829 713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31905,8 +32624,9 @@ SplineSet
  597.807 1353.09 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033E
-Encoding: 830 830 830
+Encoding: 830 830 714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31935,33 +32655,37 @@ SplineSet
  535.917 1479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni033F
-Encoding: 831 831 831
+Encoding: 831 831 715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
-Refer: 8254 8254 N 1 0 0 1 0 -240 2
+Refer: 1897 8254 N 1 0 0 1 0 0 2
+Refer: 1897 8254 N 1 0 0 1 0 -240 2
 EndChar
+
 StartChar: uni0343
-Encoding: 835 835 835
+Encoding: 835 835 716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 787 787 N 1 0 0 1 0 0 2
+Refer: 671 787 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0358
-Encoding: 856 856 856
+Encoding: 856 856 717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 651 0 2
+Refer: 634 729 N 1 0 0 1 651 0 2
 EndChar
+
 StartChar: uni0361
-Encoding: 865 865 865
+Encoding: 865 865 718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31980,8 +32704,9 @@ SplineSet
  676.651 1710 676.651 1710 621.651 1710 c 24,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0374
-Encoding: 884 884 884
+Encoding: 884 884 719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31994,8 +32719,9 @@ SplineSet
  443.6 1140 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0375
-Encoding: 885 885 885
+Encoding: 885 885 720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32008,24 +32734,27 @@ SplineSet
  789.4 72 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0376
-Encoding: 886 886 886
+Encoding: 886 886 721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 3
+Refer: 859 1048 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0377
-Encoding: 887 887 887
+Encoding: 887 887 722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 3
+Refer: 891 1080 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037A
-Encoding: 890 890 890
+Encoding: 890 890 723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32042,171 +32771,191 @@ SplineSet
  588.076 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni037B
-Encoding: 891 891 891
+Encoding: 891 891 724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 510 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037C
-Encoding: 892 892 892
+Encoding: 892 892 725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 135 -124 2
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 135 -124 2
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037D
-Encoding: 893 893 893
+Encoding: 893 893 726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -118 -124 2
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 -118 -124 2
+Refer: 510 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037E
-Encoding: 894 894 894
+Encoding: 894 894 727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 59 59 N 1 0 0 1 0 0 2
+Refer: 28 59 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni037F
-Encoding: 895 895 895
+Encoding: 895 895 728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 3
+Refer: 43 74 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: tonos
-Encoding: 900 900 900
+Encoding: 900 900 729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dieresistonos
-Encoding: 901 901 901
+Encoding: 901 901 730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 105 370 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 105 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alphatonos
-Encoding: 902 902 902
+Encoding: 902 902 731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -450 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -450 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: anoteleia
-Encoding: 903 903 903
+Encoding: 903 903 732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Epsilontonos
-Encoding: 904 904 904
+Encoding: 904 904 733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -700 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -700 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Etatonos
-Encoding: 905 905 905
+Encoding: 905 905 734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -750 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -750 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iotatonos
-Encoding: 906 906 906
+Encoding: 906 906 735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -700 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -700 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Omicrontonos
-Encoding: 908 908 908
+Encoding: 908 908 736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -550 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -550 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilontonos
-Encoding: 910 910 910
+Encoding: 910 910 737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -875 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -875 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Omegatonos
-Encoding: 911 911 911
+Encoding: 911 911 738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -525 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -525 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotadieresistonos
-Encoding: 912 912 912
+Encoding: 912 912 739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 730 901 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alpha
-Encoding: 913 913 913
+Encoding: 913 913 740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Beta
-Encoding: 914 914 914
+Encoding: 914 914 741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gamma
-Encoding: 915 915 915
+Encoding: 915 915 742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 854 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0394
-Encoding: 916 916 916
+Encoding: 916 916 743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32223,32 +32972,36 @@ SplineSet
  1050.9 0 l 9,5,-1
 EndSplineSet
 EndChar
+
 StartChar: Epsilon
-Encoding: 917 917 917
+Encoding: 917 917 744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zeta
-Encoding: 918 918 918
+Encoding: 918 918 745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eta
-Encoding: 919 919 919
+Encoding: 919 919 746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Theta
-Encoding: 920 920 920
+Encoding: 920 920 747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32279,24 +33032,27 @@ SplineSet
  1191.91 1136 1191.91 1136 1115.9 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: Iota
-Encoding: 921 921 921
+Encoding: 921 921 748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kappa
-Encoding: 922 922 922
+Encoding: 922 922 749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lambda
-Encoding: 923 923 923
+Encoding: 923 923 750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32312,24 +33068,27 @@ SplineSet
  100.896 0 l 17,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Mu
-Encoding: 924 924 924
+Encoding: 924 924 751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Nu
-Encoding: 925 925 925
+Encoding: 925 925 752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Xi
-Encoding: 926 926 926
+Encoding: 926 926 753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32352,32 +33111,36 @@ SplineSet
  983.939 170 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: Omicron
-Encoding: 927 927 927
+Encoding: 927 927 754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Pi
-Encoding: 928 928 928
+Encoding: 928 928 755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1055 1055 N 1 0 0 1 0 0 2
+Refer: 866 1055 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rho
-Encoding: 929 929 929
+Encoding: 929 929 756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Sigma
-Encoding: 931 931 931
+Encoding: 931 931 757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32398,24 +33161,27 @@ SplineSet
  786.098 747 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: Tau
-Encoding: 932 932 932
+Encoding: 932 932 758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilon
-Encoding: 933 933 933
+Encoding: 933 933 759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Phi
-Encoding: 934 934 934
+Encoding: 934 934 760
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32458,16 +33224,18 @@ SplineSet
  385.628 477.637 385.628 477.637 458.665 461.826 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: Chi
-Encoding: 935 935 935
+Encoding: 935 935 761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Psi
-Encoding: 936 936 936
+Encoding: 936 936 762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32500,8 +33268,9 @@ SplineSet
  862.104 1493 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: Omega
-Encoding: 937 937 937
+Encoding: 937 937 763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32534,71 +33303,79 @@ SplineSet
  -67.8975 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Iotadieresis
-Encoding: 938 938 938
+Encoding: 938 938 764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilondieresis
-Encoding: 939 939 939
+Encoding: 939 939 765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 57 373 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 57 373 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alphatonos
-Encoding: 940 940 940
+Encoding: 940 940 766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: epsilontonos
-Encoding: 941 941 941
+Encoding: 941 941 767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: etatonos
-Encoding: 942 942 942
+Encoding: 942 942 768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotatonos
-Encoding: 943 943 943
+Encoding: 943 943 769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresistonos
-Encoding: 944 944 944
+Encoding: 944 944 770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 730 901 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alpha
-Encoding: 945 945 945
+Encoding: 945 945 771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32634,8 +33411,9 @@ SplineSet
  924.525 1150.23 924.525 1150.23 921.013 826.833 c 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: beta
-Encoding: 946 946 946
+Encoding: 946 946 772
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32662,8 +33440,9 @@ SplineSet
  291.907 342 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: gamma
-Encoding: 947 947 947
+Encoding: 947 947 773
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32685,8 +33464,9 @@ SplineSet
  229.296 836 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: delta
-Encoding: 948 948 948
+Encoding: 948 948 774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32728,8 +33508,9 @@ SplineSet
  342.292 1034 342.292 1034 391.615 1066.53 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: epsilon
-Encoding: 949 949 949
+Encoding: 949 949 775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32777,8 +33558,9 @@ SplineSet
  398.538 599.504 398.538 599.504 433.66 591.625 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: zeta
-Encoding: 950 950 950
+Encoding: 950 950 776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32804,8 +33586,9 @@ SplineSet
  297.25 127 297.25 127 675.25 127 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: eta
-Encoding: 951 951 951
+Encoding: 951 951 777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32830,8 +33613,9 @@ SplineSet
  1160.14 922 1160.14 922 1115.83 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: theta
-Encoding: 952 952 952
+Encoding: 952 952 778
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32860,8 +33644,9 @@ SplineSet
  531.584 1500 531.584 1500 764.584 1500 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: iota
-Encoding: 953 953 953
+Encoding: 953 953 779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32882,16 +33667,18 @@ SplineSet
  817.353 1120 l 25,12,-1
 EndSplineSet
 EndChar
+
 StartChar: kappa
-Encoding: 954 954 954
+Encoding: 954 954 780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
+Refer: 893 1082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lambda
-Encoding: 955 955 955
+Encoding: 955 955 781
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32912,16 +33699,18 @@ SplineSet
  868.279 1547.44 868.279 1547.44 898.175 1381 c 2,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03BC
-Encoding: 956 956 956
+Encoding: 956 956 782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 181 181 N 1 0 0 1 0 0 2
+Refer: 117 181 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nu
-Encoding: 957 957 957
+Encoding: 957 957 783
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32944,8 +33733,9 @@ SplineSet
  349.147 0 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: xi
-Encoding: 958 958 958
+Encoding: 958 958 784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32976,16 +33766,18 @@ SplineSet
  265.003 131.096 265.003 131.096 700.25 127 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: omicron
-Encoding: 959 959 959
+Encoding: 959 959 785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: pi
-Encoding: 960 960 960
+Encoding: 960 960 786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33014,8 +33806,9 @@ SplineSet
  147.644 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rho
-Encoding: 961 961 961
+Encoding: 961 961 787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33044,8 +33837,9 @@ SplineSet
  911.986 345 911.986 345 953.584 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: sigma1
-Encoding: 962 962 962
+Encoding: 962 962 788
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33076,8 +33870,9 @@ SplineSet
  531.541 128.789 531.541 128.789 703.001 127 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: sigma
-Encoding: 963 963 963
+Encoding: 963 963 789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33105,8 +33900,9 @@ SplineSet
  949.281 936 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: tau
-Encoding: 964 964 964
+Encoding: 964 964 790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33129,8 +33925,9 @@ SplineSet
  648.175 249.652 648.175 249.652 673.301 204 c 16,9,10
 EndSplineSet
 EndChar
+
 StartChar: upsilon
-Encoding: 965 965 965
+Encoding: 965 965 791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33158,8 +33955,9 @@ SplineSet
  699.394 156 699.394 156 548.971 156 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: phi
-Encoding: 966 966 966
+Encoding: 966 966 792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33193,8 +33991,9 @@ SplineSet
  676.033 1128 676.033 1128 924.033 1128 c 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: chi
-Encoding: 967 967 967
+Encoding: 967 967 793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33223,8 +34022,9 @@ SplineSet
  666.39 -426 666.39 -426 634.357 -250.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: psi
-Encoding: 968 968 968
+Encoding: 968 968 794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33253,8 +34053,9 @@ SplineSet
  667.764 140 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: omega
-Encoding: 969 969 969
+Encoding: 969 969 795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33286,53 +34087,59 @@ SplineSet
  1150.71 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: iotadieresis
-Encoding: 970 970 970
+Encoding: 970 970 796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresis
-Encoding: 971 971 971
+Encoding: 971 971 797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omicrontonos
-Encoding: 972 972 972
+Encoding: 972 972 798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilontonos
-Encoding: 973 973 973
+Encoding: 973 973 799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omegatonos
-Encoding: 974 974 974
+Encoding: 974 974 800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D0
-Encoding: 976 976 976
+Encoding: 976 976 801
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33361,8 +34168,9 @@ SplineSet
  933.286 590 933.286 590 644.409 730 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: theta1
-Encoding: 977 977 977
+Encoding: 977 977 802
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33391,8 +34199,9 @@ SplineSet
  846.033 471.523 846.033 471.523 897.216 710 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: Upsilon1
-Encoding: 978 978 978
+Encoding: 978 978 803
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33417,26 +34226,29 @@ SplineSet
  950.632 1181.53 950.632 1181.53 959.181 1296.95 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D3
-Encoding: 979 979 979
+Encoding: 979 979 804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 900 900 N 1 0 0 1 -955 0 2
-Refer: 978 978 N 1 0 0 1 0 0 2
+Refer: 729 900 N 1 0 0 1 -955 0 2
+Refer: 803 978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D4
-Encoding: 980 980 980
+Encoding: 980 980 805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -6 373 2
-Refer: 978 978 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 -6 373 2
+Refer: 803 978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: phi1
-Encoding: 981 981 981
+Encoding: 981 981 806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33471,8 +34283,9 @@ SplineSet
  354.138 168.092 354.138 168.092 447.803 141.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: omega1
-Encoding: 982 982 982
+Encoding: 982 982 807
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33501,8 +34314,9 @@ SplineSet
  1141.74 936 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D7
-Encoding: 983 983 983
+Encoding: 983 983 808
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33537,8 +34351,9 @@ SplineSet
  646.524 21.9297 646.524 21.9297 886.422 -10 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D8
-Encoding: 984 984 984
+Encoding: 984 984 809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33567,8 +34382,9 @@ SplineSet
  324.868 -426 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D9
-Encoding: 985 985 985
+Encoding: 985 985 810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33597,8 +34413,9 @@ SplineSet
  808.315 3.50293 808.315 3.50293 633.455 -23 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DA
-Encoding: 986 986 986
+Encoding: 986 986 811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33627,8 +34444,9 @@ SplineSet
  846.352 1323 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DB
-Encoding: 987 987 987
+Encoding: 987 987 812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33657,16 +34475,18 @@ SplineSet
  1185.32 964 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DC
-Encoding: 988 988 988
+Encoding: 988 988 813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 3
+Refer: 39 70 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03DD
-Encoding: 989 989 989
+Encoding: 989 989 814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33699,8 +34519,9 @@ SplineSet
  320.175 0 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DE
-Encoding: 990 990 990
+Encoding: 990 990 815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33725,8 +34546,9 @@ SplineSet
  618.129 1340.82 618.129 1340.82 563.57 1159 c 26,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DF
-Encoding: 991 991 991
+Encoding: 991 991 816
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33743,8 +34565,9 @@ SplineSet
  1120.92 880 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E0
-Encoding: 992 992 992
+Encoding: 992 992 817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33774,8 +34597,9 @@ SplineSet
  617.036 1355 617.036 1355 542.036 1355 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E1
-Encoding: 993 993 993
+Encoding: 993 993 818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33800,8 +34624,9 @@ SplineSet
  832.449 308 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03F0
-Encoding: 1008 1008 1008
+Encoding: 1008 1008 819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33834,8 +34659,9 @@ SplineSet
  463.329 409 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03F1
-Encoding: 1009 1009 1009
+Encoding: 1009 1009 820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33867,24 +34693,27 @@ SplineSet
  911.986 345 911.986 345 953.584 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03F2
-Encoding: 1010 1010 1010
+Encoding: 1010 1010 821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F3
-Encoding: 1011 1011 1011
+Encoding: 1011 1011 822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 3
+Refer: 75 106 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F4
-Encoding: 1012 1012 1012
+Encoding: 1012 1012 823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33913,8 +34742,9 @@ SplineSet
  1191.91 1136 1191.91 1136 1115.9 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni03F5
-Encoding: 1013 1013 1013
+Encoding: 1013 1013 824
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33944,8 +34774,9 @@ SplineSet
  1107.45 942 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F6
-Encoding: 1014 1014 1014
+Encoding: 1014 1014 825
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33975,32 +34806,36 @@ SplineSet
  275.966 954.997 275.966 954.997 236.447 942 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F7
-Encoding: 1015 1015 1015
+Encoding: 1015 1015 826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 222 222 N 1 0 0 1 0 0 3
+Refer: 158 222 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F8
-Encoding: 1016 1016 1016
+Encoding: 1016 1016 827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 254 254 N 1 0 0 1 0 0 3
+Refer: 190 254 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F9
-Encoding: 1017 1017 1017
+Encoding: 1017 1017 828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 3
+Refer: 36 67 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FA
-Encoding: 1018 1018 1018
+Encoding: 1018 1018 829
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34022,8 +34857,9 @@ SplineSet
  231.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FB
-Encoding: 1019 1019 1019
+Encoding: 1019 1019 830
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34045,8 +34881,9 @@ SplineSet
  277.256 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FC
-Encoding: 1020 1020 1020
+Encoding: 1020 1020 831
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34083,8 +34920,9 @@ SplineSet
  911.986 345 911.986 345 953.584 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03FD
-Encoding: 1021 1021 1021
+Encoding: 1021 1021 832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34111,44 +34949,49 @@ SplineSet
  73.4219 12 73.4219 12 4.3916 53 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03FE
-Encoding: 1022 1022 1022
+Encoding: 1022 1022 833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1017 1017 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 139 0 2
+Refer: 828 1017 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 139 0 2
 EndChar
+
 StartChar: uni03FF
-Encoding: 1023 1023 1023
+Encoding: 1023 1023 834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -157 0 2
-Refer: 1021 1021 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 -157 0 2
+Refer: 832 1021 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0400
-Encoding: 1024 1024 1024
+Encoding: 1024 1024 835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 132 380 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 132 380 2
+Refer: 856 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0401
-Encoding: 1025 1025 1025
+Encoding: 1025 1025 836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 87 292 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 87 292 2
+Refer: 856 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0402
-Encoding: 1026 1026 1026
+Encoding: 1026 1026 837
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34188,17 +35031,19 @@ SplineSet
  385.801 -465.991 385.801 -465.991 417.572 -287.104 c 129,-1,0
 EndSplineSet
 EndChar
+
 StartChar: uni0403
-Encoding: 1027 1027 1027
+Encoding: 1027 1027 838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 125 380 2
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 125 380 2
+Refer: 854 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0404
-Encoding: 1028 1028 1028
+Encoding: 1028 1028 839
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34226,41 +35071,46 @@ SplineSet
  334 661 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0405
-Encoding: 1029 1029 1029
+Encoding: 1029 1029 840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0406
-Encoding: 1030 1030 1030
+Encoding: 1030 1030 841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0407
-Encoding: 1031 1031 1031
+Encoding: 1031 1031 842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 54.5 292 2
-Refer: 1030 1030 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 54.5 292 2
+Refer: 841 1030 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0408
-Encoding: 1032 1032 1032
+Encoding: 1032 1032 843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0409
-Encoding: 1033 1033 1033
+Encoding: 1033 1033 844
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34298,8 +35148,9 @@ SplineSet
  946 1493 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040A
-Encoding: 1034 1034 1034
+Encoding: 1034 1034 845
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34335,8 +35186,9 @@ SplineSet
  470 0 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040B
-Encoding: 1035 1035 1035
+Encoding: 1035 1035 846
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34369,35 +35221,39 @@ SplineSet
  495.255 1325 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040C
-Encoding: 1036 1036 1036
+Encoding: 1036 1036 847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 80.5 380 2
-Refer: 1050 1050 N 1 0 0 1 83 0 2
+Refer: 116 180 N 1 0 0 1 80.5 380 2
+Refer: 861 1050 N 1 0 0 1 83 0 2
 EndChar
+
 StartChar: uni040D
-Encoding: 1037 1037 1037
+Encoding: 1037 1037 848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 36.5 380 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 36.5 380 2
+Refer: 859 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040E
-Encoding: 1038 1038 1038
+Encoding: 1038 1038 849
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 870 1059 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040F
-Encoding: 1039 1039 1039
+Encoding: 1039 1039 850
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34418,16 +35274,18 @@ SplineSet
  23 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0410
-Encoding: 1040 1040 1040
+Encoding: 1040 1040 851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0411
-Encoding: 1041 1041 1041
+Encoding: 1041 1041 852
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34455,16 +35313,18 @@ SplineSet
  1180.84 1327 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0412
-Encoding: 1042 1042 1042
+Encoding: 1042 1042 853
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0413
-Encoding: 1043 1043 1043
+Encoding: 1043 1043 854
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34479,8 +35339,9 @@ SplineSet
  69.8955 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0414
-Encoding: 1044 1044 1044
+Encoding: 1044 1044 855
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34511,16 +35372,18 @@ SplineSet
  287 165 287 165 287 188 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0415
-Encoding: 1045 1045 1045
+Encoding: 1045 1045 856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0416
-Encoding: 1046 1046 1046
+Encoding: 1046 1046 857
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34549,16 +35412,18 @@ SplineSet
  -130 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0417
-Encoding: 1047 1047 1047
+Encoding: 1047 1047 858
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0418
-Encoding: 1048 1048 1048
+Encoding: 1048 1048 859
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34577,25 +35442,28 @@ SplineSet
  -6.10449 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0419
-Encoding: 1049 1049 1049
+Encoding: 1049 1049 860
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 859 1048 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041A
-Encoding: 1050 1050 1050
+Encoding: 1050 1050 861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041B
-Encoding: 1051 1051 1051
+Encoding: 1051 1051 862
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34618,32 +35486,36 @@ SplineSet
  595 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni041C
-Encoding: 1052 1052 1052
+Encoding: 1052 1052 863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041D
-Encoding: 1053 1053 1053
+Encoding: 1053 1053 864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041E
-Encoding: 1054 1054 1054
+Encoding: 1054 1054 865
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041F
-Encoding: 1055 1055 1055
+Encoding: 1055 1055 866
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34660,32 +35532,36 @@ SplineSet
  282.104 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0420
-Encoding: 1056 1056 1056
+Encoding: 1056 1056 867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0421
-Encoding: 1057 1057 1057
+Encoding: 1057 1057 868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0422
-Encoding: 1058 1058 1058
+Encoding: 1058 1058 869
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0423
-Encoding: 1059 1059 1059
+Encoding: 1059 1059 870
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34709,8 +35585,9 @@ SplineSet
  678.512 425 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0424
-Encoding: 1060 1060 1060
+Encoding: 1060 1060 871
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34749,16 +35626,18 @@ SplineSet
  634 316 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0425
-Encoding: 1061 1061 1061
+Encoding: 1061 1061 872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0426
-Encoding: 1062 1062 1062
+Encoding: 1062 1062 873
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34779,8 +35658,9 @@ SplineSet
  -34 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0427
-Encoding: 1063 1063 1063
+Encoding: 1063 1063 874
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34807,8 +35687,9 @@ SplineSet
  167 737 167 737 167 820 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni0428
-Encoding: 1064 1064 1064
+Encoding: 1064 1064 875
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34829,8 +35710,9 @@ SplineSet
  975 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0429
-Encoding: 1065 1065 1065
+Encoding: 1065 1065 876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34855,8 +35737,9 @@ SplineSet
  -54 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042A
-Encoding: 1066 1066 1066
+Encoding: 1066 1066 877
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34884,8 +35767,9 @@ SplineSet
  147.896 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042B
-Encoding: 1067 1067 1067
+Encoding: 1067 1067 878
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34916,8 +35800,9 @@ SplineSet
  -80.1045 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042C
-Encoding: 1068 1068 1068
+Encoding: 1068 1068 879
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34943,8 +35828,9 @@ SplineSet
  51.8955 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042D
-Encoding: 1069 1069 1069
+Encoding: 1069 1069 880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34972,8 +35858,9 @@ SplineSet
  605 -29 605 -29 318 -29 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni042E
-Encoding: 1070 1070 1070
+Encoding: 1070 1070 881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35006,8 +35893,9 @@ SplineSet
  364.978 836 l 9,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042F
-Encoding: 1071 1071 1071
+Encoding: 1071 1071 882
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35037,16 +35925,18 @@ SplineSet
  425 1020 425 1020 425 985 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0430
-Encoding: 1072 1072 1072
+Encoding: 1072 1072 883
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0431
-Encoding: 1073 1073 1073
+Encoding: 1073 1073 884
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35086,8 +35976,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 0" uniF6C5
 EndChar
+
 StartChar: uni0432
-Encoding: 1074 1074 1074
+Encoding: 1074 1074 885
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35124,8 +36015,9 @@ SplineSet
  384 515 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0433
-Encoding: 1075 1075 1075
+Encoding: 1075 1075 886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35140,8 +36032,9 @@ SplineSet
  521 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0434
-Encoding: 1076 1076 1076
+Encoding: 1076 1076 887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35173,16 +36066,18 @@ SplineSet
  350 172 350 172 350 161 c 128,-1,0
 EndSplineSet
 EndChar
+
 StartChar: uni0435
-Encoding: 1077 1077 1077
+Encoding: 1077 1077 888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0436
-Encoding: 1078 1078 1078
+Encoding: 1078 1078 889
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35211,16 +36106,18 @@ SplineSet
  -50 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0437
-Encoding: 1079 1079 1079
+Encoding: 1079 1079 890
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 604 604 N 1 0 0 1 0 0 2
+Refer: 518 604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0438
-Encoding: 1080 1080 1080
+Encoding: 1080 1080 891
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35239,25 +36136,28 @@ SplineSet
  914 809 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0439
-Encoding: 1081 1081 1081
+Encoding: 1081 1081 892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 891 1080 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043A
-Encoding: 1082 1082 1082
+Encoding: 1082 1082 893
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 2
+Refer: 248 312 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043B
-Encoding: 1083 1083 1083
+Encoding: 1083 1083 894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35282,8 +36182,9 @@ SplineSet
  374 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043C
-Encoding: 1084 1084 1084
+Encoding: 1084 1084 895
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35305,8 +36206,9 @@ SplineSet
  594.618 429.422 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043D
-Encoding: 1085 1085 1085
+Encoding: 1085 1085 896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35327,16 +36229,18 @@ SplineSet
  857 515 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043E
-Encoding: 1086 1086 1086
+Encoding: 1086 1086 897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043F
-Encoding: 1087 1087 1087
+Encoding: 1087 1087 898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35353,24 +36257,27 @@ SplineSet
  946 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0440
-Encoding: 1088 1088 1088
+Encoding: 1088 1088 899
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0441
-Encoding: 1089 1089 1089
+Encoding: 1089 1089 900
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0442
-Encoding: 1090 1090 1090
+Encoding: 1090 1090 901
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35387,16 +36294,18 @@ SplineSet
  800 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0443
-Encoding: 1091 1091 1091
+Encoding: 1091 1091 902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0444
-Encoding: 1092 1092 1092
+Encoding: 1092 1092 903
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35435,16 +36344,18 @@ SplineSet
  900 957 900 957 785 982 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0445
-Encoding: 1093 1093 1093
+Encoding: 1093 1093 904
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0446
-Encoding: 1094 1094 1094
+Encoding: 1094 1094 905
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35465,8 +36376,9 @@ SplineSet
  43 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0447
-Encoding: 1095 1095 1095
+Encoding: 1095 1095 906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35492,8 +36404,9 @@ SplineSet
  221 540 221 540 221 649 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0448
-Encoding: 1096 1096 1096
+Encoding: 1096 1096 907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35514,8 +36427,9 @@ SplineSet
  1000 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0449
-Encoding: 1097 1097 1097
+Encoding: 1097 1097 908
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35540,8 +36454,9 @@ SplineSet
  -1 0 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044A
-Encoding: 1098 1098 1098
+Encoding: 1098 1098 909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35569,8 +36484,9 @@ SplineSet
  631 153 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni044B
-Encoding: 1099 1099 1099
+Encoding: 1099 1099 910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35601,8 +36517,9 @@ SplineSet
  1238 1120 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044C
-Encoding: 1100 1100 1100
+Encoding: 1100 1100 911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35628,8 +36545,9 @@ SplineSet
  88.7305 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044D
-Encoding: 1101 1101 1101
+Encoding: 1101 1101 912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35657,8 +36575,9 @@ SplineSet
  229 -29 229 -29 97 57 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044E
-Encoding: 1102 1102 1102
+Encoding: 1102 1102 913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35695,8 +36614,9 @@ SplineSet
  277 634 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044F
-Encoding: 1103 1103 1103
+Encoding: 1103 1103 914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35727,26 +36647,29 @@ SplineSet
  442 760 442 760 442 737 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0450
-Encoding: 1104 1104 1104
+Encoding: 1104 1104 915
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -30 7 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -30 7 2
+Refer: 888 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0451
-Encoding: 1105 1105 1105
+Encoding: 1105 1105 916
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 35 -81 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 35 -81 2
+Refer: 888 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0452
-Encoding: 1106 1106 1106
+Encoding: 1106 1106 917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35779,17 +36702,19 @@ SplineSet
  115 0 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0453
-Encoding: 1107 1107 1107
+Encoding: 1107 1107 918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 81 7 2
-Refer: 1075 1075 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 81 7 2
+Refer: 886 1075 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0454
-Encoding: 1108 1108 1108
+Encoding: 1108 1108 919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35819,41 +36744,46 @@ SplineSet
  963.421 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0455
-Encoding: 1109 1109 1109
+Encoding: 1109 1109 920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0456
-Encoding: 1110 1110 1110
+Encoding: 1110 1110 921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0457
-Encoding: 1111 1111 1111
+Encoding: 1111 1111 922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 -44 -81 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -44 -81 2
 EndChar
+
 StartChar: uni0458
-Encoding: 1112 1112 1112
+Encoding: 1112 1112 923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0459
-Encoding: 1113 1113 1113
+Encoding: 1113 1113 924
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35891,8 +36821,9 @@ SplineSet
  886 0 886 0 722 0 c 2,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni045A
-Encoding: 1114 1114 1114
+Encoding: 1114 1114 925
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35926,8 +36857,9 @@ SplineSet
  786 667 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045B
-Encoding: 1115 1115 1115
+Encoding: 1115 1115 926
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35959,35 +36891,39 @@ SplineSet
  74 0 l 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045C
-Encoding: 1116 1116 1116
+Encoding: 1116 1116 927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 48.5 7 2
-Refer: 1082 1082 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 48.5 7 2
+Refer: 893 1082 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045D
-Encoding: 1117 1117 1117
+Encoding: 1117 1117 928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 64.5 7 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 64.5 7 2
+Refer: 891 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045E
-Encoding: 1118 1118 1118
+Encoding: 1118 1118 929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 902 1091 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045F
-Encoding: 1119 1119 1119
+Encoding: 1119 1119 930
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36008,8 +36944,9 @@ SplineSet
  114 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0462
-Encoding: 1122 1122 1122
+Encoding: 1122 1122 931
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36043,8 +36980,9 @@ SplineSet
  565 1105 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0463
-Encoding: 1123 1123 1123
+Encoding: 1123 1123 932
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36078,72 +37016,83 @@ SplineSet
  383 156 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni046A
-Encoding: 1130 1130 1130
+Encoding: 1130 1130 933
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni046B
-Encoding: 1131 1131 1131
+Encoding: 1131 1131 934
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0472
-Encoding: 1138 1138 1138
+Encoding: 1138 1138 935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 415 415 N 1 0 0 1 0 0 3
+Refer: 351 415 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0473
-Encoding: 1139 1139 1139
+Encoding: 1139 1139 936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 3
+Refer: 543 629 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni048A
-Encoding: 1162 1162 1162
+Encoding: 1162 1162 937
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048B
-Encoding: 1163 1163 1163
+Encoding: 1163 1163 938
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048C
-Encoding: 1164 1164 1164
+Encoding: 1164 1164 939
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048D
-Encoding: 1165 1165 1165
+Encoding: 1165 1165 940
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048E
-Encoding: 1166 1166 1166
+Encoding: 1166 1166 941
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048F
-Encoding: 1167 1167 1167
+Encoding: 1167 1167 942
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0490
-Encoding: 1168 1168 1168
+Encoding: 1168 1168 943
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36160,8 +37109,9 @@ SplineSet
  69.9004 0 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0491
-Encoding: 1169 1169 1169
+Encoding: 1169 1169 944
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36178,8 +37128,9 @@ SplineSet
  514.04 936 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0492
-Encoding: 1170 1170 1170
+Encoding: 1170 1170 945
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36202,8 +37153,9 @@ SplineSet
  467 1000 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0493
-Encoding: 1171 1171 1171
+Encoding: 1171 1171 946
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36226,8 +37178,9 @@ SplineSet
  462 670 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0494
-Encoding: 1172 1172 1172
+Encoding: 1172 1172 947
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36258,8 +37211,9 @@ SplineSet
  411.104 711 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0495
-Encoding: 1173 1173 1173
+Encoding: 1173 1173 948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36290,8 +37244,9 @@ SplineSet
  426.763 487 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0496
-Encoding: 1174 1174 1174
+Encoding: 1174 1174 949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36324,8 +37279,9 @@ SplineSet
  -130 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0497
-Encoding: 1175 1175 1175
+Encoding: 1175 1175 950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36358,26 +37314,29 @@ SplineSet
  -50 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0498
-Encoding: 1176 1176 1176
+Encoding: 1176 1176 951
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1047 1047 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -73 0 2
+Refer: 858 1047 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 -73 0 2
 EndChar
+
 StartChar: uni0499
-Encoding: 1177 1177 1177
+Encoding: 1177 1177 952
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1079 1079 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -67 0 2
+Refer: 890 1079 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 -67 0 2
 EndChar
+
 StartChar: uni049A
-Encoding: 1178 1178 1178
+Encoding: 1178 1178 953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36402,8 +37361,9 @@ SplineSet
  997 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049B
-Encoding: 1179 1179 1179
+Encoding: 1179 1179 954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36428,44 +37388,51 @@ SplineSet
  995 184 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049C
-Encoding: 1180 1180 1180
+Encoding: 1180 1180 955
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049D
-Encoding: 1181 1181 1181
+Encoding: 1181 1181 956
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049E
-Encoding: 1182 1182 1182
+Encoding: 1182 1182 957
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049F
-Encoding: 1183 1183 1183
+Encoding: 1183 1183 958
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A0
-Encoding: 1184 1184 1184
+Encoding: 1184 1184 959
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A1
-Encoding: 1185 1185 1185
+Encoding: 1185 1185 960
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A2
-Encoding: 1186 1186 1186
+Encoding: 1186 1186 961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36490,8 +37457,9 @@ SplineSet
  949.999 0 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A3
-Encoding: 1187 1187 1187
+Encoding: 1187 1187 962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36516,8 +37484,9 @@ SplineSet
  941.152 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A4
-Encoding: 1188 1188 1188
+Encoding: 1188 1188 963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36540,8 +37509,9 @@ SplineSet
  -31 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A5
-Encoding: 1189 1189 1189
+Encoding: 1189 1189 964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36564,50 +37534,57 @@ SplineSet
  16 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A6
-Encoding: 1190 1190 1190
+Encoding: 1190 1190 965
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A7
-Encoding: 1191 1191 1191
+Encoding: 1191 1191 966
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A8
-Encoding: 1192 1192 1192
+Encoding: 1192 1192 967
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A9
-Encoding: 1193 1193 1193
+Encoding: 1193 1193 968
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04AA
-Encoding: 1194 1194 1194
+Encoding: 1194 1194 969
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1057 1057 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 100 0 2
+Refer: 868 1057 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni04AB
-Encoding: 1195 1195 1195
+Encoding: 1195 1195 970
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1089 1089 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 104 0 2
+Refer: 900 1089 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 104 0 2
 EndChar
+
 StartChar: uni04AC
-Encoding: 1196 1196 1196
+Encoding: 1196 1196 971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36628,8 +37605,9 @@ SplineSet
  575 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AD
-Encoding: 1197 1197 1197
+Encoding: 1197 1197 972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36650,16 +37628,18 @@ SplineSet
  611.146 0 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04AE
-Encoding: 1198 1198 1198
+Encoding: 1198 1198 973
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AF
-Encoding: 1199 1199 1199
+Encoding: 1199 1199 974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36677,8 +37657,9 @@ SplineSet
  177 1120 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B0
-Encoding: 1200 1200 1200
+Encoding: 1200 1200 975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36704,8 +37685,9 @@ SplineSet
  195 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B1
-Encoding: 1201 1201 1201
+Encoding: 1201 1201 976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36731,8 +37713,9 @@ SplineSet
  177 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B2
-Encoding: 1202 1202 1202
+Encoding: 1202 1202 977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36757,8 +37740,9 @@ SplineSet
  999 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B3
-Encoding: 1203 1203 1203
+Encoding: 1203 1203 978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36783,44 +37767,51 @@ SplineSet
  945 184 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B4
-Encoding: 1204 1204 1204
+Encoding: 1204 1204 979
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B5
-Encoding: 1205 1205 1205
+Encoding: 1205 1205 980
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B6
-Encoding: 1206 1206 1206
+Encoding: 1206 1206 981
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B7
-Encoding: 1207 1207 1207
+Encoding: 1207 1207 982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B8
-Encoding: 1208 1208 1208
+Encoding: 1208 1208 983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B9
-Encoding: 1209 1209 1209
+Encoding: 1209 1209 984
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BA
-Encoding: 1210 1210 1210
+Encoding: 1210 1210 985
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36849,66 +37840,75 @@ SplineSet
  1091.21 727.993 1091.21 727.993 1046.89 500 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04BB
-Encoding: 1211 1211 1211
+Encoding: 1211 1211 986
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04BC
-Encoding: 1212 1212 1212
+Encoding: 1212 1212 987
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BD
-Encoding: 1213 1213 1213
+Encoding: 1213 1213 988
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BE
-Encoding: 1214 1214 1214
+Encoding: 1214 1214 989
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BF
-Encoding: 1215 1215 1215
+Encoding: 1215 1215 990
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C0
-Encoding: 1216 1216 1216
+Encoding: 1216 1216 991
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C1
-Encoding: 1217 1217 1217
+Encoding: 1217 1217 992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1046 1046 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 857 1046 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C2
-Encoding: 1218 1218 1218
+Encoding: 1218 1218 993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1078 1078 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 889 1078 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C3
-Encoding: 1219 1219 1219
+Encoding: 1219 1219 994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36941,8 +37941,9 @@ SplineSet
  653.249 881 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C4
-Encoding: 1220 1220 1220
+Encoding: 1220 1220 995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -36975,20 +37976,23 @@ SplineSet
  631.519 631 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C5
-Encoding: 1221 1221 1221
+Encoding: 1221 1221 996
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C6
-Encoding: 1222 1222 1222
+Encoding: 1222 1222 997
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C7
-Encoding: 1223 1223 1223
+Encoding: 1223 1223 998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37015,8 +38019,9 @@ SplineSet
  971.216 104 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C8
-Encoding: 1224 1224 1224
+Encoding: 1224 1224 999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37043,20 +38048,23 @@ SplineSet
  937.263 -20 l 18,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni04C9
-Encoding: 1225 1225 1225
+Encoding: 1225 1225 1000
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CA
-Encoding: 1226 1226 1226
+Encoding: 1226 1226 1001
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CB
-Encoding: 1227 1227 1227
+Encoding: 1227 1227 1002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37075,8 +38083,9 @@ SplineSet
  272.896 0 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04CC
-Encoding: 1228 1228 1228
+Encoding: 1228 1228 1003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37095,20 +38104,23 @@ SplineSet
  332.147 0 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04CD
-Encoding: 1229 1229 1229
+Encoding: 1229 1229 1004
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CE
-Encoding: 1230 1230 1230
+Encoding: 1230 1230 1005
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CF
-Encoding: 1231 1231 1231
+Encoding: 1231 1231 1006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37121,342 +38133,381 @@ SplineSet
  839.997 1567 l 17,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04D0
-Encoding: 1232 1232 1232
+Encoding: 1232 1232 1007
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1040 1040 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 851 1040 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D1
-Encoding: 1233 1233 1233
+Encoding: 1233 1233 1008
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1072 1072 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 883 1072 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D2
-Encoding: 1234 1234 1234
+Encoding: 1234 1234 1009
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 51 373 2
-Refer: 1040 1040 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 51 373 2
+Refer: 851 1040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D3
-Encoding: 1235 1235 1235
+Encoding: 1235 1235 1010
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 4 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 4 0 2
+Refer: 883 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D4
-Encoding: 1236 1236 1236
+Encoding: 1236 1236 1011
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D5
-Encoding: 1237 1237 1237
+Encoding: 1237 1237 1012
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D6
-Encoding: 1238 1238 1238
+Encoding: 1238 1238 1013
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1045 1045 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
+Refer: 856 1045 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni04D7
-Encoding: 1239 1239 1239
+Encoding: 1239 1239 1014
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 14 0 2
+Refer: 888 1077 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni04D8
-Encoding: 1240 1240 1240
+Encoding: 1240 1240 1015
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 399 399 N 1 0 0 1 0 0 2
+Refer: 335 399 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D9
-Encoding: 1241 1241 1241
+Encoding: 1241 1241 1016
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 477 477 N 1 0 0 1 0 0 2
+Refer: 413 477 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DA
-Encoding: 1242 1242 1242
+Encoding: 1242 1242 1017
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1240 1240 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 1015 1240 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DB
-Encoding: 1243 1243 1243
+Encoding: 1243 1243 1018
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1241 1241 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1016 1241 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DC
-Encoding: 1244 1244 1244
+Encoding: 1244 1244 1019
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 87 373 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 87 373 2
+Refer: 857 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DD
-Encoding: 1245 1245 1245
+Encoding: 1245 1245 1020
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 23 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 23 0 2
+Refer: 889 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DE
-Encoding: 1246 1246 1246
+Encoding: 1246 1246 1021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 36 373 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 36 373 2
+Refer: 858 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DF
-Encoding: 1247 1247 1247
+Encoding: 1247 1247 1022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -12 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -12 0 2
+Refer: 890 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E0
-Encoding: 1248 1248 1248
+Encoding: 1248 1248 1023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E1
-Encoding: 1249 1249 1249
+Encoding: 1249 1249 1024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 572 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E2
-Encoding: 1250 1250 1250
+Encoding: 1250 1250 1025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 859 1048 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E3
-Encoding: 1251 1251 1251
+Encoding: 1251 1251 1026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 891 1080 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E4
-Encoding: 1252 1252 1252
+Encoding: 1252 1252 1027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 859 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E5
-Encoding: 1253 1253 1253
+Encoding: 1253 1253 1028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 891 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E6
-Encoding: 1254 1254 1254
+Encoding: 1254 1254 1029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1054 1054 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 865 1054 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E7
-Encoding: 1255 1255 1255
+Encoding: 1255 1255 1030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1086 1086 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 897 1086 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E8
-Encoding: 1256 1256 1256
+Encoding: 1256 1256 1031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1012 1012 N 1 0 0 1 0 0 2
+Refer: 823 1012 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E9
-Encoding: 1257 1257 1257
+Encoding: 1257 1257 1032
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 2
+Refer: 543 629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EA
-Encoding: 1258 1258 1258
+Encoding: 1258 1258 1033
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1256 1256 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 1031 1256 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EB
-Encoding: 1259 1259 1259
+Encoding: 1259 1259 1034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1257 1257 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1032 1257 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EC
-Encoding: 1260 1260 1260
+Encoding: 1260 1260 1035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -7 373 2
-Refer: 1069 1069 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 -7 373 2
+Refer: 880 1069 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04ED
-Encoding: 1261 1261 1261
+Encoding: 1261 1261 1036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -15 0 2
-Refer: 1101 1101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -15 0 2
+Refer: 912 1101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EE
-Encoding: 1262 1262 1262
+Encoding: 1262 1262 1037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 870 1059 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EF
-Encoding: 1263 1263 1263
+Encoding: 1263 1263 1038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 902 1091 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F0
-Encoding: 1264 1264 1264
+Encoding: 1264 1264 1039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 53 373 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 53 373 2
+Refer: 870 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F1
-Encoding: 1265 1265 1265
+Encoding: 1265 1265 1040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 902 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F2
-Encoding: 1266 1266 1266
+Encoding: 1266 1266 1041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1059 1059 N 1 0 0 1 0 0 2
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
+Refer: 870 1059 N 1 0 0 1 0 0 2
+Refer: 3098 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F3
-Encoding: 1267 1267 1267
+Encoding: 1267 1267 1042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1091 1091 N 1 0 0 1 0 0 2
-Refer: 779 779 N 1 0 0 1 0 0 2
+Refer: 902 1091 N 1 0 0 1 0 0 2
+Refer: 663 779 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F4
-Encoding: 1268 1268 1268
+Encoding: 1268 1268 1043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1063 1063 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 874 1063 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F5
-Encoding: 1269 1269 1269
+Encoding: 1269 1269 1044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1095 1095 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 906 1095 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F6
-Encoding: 1270 1270 1270
+Encoding: 1270 1270 1045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37489,8 +38540,9 @@ SplineSet
  746.701 0 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F7
-Encoding: 1271 1271 1271
+Encoding: 1271 1271 1046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37520,170 +38572,195 @@ SplineSet
  757.953 0 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04F8
-Encoding: 1272 1272 1272
+Encoding: 1272 1272 1047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 43 373 2
-Refer: 1067 1067 N 1 0 0 1 0 0 2
+Refer: 3088 -1 N 1 0 0 1 43 373 2
+Refer: 878 1067 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F9
-Encoding: 1273 1273 1273
+Encoding: 1273 1273 1048
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1099 1099 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 910 1099 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0500
-Encoding: 1280 1280 1280
+Encoding: 1280 1280 1049
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0501
-Encoding: 1281 1281 1281
+Encoding: 1281 1281 1050
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0502
-Encoding: 1282 1282 1282
+Encoding: 1282 1282 1051
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0503
-Encoding: 1283 1283 1283
+Encoding: 1283 1283 1052
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0504
-Encoding: 1284 1284 1284
+Encoding: 1284 1284 1053
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0505
-Encoding: 1285 1285 1285
+Encoding: 1285 1285 1054
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0506
-Encoding: 1286 1286 1286
+Encoding: 1286 1286 1055
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0507
-Encoding: 1287 1287 1287
+Encoding: 1287 1287 1056
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0508
-Encoding: 1288 1288 1288
+Encoding: 1288 1288 1057
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0509
-Encoding: 1289 1289 1289
+Encoding: 1289 1289 1058
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050A
-Encoding: 1290 1290 1290
+Encoding: 1290 1290 1059
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050B
-Encoding: 1291 1291 1291
+Encoding: 1291 1291 1060
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050C
-Encoding: 1292 1292 1292
+Encoding: 1292 1292 1061
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050D
-Encoding: 1293 1293 1293
+Encoding: 1293 1293 1062
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050E
-Encoding: 1294 1294 1294
+Encoding: 1294 1294 1063
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050F
-Encoding: 1295 1295 1295
+Encoding: 1295 1295 1064
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0510
-Encoding: 1296 1296 1296
+Encoding: 1296 1296 1065
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 400 400 N 1 0 0 1 0 0 3
+Refer: 336 400 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0511
-Encoding: 1297 1297 1297
+Encoding: 1297 1297 1066
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 3
+Refer: 775 949 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni051A
-Encoding: 1306 1306 1306
+Encoding: 1306 1306 1067
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051B
-Encoding: 1307 1307 1307
+Encoding: 1307 1307 1068
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051C
-Encoding: 1308 1308 1308
+Encoding: 1308 1308 1069
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051D
-Encoding: 1309 1309 1309
+Encoding: 1309 1309 1070
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0531
-Encoding: 1329 1329 1329
+Encoding: 1329 1329 1071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37721,8 +38798,9 @@ SplineSet
  618 458 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0532
-Encoding: 1330 1330 1330
+Encoding: 1330 1330 1072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37757,8 +38835,9 @@ SplineSet
  1088 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0533
-Encoding: 1331 1331 1331
+Encoding: 1331 1331 1073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37802,8 +38881,9 @@ SplineSet
  878 1058 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0534
-Encoding: 1332 1332 1332
+Encoding: 1332 1332 1074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37838,8 +38918,9 @@ SplineSet
  107 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0535
-Encoding: 1333 1333 1333
+Encoding: 1333 1333 1075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37874,8 +38955,9 @@ SplineSet
  1012 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0536
-Encoding: 1334 1334 1334
+Encoding: 1334 1334 1076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37922,8 +39004,9 @@ SplineSet
  1196 1067 1196 1067 1163 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0537
-Encoding: 1335 1335 1335
+Encoding: 1335 1335 1077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37942,8 +39025,9 @@ SplineSet
  210 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0538
-Encoding: 1336 1336 1336
+Encoding: 1336 1336 1078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -37976,8 +39060,9 @@ SplineSet
  1088 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0539
-Encoding: 1337 1337 1337
+Encoding: 1337 1337 1079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38039,8 +39124,9 @@ SplineSet
  540 499 540 499 524 415 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni053A
-Encoding: 1338 1338 1338
+Encoding: 1338 1338 1080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38084,8 +39170,9 @@ SplineSet
  594 950 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni053B
-Encoding: 1339 1339 1339
+Encoding: 1339 1339 1081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38116,8 +39203,9 @@ SplineSet
  1035 494 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053C
-Encoding: 1340 1340 1340
+Encoding: 1340 1340 1082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38132,8 +39220,9 @@ SplineSet
  299 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053D
-Encoding: 1341 1341 1341
+Encoding: 1341 1341 1083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38170,8 +39259,9 @@ SplineSet
  723 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053E
-Encoding: 1342 1342 1342
+Encoding: 1342 1342 1084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38238,8 +39328,9 @@ SplineSet
  307 749 307 749 282 621 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni053F
-Encoding: 1343 1343 1343
+Encoding: 1343 1343 1085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38270,8 +39361,9 @@ SplineSet
  939 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0540
-Encoding: 1344 1344 1344
+Encoding: 1344 1344 1086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38304,8 +39396,9 @@ SplineSet
  1031 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0541
-Encoding: 1345 1345 1345
+Encoding: 1345 1345 1087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38364,8 +39457,9 @@ SplineSet
  444 408 444 408 370 408 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: uni0542
-Encoding: 1346 1346 1346
+Encoding: 1346 1346 1088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38398,8 +39492,9 @@ SplineSet
  107 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0543
-Encoding: 1347 1347 1347
+Encoding: 1347 1347 1089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38438,8 +39533,9 @@ SplineSet
  440 669 440 669 401 618 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni0544
-Encoding: 1348 1348 1348
+Encoding: 1348 1348 1090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38472,8 +39568,9 @@ SplineSet
  937 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0545
-Encoding: 1349 1349 1349
+Encoding: 1349 1349 1091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38531,8 +39628,9 @@ SplineSet
  1122 506 1122 506 1110 444 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0546
-Encoding: 1350 1350 1350
+Encoding: 1350 1350 1092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38565,8 +39663,9 @@ SplineSet
  1125 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0547
-Encoding: 1351 1351 1351
+Encoding: 1351 1351 1093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38617,8 +39716,9 @@ SplineSet
  304 722 304 722 280 596 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0548
-Encoding: 1352 1352 1352
+Encoding: 1352 1352 1094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38649,8 +39749,9 @@ SplineSet
  937 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0549
-Encoding: 1353 1353 1353
+Encoding: 1353 1353 1095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38695,8 +39796,9 @@ SplineSet
  933 769 933 769 957 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054A
-Encoding: 1354 1354 1354
+Encoding: 1354 1354 1096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38730,8 +39832,9 @@ SplineSet
  910 1342 910 1342 825 1351 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054B
-Encoding: 1355 1355 1355
+Encoding: 1355 1355 1097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38798,8 +39901,9 @@ SplineSet
  938 828 938 828 951 895 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni054C
-Encoding: 1356 1356 1356
+Encoding: 1356 1356 1098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38834,8 +39938,9 @@ SplineSet
  107 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054D
-Encoding: 1357 1357 1357
+Encoding: 1357 1357 1099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38866,8 +39971,9 @@ SplineSet
  294 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054E
-Encoding: 1358 1358 1358
+Encoding: 1358 1358 1100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38900,8 +40006,9 @@ SplineSet
  105 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054F
-Encoding: 1359 1359 1359
+Encoding: 1359 1359 1101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38962,8 +40069,9 @@ SplineSet
  26 340 26 340 46 447 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0550
-Encoding: 1360 1360 1360
+Encoding: 1360 1360 1102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38994,8 +40102,9 @@ SplineSet
  1107 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0551
-Encoding: 1361 1361 1361
+Encoding: 1361 1361 1103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39065,8 +40174,9 @@ SplineSet
  701 1520 701 1520 808 1520 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0552
-Encoding: 1362 1362 1362
+Encoding: 1362 1362 1104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39083,8 +40193,9 @@ SplineSet
  483 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0553
-Encoding: 1363 1363 1363
+Encoding: 1363 1363 1105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39135,8 +40246,9 @@ SplineSet
  403 158 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0554
-Encoding: 1364 1364 1364
+Encoding: 1364 1364 1106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39189,16 +40301,18 @@ SplineSet
  906 1356 906 1356 828 1356 c 0,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni0555
-Encoding: 1365 1365 1365
+Encoding: 1365 1365 1107
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 3
+Refer: 48 79 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0556
-Encoding: 1366 1366 1366
+Encoding: 1366 1366 1108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39261,16 +40375,18 @@ SplineSet
  906 438 906 438 926 537 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: uni0559
-Encoding: 1369 1369 1369
+Encoding: 1369 1369 1109
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 0 3
+Refer: 616 703 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni055A
-Encoding: 1370 1370 1370
+Encoding: 1370 1370 1110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39285,16 +40401,18 @@ SplineSet
  597 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055B
-Encoding: 1371 1371 1371
+Encoding: 1371 1371 1111
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -97 7 3
+Refer: 116 180 N 1 0 0 1 -97 7 3
 EndChar
+
 StartChar: uni055C
-Encoding: 1372 1372 1372
+Encoding: 1372 1372 1112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39321,16 +40439,18 @@ SplineSet
  335 1335 335 1335 322 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055D
-Encoding: 1373 1373 1373
+Encoding: 1373 1373 1113
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 0 3
+Refer: 65 96 N 1 0 0 1 98 0 3
 EndChar
+
 StartChar: uni055E
-Encoding: 1374 1374 1374
+Encoding: 1374 1374 1114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39372,8 +40492,9 @@ SplineSet
  314 1422 314 1422 283 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055F
-Encoding: 1375 1375 1375
+Encoding: 1375 1375 1115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39388,8 +40509,9 @@ SplineSet
  159 1265 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0561
-Encoding: 1377 1377 1377
+Encoding: 1377 1377 1116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39428,8 +40550,9 @@ SplineSet
  505 -27 505 -27 477 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0562
-Encoding: 1378 1378 1378
+Encoding: 1378 1378 1117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39458,8 +40581,9 @@ SplineSet
  1148 923 1148 923 1103 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0563
-Encoding: 1379 1379 1379
+Encoding: 1379 1379 1118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39498,8 +40622,9 @@ SplineSet
  348 770 348 770 306 555 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0564
-Encoding: 1380 1380 1380
+Encoding: 1380 1380 1119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39528,8 +40653,9 @@ SplineSet
  1079 923 1079 923 1034 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0565
-Encoding: 1381 1381 1381
+Encoding: 1381 1381 1120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39558,8 +40684,9 @@ SplineSet
  53 195 53 195 98 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0566
-Encoding: 1382 1382 1382
+Encoding: 1382 1382 1121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39596,8 +40723,9 @@ SplineSet
  348 770 348 770 306 555 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0567
-Encoding: 1383 1383 1383
+Encoding: 1383 1383 1122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39616,8 +40744,9 @@ SplineSet
  788 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0568
-Encoding: 1384 1384 1384
+Encoding: 1384 1384 1123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39644,8 +40773,9 @@ SplineSet
  1148 923 1148 923 1103 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0569
-Encoding: 1385 1385 1385
+Encoding: 1385 1385 1124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39705,8 +40835,9 @@ SplineSet
  606 107 606 107 644 107 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni056A
-Encoding: 1386 1386 1386
+Encoding: 1386 1386 1125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39750,8 +40881,9 @@ SplineSet
  1032 977 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056B
-Encoding: 1387 1387 1387
+Encoding: 1387 1387 1126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39776,8 +40908,9 @@ SplineSet
  934 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056C
-Encoding: 1388 1388 1388
+Encoding: 1388 1388 1127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39792,8 +40925,9 @@ SplineSet
  388 -283 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056D
-Encoding: 1389 1389 1389
+Encoding: 1389 1389 1128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39836,8 +40970,9 @@ SplineSet
  683 479 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni056E
-Encoding: 1390 1390 1390
+Encoding: 1390 1390 1129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39888,8 +41023,9 @@ SplineSet
  299 620 299 620 283 535 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni056F
-Encoding: 1391 1391 1391
+Encoding: 1391 1391 1130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39914,16 +41050,18 @@ SplineSet
  380 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0570
-Encoding: 1392 1392 1392
+Encoding: 1392 1392 1131
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 -6 0 3
+Refer: 73 104 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0571
-Encoding: 1393 1393 1393
+Encoding: 1393 1393 1132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39989,8 +41127,9 @@ SplineSet
  316 532 316 532 301 453 c 0,49,50
 EndSplineSet
 EndChar
+
 StartChar: uni0572
-Encoding: 1394 1394 1394
+Encoding: 1394 1394 1133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40017,8 +41156,9 @@ SplineSet
  1079 923 1079 923 1034 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0573
-Encoding: 1395 1395 1395
+Encoding: 1395 1395 1134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40076,8 +41216,9 @@ SplineSet
  344 583 344 583 315 435 c 0,41,42
 EndSplineSet
 EndChar
+
 StartChar: uni0574
-Encoding: 1396 1396 1396
+Encoding: 1396 1396 1135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40104,8 +41245,9 @@ SplineSet
  173 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0575
-Encoding: 1397 1397 1397
+Encoding: 1397 1397 1136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40123,8 +41265,9 @@ SplineSet
  881 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0576
-Encoding: 1398 1398 1398
+Encoding: 1398 1398 1137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40151,8 +41294,9 @@ SplineSet
  398 1413 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0577
-Encoding: 1399 1399 1399
+Encoding: 1399 1399 1138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40205,16 +41349,18 @@ SplineSet
  279 -180 279 -180 274 -207 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0578
-Encoding: 1400 1400 1400
+Encoding: 1400 1400 1139
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 -6 0 3
+Refer: 79 110 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0579
-Encoding: 1401 1401 1401
+Encoding: 1401 1401 1140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40264,8 +41410,9 @@ SplineSet
  376 -283 376 -283 399 -283 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057A
-Encoding: 1402 1402 1402
+Encoding: 1402 1402 1141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40303,8 +41450,9 @@ SplineSet
  544 -27 544 -27 516 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057B
-Encoding: 1403 1403 1403
+Encoding: 1403 1403 1142
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40374,8 +41522,9 @@ SplineSet
  783 994 783 994 718 994 c 0,49,50
 EndSplineSet
 EndChar
+
 StartChar: uni057C
-Encoding: 1404 1404 1404
+Encoding: 1404 1404 1143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40415,16 +41564,18 @@ SplineSet
  724 987 724 987 651 987 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057D
-Encoding: 1405 1405 1405
+Encoding: 1405 1405 1144
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 -6 0 3
+Refer: 86 117 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni057E
-Encoding: 1406 1406 1406
+Encoding: 1406 1406 1145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40451,8 +41602,9 @@ SplineSet
  29 195 29 195 74 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057F
-Encoding: 1407 1407 1407
+Encoding: 1407 1407 1146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40496,8 +41648,9 @@ SplineSet
  1020 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0580
-Encoding: 1408 1408 1408
+Encoding: 1408 1408 1147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40522,16 +41675,18 @@ SplineSet
  1153 923 1153 923 1108 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0581
-Encoding: 1409 1409 1409
+Encoding: 1409 1409 1148
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 34 0 3
+Refer: 72 103 N 1 0 0 1 34 0 3
 EndChar
+
 StartChar: uni0582
-Encoding: 1410 1410 1410
+Encoding: 1410 1410 1149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40546,8 +41701,9 @@ SplineSet
  351 143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0583
-Encoding: 1411 1411 1411
+Encoding: 1411 1411 1150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40591,8 +41747,9 @@ SplineSet
  1019 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0584
-Encoding: 1412 1412 1412
+Encoding: 1412 1412 1151
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40635,16 +41792,18 @@ SplineSet
  928 344 928 344 970 559 c 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0585
-Encoding: 1413 1413 1413
+Encoding: 1413 1413 1152
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 3
+Refer: 80 111 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0586
-Encoding: 1414 1414 1414
+Encoding: 1414 1414 1153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40700,8 +41859,9 @@ SplineSet
  995 482 995 482 1013 576 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni0587
-Encoding: 1415 1415 1415
+Encoding: 1415 1415 1154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40728,8 +41888,9 @@ SplineSet
  -39 195 -39 195 6 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0589
-Encoding: 1417 1417 1417
+Encoding: 1417 1417 1155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40747,8 +41908,9 @@ SplineSet
  593 850 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni058A
-Encoding: 1418 1418 1418
+Encoding: 1418 1418 1156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40763,8 +41925,9 @@ SplineSet
  379 643 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0E3F
-Encoding: 3647 3647 3647
+Encoding: 3647 3647 1157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40812,8 +41975,9 @@ SplineSet
  688 769 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0E81
-Encoding: 3713 3713 3713
+Encoding: 3713 3713 1158
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1123.56 0 basechar 0
@@ -40850,8 +42014,9 @@ SplineSet
  416 184 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni0E82
-Encoding: 3714 3714 3714
+Encoding: 3714 3714 1159
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1353.42 1184 basechar 0
@@ -40890,8 +42055,9 @@ SplineSet
  549 603 549 603 326 603 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E84
-Encoding: 3716 3716 3716
+Encoding: 3716 3716 1160
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1351.96 1184 basechar 0
@@ -40936,8 +42102,9 @@ SplineSet
  6 -21 6 -21 78 349 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni0E87
-Encoding: 3719 3719 3719
+Encoding: 3719 3719 1161
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1397.45 1184 basechar 0
@@ -40969,8 +42136,9 @@ SplineSet
  655 1008 655 1008 589 1006 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni0E88
-Encoding: 3720 3720 3720
+Encoding: 3720 3720 1162
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1348.75 1184 basechar 0
@@ -41008,8 +42176,9 @@ SplineSet
  375 1178 375 1178 727 1178 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8A
-Encoding: 3722 3722 3722
+Encoding: 3722 3722 1163
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1072.54 -492 basechar 0
@@ -41053,8 +42222,9 @@ SplineSet
  552 631 552 631 359 603 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8D
-Encoding: 3725 3725 3725
+Encoding: 3725 3725 1164
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1350.79 1184 basechar 0
@@ -41093,8 +42263,9 @@ SplineSet
  278 416 278 416 256 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E94
-Encoding: 3732 3732 3732
+Encoding: 3732 3732 1165
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1354.48 1184 basechar 0
@@ -41124,8 +42295,9 @@ SplineSet
  817 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E95
-Encoding: 3733 3733 3733
+Encoding: 3733 3733 1166
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1350.89 1184 basechar 0
@@ -41165,8 +42337,9 @@ SplineSet
  805 747 805 747 677 747 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E96
-Encoding: 3734 3734 3734
+Encoding: 3734 3734 1167
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1073.7 -492 basechar 0
@@ -41204,8 +42377,9 @@ SplineSet
  446 351 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E97
-Encoding: 3735 3735 3735
+Encoding: 3735 3735 1168
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1354.49 1184 basechar 0
@@ -41240,8 +42414,9 @@ SplineSet
  153 790 153 790 188 970 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E99
-Encoding: 3737 3737 3737
+Encoding: 3737 3737 1169
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1352.83 1184 basechar 0
@@ -41275,8 +42450,9 @@ SplineSet
  -41 -29 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9A
-Encoding: 3738 3738 3738
+Encoding: 3738 3738 1170
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1353.22 1184 basechar 0
@@ -41305,8 +42481,9 @@ SplineSet
  12 -16 12 -16 77 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9B
-Encoding: 3739 3739 3739
+Encoding: 3739 3739 1171
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1386.1 1552 basechar 0
@@ -41335,8 +42512,9 @@ SplineSet
  -28 -16 -28 -16 38 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9C
-Encoding: 3740 3740 3740
+Encoding: 3740 3740 1172
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1337.82 1184 basechar 0
@@ -41395,8 +42573,9 @@ SplineSet
  817 -17 817 -17 694 -17 c 0,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9D
-Encoding: 3741 3741 3741
+Encoding: 3741 3741 1173
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1386.1 1552 basechar 0
@@ -41439,8 +42618,9 @@ SplineSet
  391 1017 391 1017 359 1017 c 0,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0E9E
-Encoding: 3742 3742 3742
+Encoding: 3742 3742 1174
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1353.13 1184 basechar 0
@@ -41480,8 +42660,9 @@ SplineSet
  201 133 201 133 350 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9F
-Encoding: 3743 3743 3743
+Encoding: 3743 3743 1175
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1386.11 1552 basechar 0
@@ -41521,8 +42702,9 @@ SplineSet
  162 133 162 133 311 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA1
-Encoding: 3745 3745 3745
+Encoding: 3745 3745 1176
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1357.11 1184 basechar 0
@@ -41548,8 +42730,9 @@ SplineSet
  467 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA2
-Encoding: 3746 3746 3746
+Encoding: 3746 3746 1177
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1385.1 1552 basechar 0
@@ -41588,8 +42771,9 @@ SplineSet
  240 416 240 416 219 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA3
-Encoding: 3747 3747 3747
+Encoding: 3747 3747 1178
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1351.67 1184 basechar 0
@@ -41626,8 +42810,9 @@ SplineSet
  866 145 866 145 901 328 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA5
-Encoding: 3749 3749 3749
+Encoding: 3749 3749 1179
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1351.67 1184 basechar 0
@@ -41667,8 +42852,9 @@ SplineSet
  360 1165 360 1165 737 1164 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA7
-Encoding: 3751 3751 3751
+Encoding: 3751 3751 1180
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1354.29 1184 basechar 0
@@ -41699,8 +42885,9 @@ SplineSet
  183 802 l 1,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0EAA
-Encoding: 3754 3754 3754
+Encoding: 3754 3754 1181
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1325.28 1184 basechar 0
@@ -41747,8 +42934,9 @@ SplineSet
  297 856 297 856 626 855 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni0EAB
-Encoding: 3755 3755 3755
+Encoding: 3755 3755 1182
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1351.08 1184 basechar 0
@@ -41793,8 +42981,9 @@ SplineSet
  736 -25 736 -25 328 -24 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAD
-Encoding: 3757 3757 3757
+Encoding: 3757 3757 1183
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1351.67 1184 basechar 0
@@ -41833,8 +43022,9 @@ SplineSet
  964 696 964 696 995 857 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni0EAE
-Encoding: 3758 3758 3758
+Encoding: 3758 3758 1184
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1344.28 1184 basechar 0
@@ -41876,8 +43066,9 @@ SplineSet
  490 132 490 132 501 132 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAF
-Encoding: 3759 3759 3759
+Encoding: 3759 3759 1185
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41910,17 +43101,19 @@ SplineSet
  216 -218 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB0
-Encoding: 3760 3760 3760
+Encoding: 3760 3760 1186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3761 3761 N 1 0 0 1 -127 -651 2
-Refer: 3761 3761 N 1 0 0 1 -259 -1335 2
+Refer: 1187 3761 N 1 0 0 1 -127 -651 2
+Refer: 1187 3761 N 1 0 0 1 -259 -1335 2
 EndChar
+
 StartChar: uni0EB1
-Encoding: 3761 3761 3761
+Encoding: 3761 3761 1187
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1454.59 1140 mark 0
@@ -41946,8 +43139,9 @@ SplineSet
  689 1520 689 1520 702 1583 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0EB2
-Encoding: 3762 3762 3762
+Encoding: 3762 3762 1188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41971,17 +43165,19 @@ SplineSet
  473 772 473 772 462 717 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0EB3
-Encoding: 3763 3763 3763
+Encoding: 3763 3763 1189
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3789 3789 N 1 0 0 1 -1233 0 2
-Refer: 3762 3762 N 1 0 0 1 0 0 2
+Refer: 1203 3789 N 1 0 0 1 -1233 0 2
+Refer: 1188 3762 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0EB4
-Encoding: 3764 3764 3764
+Encoding: 3764 3764 1190
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.35 1143 mark 0
@@ -42001,8 +43197,9 @@ SplineSet
  311 1770 311 1770 272 1573 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB5
-Encoding: 3765 3765 3765
+Encoding: 3765 3765 1191
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.93 1143 mark 0
@@ -42026,8 +43223,9 @@ SplineSet
  311 1770 311 1770 273 1573 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB6
-Encoding: 3766 3766 3766
+Encoding: 3766 3766 1192
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.35 1143 mark 0
@@ -42052,8 +43250,9 @@ SplineSet
  775 1692 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB7
-Encoding: 3767 3767 3767
+Encoding: 3767 3767 1193
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1148.93 1143 mark 0
@@ -42082,8 +43281,9 @@ SplineSet
  771 1686 l 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB8
-Encoding: 3768 3768 3768
+Encoding: 3768 3768 1194
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -42107,8 +43307,9 @@ SplineSet
  490 -621 l 17,5,6
 EndSplineSet
 EndChar
+
 StartChar: uni0EB9
-Encoding: 3769 3769 3769
+Encoding: 3769 3769 1195
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -42136,8 +43337,9 @@ SplineSet
  799 -626 799 -626 509 -626 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0EBB
-Encoding: 3771 3771 3771
+Encoding: 3771 3771 1196
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1152.24 1140 mark 0
@@ -42163,8 +43365,9 @@ SplineSet
  345 1465 345 1465 357.5 1528 c 128,-1,22
 EndSplineSet
 EndChar
+
 StartChar: uni0EBC
-Encoding: 3772 3772 3772
+Encoding: 3772 3772 1197
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1295.98 0 mark 0
@@ -42190,8 +43393,9 @@ SplineSet
  1016 -539 1016 -539 804 -539 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0EC8
-Encoding: 3784 3784 3784
+Encoding: 3784 3784 1198
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1170.12 1120 mark 0
@@ -42205,8 +43409,9 @@ SplineSet
  561 1622 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EC9
-Encoding: 3785 3785 3785
+Encoding: 3785 3785 1199
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1157.97 1150 mark 0
@@ -42234,8 +43439,9 @@ SplineSet
  1192 1768 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0ECA
-Encoding: 3786 3786 3786
+Encoding: 3786 3786 1200
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1164.68 1150 mark 0
@@ -42274,8 +43480,9 @@ SplineSet
  386 1223 386 1223 282 1224 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECB
-Encoding: 3787 3787 3787
+Encoding: 3787 3787 1201
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1152.33 1120 mark 0
@@ -42297,17 +43504,19 @@ SplineSet
  316 1464 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0ECC
-Encoding: 3788 3788 3788
+Encoding: 3788 3788 1202
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
 LayerCount: 2
 Fore
-Refer: 3772 3772 N 1 0 0 1 0 1872 2
+Refer: 1197 3772 N 1 0 0 1 0 1872 2
 EndChar
+
 StartChar: uni0ECD
-Encoding: 3789 3789 3789
+Encoding: 3789 3789 1203
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1166.91 1120 mark 0
@@ -42326,8 +43535,9 @@ SplineSet
  554 1542 554 1542 540 1470 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni10D0
-Encoding: 4304 4304 4304
+Encoding: 4304 4304 1204
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42354,8 +43564,9 @@ SplineSet
  1069 542 1069 542 1060 495 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D1
-Encoding: 4305 4305 4305
+Encoding: 4305 4305 1205
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42388,8 +43599,9 @@ SplineSet
  765 145 765 145 843 545 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni10D2
-Encoding: 4306 4306 4306
+Encoding: 4306 4306 1206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42427,8 +43639,9 @@ SplineSet
  829 -276 829 -276 891 43 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D3
-Encoding: 4307 4307 4307
+Encoding: 4307 4307 1207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42476,8 +43689,9 @@ SplineSet
  966 185 966 185 1015 441 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D4
-Encoding: 4308 4308 4308
+Encoding: 4308 4308 1208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42509,8 +43723,9 @@ SplineSet
  1009 -32 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D5
-Encoding: 4309 4309 4309
+Encoding: 4309 4309 1209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42552,8 +43767,9 @@ SplineSet
  1005 -45 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D6
-Encoding: 4310 4310 4310
+Encoding: 4310 4310 1210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42591,8 +43807,9 @@ SplineSet
  726 984 726 984 766 1202 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D7
-Encoding: 4311 4311 4311
+Encoding: 4311 4311 1211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42632,8 +43849,9 @@ SplineSet
  510 145 510 145 555 388 c 2,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D8
-Encoding: 4312 4312 4312
+Encoding: 4312 4312 1212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42656,8 +43874,9 @@ SplineSet
  1096 636 1096 636 1079 547 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D9
-Encoding: 4313 4313 4313
+Encoding: 4313 4313 1213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42692,8 +43911,9 @@ SplineSet
  1012 -30 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DA
-Encoding: 4314 4314 4314
+Encoding: 4314 4314 1214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42726,8 +43946,9 @@ SplineSet
  953 904 953 904 735 904 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DB
-Encoding: 4315 4315 4315
+Encoding: 4315 4315 1215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42760,8 +43981,9 @@ SplineSet
  765 145 765 145 833 495 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni10DC
-Encoding: 4316 4316 4316
+Encoding: 4316 4316 1216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42793,8 +44015,9 @@ SplineSet
  769 146 769 146 846 545 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10DD
-Encoding: 4317 4317 4317
+Encoding: 4317 4317 1217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42833,8 +44056,9 @@ SplineSet
  1166 454 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DE
-Encoding: 4318 4318 4318
+Encoding: 4318 4318 1218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42871,8 +44095,9 @@ SplineSet
  1028 529 1028 529 1017 474 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DF
-Encoding: 4319 4319 4319
+Encoding: 4319 4319 1219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42901,8 +44126,9 @@ SplineSet
  1008 -18 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E0
-Encoding: 4320 4320 4320
+Encoding: 4320 4320 1220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42945,8 +44171,9 @@ SplineSet
  1161 690 1161 690 1143 596 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10E1
-Encoding: 4321 4321 4321
+Encoding: 4321 4321 1221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42975,8 +44202,9 @@ SplineSet
  1037 567 1037 567 1027 515 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E2
-Encoding: 4322 4322 4322
+Encoding: 4322 4322 1222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43004,8 +44232,9 @@ SplineSet
  303 777 303 777 208 290 c 0,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni10E3
-Encoding: 4323 4323 4323
+Encoding: 4323 4323 1223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43047,8 +44276,9 @@ SplineSet
  1030 -43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E4
-Encoding: 4324 4324 4324
+Encoding: 4324 4324 1224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43105,8 +44335,9 @@ SplineSet
  660 727 l 2,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni10E5
-Encoding: 4325 4325 4325
+Encoding: 4325 4325 1225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43141,8 +44372,9 @@ SplineSet
  980 67 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E6
-Encoding: 4326 4326 4326
+Encoding: 4326 4326 1226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43187,8 +44419,9 @@ SplineSet
  139 -201 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E7
-Encoding: 4327 4327 4327
+Encoding: 4327 4327 1227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43218,8 +44451,9 @@ SplineSet
  1007 -47 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E8
-Encoding: 4328 4328 4328
+Encoding: 4328 4328 1228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43259,8 +44493,9 @@ SplineSet
  766 145 766 145 839 515 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10E9
-Encoding: 4329 4329 4329
+Encoding: 4329 4329 1229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43294,8 +44529,9 @@ SplineSet
  850 1149 850 1149 865 1224 c 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10EA
-Encoding: 4330 4330 4330
+Encoding: 4330 4330 1230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43334,8 +44570,9 @@ SplineSet
  1184 670 1184 670 1179 645 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10EB
-Encoding: 4331 4331 4331
+Encoding: 4331 4331 1231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43360,8 +44597,9 @@ SplineSet
  769 145 769 145 842 519 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EC
-Encoding: 4332 4332 4332
+Encoding: 4332 4332 1232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43403,8 +44641,9 @@ SplineSet
  372 904 372 904 306 565 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10ED
-Encoding: 4333 4333 4333
+Encoding: 4333 4333 1233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43454,8 +44693,9 @@ SplineSet
  451 956 451 956 414 763 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni10EE
-Encoding: 4334 4334 4334
+Encoding: 4334 4334 1234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43481,8 +44721,9 @@ SplineSet
  769 145 769 145 843 525 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EF
-Encoding: 4335 4335 4335
+Encoding: 4335 4335 1235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43519,8 +44760,9 @@ SplineSet
  1012 78 1012 78 1005 41 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F0
-Encoding: 4336 4336 4336
+Encoding: 4336 4336 1236
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43567,8 +44809,9 @@ SplineSet
  999 382 999 382 995 360 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F1
-Encoding: 4337 4337 4337
+Encoding: 4337 4337 1237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43630,8 +44873,9 @@ SplineSet
  948 -85 948 -85 941 -124 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F2
-Encoding: 4338 4338 4338
+Encoding: 4338 4338 1238
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43660,8 +44904,9 @@ SplineSet
  445 902 445 902 370 519 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10F3
-Encoding: 4339 4339 4339
+Encoding: 4339 4339 1239
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43697,8 +44942,9 @@ SplineSet
  1012 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F4
-Encoding: 4340 4340 4340
+Encoding: 4340 4340 1240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43738,8 +44984,9 @@ SplineSet
  962 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F5
-Encoding: 4341 4341 4341
+Encoding: 4341 4341 1241
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43784,8 +45031,9 @@ SplineSet
  453 1415 453 1415 414 1218 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10F6
-Encoding: 4342 4342 4342
+Encoding: 4342 4342 1242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43831,8 +45079,9 @@ SplineSet
  957 145 957 145 989 312 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F7
-Encoding: 4343 4343 4343
+Encoding: 4343 4343 1243
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43865,8 +45114,9 @@ SplineSet
  1075 51 1075 51 1065 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F8
-Encoding: 4344 4344 4344
+Encoding: 4344 4344 1244
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43900,8 +45150,9 @@ SplineSet
  297 1022 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F9
-Encoding: 4345 4345 4345
+Encoding: 4345 4345 1245
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43934,8 +45185,9 @@ SplineSet
  418 917 418 917 360 619 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni10FA
-Encoding: 4346 4346 4346
+Encoding: 4346 4346 1246
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43965,8 +45217,9 @@ SplineSet
  636 -135 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FB
-Encoding: 4347 4347 4347
+Encoding: 4347 4347 1247
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43989,8 +45242,9 @@ SplineSet
  233 224 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FC
-Encoding: 4348 4348 4348
+Encoding: 4348 4348 1248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44019,524 +45273,611 @@ SplineSet
  672 836 672 836 712 1043 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni13A0
-Encoding: 5024 5024 5024
+Encoding: 5024 5024 1249
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A1
-Encoding: 5025 5025 5025
+Encoding: 5025 5025 1250
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A2
-Encoding: 5026 5026 5026
+Encoding: 5026 5026 1251
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A3
-Encoding: 5027 5027 5027
+Encoding: 5027 5027 1252
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A4
-Encoding: 5028 5028 5028
+Encoding: 5028 5028 1253
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A5
-Encoding: 5029 5029 5029
+Encoding: 5029 5029 1254
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A6
-Encoding: 5030 5030 5030
+Encoding: 5030 5030 1255
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A7
-Encoding: 5031 5031 5031
+Encoding: 5031 5031 1256
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A8
-Encoding: 5032 5032 5032
+Encoding: 5032 5032 1257
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A9
-Encoding: 5033 5033 5033
+Encoding: 5033 5033 1258
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AA
-Encoding: 5034 5034 5034
+Encoding: 5034 5034 1259
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AB
-Encoding: 5035 5035 5035
+Encoding: 5035 5035 1260
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AC
-Encoding: 5036 5036 5036
+Encoding: 5036 5036 1261
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AD
-Encoding: 5037 5037 5037
+Encoding: 5037 5037 1262
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AE
-Encoding: 5038 5038 5038
+Encoding: 5038 5038 1263
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AF
-Encoding: 5039 5039 5039
+Encoding: 5039 5039 1264
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B0
-Encoding: 5040 5040 5040
+Encoding: 5040 5040 1265
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B1
-Encoding: 5041 5041 5041
+Encoding: 5041 5041 1266
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B2
-Encoding: 5042 5042 5042
+Encoding: 5042 5042 1267
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B3
-Encoding: 5043 5043 5043
+Encoding: 5043 5043 1268
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B4
-Encoding: 5044 5044 5044
+Encoding: 5044 5044 1269
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B5
-Encoding: 5045 5045 5045
+Encoding: 5045 5045 1270
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B6
-Encoding: 5046 5046 5046
+Encoding: 5046 5046 1271
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B7
-Encoding: 5047 5047 5047
+Encoding: 5047 5047 1272
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B8
-Encoding: 5048 5048 5048
+Encoding: 5048 5048 1273
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B9
-Encoding: 5049 5049 5049
+Encoding: 5049 5049 1274
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BA
-Encoding: 5050 5050 5050
+Encoding: 5050 5050 1275
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BB
-Encoding: 5051 5051 5051
+Encoding: 5051 5051 1276
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BC
-Encoding: 5052 5052 5052
+Encoding: 5052 5052 1277
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BD
-Encoding: 5053 5053 5053
+Encoding: 5053 5053 1278
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BE
-Encoding: 5054 5054 5054
+Encoding: 5054 5054 1279
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BF
-Encoding: 5055 5055 5055
+Encoding: 5055 5055 1280
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C0
-Encoding: 5056 5056 5056
+Encoding: 5056 5056 1281
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C1
-Encoding: 5057 5057 5057
+Encoding: 5057 5057 1282
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C2
-Encoding: 5058 5058 5058
+Encoding: 5058 5058 1283
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C3
-Encoding: 5059 5059 5059
+Encoding: 5059 5059 1284
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C4
-Encoding: 5060 5060 5060
+Encoding: 5060 5060 1285
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C5
-Encoding: 5061 5061 5061
+Encoding: 5061 5061 1286
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C6
-Encoding: 5062 5062 5062
+Encoding: 5062 5062 1287
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C7
-Encoding: 5063 5063 5063
+Encoding: 5063 5063 1288
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C8
-Encoding: 5064 5064 5064
+Encoding: 5064 5064 1289
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C9
-Encoding: 5065 5065 5065
+Encoding: 5065 5065 1290
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CA
-Encoding: 5066 5066 5066
+Encoding: 5066 5066 1291
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CB
-Encoding: 5067 5067 5067
+Encoding: 5067 5067 1292
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CC
-Encoding: 5068 5068 5068
+Encoding: 5068 5068 1293
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CD
-Encoding: 5069 5069 5069
+Encoding: 5069 5069 1294
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CE
-Encoding: 5070 5070 5070
+Encoding: 5070 5070 1295
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CF
-Encoding: 5071 5071 5071
+Encoding: 5071 5071 1296
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D0
-Encoding: 5072 5072 5072
+Encoding: 5072 5072 1297
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D1
-Encoding: 5073 5073 5073
+Encoding: 5073 5073 1298
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D2
-Encoding: 5074 5074 5074
+Encoding: 5074 5074 1299
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D3
-Encoding: 5075 5075 5075
+Encoding: 5075 5075 1300
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D4
-Encoding: 5076 5076 5076
+Encoding: 5076 5076 1301
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D5
-Encoding: 5077 5077 5077
+Encoding: 5077 5077 1302
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D6
-Encoding: 5078 5078 5078
+Encoding: 5078 5078 1303
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D7
-Encoding: 5079 5079 5079
+Encoding: 5079 5079 1304
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D8
-Encoding: 5080 5080 5080
+Encoding: 5080 5080 1305
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D9
-Encoding: 5081 5081 5081
+Encoding: 5081 5081 1306
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DA
-Encoding: 5082 5082 5082
+Encoding: 5082 5082 1307
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DB
-Encoding: 5083 5083 5083
+Encoding: 5083 5083 1308
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DC
-Encoding: 5084 5084 5084
+Encoding: 5084 5084 1309
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DD
-Encoding: 5085 5085 5085
+Encoding: 5085 5085 1310
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DE
-Encoding: 5086 5086 5086
+Encoding: 5086 5086 1311
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DF
-Encoding: 5087 5087 5087
+Encoding: 5087 5087 1312
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E0
-Encoding: 5088 5088 5088
+Encoding: 5088 5088 1313
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E1
-Encoding: 5089 5089 5089
+Encoding: 5089 5089 1314
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E2
-Encoding: 5090 5090 5090
+Encoding: 5090 5090 1315
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E3
-Encoding: 5091 5091 5091
+Encoding: 5091 5091 1316
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E4
-Encoding: 5092 5092 5092
+Encoding: 5092 5092 1317
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E5
-Encoding: 5093 5093 5093
+Encoding: 5093 5093 1318
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E6
-Encoding: 5094 5094 5094
+Encoding: 5094 5094 1319
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E7
-Encoding: 5095 5095 5095
+Encoding: 5095 5095 1320
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E8
-Encoding: 5096 5096 5096
+Encoding: 5096 5096 1321
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E9
-Encoding: 5097 5097 5097
+Encoding: 5097 5097 1322
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EA
-Encoding: 5098 5098 5098
+Encoding: 5098 5098 1323
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EB
-Encoding: 5099 5099 5099
+Encoding: 5099 5099 1324
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EC
-Encoding: 5100 5100 5100
+Encoding: 5100 5100 1325
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13ED
-Encoding: 5101 5101 5101
+Encoding: 5101 5101 1326
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EE
-Encoding: 5102 5102 5102
+Encoding: 5102 5102 1327
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EF
-Encoding: 5103 5103 5103
+Encoding: 5103 5103 1328
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F0
-Encoding: 5104 5104 5104
+Encoding: 5104 5104 1329
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F1
-Encoding: 5105 5105 5105
+Encoding: 5105 5105 1330
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F2
-Encoding: 5106 5106 5106
+Encoding: 5106 5106 1331
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F3
-Encoding: 5107 5107 5107
+Encoding: 5107 5107 1332
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F4
-Encoding: 5108 5108 5108
+Encoding: 5108 5108 1333
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F5
-Encoding: 5109 5109 5109
+Encoding: 5109 5109 1334
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni1D02
-Encoding: 7426 7426 7426
+Encoding: 7426 7426 1335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44604,8 +45945,9 @@ SplineSet
  78 604 l 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D08
-Encoding: 7432 7432 7432
+Encoding: 7432 7432 1336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44643,8 +45985,9 @@ SplineSet
  911.821 541 911.821 541 775.35 518 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D09
-Encoding: 7433 7433 7433
+Encoding: 7433 7433 1337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44668,8 +46011,9 @@ SplineSet
  541 -432 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D14
-Encoding: 7444 7444 7444
+Encoding: 7444 7444 1338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44736,8 +46080,9 @@ SplineSet
  982 995 982 995 913 995 c 0,57,58
 EndSplineSet
 EndChar
+
 StartChar: uni1D16
-Encoding: 7446 7446 7446
+Encoding: 7446 7446 1339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44756,8 +46101,9 @@ SplineSet
  245.658 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D17
-Encoding: 7447 7447 7447
+Encoding: 7447 7447 1340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44776,8 +46122,9 @@ SplineSet
  1203.66 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D1D
-Encoding: 7453 7453 7453
+Encoding: 7453 7453 1341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44802,8 +46149,9 @@ SplineSet
  965.486 2.5 965.486 2.5 737.486 2.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1E
-Encoding: 7454 7454 7454
+Encoding: 7454 7454 1342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44838,8 +46186,9 @@ SplineSet
  1012.06 -1.5 1012.06 -1.5 852.458 -1.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1F
-Encoding: 7455 7455 7455
+Encoding: 7455 7455 1343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44875,8 +46224,9 @@ SplineSet
  1214.86 488 1214.86 488 1138.42 460 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2C
-Encoding: 7468 7468 7468
+Encoding: 7468 7468 1344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44897,8 +46247,9 @@ SplineSet
  621 1504 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2D
-Encoding: 7469 7469 7469
+Encoding: 7469 7469 1345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44928,8 +46279,9 @@ SplineSet
  642 1409 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2E
-Encoding: 7470 7470 7470
+Encoding: 7470 7470 1346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44969,8 +46321,9 @@ SplineSet
  392 1504 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D30
-Encoding: 7472 7472 7472
+Encoding: 7472 7472 1347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44996,8 +46349,9 @@ SplineSet
  583 1504 l 2,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni1D31
-Encoding: 7473 7473 7473
+Encoding: 7473 7473 1348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45018,8 +46372,9 @@ SplineSet
  413 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D32
-Encoding: 7474 7474 7474
+Encoding: 7474 7474 1349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45040,8 +46395,9 @@ SplineSet
  983 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D33
-Encoding: 7475 7475 7475
+Encoding: 7475 7475 1350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45074,8 +46430,9 @@ SplineSet
  864 737 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D34
-Encoding: 7476 7476 7476
+Encoding: 7476 7476 1351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45096,8 +46453,9 @@ SplineSet
  395 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D35
-Encoding: 7477 7477 7477
+Encoding: 7477 7477 1352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45118,8 +46476,9 @@ SplineSet
  437 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D36
-Encoding: 7478 7478 7478
+Encoding: 7478 7478 1353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45142,8 +46501,9 @@ SplineSet
  337 676 337 676 277 702 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D37
-Encoding: 7479 7479 7479
+Encoding: 7479 7479 1354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45164,8 +46524,9 @@ SplineSet
  355 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D38
-Encoding: 7480 7480 7480
+Encoding: 7480 7480 1355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45180,8 +46541,9 @@ SplineSet
  406 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D39
-Encoding: 7481 7481 7481
+Encoding: 7481 7481 1356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45203,8 +46565,9 @@ SplineSet
  364 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3A
-Encoding: 7482 7482 7482
+Encoding: 7482 7482 1357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45223,8 +46586,9 @@ SplineSet
  397 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3B
-Encoding: 7483 7483 7483
+Encoding: 7483 7483 1358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45243,8 +46607,9 @@ SplineSet
  998 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3C
-Encoding: 7484 7484 7484
+Encoding: 7484 7484 1359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45274,14 +46639,16 @@ SplineSet
  949 1178 949 1178 931 1085 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D3D
-Encoding: 7485 7485 7485
+Encoding: 7485 7485 1360
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni1D3E
-Encoding: 7486 7486 7486
+Encoding: 7486 7486 1361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45309,8 +46676,9 @@ SplineSet
  400 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3F
-Encoding: 7487 7487 7487
+Encoding: 7487 7487 1362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45345,8 +46713,9 @@ SplineSet
  464 1411 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D40
-Encoding: 7488 7488 7488
+Encoding: 7488 7488 1363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45363,8 +46732,9 @@ SplineSet
  339 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D41
-Encoding: 7489 7489 7489
+Encoding: 7489 7489 1364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45396,8 +46766,9 @@ SplineSet
  285 891 285 891 304 989 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D42
-Encoding: 7490 7490 7490
+Encoding: 7490 7490 1365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45419,8 +46790,9 @@ SplineSet
  309 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D43
-Encoding: 7491 7491 7491
+Encoding: 7491 7491 1366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45464,8 +46836,9 @@ SplineSet
  929 1061 929 1061 921 1026 c 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D44
-Encoding: 7492 7492 7492
+Encoding: 7492 7492 1367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45509,8 +46882,9 @@ SplineSet
  294 859 294 859 311 936 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D45
-Encoding: 7493 7493 7493
+Encoding: 7493 7493 1368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45544,8 +46918,9 @@ SplineSet
  448 1101 448 1101 421 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D46
-Encoding: 7494 7494 7494
+Encoding: 7494 7494 1369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45613,8 +46988,9 @@ SplineSet
  251 1006 l 1,26,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D47
-Encoding: 7495 7495 7495
+Encoding: 7495 7495 1370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45651,8 +47027,9 @@ SplineSet
  522 1215 l 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni1D48
-Encoding: 7496 7496 7496
+Encoding: 7496 7496 1371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45689,8 +47066,9 @@ SplineSet
  760 1262 760 1262 785 1215 c 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D49
-Encoding: 7497 7497 7497
+Encoding: 7497 7497 1372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45727,8 +47105,9 @@ SplineSet
  836 700 l 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni1D4A
-Encoding: 7498 7498 7498
+Encoding: 7498 7498 1373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45763,8 +47142,9 @@ SplineSet
  411 924 l 1,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni1D4B
-Encoding: 7499 7499 7499
+Encoding: 7499 7499 1374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45806,8 +47186,9 @@ SplineSet
  427 995 427 995 513 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4C
-Encoding: 7500 7500 7500
+Encoding: 7500 7500 1375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45849,8 +47230,9 @@ SplineSet
  806 971 806 971 720 958 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4D
-Encoding: 7501 7501 7501
+Encoding: 7501 7501 1376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45893,8 +47275,9 @@ SplineSet
  831 708 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni1D4E
-Encoding: 7502 7502 7502
+Encoding: 7502 7502 1377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45918,8 +47301,9 @@ SplineSet
  493 426 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4F
-Encoding: 7503 7503 7503
+Encoding: 7503 7503 1378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45940,8 +47324,9 @@ SplineSet
  456 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D50
-Encoding: 7504 7504 7504
+Encoding: 7504 7504 1379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45983,8 +47368,9 @@ SplineSet
  715 1268 715 1268 721 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D51
-Encoding: 7505 7505 7505
+Encoding: 7505 7505 1380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46017,8 +47403,9 @@ SplineSet
  934 1109 934 1109 923 1057 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D52
-Encoding: 7506 7506 7506
+Encoding: 7506 7506 1381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46048,8 +47435,9 @@ SplineSet
  592 1310 592 1310 678 1310 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D53
-Encoding: 7507 7507 7507
+Encoding: 7507 7507 1382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46078,8 +47466,9 @@ SplineSet
  431 1262 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D54
-Encoding: 7508 7508 7508
+Encoding: 7508 7508 1383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46100,8 +47489,9 @@ SplineSet
  308 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D55
-Encoding: 7509 7509 7509
+Encoding: 7509 7509 1384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46122,8 +47512,9 @@ SplineSet
  925 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D56
-Encoding: 7510 7510 7510
+Encoding: 7510 7510 1385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46160,8 +47551,9 @@ SplineSet
  555 739 555 739 620 739 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni1D57
-Encoding: 7511 7511 7511
+Encoding: 7511 7511 1386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46192,8 +47584,9 @@ SplineSet
  685 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D58
-Encoding: 7512 7512 7512
+Encoding: 7512 7512 1387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46222,8 +47615,9 @@ SplineSet
  305 880 305 880 310 907 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D59
-Encoding: 7513 7513 7513
+Encoding: 7513 7513 1388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46250,8 +47644,9 @@ SplineSet
  793 669 793 669 649 669 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5A
-Encoding: 7514 7514 7514
+Encoding: 7514 7514 1389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46290,8 +47685,9 @@ SplineSet
  519 707 519 707 510 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5B
-Encoding: 7515 7515 7515
+Encoding: 7515 7515 1390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46307,40 +47703,45 @@ SplineSet
  291 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D62
-Encoding: 7522 7522 7522
+Encoding: 7522 7522 1391
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8305 8305 N 1 0 0 1 0 -668 3
+Refer: 1907 8305 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D63
-Encoding: 7523 7523 7523
+Encoding: 7523 7523 1392
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 691 691 N 1 0 0 1 0 -668 3
+Refer: 605 691 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D64
-Encoding: 7524 7524 7524
+Encoding: 7524 7524 1393
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7512 7512 N 1 0 0 1 0 -668 3
+Refer: 1387 7512 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D65
-Encoding: 7525 7525 7525
+Encoding: 7525 7525 1394
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7515 7515 N 1 0 0 1 0 -668 3
+Refer: 1390 7515 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D77
-Encoding: 7543 7543 7543
+Encoding: 7543 7543 1395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46383,16 +47784,18 @@ SplineSet
  276.5 635 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni1D78
-Encoding: 7544 7544 7544
+Encoding: 7544 7544 1396
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7476 7476 N 1 0 0 1 0 0 2
+Refer: 1351 7476 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1D7B
-Encoding: 7547 7547 7547
+Encoding: 7547 7547 1397
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46421,8 +47824,9 @@ SplineSet
  1196 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D85
-Encoding: 7557 7557 7557
+Encoding: 7557 7557 1398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46453,8 +47857,9 @@ SplineSet
  717.918 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9B
-Encoding: 7579 7579 7579
+Encoding: 7579 7579 1399
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46488,8 +47893,9 @@ SplineSet
  785 861 785 861 812 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D9C
-Encoding: 7580 7580 7580
+Encoding: 7580 7580 1400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46520,8 +47926,9 @@ SplineSet
  801 697 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9D
-Encoding: 7581 7581 7581
+Encoding: 7581 7581 1401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46559,8 +47966,9 @@ SplineSet
  535 647 535 647 492 657 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni1D9E
-Encoding: 7582 7582 7582
+Encoding: 7582 7582 1402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46605,8 +48013,9 @@ SplineSet
  786 1155 786 1155 774 1176 c 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni1D9F
-Encoding: 7583 7583 7583
+Encoding: 7583 7583 1403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46648,8 +48057,9 @@ SplineSet
  828 1022 828 1022 750 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA0
-Encoding: 7584 7584 7584
+Encoding: 7584 7584 1404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46676,8 +48086,9 @@ SplineSet
  926 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA1
-Encoding: 7585 7585 7585
+Encoding: 7585 7585 1405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46706,8 +48117,9 @@ SplineSet
  478 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA2
-Encoding: 7586 7586 7586
+Encoding: 7586 7586 1406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46746,8 +48158,9 @@ SplineSet
  831 708 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1DA3
-Encoding: 7587 7587 7587
+Encoding: 7587 7587 1407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46774,8 +48187,9 @@ SplineSet
  298 852 298 852 310 905 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA4
-Encoding: 7588 7588 7588
+Encoding: 7588 7588 1408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46807,8 +48221,9 @@ SplineSet
  481 1295 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA5
-Encoding: 7589 7589 7589
+Encoding: 7589 7589 1409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46831,8 +48246,9 @@ SplineSet
  811 668 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DA6
-Encoding: 7590 7590 7590
+Encoding: 7590 7590 1410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46853,8 +48269,9 @@ SplineSet
  397 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA7
-Encoding: 7591 7591 7591
+Encoding: 7591 7591 1411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46883,8 +48300,9 @@ SplineSet
  913 1013 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA8
-Encoding: 7592 7592 7592
+Encoding: 7592 7592 1412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46916,8 +48334,9 @@ SplineSet
  586 557 586 557 598 582 c 1,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni1DA9
-Encoding: 7593 7593 7593
+Encoding: 7593 7593 1413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46940,8 +48359,9 @@ SplineSet
  570 657 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAA
-Encoding: 7594 7594 7594
+Encoding: 7594 7594 1414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46972,8 +48392,9 @@ SplineSet
  607 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAB
-Encoding: 7595 7595 7595
+Encoding: 7595 7595 1415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46988,8 +48409,9 @@ SplineSet
  513 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAC
-Encoding: 7596 7596 7596
+Encoding: 7596 7596 1416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47037,8 +48459,9 @@ SplineSet
  714 1271 714 1271 723 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAD
-Encoding: 7597 7597 7597
+Encoding: 7597 7597 1417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47077,8 +48500,9 @@ SplineSet
  519 707 519 707 510 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAE
-Encoding: 7598 7598 7598
+Encoding: 7598 7598 1418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47111,8 +48535,9 @@ SplineSet
  512 657 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAF
-Encoding: 7599 7599 7599
+Encoding: 7599 7599 1419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47151,8 +48576,9 @@ SplineSet
  703 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB0
-Encoding: 7600 7600 7600
+Encoding: 7600 7600 1420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47171,8 +48597,9 @@ SplineSet
  389 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB1
-Encoding: 7601 7601 7601
+Encoding: 7601 7601 1421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47205,8 +48632,9 @@ SplineSet
  753 844 753 844 778 918 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB2
-Encoding: 7602 7602 7602
+Encoding: 7602 7602 1422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47253,8 +48681,9 @@ SplineSet
  459 759 459 759 506 746 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB3
-Encoding: 7603 7603 7603
+Encoding: 7603 7603 1423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47306,8 +48735,9 @@ SplineSet
  896 1294 896 1294 940 1277 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB4
-Encoding: 7604 7604 7604
+Encoding: 7604 7604 1424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47332,8 +48762,9 @@ SplineSet
  430 571 430 571 449 657 c 0,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB5
-Encoding: 7605 7605 7605
+Encoding: 7605 7605 1425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47370,8 +48801,9 @@ SplineSet
  738 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB6
-Encoding: 7606 7606 7606
+Encoding: 7606 7606 1426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47410,8 +48842,9 @@ SplineSet
  759 842 759 842 782 921 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB7
-Encoding: 7607 7607 7607
+Encoding: 7607 7607 1427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47448,8 +48881,9 @@ SplineSet
  306 1203 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB9
-Encoding: 7609 7609 7609
+Encoding: 7609 7609 1428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47482,8 +48916,9 @@ SplineSet
  656 1213 656 1213 628 1220 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBA
-Encoding: 7610 7610 7610
+Encoding: 7610 7610 1429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47499,8 +48934,9 @@ SplineSet
  960 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBB
-Encoding: 7611 7611 7611
+Encoding: 7611 7611 1430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47519,8 +48955,9 @@ SplineSet
  436 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBC
-Encoding: 7612 7612 7612
+Encoding: 7612 7612 1431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47551,8 +48988,9 @@ SplineSet
  485 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBD
-Encoding: 7613 7613 7613
+Encoding: 7613 7613 1432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47584,8 +49022,9 @@ SplineSet
  660 831 660 831 620 750 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1DBE
-Encoding: 7614 7614 7614
+Encoding: 7614 7614 1433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47618,8 +49057,9 @@ SplineSet
  651 935 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DBF
-Encoding: 7615 7615 7615
+Encoding: 7615 7615 1434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47652,3230 +49092,3588 @@ SplineSet
  563 1508 563 1508 710 1508 c 128,-1,13
 EndSplineSet
 EndChar
+
 StartChar: uni1E00
-Encoding: 7680 7680 7680
+Encoding: 7680 7680 1435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 689 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E01
-Encoding: 7681 7681 7681
+Encoding: 7681 7681 1436
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 689 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E02
-Encoding: 7682 7682 7682
+Encoding: 7682 7682 1437
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E03
-Encoding: 7683 7683 7683
+Encoding: 7683 7683 1438
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 50 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E04
-Encoding: 7684 7684 7684
+Encoding: 7684 7684 1439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E05
-Encoding: 7685 7685 7685
+Encoding: 7685 7685 1440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E06
-Encoding: 7686 7686 7686
+Encoding: 7686 7686 1441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E07
-Encoding: 7687 7687 7687
+Encoding: 7687 7687 1442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E08
-Encoding: 7688 7688 7688
+Encoding: 7688 7688 1443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 174 373 2
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 100 0 2
+Refer: 3089 -1 N 1 0 0 1 174 373 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1E09
-Encoding: 7689 7689 7689
+Encoding: 7689 7689 1444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 90 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 104 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 104 0 2
 EndChar
+
 StartChar: uni1E0A
-Encoding: 7690 7690 7690
+Encoding: 7690 7690 1445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0B
-Encoding: 7691 7691 7691
+Encoding: 7691 7691 1446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 -50 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0C
-Encoding: 7692 7692 7692
+Encoding: 7692 7692 1447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0D
-Encoding: 7693 7693 7693
+Encoding: 7693 7693 1448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0E
-Encoding: 7694 7694 7694
+Encoding: 7694 7694 1449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E0F
-Encoding: 7695 7695 7695
+Encoding: 7695 7695 1450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E10
-Encoding: 7696 7696 7696
+Encoding: 7696 7696 1451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 3
-Refer: 807 807 N 1 0 0 1 -270 0 2
+Refer: 37 68 N 1 0 0 1 0 0 3
+Refer: 691 807 N 1 0 0 1 -270 0 2
 EndChar
+
 StartChar: uni1E11
-Encoding: 7697 7697 7697
+Encoding: 7697 7697 1452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 3
-Refer: 807 807 N 1 0 0 1 -20 0 2
+Refer: 69 100 N 1 0 0 1 0 0 3
+Refer: 691 807 N 1 0 0 1 -20 0 2
 EndChar
+
 StartChar: uni1E12
-Encoding: 7698 7698 7698
+Encoding: 7698 7698 1453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E13
-Encoding: 7699 7699 7699
+Encoding: 7699 7699 1454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E18
-Encoding: 7704 7704 7704
+Encoding: 7704 7704 1455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni1E19
-Encoding: 7705 7705 7705
+Encoding: 7705 7705 1456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1E1A
-Encoding: 7706 7706 7706
+Encoding: 7706 7706 1457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni1E1B
-Encoding: 7707 7707 7707
+Encoding: 7707 7707 1458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1E1C
-Encoding: 7708 7708 7708
+Encoding: 7708 7708 1459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
+Refer: 691 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni1E1D
-Encoding: 7709 7709 7709
+Encoding: 7709 7709 1460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 14 0 2
+Refer: 691 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1E1E
-Encoding: 7710 7710 7710
+Encoding: 7710 7710 1461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 14 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1E1F
-Encoding: 7711 7711 7711
+Encoding: 7711 7711 1462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 102 102 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E20
-Encoding: 7712 7712 7712
+Encoding: 7712 7712 1463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E21
-Encoding: 7713 7713 7713
+Encoding: 7713 7713 1464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E22
-Encoding: 7714 7714 7714
+Encoding: 7714 7714 1465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E23
-Encoding: 7715 7715 7715
+Encoding: 7715 7715 1466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E24
-Encoding: 7716 7716 7716
+Encoding: 7716 7716 1467
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E25
-Encoding: 7717 7717 7717
+Encoding: 7717 7717 1468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E26
-Encoding: 7718 7718 7718
+Encoding: 7718 7718 1469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 96 373 2
-Refer: 72 72 N 1 0 0 1 0 0 3
+Refer: 3088 -1 N 1 0 0 1 96 373 2
+Refer: 41 72 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E27
-Encoding: 7719 7719 7719
+Encoding: 7719 7719 1470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 7 328 2
+Refer: 73 104 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 7 328 2
 EndChar
+
 StartChar: uni1E28
-Encoding: 7720 7720 7720
+Encoding: 7720 7720 1471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -375 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 -375 0 2
 EndChar
+
 StartChar: uni1E29
-Encoding: 7721 7721 7721
+Encoding: 7721 7721 1472
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 -340 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 691 807 N 1 0 0 1 -340 0 2
 EndChar
+
 StartChar: uni1E2A
-Encoding: 7722 7722 7722
+Encoding: 7722 7722 1473
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
-Refer: 814 814 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
+Refer: 698 814 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2B
-Encoding: 7723 7723 7723
+Encoding: 7723 7723 1474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 814 814 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 698 814 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2C
-Encoding: 7724 7724 7724
+Encoding: 7724 7724 1475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2D
-Encoding: 7725 7725 7725
+Encoding: 7725 7725 1476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E30
-Encoding: 7728 7728 7728
+Encoding: 7728 7728 1477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni1E31
-Encoding: 7729 7729 7729
+Encoding: 7729 7729 1478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 -142 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 -142 373 2
 EndChar
+
 StartChar: uni1E32
-Encoding: 7730 7730 7730
+Encoding: 7730 7730 1479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E33
-Encoding: 7731 7731 7731
+Encoding: 7731 7731 1480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E34
-Encoding: 7732 7732 7732
+Encoding: 7732 7732 1481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E35
-Encoding: 7733 7733 7733
+Encoding: 7733 7733 1482
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E36
-Encoding: 7734 7734 7734
+Encoding: 7734 7734 1483
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E37
-Encoding: 7735 7735 7735
+Encoding: 7735 7735 1484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E38
-Encoding: 7736 7736 7736
+Encoding: 7736 7736 1485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7734 7734 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 1483 7734 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E39
-Encoding: 7737 7737 7737
+Encoding: 7737 7737 1486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7735 7735 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 1484 7735 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3A
-Encoding: 7738 7738 7738
+Encoding: 7738 7738 1487
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E3B
-Encoding: 7739 7739 7739
+Encoding: 7739 7739 1488
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3C
-Encoding: 7740 7740 7740
+Encoding: 7740 7740 1489
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E3D
-Encoding: 7741 7741 7741
+Encoding: 7741 7741 1490
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3E
-Encoding: 7742 7742 7742
+Encoding: 7742 7742 1491
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 56 373 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 56 373 2
 EndChar
+
 StartChar: uni1E3F
-Encoding: 7743 7743 7743
+Encoding: 7743 7743 1492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E40
-Encoding: 7744 7744 7744
+Encoding: 7744 7744 1493
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E41
-Encoding: 7745 7745 7745
+Encoding: 7745 7745 1494
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 3
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E42
-Encoding: 7746 7746 7746
+Encoding: 7746 7746 1495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E43
-Encoding: 7747 7747 7747
+Encoding: 7747 7747 1496
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E44
-Encoding: 7748 7748 7748
+Encoding: 7748 7748 1497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E45
-Encoding: 7749 7749 7749
+Encoding: 7749 7749 1498
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E46
-Encoding: 7750 7750 7750
+Encoding: 7750 7750 1499
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E47
-Encoding: 7751 7751 7751
+Encoding: 7751 7751 1500
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E48
-Encoding: 7752 7752 7752
+Encoding: 7752 7752 1501
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E49
-Encoding: 7753 7753 7753
+Encoding: 7753 7753 1502
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4A
-Encoding: 7754 7754 7754
+Encoding: 7754 7754 1503
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4B
-Encoding: 7755 7755 7755
+Encoding: 7755 7755 1504
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4C
-Encoding: 7756 7756 7756
+Encoding: 7756 7756 1505
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 50 515 2
+Refer: 3090 -1 N 1 0 0 1 0 262 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4D
-Encoding: 7757 7757 7757
+Encoding: 7757 7757 1506
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 72 403 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
+Refer: 653 769 N 1 0 0 1 72 403 2
 EndChar
+
 StartChar: uni1E54
-Encoding: 7764 7764 7764
+Encoding: 7764 7764 1507
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -137 380 2
+Refer: 49 80 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -137 380 2
 EndChar
+
 StartChar: uni1E55
-Encoding: 7765 7765 7765
+Encoding: 7765 7765 1508
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 3
-Refer: 769 769 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
+Refer: 653 769 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E56
-Encoding: 7766 7766 7766
+Encoding: 7766 7766 1509
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E57
-Encoding: 7767 7767 7767
+Encoding: 7767 7767 1510
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E58
-Encoding: 7768 7768 7768
+Encoding: 7768 7768 1511
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E59
-Encoding: 7769 7769 7769
+Encoding: 7769 7769 1512
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5A
-Encoding: 7770 7770 7770
+Encoding: 7770 7770 1513
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E5B
-Encoding: 7771 7771 7771
+Encoding: 7771 7771 1514
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5C
-Encoding: 7772 7772 7772
+Encoding: 7772 7772 1515
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7770 7770 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 -50 0 2
+Refer: 1513 7770 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 -50 0 2
 EndChar
+
 StartChar: uni1E5D
-Encoding: 7773 7773 7773
+Encoding: 7773 7773 1516
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7771 7771 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 1514 7771 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5E
-Encoding: 7774 7774 7774
+Encoding: 7774 7774 1517
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5F
-Encoding: 7775 7775 7775
+Encoding: 7775 7775 1518
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E60
-Encoding: 7776 7776 7776
+Encoding: 7776 7776 1519
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E61
-Encoding: 7777 7777 7777
+Encoding: 7777 7777 1520
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 3
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 3
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E62
-Encoding: 7778 7778 7778
+Encoding: 7778 7778 1521
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E63
-Encoding: 7779 7779 7779
+Encoding: 7779 7779 1522
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E68
-Encoding: 7784 7784 7784
+Encoding: 7784 7784 1523
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E69
-Encoding: 7785 7785 7785
+Encoding: 7785 7785 1524
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6A
-Encoding: 7786 7786 7786
+Encoding: 7786 7786 1525
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6B
-Encoding: 7787 7787 7787
+Encoding: 7787 7787 1526
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6C
-Encoding: 7788 7788 7788
+Encoding: 7788 7788 1527
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6D
-Encoding: 7789 7789 7789
+Encoding: 7789 7789 1528
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6E
-Encoding: 7790 7790 7790
+Encoding: 7790 7790 1529
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6F
-Encoding: 7791 7791 7791
+Encoding: 7791 7791 1530
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E70
-Encoding: 7792 7792 7792
+Encoding: 7792 7792 1531
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E71
-Encoding: 7793 7793 7793
+Encoding: 7793 7793 1532
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E72
-Encoding: 7794 7794 7794
+Encoding: 7794 7794 1533
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 804 804 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 688 804 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E73
-Encoding: 7795 7795 7795
+Encoding: 7795 7795 1534
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 804 804 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 688 804 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E74
-Encoding: 7796 7796 7796
+Encoding: 7796 7796 1535
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E75
-Encoding: 7797 7797 7797
+Encoding: 7797 7797 1536
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 816 816 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 700 816 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E76
-Encoding: 7798 7798 7798
+Encoding: 7798 7798 1537
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E77
-Encoding: 7799 7799 7799
+Encoding: 7799 7799 1538
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 813 813 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 697 813 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E78
-Encoding: 7800 7800 7800
+Encoding: 7800 7800 1539
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 50 515 2
+Refer: 3090 -1 N 1 0 0 1 0 262 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E79
-Encoding: 7801 7801 7801
+Encoding: 7801 7801 1540
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 72 403 2
+Refer: 637 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 653 769 N 1 0 0 1 72 403 2
 EndChar
+
 StartChar: uni1E7C
-Encoding: 7804 7804 7804
+Encoding: 7804 7804 1541
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 0 348 2
+Refer: 55 86 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 0 348 2
 EndChar
+
 StartChar: uni1E7D
-Encoding: 7805 7805 7805
+Encoding: 7805 7805 1542
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 0 -40 2
+Refer: 87 118 N 1 0 0 1 0 0 3
+Refer: 637 732 N 1 0 0 1 0 -40 2
 EndChar
+
 StartChar: uni1E7E
-Encoding: 7806 7806 7806
+Encoding: 7806 7806 1543
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7F
-Encoding: 7807 7807 7807
+Encoding: 7807 7807 1544
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wgrave
-Encoding: 7808 7808 7808
+Encoding: 7808 7808 1545
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: wgrave
-Encoding: 7809 7809 7809
+Encoding: 7809 7809 1546
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -43 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -43 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wacute
-Encoding: 7810 7810 7810
+Encoding: 7810 7810 1547
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3089 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: wacute
-Encoding: 7811 7811 7811
+Encoding: 7811 7811 1548
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 79 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 79 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wdieresis
-Encoding: 7812 7812 7812
+Encoding: 7812 7812 1549
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 56 292 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 56 292 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wdieresis
-Encoding: 7813 7813 7813
+Encoding: 7813 7813 1550
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -81 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -81 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E86
-Encoding: 7814 7814 7814
+Encoding: 7814 7814 1551
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E87
-Encoding: 7815 7815 7815
+Encoding: 7815 7815 1552
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E88
-Encoding: 7816 7816 7816
+Encoding: 7816 7816 1553
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E89
-Encoding: 7817 7817 7817
+Encoding: 7817 7817 1554
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8A
-Encoding: 7818 7818 7818
+Encoding: 7818 7818 1555
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8B
-Encoding: 7819 7819 7819
+Encoding: 7819 7819 1556
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8C
-Encoding: 7820 7820 7820
+Encoding: 7820 7820 1557
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 96 373 2
-Refer: 88 88 N 1 0 0 1 0 0 3
+Refer: 3088 -1 N 1 0 0 1 96 373 2
+Refer: 57 88 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8D
-Encoding: 7821 7821 7821
+Encoding: 7821 7821 1558
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 0.5 -81 2
+Refer: 89 120 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 0.5 -81 2
 EndChar
+
 StartChar: uni1E8E
-Encoding: 7822 7822 7822
+Encoding: 7822 7822 1559
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8F
-Encoding: 7823 7823 7823
+Encoding: 7823 7823 1560
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 775 775 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 659 775 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E90
-Encoding: 7824 7824 7824
+Encoding: 7824 7824 1561
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 46 380 2
+Refer: 59 90 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 46 380 2
 EndChar
+
 StartChar: uni1E91
-Encoding: 7825 7825 7825
+Encoding: 7825 7825 1562
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 17 7 2
+Refer: 91 122 N 1 0 0 1 0 0 3
+Refer: 619 710 N 1 0 0 1 17 7 2
 EndChar
+
 StartChar: uni1E92
-Encoding: 7826 7826 7826
+Encoding: 7826 7826 1563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 28 0 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 28 0 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E93
-Encoding: 7827 7827 7827
+Encoding: 7827 7827 1564
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 25 0 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 25 0 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E94
-Encoding: 7828 7828 7828
+Encoding: 7828 7828 1565
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E95
-Encoding: 7829 7829 7829
+Encoding: 7829 7829 1566
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E96
-Encoding: 7830 7830 7830
+Encoding: 7830 7830 1567
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
+Refer: 701 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E97
-Encoding: 7831 7831 7831
+Encoding: 7831 7831 1568
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 3
-Refer: 168 168 N 1 0 0 1 -94 210 2
+Refer: 85 116 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 -94 210 2
 EndChar
+
 StartChar: uni1E98
-Encoding: 7832 7832 7832
+Encoding: 7832 7832 1569
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 0 20 2
+Refer: 88 119 N 1 0 0 1 0 0 3
+Refer: 635 730 N 1 0 0 1 0 20 2
 EndChar
+
 StartChar: uni1E99
-Encoding: 7833 7833 7833
+Encoding: 7833 7833 1570
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 3
-Refer: 730 730 N 1 0 0 1 12 20 2
+Refer: 90 121 N 1 0 0 1 0 0 3
+Refer: 635 730 N 1 0 0 1 12 20 2
 EndChar
+
 StartChar: uni1E9B
-Encoding: 7835 7835 7835
+Encoding: 7835 7835 1571
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 383 383 N 1 0 0 1 0 0 2
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
+Refer: 319 383 N 1 0 0 1 0 0 2
+Refer: 3097 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E9F
-Encoding: 7839 7839 7839
+Encoding: 7839 7839 1572
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 948 948 N 1 0 0 1 0 0 2
+Refer: 774 948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA0
-Encoding: 7840 7840 7840
+Encoding: 7840 7840 1573
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 34 65 S 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA1
-Encoding: 7841 7841 7841
+Encoding: 7841 7841 1574
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EAC
-Encoding: 7852 7852 7852
+Encoding: 7852 7852 1575
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
+Refer: 1573 7840 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: uni1EAD
-Encoding: 7853 7853 7853
+Encoding: 7853 7853 1576
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -24.5 7 2
+Refer: 1574 7841 N 1 0 0 1 0 0 3
+Refer: 619 710 N 1 0 0 1 -24.5 7 2
 EndChar
+
 StartChar: uni1EB0
-Encoding: 7856 7856 7856
+Encoding: 7856 7856 1577
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 84.4999 515 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 -128 2
+Refer: 3091 -1 N 1 0 0 1 106.427 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB1
-Encoding: 7857 7857 7857
+Encoding: 7857 7857 1578
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 259 259 N 1 0 0 1 0 0 3
-Refer: 768 768 N 1 0 0 1 0 316 2
+Refer: 652 768 N 1 0 0 1 32.4088 468 2
+Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB6
-Encoding: 7862 7862 7862
+Encoding: 7862 7862 1579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7840 7840 N 1 0 0 1 0 0 3
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 1573 7840 N 1 0 0 1 0 0 3
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB7
-Encoding: 7863 7863 7863
+Encoding: 7863 7863 1580
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7841 7841 N 1 0 0 1 0 0 3
-Refer: 728 728 N 1 0 0 1 -24.5 -52 2
+Refer: 1574 7841 N 1 0 0 1 0 0 3
+Refer: 633 728 N 1 0 0 1 -24.5 -52 2
 EndChar
+
 StartChar: uni1EB8
-Encoding: 7864 7864 7864
+Encoding: 7864 7864 1581
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 18 0 2
 EndChar
+
 StartChar: uni1EB9
-Encoding: 7865 7865 7865
+Encoding: 7865 7865 1582
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 14 0 2
 EndChar
+
 StartChar: uni1EBC
-Encoding: 7868 7868 7868
+Encoding: 7868 7868 1583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 84 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 84 373 2
 EndChar
+
 StartChar: uni1EBD
-Encoding: 7869 7869 7869
+Encoding: 7869 7869 1584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EC6
-Encoding: 7878 7878 7878
+Encoding: 7878 7878 1585
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7864 7864 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 23.5 380 2
+Refer: 1581 7864 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 23.5 380 2
 EndChar
+
 StartChar: uni1EC7
-Encoding: 7879 7879 7879
+Encoding: 7879 7879 1586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7865 7865 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 34.5 7 2
+Refer: 1582 7865 N 1 0 0 1 0 0 3
+Refer: 619 710 N 1 0 0 1 34.5 7 2
 EndChar
+
 StartChar: uni1ECA
-Encoding: 7882 7882 7882
+Encoding: 7882 7882 1587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECB
-Encoding: 7883 7883 7883
+Encoding: 7883 7883 1588
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECC
-Encoding: 7884 7884 7884
+Encoding: 7884 7884 1589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECD
-Encoding: 7885 7885 7885
+Encoding: 7885 7885 1590
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ED8
-Encoding: 7896 7896 7896
+Encoding: 7896 7896 1591
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7884 7884 N 1 0 0 1 0 0 3
-Refer: 1114118 -1 N 1 0 0 1 -0.5 380 2
+Refer: 1589 7884 N 1 0 0 1 0 0 3
+Refer: 3092 -1 N 1 0 0 1 -0.5 380 2
 EndChar
+
 StartChar: uni1ED9
-Encoding: 7897 7897 7897
+Encoding: 7897 7897 1592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7885 7885 N 1 0 0 1 0 0 3
-Refer: 710 710 N 1 0 0 1 -0.5 7 2
+Refer: 1590 7885 N 1 0 0 1 0 0 3
+Refer: 619 710 N 1 0 0 1 -0.5 7 2
 EndChar
+
 StartChar: uni1EDA
-Encoding: 7898 7898 7898
+Encoding: 7898 7898 1593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDB
-Encoding: 7899 7899 7899
+Encoding: 7899 7899 1594
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EDC
-Encoding: 7900 7900 7900
+Encoding: 7900 7900 1595
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114117 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3091 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EDD
-Encoding: 7901 7901 7901
+Encoding: 7901 7901 1596
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE0
-Encoding: 7904 7904 7904
+Encoding: 7904 7904 1597
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 -111 373 2
 EndChar
+
 StartChar: uni1EE1
-Encoding: 7905 7905 7905
+Encoding: 7905 7905 1598
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 637 732 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE2
-Encoding: 7906 7906 7906
+Encoding: 7906 7906 1599
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 416 416 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -111 0 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 -111 0 2
 EndChar
+
 StartChar: uni1EE3
-Encoding: 7907 7907 7907
+Encoding: 7907 7907 1600
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 417 417 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni1EE4
-Encoding: 7908 7908 7908
+Encoding: 7908 7908 1601
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE5
-Encoding: 7909 7909 7909
+Encoding: 7909 7909 1602
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE8
-Encoding: 7912 7912 7912
+Encoding: 7912 7912 1603
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114115 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3089 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EE9
-Encoding: 7913 7913 7913
+Encoding: 7913 7913 1604
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 180 180 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEA
-Encoding: 7914 7914 7914
+Encoding: 7914 7914 1605
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114117 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3091 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEB
-Encoding: 7915 7915 7915
+Encoding: 7915 7915 1606
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 96 96 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EEE
-Encoding: 7918 7918 7918
+Encoding: 7918 7918 1607
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 1114116 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 3090 -1 N 1 0 0 1 -138 373 2
 EndChar
+
 StartChar: uni1EEF
-Encoding: 7919 7919 7919
+Encoding: 7919 7919 1608
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 732 732 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 637 732 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni1EF0
-Encoding: 7920 7920 7920
+Encoding: 7920 7920 1609
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 431 431 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -138 0 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 -138 0 2
 EndChar
+
 StartChar: uni1EF1
-Encoding: 7921 7921 7921
+Encoding: 7921 7921 1610
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 432 432 N 1 0 0 1 0 0 3
-Refer: 803 803 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+Refer: 687 803 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: Ygrave
-Encoding: 7922 7922 7922
+Encoding: 7922 7922 1611
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3091 -1 N 1 0 0 1 0 380 2
 EndChar
+
 StartChar: ygrave
-Encoding: 7923 7923 7923
+Encoding: 7923 7923 1612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -43 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -43 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF4
-Encoding: 7924 7924 7924
+Encoding: 7924 7924 1613
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF5
-Encoding: 7925 7925 7925
+Encoding: 7925 7925 1614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 250 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 687 803 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni1EF8
-Encoding: 7928 7928 7928
+Encoding: 7928 7928 1615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 84 373 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3090 -1 N 1 0 0 1 84 373 2
 EndChar
+
 StartChar: uni1EF9
-Encoding: 7929 7929 7929
+Encoding: 7929 7929 1616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F00
-Encoding: 7936 7936 7936
+Encoding: 7936 7936 1617
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F01
-Encoding: 7937 7937 7937
+Encoding: 7937 7937 1618
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F02
-Encoding: 7938 7938 7938
+Encoding: 7938 7938 1619
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F03
-Encoding: 7939 7939 7939
+Encoding: 7939 7939 1620
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F04
-Encoding: 7940 7940 7940
+Encoding: 7940 7940 1621
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F05
-Encoding: 7941 7941 7941
+Encoding: 7941 7941 1622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F06
-Encoding: 7942 7942 7942
+Encoding: 7942 7942 1623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F07
-Encoding: 7943 7943 7943
+Encoding: 7943 7943 1624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F08
-Encoding: 7944 7944 7944
+Encoding: 7944 7944 1625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -350 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -350 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F09
-Encoding: 7945 7945 7945
+Encoding: 7945 7945 1626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -400 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -400 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0A
-Encoding: 7946 7946 7946
+Encoding: 7946 7946 1627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -650 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -650 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0B
-Encoding: 7947 7947 7947
+Encoding: 7947 7947 1628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -650 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -650 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0C
-Encoding: 7948 7948 7948
+Encoding: 7948 7948 1629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -525 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -525 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0D
-Encoding: 7949 7949 7949
+Encoding: 7949 7949 1630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -525 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -525 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0E
-Encoding: 7950 7950 7950
+Encoding: 7950 7950 1631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -350 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -350 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F0F
-Encoding: 7951 7951 7951
+Encoding: 7951 7951 1632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -400 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -400 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F10
-Encoding: 7952 7952 7952
+Encoding: 7952 7952 1633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F11
-Encoding: 7953 7953 7953
+Encoding: 7953 7953 1634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F12
-Encoding: 7954 7954 7954
+Encoding: 7954 7954 1635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F13
-Encoding: 7955 7955 7955
+Encoding: 7955 7955 1636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F14
-Encoding: 7956 7956 7956
+Encoding: 7956 7956 1637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F15
-Encoding: 7957 7957 7957
+Encoding: 7957 7957 1638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F18
-Encoding: 7960 7960 7960
+Encoding: 7960 7960 1639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -625 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F19
-Encoding: 7961 7961 7961
+Encoding: 7961 7961 1640
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -625 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1A
-Encoding: 7962 7962 7962
+Encoding: 7962 7962 1641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -875 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1B
-Encoding: 7963 7963 7963
+Encoding: 7963 7963 1642
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -875 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1C
-Encoding: 7964 7964 7964
+Encoding: 7964 7964 1643
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -800 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F1D
-Encoding: 7965 7965 7965
+Encoding: 7965 7965 1644
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -800 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F20
-Encoding: 7968 7968 7968
+Encoding: 7968 7968 1645
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F21
-Encoding: 7969 7969 7969
+Encoding: 7969 7969 1646
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F22
-Encoding: 7970 7970 7970
+Encoding: 7970 7970 1647
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F23
-Encoding: 7971 7971 7971
+Encoding: 7971 7971 1648
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F24
-Encoding: 7972 7972 7972
+Encoding: 7972 7972 1649
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F25
-Encoding: 7973 7973 7973
+Encoding: 7973 7973 1650
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F26
-Encoding: 7974 7974 7974
+Encoding: 7974 7974 1651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F27
-Encoding: 7975 7975 7975
+Encoding: 7975 7975 1652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F28
-Encoding: 7976 7976 7976
+Encoding: 7976 7976 1653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -675 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -675 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F29
-Encoding: 7977 7977 7977
+Encoding: 7977 7977 1654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -675 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -675 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2A
-Encoding: 7978 7978 7978
+Encoding: 7978 7978 1655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -950 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -950 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2B
-Encoding: 7979 7979 7979
+Encoding: 7979 7979 1656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -950 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2C
-Encoding: 7980 7980 7980
+Encoding: 7980 7980 1657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -900 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -900 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2D
-Encoding: 7981 7981 7981
+Encoding: 7981 7981 1658
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -900 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -900 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2E
-Encoding: 7982 7982 7982
+Encoding: 7982 7982 1659
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -700 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -700 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F2F
-Encoding: 7983 7983 7983
+Encoding: 7983 7983 1660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -700 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -700 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F30
-Encoding: 7984 7984 7984
+Encoding: 7984 7984 1661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F31
-Encoding: 7985 7985 7985
+Encoding: 7985 7985 1662
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F32
-Encoding: 7986 7986 7986
+Encoding: 7986 7986 1663
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F33
-Encoding: 7987 7987 7987
+Encoding: 7987 7987 1664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F34
-Encoding: 7988 7988 7988
+Encoding: 7988 7988 1665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F35
-Encoding: 7989 7989 7989
+Encoding: 7989 7989 1666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F36
-Encoding: 7990 7990 7990
+Encoding: 7990 7990 1667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F37
-Encoding: 7991 7991 7991
+Encoding: 7991 7991 1668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F38
-Encoding: 7992 7992 7992
+Encoding: 7992 7992 1669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -625 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F39
-Encoding: 7993 7993 7993
+Encoding: 7993 7993 1670
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -625 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3A
-Encoding: 7994 7994 7994
+Encoding: 7994 7994 1671
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -850 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -850 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3B
-Encoding: 7995 7995 7995
+Encoding: 7995 7995 1672
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -850 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -850 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3C
-Encoding: 7996 7996 7996
+Encoding: 7996 7996 1673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -800 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3D
-Encoding: 7997 7997 7997
+Encoding: 7997 7997 1674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -800 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3E
-Encoding: 7998 7998 7998
+Encoding: 7998 7998 1675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -625 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -625 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F3F
-Encoding: 7999 7999 7999
+Encoding: 7999 7999 1676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -625 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F40
-Encoding: 8000 8000 8000
+Encoding: 8000 8000 1677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F41
-Encoding: 8001 8001 8001
+Encoding: 8001 8001 1678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F42
-Encoding: 8002 8002 8002
+Encoding: 8002 8002 1679
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F43
-Encoding: 8003 8003 8003
+Encoding: 8003 8003 1680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F44
-Encoding: 8004 8004 8004
+Encoding: 8004 8004 1681
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F45
-Encoding: 8005 8005 8005
+Encoding: 8005 8005 1682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F48
-Encoding: 8008 8008 8008
+Encoding: 8008 8008 1683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -550 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F49
-Encoding: 8009 8009 8009
+Encoding: 8009 8009 1684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -625 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4A
-Encoding: 8010 8010 8010
+Encoding: 8010 8010 1685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -875 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4B
-Encoding: 8011 8011 8011
+Encoding: 8011 8011 1686
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -875 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4C
-Encoding: 8012 8012 8012
+Encoding: 8012 8012 1687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -650 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -650 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F4D
-Encoding: 8013 8013 8013
+Encoding: 8013 8013 1688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -650 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -650 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F50
-Encoding: 8016 8016 8016
+Encoding: 8016 8016 1689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F51
-Encoding: 8017 8017 8017
+Encoding: 8017 8017 1690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F52
-Encoding: 8018 8018 8018
+Encoding: 8018 8018 1691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F53
-Encoding: 8019 8019 8019
+Encoding: 8019 8019 1692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F54
-Encoding: 8020 8020 8020
+Encoding: 8020 8020 1693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F55
-Encoding: 8021 8021 8021
+Encoding: 8021 8021 1694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F56
-Encoding: 8022 8022 8022
+Encoding: 8022 8022 1695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F57
-Encoding: 8023 8023 8023
+Encoding: 8023 8023 1696
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F59
-Encoding: 8025 8025 8025
+Encoding: 8025 8025 1697
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -775 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -775 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5B
-Encoding: 8027 8027 8027
+Encoding: 8027 8027 1698
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -950 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5D
-Encoding: 8029 8029 8029
+Encoding: 8029 8029 1699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -975 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -975 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F5F
-Encoding: 8031 8031 8031
+Encoding: 8031 8031 1700
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -775 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -775 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F60
-Encoding: 8032 8032 8032
+Encoding: 8032 8032 1701
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F61
-Encoding: 8033 8033 8033
+Encoding: 8033 8033 1702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F62
-Encoding: 8034 8034 8034
+Encoding: 8034 8034 1703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F63
-Encoding: 8035 8035 8035
+Encoding: 8035 8035 1704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F64
-Encoding: 8036 8036 8036
+Encoding: 8036 8036 1705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F65
-Encoding: 8037 8037 8037
+Encoding: 8037 8037 1706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F66
-Encoding: 8038 8038 8038
+Encoding: 8038 8038 1707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F67
-Encoding: 8039 8039 8039
+Encoding: 8039 8039 1708
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F68
-Encoding: 8040 8040 8040
+Encoding: 8040 8040 1709
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 -550 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F69
-Encoding: 8041 8041 8041
+Encoding: 8041 8041 1710
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -650 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -650 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6A
-Encoding: 8042 8042 8042
+Encoding: 8042 8042 1711
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1806 8141 N 1 0 0 1 -875 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6B
-Encoding: 8043 8043 8043
+Encoding: 8043 8043 1712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1819 8157 N 1 0 0 1 -875 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6C
-Encoding: 8044 8044 8044
+Encoding: 8044 8044 1713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8142 8142 N 1 0 0 1 -625 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1807 8142 N 1 0 0 1 -625 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6D
-Encoding: 8045 8045 8045
+Encoding: 8045 8045 1714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8158 8158 N 1 0 0 1 -625 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1820 8158 N 1 0 0 1 -625 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6E
-Encoding: 8046 8046 8046
+Encoding: 8046 8046 1715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8143 8143 N 1 0 0 1 -550 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1808 8143 N 1 0 0 1 -550 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F6F
-Encoding: 8047 8047 8047
+Encoding: 8047 8047 1716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1821 8159 N 1 0 0 1 -625 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F70
-Encoding: 8048 8048 8048
+Encoding: 8048 8048 1717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F71
-Encoding: 8049 8049 8049
+Encoding: 8049 8049 1718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 766 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F72
-Encoding: 8050 8050 8050
+Encoding: 8050 8050 1719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 949 949 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 775 949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F73
-Encoding: 8051 8051 8051
+Encoding: 8051 8051 1720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 941 941 N 1 0 0 1 0 0 2
+Refer: 767 941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F74
-Encoding: 8052 8052 8052
+Encoding: 8052 8052 1721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F75
-Encoding: 8053 8053 8053
+Encoding: 8053 8053 1722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 768 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F76
-Encoding: 8054 8054 8054
+Encoding: 8054 8054 1723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F77
-Encoding: 8055 8055 8055
+Encoding: 8055 8055 1724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 943 943 N 1 0 0 1 0 0 2
+Refer: 769 943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F78
-Encoding: 8056 8056 8056
+Encoding: 8056 8056 1725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 959 959 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 785 959 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F79
-Encoding: 8057 8057 8057
+Encoding: 8057 8057 1726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 972 972 N 1 0 0 1 0 0 2
+Refer: 798 972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7A
-Encoding: 8058 8058 8058
+Encoding: 8058 8058 1727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7B
-Encoding: 8059 8059 8059
+Encoding: 8059 8059 1728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 973 973 N 1 0 0 1 0 0 2
+Refer: 799 973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7C
-Encoding: 8060 8060 8060
+Encoding: 8060 8060 1729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7D
-Encoding: 8061 8061 8061
+Encoding: 8061 8061 1730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 800 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F80
-Encoding: 8064 8064 8064
+Encoding: 8064 8064 1731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7936 7936 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1617 7936 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F81
-Encoding: 8065 8065 8065
+Encoding: 8065 8065 1732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7937 7937 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1618 7937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F82
-Encoding: 8066 8066 8066
+Encoding: 8066 8066 1733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7938 7938 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1619 7938 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F83
-Encoding: 8067 8067 8067
+Encoding: 8067 8067 1734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7939 7939 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1620 7939 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F84
-Encoding: 8068 8068 8068
+Encoding: 8068 8068 1735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7940 7940 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1621 7940 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F85
-Encoding: 8069 8069 8069
+Encoding: 8069 8069 1736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7941 7941 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1622 7941 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F86
-Encoding: 8070 8070 8070
+Encoding: 8070 8070 1737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7942 7942 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1623 7942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F87
-Encoding: 8071 8071 8071
+Encoding: 8071 8071 1738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7943 7943 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1624 7943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F88
-Encoding: 8072 8072 8072
+Encoding: 8072 8072 1739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7944 7944 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1625 7944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F89
-Encoding: 8073 8073 8073
+Encoding: 8073 8073 1740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7945 7945 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1626 7945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8A
-Encoding: 8074 8074 8074
+Encoding: 8074 8074 1741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7946 7946 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1627 7946 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8B
-Encoding: 8075 8075 8075
+Encoding: 8075 8075 1742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7947 7947 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1628 7947 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8C
-Encoding: 8076 8076 8076
+Encoding: 8076 8076 1743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7948 7948 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1629 7948 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8D
-Encoding: 8077 8077 8077
+Encoding: 8077 8077 1744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7949 7949 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1630 7949 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8E
-Encoding: 8078 8078 8078
+Encoding: 8078 8078 1745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7950 7950 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1631 7950 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8F
-Encoding: 8079 8079 8079
+Encoding: 8079 8079 1746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7951 7951 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1632 7951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F90
-Encoding: 8080 8080 8080
+Encoding: 8080 8080 1747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7968 7968 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1645 7968 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F91
-Encoding: 8081 8081 8081
+Encoding: 8081 8081 1748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7969 7969 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1646 7969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F92
-Encoding: 8082 8082 8082
+Encoding: 8082 8082 1749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7970 7970 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1647 7970 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F93
-Encoding: 8083 8083 8083
+Encoding: 8083 8083 1750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7971 7971 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1648 7971 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F94
-Encoding: 8084 8084 8084
+Encoding: 8084 8084 1751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7972 7972 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1649 7972 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F95
-Encoding: 8085 8085 8085
+Encoding: 8085 8085 1752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7973 7973 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1650 7973 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F96
-Encoding: 8086 8086 8086
+Encoding: 8086 8086 1753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7974 7974 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1651 7974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F97
-Encoding: 8087 8087 8087
+Encoding: 8087 8087 1754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7975 7975 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1652 7975 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F98
-Encoding: 8088 8088 8088
+Encoding: 8088 8088 1755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7976 7976 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1653 7976 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F99
-Encoding: 8089 8089 8089
+Encoding: 8089 8089 1756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7977 7977 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1654 7977 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9A
-Encoding: 8090 8090 8090
+Encoding: 8090 8090 1757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7978 7978 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1655 7978 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9B
-Encoding: 8091 8091 8091
+Encoding: 8091 8091 1758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7979 7979 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1656 7979 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9C
-Encoding: 8092 8092 8092
+Encoding: 8092 8092 1759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7980 7980 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1657 7980 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9D
-Encoding: 8093 8093 8093
+Encoding: 8093 8093 1760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7981 7981 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1658 7981 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9E
-Encoding: 8094 8094 8094
+Encoding: 8094 8094 1761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7982 7982 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1659 7982 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9F
-Encoding: 8095 8095 8095
+Encoding: 8095 8095 1762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7983 7983 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1660 7983 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA0
-Encoding: 8096 8096 8096
+Encoding: 8096 8096 1763
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8032 8032 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1701 8032 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA1
-Encoding: 8097 8097 8097
+Encoding: 8097 8097 1764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8033 8033 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1702 8033 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA2
-Encoding: 8098 8098 8098
+Encoding: 8098 8098 1765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8034 8034 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1703 8034 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA3
-Encoding: 8099 8099 8099
+Encoding: 8099 8099 1766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8035 8035 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1704 8035 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA4
-Encoding: 8100 8100 8100
+Encoding: 8100 8100 1767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8036 8036 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1705 8036 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA5
-Encoding: 8101 8101 8101
+Encoding: 8101 8101 1768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8037 8037 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1706 8037 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA6
-Encoding: 8102 8102 8102
+Encoding: 8102 8102 1769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8038 8038 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1707 8038 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA7
-Encoding: 8103 8103 8103
+Encoding: 8103 8103 1770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8039 8039 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1708 8039 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA8
-Encoding: 8104 8104 8104
+Encoding: 8104 8104 1771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8040 8040 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1709 8040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA9
-Encoding: 8105 8105 8105
+Encoding: 8105 8105 1772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8041 8041 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1710 8041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAA
-Encoding: 8106 8106 8106
+Encoding: 8106 8106 1773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8042 8042 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1711 8042 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAB
-Encoding: 8107 8107 8107
+Encoding: 8107 8107 1774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8043 8043 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1712 8043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAC
-Encoding: 8108 8108 8108
+Encoding: 8108 8108 1775
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8044 8044 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1713 8044 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAD
-Encoding: 8109 8109 8109
+Encoding: 8109 8109 1776
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8045 8045 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1714 8045 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAE
-Encoding: 8110 8110 8110
+Encoding: 8110 8110 1777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8046 8046 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1715 8046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAF
-Encoding: 8111 8111 8111
+Encoding: 8111 8111 1778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8047 8047 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 1716 8047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB0
-Encoding: 8112 8112 8112
+Encoding: 8112 8112 1779
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB1
-Encoding: 8113 8113 8113
+Encoding: 8113 8113 1780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB2
-Encoding: 8114 8114 8114
+Encoding: 8114 8114 1781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 8048 8048 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1717 8048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB3
-Encoding: 8115 8115 8115
+Encoding: 8115 8115 1782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB4
-Encoding: 8116 8116 8116
+Encoding: 8116 8116 1783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 766 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB6
-Encoding: 8118 8118 8118
+Encoding: 8118 8118 1784
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
+Refer: 771 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB7
-Encoding: 8119 8119 8119
+Encoding: 8119 8119 1785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 8118 8118 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -100 0 2
+Refer: 1784 8118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB8
-Encoding: 8120 8120 8120
+Encoding: 8120 8120 1786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB9
-Encoding: 8121 8121 8121
+Encoding: 8121 8121 1787
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBA
-Encoding: 8122 8122 8122
+Encoding: 8122 8122 1788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -400 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -400 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBB
-Encoding: 8123 8123 8123
+Encoding: 8123 8123 1789
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 902 902 N 1 0 0 1 0 0 2
+Refer: 731 902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBC
-Encoding: 8124 8124 8124
+Encoding: 8124 8124 1790
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 740 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBD
-Encoding: 8125 8125 8125
+Encoding: 8125 8125 1791
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBE
-Encoding: 8126 8126 8126
+Encoding: 8126 8126 1792
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBF
-Encoding: 8127 8127 8127
+Encoding: 8127 8127 1793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50891,491 +52689,547 @@ SplineSet
  853.983 1475 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1FC0
-Encoding: 8128 8128 8128
+Encoding: 8128 8128 1794
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 637 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC1
-Encoding: 8129 8129 8129
+Encoding: 8129 8129 1795
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 77 340 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 77 340 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC2
-Encoding: 8130 8130 8130
+Encoding: 8130 8130 1796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 8052 8052 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1721 8052 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC3
-Encoding: 8131 8131 8131
+Encoding: 8131 8131 1797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC4
-Encoding: 8132 8132 8132
+Encoding: 8132 8132 1798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 768 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC6
-Encoding: 8134 8134 8134
+Encoding: 8134 8134 1799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 951 951 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
+Refer: 777 951 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC7
-Encoding: 8135 8135 8135
+Encoding: 8135 8135 1800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 8134 8134 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 -312 0 2
+Refer: 1799 8134 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC8
-Encoding: 8136 8136 8136
+Encoding: 8136 8136 1801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -650 0 2
-Refer: 917 917 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -650 0 2
+Refer: 744 917 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC9
-Encoding: 8137 8137 8137
+Encoding: 8137 8137 1802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 904 904 N 1 0 0 1 0 0 2
+Refer: 733 904 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCA
-Encoding: 8138 8138 8138
+Encoding: 8138 8138 1803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -700 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCB
-Encoding: 8139 8139 8139
+Encoding: 8139 8139 1804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 905 905 N 1 0 0 1 0 0 2
+Refer: 734 905 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCC
-Encoding: 8140 8140 8140
+Encoding: 8140 8140 1805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 919 919 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 746 919 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCD
-Encoding: 8141 8141 8141
+Encoding: 8141 8141 1806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 250 0 2
-Refer: 8127 8127 N 1 0 0 1 -250 0 2
+Refer: 1837 8175 N 1 0 0 1 250 0 2
+Refer: 1793 8127 N 1 0 0 1 -250 0 2
 EndChar
+
 StartChar: uni1FCE
-Encoding: 8142 8142 8142
+Encoding: 8142 8142 1807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8189 8189 N 1 0 0 1 100 0 2
-Refer: 8127 8127 N 1 0 0 1 -200 0 2
+Refer: 1848 8189 N 1 0 0 1 100 0 2
+Refer: 1793 8127 N 1 0 0 1 -200 0 2
 EndChar
+
 StartChar: uni1FCF
-Encoding: 8143 8143 8143
+Encoding: 8143 8143 1808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 70 410 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 70 410 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD0
-Encoding: 8144 8144 8144
+Encoding: 8144 8144 1809
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD1
-Encoding: 8145 8145 8145
+Encoding: 8145 8145 1810
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD2
-Encoding: 8146 8146 8146
+Encoding: 8146 8146 1811
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8173 8173 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1835 8173 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD3
-Encoding: 8147 8147 8147
+Encoding: 8147 8147 1812
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 912 912 N 1 0 0 1 0 0 2
+Refer: 739 912 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD6
-Encoding: 8150 8150 8150
+Encoding: 8150 8150 1813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD7
-Encoding: 8151 8151 8151
+Encoding: 8151 8151 1814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8129 8129 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 1795 8129 N 1 0 0 1 0 0 2
+Refer: 779 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD8
-Encoding: 8152 8152 8152
+Encoding: 8152 8152 1815
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD9
-Encoding: 8153 8153 8153
+Encoding: 8153 8153 1816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDA
-Encoding: 8154 8154 8154
+Encoding: 8154 8154 1817
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -600 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -600 0 2
+Refer: 748 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDB
-Encoding: 8155 8155 8155
+Encoding: 8155 8155 1818
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 906 906 N 1 0 0 1 0 0 2
+Refer: 735 906 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDD
-Encoding: 8157 8157 8157
+Encoding: 8157 8157 1819
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 250 0 2
-Refer: 8190 8190 N 1 0 0 1 -250 0 2
+Refer: 1837 8175 N 1 0 0 1 250 0 2
+Refer: 1849 8190 N 1 0 0 1 -250 0 2
 EndChar
+
 StartChar: uni1FDE
-Encoding: 8158 8158 8158
+Encoding: 8158 8158 1820
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8189 8189 N 1 0 0 1 100 0 2
-Refer: 8190 8190 N 1 0 0 1 -220 0 2
+Refer: 1848 8189 N 1 0 0 1 100 0 2
+Refer: 1849 8190 N 1 0 0 1 -220 0 2
 EndChar
+
 StartChar: uni1FDF
-Encoding: 8159 8159 8159
+Encoding: 8159 8159 1821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 62 410 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 62 410 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE0
-Encoding: 8160 8160 8160
+Encoding: 8160 8160 1822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 774 774 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
+Refer: 658 774 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE1
-Encoding: 8161 8161 8161
+Encoding: 8161 8161 1823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
+Refer: 656 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE2
-Encoding: 8162 8162 8162
+Encoding: 8162 8162 1824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8173 8173 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1835 8173 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE3
-Encoding: 8163 8163 8163
+Encoding: 8163 8163 1825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 944 944 N 1 0 0 1 0 0 2
+Refer: 770 944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE4
-Encoding: 8164 8164 8164
+Encoding: 8164 8164 1826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 1793 8127 N 1 0 0 1 0 0 2
+Refer: 787 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE5
-Encoding: 8165 8165 8165
+Encoding: 8165 8165 1827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 0 0 2
+Refer: 787 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE6
-Encoding: 8166 8166 8166
+Encoding: 8166 8166 1828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE7
-Encoding: 8167 8167 8167
+Encoding: 8167 8167 1829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8129 8129 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 1795 8129 N 1 0 0 1 0 0 2
+Refer: 791 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE8
-Encoding: 8168 8168 8168
+Encoding: 8168 8168 1830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
+Refer: 3096 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE9
-Encoding: 8169 8169 8169
+Encoding: 8169 8169 1831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
+Refer: 3101 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEA
-Encoding: 8170 8170 8170
+Encoding: 8170 8170 1832
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -700 0 2
+Refer: 759 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEB
-Encoding: 8171 8171 8171
+Encoding: 8171 8171 1833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 910 910 N 1 0 0 1 0 0 2
+Refer: 737 910 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEC
-Encoding: 8172 8172 8172
+Encoding: 8172 8172 1834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
-Refer: 929 929 N 1 0 0 1 0 0 2
+Refer: 1849 8190 N 1 0 0 1 -625 0 2
+Refer: 756 929 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FED
-Encoding: 8173 8173 8173
+Encoding: 8173 8173 1835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 0 370 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEE
-Encoding: 8174 8174 8174
+Encoding: 8174 8174 1836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 730 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEF
-Encoding: 8175 8175 8175
+Encoding: 8175 8175 1837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF2
-Encoding: 8178 8178 8178
+Encoding: 8178 8178 1838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8060 8060 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1729 8060 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF3
-Encoding: 8179 8179 8179
+Encoding: 8179 8179 1839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF4
-Encoding: 8180 8180 8180
+Encoding: 8180 8180 1840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 800 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF6
-Encoding: 8182 8182 8182
+Encoding: 8182 8182 1841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8128 8128 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 1794 8128 N 1 0 0 1 0 0 2
+Refer: 795 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF7
-Encoding: 8183 8183 8183
+Encoding: 8183 8183 1842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8182 8182 N 1 0 0 1 0 0 2
+Refer: 723 890 N 1 0 0 1 0 0 2
+Refer: 1841 8182 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF8
-Encoding: 8184 8184 8184
+Encoding: 8184 8184 1843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
-Refer: 927 927 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -625 0 2
+Refer: 754 927 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF9
-Encoding: 8185 8185 8185
+Encoding: 8185 8185 1844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 908 908 N 1 0 0 1 0 0 2
+Refer: 736 908 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFA
-Encoding: 8186 8186 8186
+Encoding: 8186 8186 1845
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1837 8175 N 1 0 0 1 -625 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFB
-Encoding: 8187 8187 8187
+Encoding: 8187 8187 1846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 911 911 N 1 0 0 1 0 0 2
+Refer: 738 911 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFC
-Encoding: 8188 8188 8188
+Encoding: 8188 8188 1847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 1792 8126 N 1 0 0 1 0 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFD
-Encoding: 8189 8189 8189
+Encoding: 8189 8189 1848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFE
-Encoding: 8190 8190 8190
+Encoding: 8190 8190 1849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51391,74 +53245,86 @@ SplineSet
  563.027 1218 563.027 1218 612.983 1475 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2000
-Encoding: 8192 8192 8192
+Encoding: 8192 8192 1850
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2001
-Encoding: 8193 8193 8193
+Encoding: 8193 8193 1851
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2002
-Encoding: 8194 8194 8194
+Encoding: 8194 8194 1852
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2003
-Encoding: 8195 8195 8195
+Encoding: 8195 8195 1853
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2004
-Encoding: 8196 8196 8196
+Encoding: 8196 8196 1854
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2005
-Encoding: 8197 8197 8197
+Encoding: 8197 8197 1855
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2006
-Encoding: 8198 8198 8198
+Encoding: 8198 8198 1856
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2007
-Encoding: 8199 8199 8199
+Encoding: 8199 8199 1857
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2008
-Encoding: 8200 8200 8200
+Encoding: 8200 8200 1858
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2009
-Encoding: 8201 8201 8201
+Encoding: 8201 8201 1859
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni200A
-Encoding: 8202 8202 8202
+Encoding: 8202 8202 1860
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2010
-Encoding: 8208 8208 8208
+Encoding: 8208 8208 1861
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51493,16 +53359,18 @@ SplineSet
  336 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2011
-Encoding: 8209 8209 8209
+Encoding: 8209 8209 1862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8208 8208 N 1 0 0 1 0 0 2
+Refer: 1861 8208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: figuredash
-Encoding: 8210 8210 8210
+Encoding: 8210 8210 1863
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51544,8 +53412,9 @@ SplineSet
  -23 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: endash
-Encoding: 8211 8211 8211
+Encoding: 8211 8211 1864
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51587,8 +53456,9 @@ SplineSet
  -23 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: emdash
-Encoding: 8212 8212 8212
+Encoding: 8212 8212 1865
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51629,8 +53499,9 @@ SplineSet
  -23 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2015
-Encoding: 8213 8213 8213
+Encoding: 8213 8213 1866
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51671,26 +53542,29 @@ SplineSet
  -23 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2016
-Encoding: 8214 8214 8214
+Encoding: 8214 8214 1867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 245 0 2
-Refer: 124 124 N 1 0 0 1 -245 0 2
+Refer: 93 124 N 1 0 0 1 245 0 2
+Refer: 93 124 N 1 0 0 1 -245 0 2
 EndChar
+
 StartChar: underscoredbl
-Encoding: 8215 8215 8215
+Encoding: 8215 8215 1868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
-Refer: 95 95 N 1 0 0 1 0 240 2
+Refer: 64 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 240 2
 EndChar
+
 StartChar: quoteleft
-Encoding: 8216 8216 8216
+Encoding: 8216 8216 1869
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51764,8 +53638,9 @@ SplineSet
  715 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quoteright
-Encoding: 8217 8217 8217
+Encoding: 8217 8217 1870
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51835,8 +53710,9 @@ SplineSet
  676 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotesinglbase
-Encoding: 8218 8218 8218
+Encoding: 8218 8218 1871
 Width: 1233
 Flags: W
 TtInstrs:
@@ -51906,8 +53782,9 @@ SplineSet
  416 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotereversed
-Encoding: 8219 8219 8219
+Encoding: 8219 8219 1872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51922,8 +53799,9 @@ SplineSet
  833.985 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblleft
-Encoding: 8220 8220 8220
+Encoding: 8220 8220 1873
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52048,8 +53926,9 @@ SplineSet
  498 967 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblright
-Encoding: 8221 8221 8221
+Encoding: 8221 8221 1874
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52168,8 +54047,9 @@ SplineSet
  893 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblbase
-Encoding: 8222 8222 8222
+Encoding: 8222 8222 1875
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52288,8 +54168,9 @@ SplineSet
  655 303 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni201F
-Encoding: 8223 8223 8223
+Encoding: 8223 8223 1876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52311,8 +54192,9 @@ SplineSet
  591.985 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: dagger
-Encoding: 8224 8224 8224
+Encoding: 8224 8224 1877
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52427,8 +54309,9 @@ SplineSet
  674 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: daggerdbl
-Encoding: 8225 8225 8225
+Encoding: 8225 8225 1878
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52596,8 +54479,9 @@ SplineSet
  969 223 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bullet
-Encoding: 8226 8226 8226
+Encoding: 8226 8226 1879
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52634,8 +54518,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2023
-Encoding: 8227 8227 8227
+Encoding: 8227 8227 1880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52647,20 +54532,23 @@ SplineSet
  319 385 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: onedotenleader
-Encoding: 8228 8228 8228
+Encoding: 8228 8228 1881
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: twodotenleader
-Encoding: 8229 8229 8229
+Encoding: 8229 8229 1882
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: ellipsis
-Encoding: 8230 8230 8230
+Encoding: 8230 8230 1883
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52804,14 +54692,16 @@ SplineSet
  403 303 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni202F
-Encoding: 8239 8239 8239
+Encoding: 8239 8239 1884
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: perthousand
-Encoding: 8240 8240 8240
+Encoding: 8240 8240 1885
 Width: 1233
 Flags: W
 TtInstrs:
@@ -52944,22 +54834,22 @@ SplineSet
  166 358 166 358 166 289 c 0,4,5
 45 289 m 0,16,17
  45 410 45 410 127.5 492.5 c 128,-1,18
- 210 575 210 575 330 575 c 0,19,20
+ 210 575 210 575 330 575 c 256,19,20
  450 575 450 575 533 492 c 128,-1,21
  616 409 616 409 616 289 c 0,22,23
  616 168 616 168 532.5 84 c 128,-1,24
  449 0 449 0 330 0 c 0,25,26
  209 0 209 0 127 83 c 128,-1,27
  45 166 45 166 45 289 c 0,16,17
-121 1145 m 0,28,29
+121 1145 m 256,28,29
  121 1076 121 1076 169.5 1027.5 c 128,-1,30
- 218 979 218 979 287 979 c 0,31,32
+ 218 979 218 979 287 979 c 256,31,32
  356 979 356 979 404.5 1027.5 c 128,-1,33
  453 1076 453 1076 453 1145 c 0,34,35
  453 1212 453 1212 403.5 1261.5 c 128,-1,36
  354 1311 354 1311 287 1311 c 0,37,38
  218 1311 218 1311 169.5 1262.5 c 128,-1,39
- 121 1214 121 1214 121 1145 c 0,28,29
+ 121 1214 121 1214 121 1145 c 256,28,29
 0 1145 m 0,40,41
  0 1265 0 1265 83 1348.5 c 128,-1,42
  166 1432 166 1432 287 1432 c 0,43,44
@@ -52989,8 +54879,9 @@ SplineSet
  659 167 659 167 659 289 c 0,64,65
 EndSplineSet
 EndChar
+
 StartChar: uni2031
-Encoding: 8241 8241 8241
+Encoding: 8241 8241 1886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53073,8 +54964,9 @@ SplineSet
  855 358 855 358 855 289 c 0,93,94
 EndSplineSet
 EndChar
+
 StartChar: minute
-Encoding: 8242 8242 8242
+Encoding: 8242 8242 1887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53087,27 +54979,30 @@ SplineSet
  646 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: second
-Encoding: 8243 8243 8243
+Encoding: 8243 8243 1888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 -150 0 2
-Refer: 8242 8242 N 1 0 0 1 150 0 2
+Refer: 1887 8242 N 1 0 0 1 -150 0 2
+Refer: 1887 8242 N 1 0 0 1 150 0 2
 EndChar
+
 StartChar: uni2034
-Encoding: 8244 8244 8244
+Encoding: 8244 8244 1889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 0 0 2
-Refer: 8242 8242 N 1 0 0 1 -300 0 2
-Refer: 8242 8242 N 1 0 0 1 300 0 2
+Refer: 1887 8242 N 1 0 0 1 0 0 2
+Refer: 1887 8242 N 1 0 0 1 -300 0 2
+Refer: 1887 8242 N 1 0 0 1 300 0 2
 EndChar
+
 StartChar: uni2035
-Encoding: 8245 8245 8245
+Encoding: 8245 8245 1890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53120,27 +55015,30 @@ SplineSet
  1022 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2036
-Encoding: 8246 8246 8246
+Encoding: 8246 8246 1891
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 -150 0 2
-Refer: 8245 8245 N 1 0 0 1 150 0 2
+Refer: 1890 8245 N 1 0 0 1 -150 0 2
+Refer: 1890 8245 N 1 0 0 1 150 0 2
 EndChar
+
 StartChar: uni2037
-Encoding: 8247 8247 8247
+Encoding: 8247 8247 1892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 -300 0 2
-Refer: 8245 8245 N 1 0 0 1 300 0 2
-Refer: 8245 8245 N 1 0 0 1 0 0 2
+Refer: 1890 8245 N 1 0 0 1 -300 0 2
+Refer: 1890 8245 N 1 0 0 1 300 0 2
+Refer: 1890 8245 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: guilsinglleft
-Encoding: 8249 8249 8249
+Encoding: 8249 8249 1893
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53186,8 +55084,9 @@ SplineSet
  877 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: guilsinglright
-Encoding: 8250 8250 8250
+Encoding: 8250 8250 1894
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53233,18 +55132,20 @@ SplineSet
  317 141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdbl
-Encoding: 8252 8252 8252
+Encoding: 8252 8252 1895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni203D
-Encoding: 8253 8253 8253
+Encoding: 8253 8253 1896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53280,16 +55181,18 @@ SplineSet
  846 1332 846 1332 798 1346 c 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni203E
-Encoding: 8254 8254 8254
+Encoding: 8254 8254 1897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 1950 2
+Refer: 64 95 N 1 0 0 1 0 1950 2
 EndChar
+
 StartChar: uni203F
-Encoding: 8255 8255 8255
+Encoding: 8255 8255 1898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53308,8 +55211,9 @@ SplineSet
  442 -331 442 -331 615 -331 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2045
-Encoding: 8261 8261 8261
+Encoding: 8261 8261 1899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53330,8 +55234,9 @@ SplineSet
  621 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2046
-Encoding: 8262 8262 8262
+Encoding: 8262 8262 1900
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53352,38 +55257,42 @@ SplineSet
  551 571 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2047
-Encoding: 8263 8263 8263
+Encoding: 8263 8263 1901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -308 0 2
-Refer: 1114126 -1 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3100 -1 N 1 0 0 1 -308 0 2
+Refer: 3100 -1 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2048
-Encoding: 8264 8264 8264
+Encoding: 8264 8264 1902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -162 0 2
-Refer: 33 33 N 1 0 0 1 339 0 2
-LCarets2: 1 0 
+Refer: 3100 -1 N 1 0 0 1 -162 0 2
+Refer: 2 33 N 1 0 0 1 339 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2049
-Encoding: 8265 8265 8265
+Encoding: 8265 8265 1903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 1114126 -1 N 1 0 0 1 283.5 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 3100 -1 N 1 0 0 1 283.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni204B
-Encoding: 8267 8267 8267
+Encoding: 8267 8267 1904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53404,14 +55313,16 @@ SplineSet
  815 1493 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni205F
-Encoding: 8287 8287 8287
+Encoding: 8287 8287 1905
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2070
-Encoding: 8304 8304 8304
+Encoding: 8304 8304 1906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53454,8 +55365,9 @@ SplineSet
  557.001 745 557.001 745 627 745 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2071
-Encoding: 8305 8305 8305
+Encoding: 8305 8305 1907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53479,8 +55391,9 @@ SplineSet
  740 1539 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2074
-Encoding: 8308 8308 8308
+Encoding: 8308 8308 1908
 Width: 1233
 Flags: W
 TtInstrs:
@@ -53622,8 +55535,9 @@ SplineSet
  760 1354 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2075
-Encoding: 8309 8309 8309
+Encoding: 8309 8309 1909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53656,8 +55570,9 @@ SplineSet
  542 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2076
-Encoding: 8310 8310 8310
+Encoding: 8310 8310 1910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53696,8 +55611,9 @@ SplineSet
  1008 1503.01 1008 1503.01 1050 1487 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2077
-Encoding: 8311 8311 8311
+Encoding: 8311 8311 1911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53713,8 +55629,9 @@ SplineSet
  421 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2078
-Encoding: 8312 8312 8312
+Encoding: 8312 8312 1912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53757,8 +55674,9 @@ SplineSet
  835 1433 835 1433 768 1433 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2079
-Encoding: 8313 8313 8313
+Encoding: 8313 8313 1913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53797,8 +55715,9 @@ SplineSet
  396 670 396 670 353 686 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni207A
-Encoding: 8314 8314 8314
+Encoding: 8314 8314 1914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53819,8 +55738,9 @@ SplineSet
  670 1324 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207B
-Encoding: 8315 8315 8315
+Encoding: 8315 8315 1915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53833,8 +55753,9 @@ SplineSet
  284 1075 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207C
-Encoding: 8316 8316 8316
+Encoding: 8316 8316 1916
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53852,8 +55773,9 @@ SplineSet
  284 1189 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207D
-Encoding: 8317 8317 8317
+Encoding: 8317 8317 1917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53872,8 +55794,9 @@ SplineSet
  827 1538 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207E
-Encoding: 8318 8318 8318
+Encoding: 8318 8318 1918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53892,8 +55815,9 @@ SplineSet
  406 517 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207F
-Encoding: 8319 8319 8319
+Encoding: 8319 8319 1919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -53918,232 +55842,261 @@ SplineSet
  957.904 1184 957.904 1184 933.218 1057 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2080
-Encoding: 8320 8320 8320
+Encoding: 8320 8320 1920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 0 -668 3
+Refer: 1906 8304 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2081
-Encoding: 8321 8321 8321
+Encoding: 8321 8321 1921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 0 -668 3
+Refer: 121 185 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2082
-Encoding: 8322 8322 8322
+Encoding: 8322 8322 1922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 0 -668 3
+Refer: 114 178 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2083
-Encoding: 8323 8323 8323
+Encoding: 8323 8323 1923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 0 -668 3
+Refer: 115 179 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2084
-Encoding: 8324 8324 8324
+Encoding: 8324 8324 1924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 0 -668 3
+Refer: 1908 8308 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2085
-Encoding: 8325 8325 8325
+Encoding: 8325 8325 1925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 0 -668 3
+Refer: 1909 8309 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2086
-Encoding: 8326 8326 8326
+Encoding: 8326 8326 1926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 0 -668 3
+Refer: 1910 8310 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2087
-Encoding: 8327 8327 8327
+Encoding: 8327 8327 1927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 0 -668 3
+Refer: 1911 8311 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2088
-Encoding: 8328 8328 8328
+Encoding: 8328 8328 1928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 0 -668 3
+Refer: 1912 8312 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2089
-Encoding: 8329 8329 8329
+Encoding: 8329 8329 1929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8313 8313 N 1 0 0 1 0 -668 3
+Refer: 1913 8313 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208A
-Encoding: 8330 8330 8330
+Encoding: 8330 8330 1930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8314 8314 N 1 0 0 1 0 -668 3
+Refer: 1914 8314 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208B
-Encoding: 8331 8331 8331
+Encoding: 8331 8331 1931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8315 8315 N 1 0 0 1 0 -668 3
+Refer: 1915 8315 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208C
-Encoding: 8332 8332 8332
+Encoding: 8332 8332 1932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8316 8316 N 1 0 0 1 0 -668 3
+Refer: 1916 8316 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208D
-Encoding: 8333 8333 8333
+Encoding: 8333 8333 1933
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8317 8317 N 1 0 0 1 0 -668 3
+Refer: 1917 8317 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208E
-Encoding: 8334 8334 8334
+Encoding: 8334 8334 1934
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8318 8318 N 1 0 0 1 0 -668 3
+Refer: 1918 8318 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2090
-Encoding: 8336 8336 8336
+Encoding: 8336 8336 1935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7491 7491 N 1 0 0 1 0 -668 3
+Refer: 1366 7491 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2091
-Encoding: 8337 8337 8337
+Encoding: 8337 8337 1936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7497 7497 N 1 0 0 1 0 -668 3
+Refer: 1372 7497 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2092
-Encoding: 8338 8338 8338
+Encoding: 8338 8338 1937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7506 7506 N 1 0 0 1 0 -668 3
+Refer: 1381 7506 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2093
-Encoding: 8339 8339 8339
+Encoding: 8339 8339 1938
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 739 739 N 1 0 0 1 0 -668 3
+Refer: 643 739 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2094
-Encoding: 8340 8340 8340
+Encoding: 8340 8340 1939
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7498 7498 N 1 0 0 1 0 -668 3
+Refer: 1373 7498 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2095
-Encoding: 8341 8341 8341
+Encoding: 8341 8341 1940
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 688 688 N 1 0 0 1 0 -668 3
+Refer: 602 688 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2096
-Encoding: 8342 8342 8342
+Encoding: 8342 8342 1941
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7503 7503 N 1 0 0 1 0 -668 3
+Refer: 1378 7503 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2097
-Encoding: 8343 8343 8343
+Encoding: 8343 8343 1942
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 737 737 N 1 0 0 1 0 -668 3
+Refer: 641 737 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2098
-Encoding: 8344 8344 8344
+Encoding: 8344 8344 1943
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7504 7504 N 1 0 0 1 0 -668 3
+Refer: 1379 7504 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2099
-Encoding: 8345 8345 8345
+Encoding: 8345 8345 1944
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8319 8319 N 1 0 0 1 0 -668 3
+Refer: 1919 8319 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209A
-Encoding: 8346 8346 8346
+Encoding: 8346 8346 1945
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7510 7510 N 1 0 0 1 0 -668 3
+Refer: 1385 7510 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209B
-Encoding: 8347 8347 8347
+Encoding: 8347 8347 1946
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 738 738 N 1 0 0 1 0 -668 3
+Refer: 642 738 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209C
-Encoding: 8348 8348 8348
+Encoding: 8348 8348 1947
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7511 7511 N 1 0 0 1 0 -668 3
+Refer: 1386 7511 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni20A0
-Encoding: 8352 8352 8352
+Encoding: 8352 8352 1948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54182,8 +56135,9 @@ SplineSet
  639 440 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: colonmonetary
-Encoding: 8353 8353 8353
+Encoding: 8353 8353 1949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54237,8 +56191,9 @@ SplineSet
  951 1321 l 1,55,56
 EndSplineSet
 EndChar
+
 StartChar: uni20A2
-Encoding: 8354 8354 8354
+Encoding: 8354 8354 1950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54282,8 +56237,9 @@ SplineSet
  671 140 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: franc
-Encoding: 8355 8355 8355
+Encoding: 8355 8355 1951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54310,8 +56266,9 @@ SplineSet
  243 408 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lira
-Encoding: 8356 8356 8356
+Encoding: 8356 8356 1952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54352,8 +56309,9 @@ SplineSet
  543 535 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A5
-Encoding: 8357 8357 8357
+Encoding: 8357 8357 1953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54394,8 +56352,9 @@ SplineSet
  339 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A6
-Encoding: 8358 8358 8358
+Encoding: 8358 8358 1954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54450,8 +56409,9 @@ SplineSet
  757.739 550 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: peseta
-Encoding: 8359 8359 8359
+Encoding: 8359 8359 1955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54527,8 +56487,9 @@ SplineSet
  808 887 808 887 842 977 c 1,64,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A8
-Encoding: 8360 8360 8360
+Encoding: 8360 8360 1956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54589,8 +56550,9 @@ SplineSet
  700 -3 700 -3 676 7 c 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A9
-Encoding: 8361 8361 8361
+Encoding: 8361 8361 1957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54654,8 +56616,9 @@ SplineSet
  231 1156 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AA
-Encoding: 8362 8362 8362
+Encoding: 8362 8362 1958
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54689,17 +56652,19 @@ SplineSet
  1062 -29 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dong
-Encoding: 8363 8363 8363
+Encoding: 8363 8363 1959
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 273 273 N 1 0 0 1 0 0 2
-Refer: 717 717 N 1 0 0 1 107 -1 2
+Refer: 209 273 N 1 0 0 1 0 0 2
+Refer: 624 717 N 1 0 0 1 107 -1 2
 EndChar
+
 StartChar: Euro
-Encoding: 8364 8364 8364
+Encoding: 8364 8364 1960
 Width: 1233
 Flags: W
 TtInstrs:
@@ -54870,8 +56835,9 @@ SplineSet
  238 948 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20AD
-Encoding: 8365 8365 8365
+Encoding: 8365 8365 1961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54898,8 +56864,9 @@ SplineSet
  185 858 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AE
-Encoding: 8366 8366 8366
+Encoding: 8366 8366 1962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -54932,8 +56899,9 @@ SplineSet
  527 805 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AF
-Encoding: 8367 8367 8367
+Encoding: 8367 8367 1963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55028,8 +56996,9 @@ SplineSet
  160 136 160 136 181 199 c 1,132,133
 EndSplineSet
 EndChar
+
 StartChar: uni20B0
-Encoding: 8368 8368 8368
+Encoding: 8368 8368 1964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55073,8 +57042,9 @@ SplineSet
  686 975 686 975 782 881 c 1,50,51
 EndSplineSet
 EndChar
+
 StartChar: uni20B1
-Encoding: 8369 8369 8369
+Encoding: 8369 8369 1965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55122,8 +57092,9 @@ SplineSet
  990.561 1188 l 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: uni20B2
-Encoding: 8370 8370 8370
+Encoding: 8370 8370 1966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55165,8 +57136,9 @@ SplineSet
  343 182 343 182 459 150 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B3
-Encoding: 8371 8371 8371
+Encoding: 8371 8371 1967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55208,8 +57180,9 @@ SplineSet
  596 973 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B4
-Encoding: 8372 8372 8372
+Encoding: 8372 8372 1968
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55257,8 +57230,9 @@ SplineSet
  869.32 943 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B5
-Encoding: 8373 8373 8373
+Encoding: 8373 8373 1969
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55296,8 +57270,9 @@ SplineSet
  460.134 164.957 460.134 164.957 547.47 142.417 c 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B8
-Encoding: 8376 8376 8376
+Encoding: 8376 8376 1970
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55319,8 +57294,9 @@ SplineSet
  136 1203 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B9
-Encoding: 8377 8377 8377
+Encoding: 8377 8377 1971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55357,8 +57333,9 @@ SplineSet
  1282 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20BA
-Encoding: 8378 8378 8378
+Encoding: 8378 8378 1972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55392,8 +57369,9 @@ SplineSet
  1180 748 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20BD
-Encoding: 8381 8381 8381
+Encoding: 8381 8381 1973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55431,8 +57409,9 @@ SplineSet
  619 1327 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2102
-Encoding: 8450 8450 8450
+Encoding: 8450 8450 1974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55466,8 +57445,9 @@ SplineSet
  512 1282 l 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni2105
-Encoding: 8453 8453 8453
+Encoding: 8453 8453 1975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55527,8 +57507,9 @@ SplineSet
  791 396 791 396 791 323 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: uni210D
-Encoding: 8461 8461 8461
+Encoding: 8461 8461 1976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55559,16 +57540,18 @@ SplineSet
  58 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210E
-Encoding: 8462 8462 8462
+Encoding: 8462 8462 1977
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni210F
-Encoding: 8463 8463 8463
+Encoding: 8463 8463 1978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55602,8 +57585,9 @@ SplineSet
  455 952 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2115
-Encoding: 8469 8469 8469
+Encoding: 8469 8469 1979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55627,8 +57611,9 @@ SplineSet
  74 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2116
-Encoding: 8470 8470 8470
+Encoding: 8470 8470 1980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55674,8 +57659,9 @@ SplineSet
  36 246 36 246 47 305 c 2,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2117
-Encoding: 8471 8471 8471
+Encoding: 8471 8471 1981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55735,8 +57721,9 @@ SplineSet
  411 1113 l 1,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2119
-Encoding: 8473 8473 8473
+Encoding: 8473 8473 1982
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55772,8 +57759,9 @@ SplineSet
  943 1348 943 1348 883 1370 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211A
-Encoding: 8474 8474 8474
+Encoding: 8474 8474 1983
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55814,8 +57802,9 @@ SplineSet
  947 1269 947 1269 917 1298 c 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211D
-Encoding: 8477 8477 8477
+Encoding: 8477 8477 1984
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55866,8 +57855,9 @@ SplineSet
  122 1393 l 1,47,-1
 EndSplineSet
 EndChar
+
 StartChar: trademark
-Encoding: 8482 8482 8482
+Encoding: 8482 8482 1985
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56004,8 +57994,9 @@ SplineSet
  692 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2124
-Encoding: 8484 8484 8484
+Encoding: 8484 8484 1986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56029,32 +58020,36 @@ SplineSet
  67 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2126
-Encoding: 8486 8486 8486
+Encoding: 8486 8486 1987
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 763 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212A
-Encoding: 8490 8490 8490
+Encoding: 8490 8490 1988
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212B
-Encoding: 8491 8491 8491
+Encoding: 8491 8491 1989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 197 197 N 1 0 0 1 0 0 2
+Refer: 133 197 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: estimated
-Encoding: 8494 8494 8494
+Encoding: 8494 8494 1990
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56092,8 +58087,9 @@ SplineSet
  233 704 l 2,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2148
-Encoding: 8520 8520 8520
+Encoding: 8520 8520 1991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56122,180 +58118,197 @@ SplineSet
  693 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2150
-Encoding: 8528 8528 8528
+Encoding: 8528 8528 1992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 137 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1911 8311 N 1 0 0 1 137 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2151
-Encoding: 8529 8529 8529
+Encoding: 8529 8529 1993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8313 8313 N 1 0 0 1 137 -928 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1913 8313 N 1 0 0 1 137 -928 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: onethird
-Encoding: 8531 8531 8531
+Encoding: 8531 8531 1994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 179 179 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: twothirds
-Encoding: 8532 8532 8532
+Encoding: 8532 8532 1995
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 179 179 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2155
-Encoding: 8533 8533 8533
+Encoding: 8533 8533 1996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2156
-Encoding: 8534 8534 8534
+Encoding: 8534 8534 1997
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2157
-Encoding: 8535 8535 8535
+Encoding: 8535 8535 1998
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -228 156 2
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -228 156 2
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2158
-Encoding: 8536 8536 8536
+Encoding: 8536 8536 1999
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8308 8308 N 1 0 0 1 -228 156 2
-Refer: 8309 8309 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1908 8308 N 1 0 0 1 -228 156 2
+Refer: 1909 8309 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni2159
-Encoding: 8537 8537 8537
+Encoding: 8537 8537 2000
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8310 8310 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 1910 8310 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni215A
-Encoding: 8538 8538 8538
+Encoding: 8538 8538 2001
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -228 156 2
-Refer: 8310 8310 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1909 8309 N 1 0 0 1 -228 156 2
+Refer: 1910 8310 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: oneeighth
-Encoding: 8539 8539 8539
+Encoding: 8539 8539 2002
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: threeeighths
-Encoding: 8540 8540 8540
+Encoding: 8540 8540 2003
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -228 156 2
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -228 156 2
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: fiveeighths
-Encoding: 8541 8541 8541
+Encoding: 8541 8541 2004
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -228 156 2
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1909 8309 N 1 0 0 1 -228 156 2
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: seveneighths
-Encoding: 8542 8542 8542
+Encoding: 8542 8542 2005
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 -258 156 2
-Refer: 8312 8312 N 1 0 0 1 137 -938 2
-LCarets2: 2 0 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1911 8311 N 1 0 0 1 -258 156 2
+Refer: 1912 8312 N 1 0 0 1 137 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni215F
-Encoding: 8543 8543 8543
+Encoding: 8543 8543 2006
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-LCarets2: 1 0 
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2189
-Encoding: 8585 8585 8585
+Encoding: 8585 8585 2007
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 137 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8304 8304 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 137 -938 2
+Refer: 3094 -1 N 1 0 0 1 0 0 2
+Refer: 1906 8304 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: arrowleft
-Encoding: 8592 8592 8592
+Encoding: 8592 8592 2008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56314,8 +58327,9 @@ SplineSet
  66 520 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowup
-Encoding: 8593 8593 8593
+Encoding: 8593 8593 2009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56334,8 +58348,9 @@ SplineSet
  657.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowright
-Encoding: 8594 8594 8594
+Encoding: 8594 8594 2010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56354,8 +58369,9 @@ SplineSet
  1167 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdown
-Encoding: 8595 8595 8595
+Encoding: 8595 8595 2011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56374,8 +58390,9 @@ SplineSet
  575.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowboth
-Encoding: 8596 8596 8596
+Encoding: 8596 8596 2012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56400,8 +58417,9 @@ SplineSet
  946 479 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdn
-Encoding: 8597 8597 8597
+Encoding: 8597 8597 2013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56426,8 +58444,9 @@ SplineSet
  698.5 221 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2196
-Encoding: 8598 8598 8598
+Encoding: 8598 8598 2014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56446,8 +58465,9 @@ SplineSet
  184 807 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2197
-Encoding: 8599 8599 8599
+Encoding: 8599 8599 2015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56466,8 +58486,9 @@ SplineSet
  1049 807 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2198
-Encoding: 8600 8600 8600
+Encoding: 8600 8600 2016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56486,8 +58507,9 @@ SplineSet
  991 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2199
-Encoding: 8601 8601 8601
+Encoding: 8601 8601 2017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56506,8 +58528,9 @@ SplineSet
  184 58 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219A
-Encoding: 8602 8602 8602
+Encoding: 8602 8602 2018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56534,8 +58557,9 @@ SplineSet
  961 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219B
-Encoding: 8603 8603 8603
+Encoding: 8603 8603 2019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56562,8 +58586,9 @@ SplineSet
  272 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219C
-Encoding: 8604 8604 8604
+Encoding: 8604 8604 2020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56604,8 +58629,9 @@ SplineSet
  292.277 738 l 17,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219D
-Encoding: 8605 8605 8605
+Encoding: 8605 8605 2021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56646,8 +58672,9 @@ SplineSet
  933.723 726 933.723 726 940.723 738 c 9,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219E
-Encoding: 8606 8606 8606
+Encoding: 8606 8606 2022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56674,8 +58701,9 @@ SplineSet
  617 643 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219F
-Encoding: 8607 8607 8607
+Encoding: 8607 8607 2023
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56702,8 +58730,9 @@ SplineSet
  534.5 550 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A0
-Encoding: 8608 8608 8608
+Encoding: 8608 8608 2024
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56730,8 +58759,9 @@ SplineSet
  616 643 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A1
-Encoding: 8609 8609 8609
+Encoding: 8609 8609 2025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56758,8 +58788,9 @@ SplineSet
  698.5 551 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A2
-Encoding: 8610 8610 8610
+Encoding: 8610 8610 2026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56783,8 +58814,9 @@ SplineSet
  925 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A3
-Encoding: 8611 8611 8611
+Encoding: 8611 8611 2027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56808,8 +58840,9 @@ SplineSet
  308 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A4
-Encoding: 8612 8612 8612
+Encoding: 8612 8612 2028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56832,8 +58865,9 @@ SplineSet
  1003 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A5
-Encoding: 8613 8613 8613
+Encoding: 8613 8613 2029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56856,8 +58890,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A6
-Encoding: 8614 8614 8614
+Encoding: 8614 8614 2030
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56880,8 +58915,9 @@ SplineSet
  230 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A7
-Encoding: 8615 8615 8615
+Encoding: 8615 8615 2031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56904,8 +58940,9 @@ SplineSet
  698.5 937 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdnbse
-Encoding: 8616 8616 8616
+Encoding: 8616 8616 2032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56934,8 +58971,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A9
-Encoding: 8617 8617 8617
+Encoding: 8617 8617 2033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56970,8 +59008,9 @@ SplineSet
  868 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AA
-Encoding: 8618 8618 8618
+Encoding: 8618 8618 2034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57006,8 +59045,9 @@ SplineSet
  334.689 643.263 334.689 643.263 365 643 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AB
-Encoding: 8619 8619 8619
+Encoding: 8619 8619 2035
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57057,8 +59097,9 @@ SplineSet
  901.207 894.534 901.207 894.534 876 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AC
-Encoding: 8620 8620 8620
+Encoding: 8620 8620 2036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57108,8 +59149,9 @@ SplineSet
  373.894 895.312 373.894 895.312 357 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AD
-Encoding: 8621 8621 8621
+Encoding: 8621 8621 2037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57176,8 +59218,9 @@ SplineSet
  287 643.002 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AE
-Encoding: 8622 8622 8622
+Encoding: 8622 8622 2038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57210,8 +59253,9 @@ SplineSet
  946 479 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AF
-Encoding: 8623 8623 8623
+Encoding: 8623 8623 2039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57234,8 +59278,9 @@ SplineSet
  860.688 210.873 l 9,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B0
-Encoding: 8624 8624 8624
+Encoding: 8624 8624 2040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57256,8 +59301,9 @@ SplineSet
  404.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B1
-Encoding: 8625 8625 8625
+Encoding: 8625 8625 2041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57278,8 +59324,9 @@ SplineSet
  828.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B2
-Encoding: 8626 8626 8626
+Encoding: 8626 8626 2042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57300,8 +59347,9 @@ SplineSet
  404.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B3
-Encoding: 8627 8627 8627
+Encoding: 8627 8627 2043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57322,8 +59370,9 @@ SplineSet
  828.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B4
-Encoding: 8628 8628 8628
+Encoding: 8628 8628 2044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57344,8 +59393,9 @@ SplineSet
  633 221 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: carriagereturn
-Encoding: 8629 8629 8629
+Encoding: 8629 8629 2045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57366,8 +59416,9 @@ SplineSet
  284.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B6
-Encoding: 8630 8630 8630
+Encoding: 8630 8630 2046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57402,8 +59453,9 @@ SplineSet
  331.244 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B7
-Encoding: 8631 8631 8631
+Encoding: 8631 8631 2047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57438,8 +59490,9 @@ SplineSet
  901.756 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B8
-Encoding: 8632 8632 8632
+Encoding: 8632 8632 2048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57463,8 +59516,9 @@ SplineSet
  50.5 970 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B9
-Encoding: 8633 8633 8633
+Encoding: 8633 8633 2049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57502,8 +59556,9 @@ SplineSet
  1003 373.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21BA
-Encoding: 8634 8634 8634
+Encoding: 8634 8634 2050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57546,8 +59601,9 @@ SplineSet
  917.375 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BB
-Encoding: 8635 8635 8635
+Encoding: 8635 8635 2051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57590,8 +59646,9 @@ SplineSet
  315.625 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BC
-Encoding: 8636 8636 8636
+Encoding: 8636 8636 2052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57607,8 +59664,9 @@ SplineSet
  66 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BD
-Encoding: 8637 8637 8637
+Encoding: 8637 8637 2053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57624,8 +59682,9 @@ SplineSet
  66 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BE
-Encoding: 8638 8638 8638
+Encoding: 8638 8638 2054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57641,8 +59700,9 @@ SplineSet
  534.5 1101 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BF
-Encoding: 8639 8639 8639
+Encoding: 8639 8639 2055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57658,8 +59718,9 @@ SplineSet
  698.5 1101 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C0
-Encoding: 8640 8640 8640
+Encoding: 8640 8640 2056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57675,8 +59736,9 @@ SplineSet
  1167 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C1
-Encoding: 8641 8641 8641
+Encoding: 8641 8641 2057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57692,8 +59754,9 @@ SplineSet
  1167 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C2
-Encoding: 8642 8642 8642
+Encoding: 8642 8642 2058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57709,8 +59772,9 @@ SplineSet
  534.5 0 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C3
-Encoding: 8643 8643 8643
+Encoding: 8643 8643 2059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57726,8 +59790,9 @@ SplineSet
  741 0 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C4
-Encoding: 8644 8644 8644
+Encoding: 8644 8644 2060
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57757,8 +59822,9 @@ SplineSet
  66 291 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C5
-Encoding: 8645 8645 8645
+Encoding: 8645 8645 2061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57788,8 +59854,9 @@ SplineSet
  333.5 1101 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C6
-Encoding: 8646 8646 8646
+Encoding: 8646 8646 2062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57819,8 +59886,9 @@ SplineSet
  66 857 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C7
-Encoding: 8647 8647 8647
+Encoding: 8647 8647 2063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57847,8 +59915,9 @@ SplineSet
  267 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C8
-Encoding: 8648 8648 8648
+Encoding: 8648 8648 2064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57875,8 +59944,9 @@ SplineSet
  616.5 900 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C9
-Encoding: 8649 8649 8649
+Encoding: 8649 8649 2065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57903,8 +59973,9 @@ SplineSet
  966 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CA
-Encoding: 8650 8650 8650
+Encoding: 8650 8650 2066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57931,8 +60002,9 @@ SplineSet
  616.5 201 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CB
-Encoding: 8651 8651 8651
+Encoding: 8651 8651 2067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57956,8 +60028,9 @@ SplineSet
  66 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CC
-Encoding: 8652 8652 8652
+Encoding: 8652 8652 2068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57981,8 +60054,9 @@ SplineSet
  1167 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CD
-Encoding: 8653 8653 8653
+Encoding: 8653 8653 2069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58019,8 +60093,9 @@ SplineSet
  737 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CE
-Encoding: 8654 8654 8654
+Encoding: 8654 8654 2070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58065,8 +60140,9 @@ SplineSet
  692 643.001 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CF
-Encoding: 8655 8655 8655
+Encoding: 8655 8655 2071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58103,8 +60179,9 @@ SplineSet
  496 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblleft
-Encoding: 8656 8656 8656
+Encoding: 8656 8656 2072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58128,8 +60205,9 @@ SplineSet
  287 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblup
-Encoding: 8657 8657 8657
+Encoding: 8657 8657 2073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58153,8 +60231,9 @@ SplineSet
  534.499 880 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblright
-Encoding: 8658 8658 8658
+Encoding: 8658 8658 2074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58178,8 +60257,9 @@ SplineSet
  946 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdbldown
-Encoding: 8659 8659 8659
+Encoding: 8659 8659 2075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58203,8 +60283,9 @@ SplineSet
  698.501 221 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblboth
-Encoding: 8660 8660 8660
+Encoding: 8660 8660 2076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58236,8 +60317,9 @@ SplineSet
  864 725 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D5
-Encoding: 8661 8661 8661
+Encoding: 8661 8661 2077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58269,8 +60351,9 @@ SplineSet
  780.5 798 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D6
-Encoding: 8662 8662 8662
+Encoding: 8662 8662 2078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58294,8 +60377,9 @@ SplineSet
  398 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D7
-Encoding: 8663 8663 8663
+Encoding: 8663 8663 2079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58319,8 +60403,9 @@ SplineSet
  835 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D8
-Encoding: 8664 8664 8664
+Encoding: 8664 8664 2080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58344,8 +60429,9 @@ SplineSet
  951 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D9
-Encoding: 8665 8665 8665
+Encoding: 8665 8665 2081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58369,8 +60455,9 @@ SplineSet
  398 127 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DA
-Encoding: 8666 8666 8666
+Encoding: 8666 8666 2082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58395,8 +60482,9 @@ SplineSet
  447 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DB
-Encoding: 8667 8667 8667
+Encoding: 8667 8667 2083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58421,8 +60509,9 @@ SplineSet
  786 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DC
-Encoding: 8668 8668 8668
+Encoding: 8668 8668 2084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58454,8 +60543,9 @@ SplineSet
  287 643 l 17,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DD
-Encoding: 8669 8669 8669
+Encoding: 8669 8669 2085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58487,8 +60577,9 @@ SplineSet
  946 643 l 9,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DE
-Encoding: 8670 8670 8670
+Encoding: 8670 8670 2086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58523,8 +60614,9 @@ SplineSet
  698.5 188.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DF
-Encoding: 8671 8671 8671
+Encoding: 8671 8671 2087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58559,8 +60651,9 @@ SplineSet
  534.5 912.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E0
-Encoding: 8672 8672 8672
+Encoding: 8672 8672 2088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58589,8 +60682,9 @@ SplineSet
  980.001 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E1
-Encoding: 8673 8673 8673
+Encoding: 8673 8673 2089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58619,8 +60713,9 @@ SplineSet
  698.499 186.999 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E2
-Encoding: 8674 8674 8674
+Encoding: 8674 8674 2090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58649,8 +60744,9 @@ SplineSet
  252.999 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E3
-Encoding: 8675 8675 8675
+Encoding: 8675 8675 2091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58679,8 +60775,9 @@ SplineSet
  534.501 914.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E4
-Encoding: 8676 8676 8676
+Encoding: 8676 8676 2092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58703,8 +60800,9 @@ SplineSet
  230.001 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E5
-Encoding: 8677 8677 8677
+Encoding: 8677 8677 2093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58727,8 +60825,9 @@ SplineSet
  1003 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E6
-Encoding: 8678 8678 8678
+Encoding: 8678 8678 2094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58752,8 +60851,9 @@ SplineSet
  398 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E7
-Encoding: 8679 8679 8679
+Encoding: 8679 8679 2095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58777,8 +60877,9 @@ SplineSet
  989.5 769 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E8
-Encoding: 8680 8680 8680
+Encoding: 8680 8680 2096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58802,8 +60903,9 @@ SplineSet
  835.5 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E9
-Encoding: 8681 8681 8681
+Encoding: 8681 8681 2097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58827,8 +60929,9 @@ SplineSet
  243.5 373 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EA
-Encoding: 8682 8682 8682
+Encoding: 8682 8682 2098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58862,8 +60965,9 @@ SplineSet
  444.5 410 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EB
-Encoding: 8683 8683 8683
+Encoding: 8683 8683 2099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58895,8 +60999,9 @@ SplineSet
  444.495 280 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EC
-Encoding: 8684 8684 8684
+Encoding: 8684 8684 2100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58933,8 +61038,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21ED
-Encoding: 8685 8685 8685
+Encoding: 8685 8685 2101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58970,8 +61076,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EE
-Encoding: 8686 8686 8686
+Encoding: 8686 8686 2102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59006,8 +61113,9 @@ SplineSet
  443.5 769 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EF
-Encoding: 8687 8687 8687
+Encoding: 8687 8687 2103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59050,8 +61158,9 @@ SplineSet
  444.5 569 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F0
-Encoding: 8688 8688 8688
+Encoding: 8688 8688 2104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59083,8 +61192,9 @@ SplineSet
  346.5 388.995 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F1
-Encoding: 8689 8689 8689
+Encoding: 8689 8689 2105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59110,8 +61220,9 @@ SplineSet
  1162.74 1094 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F2
-Encoding: 8690 8690 8690
+Encoding: 8690 8690 2106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59137,8 +61248,9 @@ SplineSet
  1163.5 1093 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F3
-Encoding: 8691 8691 8691
+Encoding: 8691 8691 2107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59168,8 +61280,9 @@ SplineSet
  444.5 769 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F4
-Encoding: 8692 8692 8692
+Encoding: 8692 8692 2108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59212,8 +61325,9 @@ SplineSet
  576.115 460.271 576.115 460.271 587 479 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F5
-Encoding: 8693 8693 8693
+Encoding: 8693 8693 2109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59243,8 +61357,9 @@ SplineSet
  899.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F6
-Encoding: 8694 8694 8694
+Encoding: 8694 8694 2110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59279,8 +61394,9 @@ SplineSet
  786.001 319 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F7
-Encoding: 8695 8695 8695
+Encoding: 8695 8695 2111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59307,8 +61423,9 @@ SplineSet
  798.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F8
-Encoding: 8696 8696 8696
+Encoding: 8696 8696 2112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59335,8 +61452,9 @@ SplineSet
  434.5 479 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F9
-Encoding: 8697 8697 8697
+Encoding: 8697 8697 2113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59369,8 +61487,9 @@ SplineSet
  534.5 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FA
-Encoding: 8698 8698 8698
+Encoding: 8698 8698 2114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59405,8 +61524,9 @@ SplineSet
  978.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FB
-Encoding: 8699 8699 8699
+Encoding: 8699 8699 2115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59441,8 +61561,9 @@ SplineSet
  254.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FC
-Encoding: 8700 8700 8700
+Encoding: 8700 8700 2116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59483,8 +61604,9 @@ SplineSet
  287 479 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FD
-Encoding: 8701 8701 8701
+Encoding: 8701 8701 2117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59504,8 +61626,9 @@ SplineSet
  398 643 l 9,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FE
-Encoding: 8702 8702 8702
+Encoding: 8702 8702 2118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59525,8 +61648,9 @@ SplineSet
  835 643 l 17,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FF
-Encoding: 8703 8703 8703
+Encoding: 8703 8703 2119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59553,8 +61677,9 @@ SplineSet
  398 479 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: universal
-Encoding: 8704 8704 8704
+Encoding: 8704 8704 2120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59575,8 +61700,9 @@ SplineSet
  494 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2201
-Encoding: 8705 8705 8705
+Encoding: 8705 8705 2121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59603,8 +61729,9 @@ SplineSet
  117 367 117 367 117 745 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: partialdiff
-Encoding: 8706 8706 8706
+Encoding: 8706 8706 2122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59639,8 +61766,9 @@ SplineSet
  353 412 353 412 353 310 c 0,33,34
 EndSplineSet
 EndChar
+
 StartChar: existential
-Encoding: 8707 8707 8707
+Encoding: 8707 8707 2123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59661,8 +61789,9 @@ SplineSet
  178 170 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2204
-Encoding: 8708 8708 8708
+Encoding: 8708 8708 2124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59701,8 +61830,9 @@ SplineSet
  609 662 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: emptyset
-Encoding: 8709 8709 8709
+Encoding: 8709 8709 2125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59753,8 +61883,9 @@ SplineSet
  967.676 833.623 967.676 833.623 942.785 868.669 c 1,49,-1
 EndSplineSet
 EndChar
+
 StartChar: Delta
-Encoding: 8710 8710 8710
+Encoding: 8710 8710 2126
 Width: 1233
 Flags: W
 TtInstrs:
@@ -59852,8 +61983,9 @@ SplineSet
  616 1219 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: gradient
-Encoding: 8711 8711 8711
+Encoding: 8711 8711 2127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59870,8 +62002,9 @@ SplineSet
  616 204 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: element
-Encoding: 8712 8712 8712
+Encoding: 8712 8712 2128
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -59971,8 +62104,9 @@ SplineSet
  304.5 647 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: notelement
-Encoding: 8713 8713 8713
+Encoding: 8713 8713 2129
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -60126,8 +62260,9 @@ SplineSet
  554 647 l 17,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220A
-Encoding: 8714 8714 8714
+Encoding: 8714 8714 2130
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -60224,8 +62359,9 @@ SplineSet
  1102 726 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: suchthat
-Encoding: 8715 8715 8715
+Encoding: 8715 8715 2131
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -60325,8 +62461,9 @@ SplineSet
  928.5 817 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni220C
-Encoding: 8716 8716 8716
+Encoding: 8716 8716 2132
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -60479,8 +62616,9 @@ SplineSet
  679 817 l 17,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220D
-Encoding: 8717 8717 8717
+Encoding: 8717 8717 2133
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -60577,8 +62715,9 @@ SplineSet
  131 556 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220E
-Encoding: 8718 8718 8718
+Encoding: 8718 8718 2134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60591,8 +62730,9 @@ SplineSet
  250 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: product
-Encoding: 8719 8719 8719
+Encoding: 8719 8719 2135
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60639,8 +62779,9 @@ SplineSet
  152 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2210
-Encoding: 8720 8720 8720
+Encoding: 8720 8720 2136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60657,8 +62798,9 @@ SplineSet
  1081 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: summation
-Encoding: 8721 8721 8721
+Encoding: 8721 8721 2137
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60726,8 +62868,9 @@ SplineSet
  332 -299 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: minus
-Encoding: 8722 8722 8722
+Encoding: 8722 8722 2138
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60759,8 +62902,9 @@ SplineSet
  88 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2213
-Encoding: 8723 8723 8723
+Encoding: 8723 8723 2139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60786,40 +62930,45 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2215
-Encoding: 8725 8725 8725
+Encoding: 8725 8725 2140
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 47 47 N 1 0 0 1 0 0 2
+Refer: 16 47 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: asteriskmath
-Encoding: 8727 8727 8727
+Encoding: 8727 8727 2141
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42 42 N 1 0 0 1 0 -411 2
+Refer: 11 42 N 1 0 0 1 0 -411 2
 EndChar
+
 StartChar: uni2218
-Encoding: 8728 8728 8728
+Encoding: 8728 8728 2142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 176 176 N 1 0 0 1 0 -558 2
+Refer: 112 176 N 1 0 0 1 0 -558 2
 EndChar
+
 StartChar: uni2219
-Encoding: 8729 8729 8729
+Encoding: 8729 8729 2143
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8226 8226 N 1 0 0 1 0 -55 2
+Refer: 1879 8226 N 1 0 0 1 0 -55 2
 EndChar
+
 StartChar: radical
-Encoding: 8730 8730 8730
+Encoding: 8730 8730 2144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60888,8 +63037,9 @@ SplineSet
  100 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221B
-Encoding: 8731 8731 8731
+Encoding: 8731 8731 2145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60939,8 +63089,9 @@ SplineSet
  660 1529 660 1529 576 1510 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni221C
-Encoding: 8732 8732 8732
+Encoding: 8732 8732 2146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60976,8 +63127,9 @@ SplineSet
  500 1768 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: proportional
-Encoding: 8733 8733 8733
+Encoding: 8733 8733 2147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61013,8 +63165,9 @@ SplineSet
  1046.5 250 l 17,33,34
 EndSplineSet
 EndChar
+
 StartChar: infinity
-Encoding: 8734 8734 8734
+Encoding: 8734 8734 2148
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61114,8 +63267,9 @@ SplineSet
  560 893 560 893 616 764 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: orthogonal
-Encoding: 8735 8735 8735
+Encoding: 8735 8735 2149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61130,8 +63284,9 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: angle
-Encoding: 8736 8736 8736
+Encoding: 8736 8736 2150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61146,16 +63301,18 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2223
-Encoding: 8739 8739 8739
+Encoding: 8739 8739 2151
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 0 0 3
+Refer: 93 124 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: logicaland
-Encoding: 8743 8743 8743
+Encoding: 8743 8743 2152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61171,8 +63328,9 @@ SplineSet
  164.25 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalor
-Encoding: 8744 8744 8744
+Encoding: 8744 8744 2153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61188,8 +63346,9 @@ SplineSet
  164.25 1186 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: intersection
-Encoding: 8745 8745 8745
+Encoding: 8745 8745 2154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61220,8 +63379,9 @@ SplineSet
  164.25 580 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: union
-Encoding: 8746 8746 8746
+Encoding: 8746 8746 2155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61252,8 +63412,9 @@ SplineSet
  164.25 376 164.25 376 164.25 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integral
-Encoding: 8747 8747 8747
+Encoding: 8747 8747 2156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61276,8 +63437,9 @@ SplineSet
  524.5 -213.72 524.5 -213.72 524.5 -68 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni222C
-Encoding: 8748 8748 8748
+Encoding: 8748 8748 2157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61314,10 +63476,11 @@ SplineSet
  206.738 -247.167 206.738 -247.167 255 -232 c 0,22,23
  308.5 -215.188 308.5 -215.188 308.5 -68 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uni222D
-Encoding: 8749 8749 8749
+Encoding: 8749 8749 2158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61369,59 +63532,65 @@ SplineSet
  200.5 1611.39 200.5 1611.39 200.5 1502 c 2,0,1
  200.5 -127 l 2,13,-1
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
+
 StartChar: therefore
-Encoding: 8756 8756 8756
+Encoding: 8756 8756 2159
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
+Refer: 2274 8901 N 1 0 0 1 308 -425 2
+Refer: 2274 8901 N 1 0 0 1 -302 -425 2
+Refer: 2274 8901 N 1 0 0 1 -1 292 2
 EndChar
+
 StartChar: uni2235
-Encoding: 8757 8757 8757
+Encoding: 8757 8757 2160
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 304 292 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
+Refer: 2274 8901 N 1 0 0 1 304 292 2
+Refer: 2274 8901 N 1 0 0 1 -301 292 2
+Refer: 2274 8901 N 1 0 0 1 3 -425 2
 EndChar
+
 StartChar: uni2236
-Encoding: 8758 8758 8758
+Encoding: 8758 8758 2161
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
+Refer: 2274 8901 N 1 0 0 1 -1 292 2
+Refer: 2274 8901 N 1 0 0 1 3 -425 2
 EndChar
+
 StartChar: uni2237
-Encoding: 8759 8759 8759
+Encoding: 8759 8759 2162
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 304 292 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
+Refer: 2274 8901 N 1 0 0 1 304 292 2
+Refer: 2274 8901 N 1 0 0 1 308 -425 2
+Refer: 2274 8901 N 1 0 0 1 -301 292 2
+Refer: 2274 8901 N 1 0 0 1 -302 -425 2
 EndChar
+
 StartChar: uni2238
-Encoding: 8760 8760 8760
+Encoding: 8760 8760 2163
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1.5 292 2
-Refer: 8722 8722 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1.5 292 2
+Refer: 2138 8722 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2239
-Encoding: 8761 8761 8761
+Encoding: 8761 8761 2164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61444,30 +63613,33 @@ SplineSet
  74 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni223A
-Encoding: 8762 8762 8762
+Encoding: 8762 8762 2165
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -402 -425 2
-Refer: 8901 8901 N 1 0 0 1 -401 292 2
-Refer: 8901 8901 N 1 0 0 1 408 -425 2
-Refer: 8901 8901 N 1 0 0 1 404 292 2
-Refer: 8722 8722 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 -402 -425 2
+Refer: 2274 8901 N 1 0 0 1 -401 292 2
+Refer: 2274 8901 N 1 0 0 1 408 -425 2
+Refer: 2274 8901 N 1 0 0 1 404 292 2
+Refer: 2138 8722 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni223B
-Encoding: 8763 8763 8763
+Encoding: 8763 8763 2166
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
-Refer: 8901 8901 N 1 0 0 1 2 292 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 -425 2
+Refer: 2274 8901 N 1 0 0 1 2 292 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: similar
-Encoding: 8764 8764 8764
+Encoding: 8764 8764 2167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61494,8 +63666,9 @@ SplineSet
  1071.01 723 1071.01 723 1145 786 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni223D
-Encoding: 8765 8765 8765
+Encoding: 8765 8765 2168
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61522,8 +63695,9 @@ SplineSet
  88 786 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2241
-Encoding: 8769 8769 8769
+Encoding: 8769 8769 2169
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61554,8 +63728,9 @@ SplineSet
  536 592.401 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2242
-Encoding: 8770 8770 8770
+Encoding: 8770 8770 2170
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61587,8 +63762,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2243
-Encoding: 8771 8771 8771
+Encoding: 8771 8771 2171
 Width: 1233
 LayerCount: 2
 Fore
@@ -61619,8 +63795,9 @@ SplineSet
  1071.01 900 1071.01 900 1145 963 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2244
-Encoding: 8772 8772 8772
+Encoding: 8772 8772 2172
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61658,8 +63835,9 @@ SplineSet
  967.079 1137.1 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: congruent
-Encoding: 8773 8773 8773
+Encoding: 8773 8773 2173
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61696,8 +63874,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2246
-Encoding: 8774 8774 8774
+Encoding: 8774 8774 2174
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61745,8 +63924,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2247
-Encoding: 8775 8775 8775
+Encoding: 8775 8775 2175
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61795,8 +63975,9 @@ SplineSet
  360 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: approxequal
-Encoding: 8776 8776 8776
+Encoding: 8776 8776 2176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -61919,8 +64100,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2249
-Encoding: 8777 8777 8777
+Encoding: 8777 8777 2177
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61968,8 +64150,9 @@ SplineSet
  477 419.074 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224A
-Encoding: 8778 8778 8778
+Encoding: 8778 8778 2178
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62020,8 +64203,9 @@ SplineSet
  88 364 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224B
-Encoding: 8779 8779 8779
+Encoding: 8779 8779 2179
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62086,8 +64270,9 @@ SplineSet
  1070 740 1070 740 1145 804 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224C
-Encoding: 8780 8780 8780
+Encoding: 8780 8780 2180
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62124,8 +64309,9 @@ SplineSet
  88 1167 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224D
-Encoding: 8781 8781 8781
+Encoding: 8781 8781 2181
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62147,8 +64333,9 @@ SplineSet
  416 555 416 555 616 555 c 129,-1,4
 EndSplineSet
 EndChar
+
 StartChar: uni224E
-Encoding: 8782 8782 8782
+Encoding: 8782 8782 2182
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62194,8 +64381,9 @@ SplineSet
  666 1062 666 1062 617 1059 c 24,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224F
-Encoding: 8783 8783 8783
+Encoding: 8783 8783 2183
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62227,47 +64415,52 @@ SplineSet
  88 522 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2250
-Encoding: 8784 8784 8784
+Encoding: 8784 8784 2184
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1.5 441 2
-Refer: 61 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1.5 441 2
+Refer: 30 61 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2251
-Encoding: 8785 8785 8785
+Encoding: 8785 8785 2185
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 -582 2
-Refer: 8901 8901 N 1 0 0 1 2 441 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 -582 2
+Refer: 2274 8901 N 1 0 0 1 2 441 2
 EndChar
+
 StartChar: uni2252
-Encoding: 8786 8786 8786
+Encoding: 8786 8786 2186
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -401 441 2
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 404 -579 2
+Refer: 2274 8901 N 1 0 0 1 -401 441 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 404 -579 2
 EndChar
+
 StartChar: uni2253
-Encoding: 8787 8787 8787
+Encoding: 8787 8787 2187
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -401.5 -579 2
-Refer: 61 61 N 1 0 0 1 -0.5 0 2
-Refer: 8901 8901 N 1 0 0 1 404.5 441 2
+Refer: 2274 8901 N 1 0 0 1 -401.5 -579 2
+Refer: 30 61 N 1 0 0 1 -0.5 0 2
+Refer: 2274 8901 N 1 0 0 1 404.5 441 2
 EndChar
+
 StartChar: uni2254
-Encoding: 8788 8788 8788
+Encoding: 8788 8788 2188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62295,8 +64488,9 @@ SplineSet
  1159 930 l 17,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2255
-Encoding: 8789 8789 8789
+Encoding: 8789 8789 2189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62324,8 +64518,9 @@ SplineSet
  74 930 l 9,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2256
-Encoding: 8790 8790 8790
+Encoding: 8790 8790 2190
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62355,8 +64550,9 @@ SplineSet
  860 585 860 585 833 522 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2257
-Encoding: 8791 8791 8791
+Encoding: 8791 8791 2191
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62394,8 +64590,9 @@ SplineSet
  495.949 1556.95 495.949 1556.95 617 1556.95 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2258
-Encoding: 8792 8792 8792
+Encoding: 8792 8792 2192
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62420,8 +64617,9 @@ SplineSet
  392.396 1355 392.396 1355 617.85 1355 c 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni2259
-Encoding: 8793 8793 8793
+Encoding: 8793 8793 2193
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62447,8 +64645,9 @@ SplineSet
  302 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225A
-Encoding: 8794 8794 8794
+Encoding: 8794 8794 2194
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62474,8 +64673,9 @@ SplineSet
  302 1604 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225B
-Encoding: 8795 8795 8795
+Encoding: 8795 8795 2195
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62504,8 +64704,9 @@ SplineSet
  264.2 1445.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225C
-Encoding: 8796 8796 8796
+Encoding: 8796 8796 2196
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62532,8 +64733,9 @@ SplineSet
  566.1 1711.15 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225D
-Encoding: 8797 8797 8797
+Encoding: 8797 8797 2197
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62615,8 +64817,9 @@ SplineSet
  137.64 1278.51 137.64 1278.51 137.64 1205.43 c 0,73,74
 EndSplineSet
 EndChar
+
 StartChar: uni225E
-Encoding: 8798 8798 8798
+Encoding: 8798 8798 2198
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62662,8 +64865,9 @@ SplineSet
  626.424 1495.24 626.424 1495.24 646.267 1437.43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni225F
-Encoding: 8799 8799 8799
+Encoding: 8799 8799 2199
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62711,8 +64915,9 @@ SplineSet
  637.75 1194.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notequal
-Encoding: 8800 8800 8800
+Encoding: 8800 8800 2200
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62803,8 +65008,9 @@ SplineSet
  88 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equivalence
-Encoding: 8801 8801 8801
+Encoding: 8801 8801 2201
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62827,8 +65033,9 @@ SplineSet
  88 1090 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2262
-Encoding: 8802 8802 8802
+Encoding: 8802 8802 2202
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62865,8 +65072,9 @@ SplineSet
  327 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2263
-Encoding: 8803 8803 8803
+Encoding: 8803 8803 2203
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62894,8 +65102,9 @@ SplineSet
  88 1262 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: lessequal
-Encoding: 8804 8804 8804
+Encoding: 8804 8804 2204
 Width: 1233
 Flags: W
 TtInstrs:
@@ -62958,8 +65167,9 @@ SplineSet
  1143 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: greaterequal
-Encoding: 8805 8805 8805
+Encoding: 8805 8805 2205
 Width: 1233
 Flags: W
 TtInstrs:
@@ -63022,8 +65232,9 @@ SplineSet
  88 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2266
-Encoding: 8806 8806 8806
+Encoding: 8806 8806 2206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63049,8 +65260,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2267
-Encoding: 8807 8807 8807
+Encoding: 8807 8807 2207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63076,8 +65288,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2268
-Encoding: 8808 8808 8808
+Encoding: 8808 8808 2208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63114,8 +65327,9 @@ SplineSet
  1143 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2269
-Encoding: 8809 8809 8809
+Encoding: 8809 8809 2209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63152,8 +65366,9 @@ SplineSet
  86 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni226D
-Encoding: 8813 8813 8813
+Encoding: 8813 8813 2210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63182,8 +65397,9 @@ SplineSet
  564 731 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226E
-Encoding: 8814 8814 8814
+Encoding: 8814 8814 2211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63212,8 +65428,9 @@ SplineSet
  590 751.908 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226F
-Encoding: 8815 8815 8815
+Encoding: 8815 8815 2212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63242,8 +65459,9 @@ SplineSet
  643 531 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2270
-Encoding: 8816 8816 8816
+Encoding: 8816 8816 2213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63280,8 +65498,9 @@ SplineSet
  356 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2271
-Encoding: 8817 8817 8817
+Encoding: 8817 8817 2214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63318,8 +65537,9 @@ SplineSet
  643 599.856 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2272
-Encoding: 8818 8818 8818
+Encoding: 8818 8818 2215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63354,8 +65574,9 @@ SplineSet
  1143 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2273
-Encoding: 8819 8819 8819
+Encoding: 8819 8819 2216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63390,8 +65611,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2274
-Encoding: 8820 8820 8820
+Encoding: 8820 8820 2217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63438,8 +65660,9 @@ SplineSet
  601 746.693 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2275
-Encoding: 8821 8821 8821
+Encoding: 8821 8821 2218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63486,8 +65709,9 @@ SplineSet
  736 883.452 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2276
-Encoding: 8822 8822 8822
+Encoding: 8822 8822 2219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63511,8 +65735,9 @@ SplineSet
  1143 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2277
-Encoding: 8823 8823 8823
+Encoding: 8823 8823 2220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63536,8 +65761,9 @@ SplineSet
  86 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2278
-Encoding: 8824 8824 8824
+Encoding: 8824 8824 2221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63582,8 +65808,9 @@ SplineSet
  587 146.067 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2279
-Encoding: 8825 8825 8825
+Encoding: 8825 8825 2222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63628,8 +65855,9 @@ SplineSet
  801.872 844.55 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227A
-Encoding: 8826 8826 8826
+Encoding: 8826 8826 2223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63645,8 +65873,9 @@ SplineSet
  1143 1088 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227B
-Encoding: 8827 8827 8827
+Encoding: 8827 8827 2224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63662,8 +65891,9 @@ SplineSet
  415 728 415 728 88 1088 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227C
-Encoding: 8828 8828 8828
+Encoding: 8828 8828 2225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63688,8 +65918,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227D
-Encoding: 8829 8829 8829
+Encoding: 8829 8829 2226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63714,8 +65945,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227E
-Encoding: 8830 8830 8830
+Encoding: 8830 8830 2227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63752,8 +65984,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227F
-Encoding: 8831 8831 8831
+Encoding: 8831 8831 2228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63790,8 +66023,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2280
-Encoding: 8832 8832 8832
+Encoding: 8832 8832 2229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63820,8 +66054,9 @@ SplineSet
  480.263 621.903 480.263 621.903 560.301 593 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2281
-Encoding: 8833 8833 8833
+Encoding: 8833 8833 2230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63850,8 +66085,9 @@ SplineSet
  748.737 660.097 748.737 660.097 668.699 689 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: propersubset
-Encoding: 8834 8834 8834
+Encoding: 8834 8834 2231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63874,8 +66110,9 @@ SplineSet
  1145 163 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: propersuperset
-Encoding: 8835 8835 8835
+Encoding: 8835 8835 2232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63898,8 +66135,9 @@ SplineSet
  88 163 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notsubset
-Encoding: 8836 8836 8836
+Encoding: 8836 8836 2233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63934,8 +66172,9 @@ SplineSet
  379 198.472 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2285
-Encoding: 8837 8837 8837
+Encoding: 8837 8837 2234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63970,8 +66209,9 @@ SplineSet
  854 1083.53 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: reflexsubset
-Encoding: 8838 8838 8838
+Encoding: 8838 8838 2235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63999,8 +66239,9 @@ SplineSet
  1145 324 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: reflexsuperset
-Encoding: 8839 8839 8839
+Encoding: 8839 8839 2236
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64028,8 +66269,9 @@ SplineSet
  88 324 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2288
-Encoding: 8840 8840 8840
+Encoding: 8840 8840 2237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64071,8 +66313,9 @@ SplineSet
  692 1130 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2289
-Encoding: 8841 8841 8841
+Encoding: 8841 8841 2238
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64116,8 +66359,9 @@ SplineSet
  648 474 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni228A
-Encoding: 8842 8842 8842
+Encoding: 8842 8842 2239
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64125,10 +66369,10 @@ Fore
 SplineSet
 1145 170 m 1,0,-1
  1145 0 l 1,1,-1
- 657.182 -7.04992e-15 l 1,2,-1
+ 657.182 -7.04992e-015 l 1,2,-1
  490 -208 l 1,3,-1
  358 -102 l 1,4,-1
- 439.812 -1.33227e-15 l 1,5,-1
+ 439.812 -1.33227e-015 l 1,5,-1
  88 0 l 1,6,-1
  88 170 l 1,7,-1
  576.167 170 l 1,8,-1
@@ -64153,8 +66397,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228B
-Encoding: 8843 8843 8843
+Encoding: 8843 8843 2240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64162,10 +66407,10 @@ Fore
 SplineSet
 1145 170 m 1,0,-1
  1145 0 l 1,1,-1
- 657.182 -7.04992e-15 l 1,2,-1
+ 657.182 -7.04992e-015 l 1,2,-1
  490 -208 l 1,3,-1
  358 -102 l 1,4,-1
- 439.812 -1.33227e-15 l 1,5,-1
+ 439.812 -1.33227e-015 l 1,5,-1
  88 0 l 1,6,-1
  88 170 l 1,7,-1
  576.167 170 l 1,8,-1
@@ -64190,8 +66435,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228D
-Encoding: 8845 8845 8845
+Encoding: 8845 8845 2241
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64219,8 +66465,9 @@ SplineSet
  131 199 131 199 131 495 c 2,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228E
-Encoding: 8846 8846 8846
+Encoding: 8846 8846 2242
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64256,8 +66503,9 @@ SplineSet
  667 779 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228F
-Encoding: 8847 8847 8847
+Encoding: 8847 8847 2243
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64325,8 +66573,9 @@ SplineSet
  88 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2290
-Encoding: 8848 8848 8848
+Encoding: 8848 8848 2244
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64394,8 +66643,9 @@ SplineSet
  1145 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2291
-Encoding: 8849 8849 8849
+Encoding: 8849 8849 2245
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64491,8 +66741,9 @@ SplineSet
  88 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2292
-Encoding: 8850 8850 8850
+Encoding: 8850 8850 2246
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64590,8 +66841,9 @@ SplineSet
  1145 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2293
-Encoding: 8851 8851 8851
+Encoding: 8851 8851 2247
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64608,8 +66860,9 @@ SplineSet
  1138 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2294
-Encoding: 8852 8852 8852
+Encoding: 8852 8852 2248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64626,8 +66879,9 @@ SplineSet
  94 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circleplus
-Encoding: 8853 8853 8853
+Encoding: 8853 8853 2249
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64682,8 +66936,9 @@ SplineSet
  546 989 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2296
-Encoding: 8854 8854 8854
+Encoding: 8854 8854 2250
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64730,8 +66985,9 @@ SplineSet
  962 712 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: circlemultiply
-Encoding: 8855 8855 8855
+Encoding: 8855 8855 2251
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64786,8 +67042,9 @@ SplineSet
  322.344 837.954 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2298
-Encoding: 8856 8856 8856
+Encoding: 8856 8856 2252
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64834,8 +67091,9 @@ SplineSet
  812.368 936.242 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2299
-Encoding: 8857 8857 8857
+Encoding: 8857 8857 2253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64882,8 +67140,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,33
 EndSplineSet
 EndChar
+
 StartChar: uni229A
-Encoding: 8858 8858 8858
+Encoding: 8858 8858 2254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64945,8 +67204,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229B
-Encoding: 8859 8859 8859
+Encoding: 8859 8859 2255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65005,8 +67265,9 @@ SplineSet
  318.758 905.499 318.758 905.499 303.521 886.352 c 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229C
-Encoding: 8860 8860 8860
+Encoding: 8860 8860 2256
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65058,8 +67319,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,35
 EndSplineSet
 EndChar
+
 StartChar: uni229D
-Encoding: 8861 8861 8861
+Encoding: 8861 8861 2257
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65106,8 +67368,9 @@ SplineSet
  818 572 l 1,47,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229E
-Encoding: 8862 8862 8862
+Encoding: 8862 8862 2258
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65138,8 +67401,9 @@ SplineSet
  546 1025 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229F
-Encoding: 8863 8863 8863
+Encoding: 8863 8863 2259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65162,8 +67426,9 @@ SplineSet
  962 712 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A0
-Encoding: 8864 8864 8864
+Encoding: 8864 8864 2260
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65194,8 +67459,9 @@ SplineSet
  252.072 907.604 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A1
-Encoding: 8865 8865 8865
+Encoding: 8865 8865 2261
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65218,8 +67484,9 @@ SplineSet
  80 1180 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A2
-Encoding: 8866 8866 8866
+Encoding: 8866 8866 2262
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65236,8 +67503,9 @@ SplineSet
  256 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A3
-Encoding: 8867 8867 8867
+Encoding: 8867 8867 2263
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65254,8 +67522,9 @@ SplineSet
  977 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A4
-Encoding: 8868 8868 8868
+Encoding: 8868 8868 2264
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65272,8 +67541,9 @@ SplineSet
  533 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: perpendicular
-Encoding: 8869 8869 8869
+Encoding: 8869 8869 2265
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65290,8 +67560,9 @@ SplineSet
  701 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B2
-Encoding: 8882 8882 8882
+Encoding: 8882 8882 2266
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65308,8 +67579,9 @@ SplineSet
  1145 141 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B3
-Encoding: 8883 8883 8883
+Encoding: 8883 8883 2267
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65326,8 +67598,9 @@ SplineSet
  256 387 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B4
-Encoding: 8884 8884 8884
+Encoding: 8884 8884 2268
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65349,8 +67622,9 @@ SplineSet
  1145 256 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B5
-Encoding: 8885 8885 8885
+Encoding: 8885 8885 2269
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65372,8 +67646,9 @@ SplineSet
  256 487 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B8
-Encoding: 8888 8888 8888
+Encoding: 8888 8888 2270
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65402,8 +67677,9 @@ SplineSet
  1057 700 1057 700 1017.5 740 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni22C2
-Encoding: 8898 8898 8898
+Encoding: 8898 8898 2271
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65426,8 +67702,9 @@ SplineSet
  1102 1319 1102 1319 1102 1023 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C3
-Encoding: 8899 8899 8899
+Encoding: 8899 8899 2272
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65450,8 +67727,9 @@ SplineSet
  131 -237 131 -237 131 59 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C4
-Encoding: 8900 8900 8900
+Encoding: 8900 8900 2273
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65469,8 +67747,9 @@ SplineSet
  105 642 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dotmath
-Encoding: 8901 8901 8901
+Encoding: 8901 8901 2274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65503,8 +67782,9 @@ SplineSet
  489 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C6
-Encoding: 8902 8902 8902
+Encoding: 8902 8902 2275
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65523,8 +67803,9 @@ SplineSet
  264.907 823.703 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22CD
-Encoding: 8909 8909 8909
+Encoding: 8909 8909 2276
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65556,8 +67837,9 @@ SplineSet
  88 963 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni22CE
-Encoding: 8910 8910 8910
+Encoding: 8910 8910 2277
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65573,8 +67855,9 @@ SplineSet
  532 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22CF
-Encoding: 8911 8911 8911
+Encoding: 8911 8911 2278
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65590,8 +67873,9 @@ SplineSet
  698 1284 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22D0
-Encoding: 8912 8912 8912
+Encoding: 8912 8912 2279
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65629,8 +67913,9 @@ SplineSet
  1143 -6 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22D1
-Encoding: 8913 8913 8913
+Encoding: 8913 8913 2280
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65668,8 +67953,9 @@ SplineSet
  90 1290 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DA
-Encoding: 8922 8922 8922
+Encoding: 8922 8922 2281
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65698,8 +67984,9 @@ SplineSet
  1145 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DB
-Encoding: 8923 8923 8923
+Encoding: 8923 8923 2282
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65728,8 +68015,9 @@ SplineSet
  88 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DC
-Encoding: 8924 8924 8924
+Encoding: 8924 8924 2283
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65750,8 +68038,9 @@ SplineSet
  1143 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DD
-Encoding: 8925 8925 8925
+Encoding: 8925 8925 2284
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65772,8 +68061,9 @@ SplineSet
  88 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DE
-Encoding: 8926 8926 8926
+Encoding: 8926 8926 2285
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65798,8 +68088,9 @@ SplineSet
  852 291 852 291 1143 -13 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DF
-Encoding: 8927 8927 8927
+Encoding: 8927 8927 2286
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65824,8 +68115,9 @@ SplineSet
  86 -13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E0
-Encoding: 8928 8928 8928
+Encoding: 8928 8928 2287
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65865,8 +68157,9 @@ SplineSet
  536.138 814.711 536.138 814.711 618.897 785.045 c 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E1
-Encoding: 8929 8929 8929
+Encoding: 8929 8929 2288
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65905,8 +68198,9 @@ SplineSet
  766.207 837.893 766.207 837.893 751.566 841.087 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E2
-Encoding: 8930 8930 8930
+Encoding: 8930 8930 2289
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65936,8 +68230,9 @@ SplineSet
  383.753 289 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E3
-Encoding: 8931 8931 8931
+Encoding: 8931 8931 2290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65967,8 +68262,9 @@ SplineSet
  849.247 993 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E4
-Encoding: 8932 8932 8932
+Encoding: 8932 8932 2291
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65998,8 +68294,9 @@ SplineSet
  88 1268 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E5
-Encoding: 8933 8933 8933
+Encoding: 8933 8933 2292
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66029,8 +68326,9 @@ SplineSet
  1145 184 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E6
-Encoding: 8934 8934 8934
+Encoding: 8934 8934 2293
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66068,8 +68366,9 @@ SplineSet
  534 51.4014 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22E7
-Encoding: 8935 8935 8935
+Encoding: 8935 8935 2294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66108,8 +68407,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E8
-Encoding: 8936 8936 8936
+Encoding: 8936 8936 2295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66150,8 +68450,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E9
-Encoding: 8937 8937 8937
+Encoding: 8937 8937 2296
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66192,8 +68493,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22EF
-Encoding: 8943 8943 8943
+Encoding: 8943 8943 2297
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66216,16 +68518,18 @@ SplineSet
  489 795 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2300
-Encoding: 8960 8960 8960
+Encoding: 8960 8960 2298
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8709 8709 N 1 0 0 1 0 0 2
+Refer: 2125 8709 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2301
-Encoding: 8961 8961 8961
+Encoding: 8961 8961 2299
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66242,8 +68546,9 @@ SplineSet
  674 634 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: house
-Encoding: 8962 8962 8962
+Encoding: 8962 8962 2300
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66263,8 +68568,9 @@ SplineSet
  268.5 122 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2303
-Encoding: 8963 8963 8963
+Encoding: 8963 8963 2301
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66279,8 +68585,9 @@ SplineSet
  616 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2304
-Encoding: 8964 8964 8964
+Encoding: 8964 8964 2302
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66295,8 +68602,9 @@ SplineSet
  616 -269.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2305
-Encoding: 8965 8965 8965
+Encoding: 8965 8965 2303
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66316,8 +68624,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2306
-Encoding: 8966 8966 8966
+Encoding: 8966 8966 2304
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66342,8 +68651,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2308
-Encoding: 8968 8968 8968
+Encoding: 8968 8968 2305
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66358,8 +68668,9 @@ SplineSet
  640.469 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2309
-Encoding: 8969 8969 8969
+Encoding: 8969 8969 2306
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66374,8 +68685,9 @@ SplineSet
  947.469 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230A
-Encoding: 8970 8970 8970
+Encoding: 8970 8970 2307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66390,8 +68702,9 @@ SplineSet
  285.531 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230B
-Encoding: 8971 8971 8971
+Encoding: 8971 8971 2308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66406,8 +68719,9 @@ SplineSet
  592.531 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230C
-Encoding: 8972 8972 8972
+Encoding: 8972 8972 2309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66425,8 +68739,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230D
-Encoding: 8973 8973 8973
+Encoding: 8973 8973 2310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66444,8 +68759,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230E
-Encoding: 8974 8974 8974
+Encoding: 8974 8974 2311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66463,8 +68779,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230F
-Encoding: 8975 8975 8975
+Encoding: 8975 8975 2312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66482,8 +68799,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: revlogicalnot
-Encoding: 8976 8976 8976
+Encoding: 8976 8976 2313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66498,8 +68816,9 @@ SplineSet
  1145 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2311
-Encoding: 8977 8977 8977
+Encoding: 8977 8977 2314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66517,16 +68836,18 @@ SplineSet
  616 435.5 616 435.5 97 258.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2312
-Encoding: 8978 8978 8978
+Encoding: 8978 8978 2315
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9696 9696 N 1 0 0 1 0 -100 2
+Refer: 2659 9696 N 1 0 0 1 0 -100 2
 EndChar
+
 StartChar: uni2313
-Encoding: 8979 8979 8979
+Encoding: 8979 8979 2316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66546,8 +68867,9 @@ SplineSet
  180.288 743.534 180.288 743.534 139.268 546 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2314
-Encoding: 8980 8980 8980
+Encoding: 8980 8980 2317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66567,8 +68889,9 @@ SplineSet
  740 925 740 925 616 925 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2315
-Encoding: 8981 8981 8981
+Encoding: 8981 8981 2318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66598,8 +68921,9 @@ SplineSet
  518.878 1103.87 518.878 1103.87 674.11 1103.87 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2318
-Encoding: 8984 8984 8984
+Encoding: 8984 8984 2319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66685,8 +69009,9 @@ SplineSet
  824 570 l 1,85,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2319
-Encoding: 8985 8985 8985
+Encoding: 8985 8985 2320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66701,8 +69026,9 @@ SplineSet
  1145 371 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni231C
-Encoding: 8988 8988 8988
+Encoding: 8988 8988 2321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66717,8 +69043,9 @@ SplineSet
  949 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231D
-Encoding: 8989 8989 8989
+Encoding: 8989 8989 2322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66733,8 +69060,9 @@ SplineSet
  284 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231E
-Encoding: 8990 8990 8990
+Encoding: 8990 8990 2323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66749,8 +69077,9 @@ SplineSet
  949 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231F
-Encoding: 8991 8991 8991
+Encoding: 8991 8991 2324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66765,8 +69094,9 @@ SplineSet
  284 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: integraltp
-Encoding: 8992 8992 8992
+Encoding: 8992 8992 2325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66791,8 +69121,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integralbt
-Encoding: 8993 8993 8993
+Encoding: 8993 8993 2326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66817,8 +69148,9 @@ SplineSet
  711 1929 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2325
-Encoding: 8997 8997 8997
+Encoding: 8997 8997 2327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66840,8 +69172,9 @@ SplineSet
  713 1225 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2326
-Encoding: 8998 8998 8998
+Encoding: 8998 8998 2328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66876,8 +69209,9 @@ SplineSet
  578.025 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2327
-Encoding: 8999 8999 8999
+Encoding: 8999 8999 2329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66910,8 +69244,9 @@ SplineSet
  747.024 410 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2328
-Encoding: 9000 9000 9000
+Encoding: 9000 9000 2330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67309,8 +69644,9 @@ SplineSet
  402 535 l 2,509,510
 EndSplineSet
 EndChar
+
 StartChar: uni232B
-Encoding: 9003 9003 9003
+Encoding: 9003 9003 2331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67345,8 +69681,9 @@ SplineSet
  654.976 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2335
-Encoding: 9013 9013 9013
+Encoding: 9013 9013 2332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67361,8 +69698,9 @@ SplineSet
  616 -45 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2336
-Encoding: 9014 9014 9014
+Encoding: 9014 9014 2333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67383,8 +69721,9 @@ SplineSet
  532 1114 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2337
-Encoding: 9015 9015 9015
+Encoding: 9015 9015 2334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67402,8 +69741,9 @@ SplineSet
  256 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2338
-Encoding: 9016 9016 9016
+Encoding: 9016 9016 2335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67431,8 +69771,9 @@ SplineSet
  120 930 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2339
-Encoding: 9017 9017 9017
+Encoding: 9017 9017 2336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67465,8 +69806,9 @@ SplineSet
  120 727 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233A
-Encoding: 9018 9018 9018
+Encoding: 9018 9018 2337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67496,17 +69838,19 @@ SplineSet
  120 846.093 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233B
-Encoding: 9019 9019 9019
+Encoding: 9019 9019 2338
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 2411 9109 N 1 0 0 1 0 0 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233C
-Encoding: 9020 9020 9020
+Encoding: 9020 9020 2339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67544,8 +69888,9 @@ SplineSet
  120 1096.51 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni233D
-Encoding: 9021 9021 9021
+Encoding: 9021 9021 2340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67580,17 +69925,19 @@ SplineSet
  775.861 1202.85 775.861 1202.85 692 1217.96 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233E
-Encoding: 9022 9022 9022
+Encoding: 9022 9022 2341
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233F
-Encoding: 9023 9023 9023
+Encoding: 9023 9023 2342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67611,8 +69958,9 @@ SplineSet
  889 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2340
-Encoding: 9024 9024 9024
+Encoding: 9024 9024 2343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67633,8 +69981,9 @@ SplineSet
  460 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2341
-Encoding: 9025 9025 9025
+Encoding: 9025 9025 2344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67655,8 +70004,9 @@ SplineSet
  1113 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2342
-Encoding: 9026 9026 9026
+Encoding: 9026 9026 2345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67677,8 +70027,9 @@ SplineSet
  120 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2343
-Encoding: 9027 9027 9027
+Encoding: 9027 9027 2346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67705,8 +70056,9 @@ SplineSet
  1113 435.934 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2344
-Encoding: 9028 9028 9028
+Encoding: 9028 9028 2347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67733,8 +70085,9 @@ SplineSet
  120 1230.35 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2345
-Encoding: 9029 9029 9029
+Encoding: 9029 9029 2348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67761,8 +70114,9 @@ SplineSet
  66 682 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2346
-Encoding: 9030 9030 9030
+Encoding: 9030 9030 2349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67789,8 +70143,9 @@ SplineSet
  1167 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2347
-Encoding: 9031 9031 9031
+Encoding: 9031 9031 2350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67819,8 +70174,9 @@ SplineSet
  120 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2348
-Encoding: 9032 9032 9032
+Encoding: 9032 9032 2351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67849,8 +70205,9 @@ SplineSet
  1113 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2349
-Encoding: 9033 9033 9033
+Encoding: 9033 9033 2352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67885,8 +70242,9 @@ SplineSet
  553.559 1224.8 553.559 1224.8 491.148 1206.37 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234A
-Encoding: 9034 9034 9034
+Encoding: 9034 9034 2353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67908,8 +70266,9 @@ SplineSet
  701 1284 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234B
-Encoding: 9035 9035 9035
+Encoding: 9035 9035 2354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67921,10 +70280,10 @@ SplineSet
  692 1493 l 1,3,-1
  739 1493 l 1,4,-1
  1196 0 l 1,5,-1
- 692 -3.28626e-14 l 1,6,-1
+ 692 -3.28626e-014 l 1,6,-1
  692 -350 l 1,7,-1
  540 -350 l 1,8,-1
- 540 -2.42861e-15 l 1,9,-1
+ 540 -2.42861e-015 l 1,9,-1
  37 0 l 1,10,-1
  494 1493 l 1,11,-1
  540 1493 l 1,0,-1
@@ -67938,8 +70297,9 @@ SplineSet
  692 170 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234C
-Encoding: 9036 9036 9036
+Encoding: 9036 9036 2355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67965,8 +70325,9 @@ SplineSet
  120 909.059 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234D
-Encoding: 9037 9037 9037
+Encoding: 9037 9037 2356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67983,8 +70344,8 @@ SplineSet
  6 -204 l 1,3,-1
 120 -90 m 1,7,-1
  1113 -90 l 1,8,-1
- 1113 4.89192e-16 l 1,9,10
- 120 -2.85327e-14 l 1,11,-1
+ 1113 4.89192e-016 l 1,9,10
+ 120 -2.85327e-014 l 1,11,-1
  120 -90 l 1,7,-1
 120 90.9297 m 1,12,-1
  506.25 1493 l 1,13,-1
@@ -67995,8 +70356,9 @@ SplineSet
  120 90.9297 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234E
-Encoding: 9038 9038 9038
+Encoding: 9038 9038 2357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68031,8 +70393,9 @@ SplineSet
  700 616 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni234F
-Encoding: 9039 9039 9039
+Encoding: 9039 9039 2358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68059,8 +70422,9 @@ SplineSet
  658 1550 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2350
-Encoding: 9040 9040 9040
+Encoding: 9040 9040 2359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68089,8 +70453,9 @@ SplineSet
  534.5 -90 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2351
-Encoding: 9041 9041 9041
+Encoding: 9041 9041 2360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68112,8 +70477,9 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2352
-Encoding: 9042 9042 9042
+Encoding: 9042 9042 2361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68142,8 +70508,9 @@ SplineSet
  692 1323 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2353
-Encoding: 9043 9043 9043
+Encoding: 9043 9043 2362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68169,8 +70536,9 @@ SplineSet
  120 583.942 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2354
-Encoding: 9044 9044 9044
+Encoding: 9044 9044 2363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68199,8 +70567,9 @@ SplineSet
  120 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2355
-Encoding: 9045 9045 9045
+Encoding: 9045 9045 2364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68235,8 +70604,9 @@ SplineSet
  532 850 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2356
-Encoding: 9046 9046 9046
+Encoding: 9046 9046 2365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68263,8 +70633,9 @@ SplineSet
  576 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2357
-Encoding: 9047 9047 9047
+Encoding: 9047 9047 2366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68293,17 +70664,19 @@ SplineSet
  534.5 1583 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2358
-Encoding: 9048 9048 9048
+Encoding: 9048 9048 2367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2359
-Encoding: 9049 9049 9049
+Encoding: 9049 9049 2368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68325,35 +70698,39 @@ SplineSet
  1227 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni235A
-Encoding: 9050 9050 9050
+Encoding: 9050 9050 2369
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9671 9671 N 1 0 0 1 0 200 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 2634 9671 N 1 0 0 1 0 200 2
+Refer: 3103 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235B
-Encoding: 9051 9051 9051
+Encoding: 9051 9051 2370
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235C
-Encoding: 9052 9052 9052
+Encoding: 9052 9052 2371
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
+Refer: 3103 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235D
-Encoding: 9053 9053 9053
+Encoding: 9053 9053 2372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68396,26 +70773,29 @@ SplineSet
  761 792 761 792 718 834.5 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni235E
-Encoding: 9054 9054 9054
+Encoding: 9054 9054 2373
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9109 9109 N 1 0 0 1 0 0 2
-Refer: 39 39 N 1 0 0 1 0 0 2
+Refer: 2411 9109 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235F
-Encoding: 9055 9055 9055
+Encoding: 9055 9055 2374
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9711 9711 N 1 0 0 1 0 200 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 2674 9711 N 1 0 0 1 0 200 2
+Refer: 2275 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2360
-Encoding: 9056 9056 9056
+Encoding: 9056 9056 2375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68443,8 +70823,9 @@ SplineSet
  489 305 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2361
-Encoding: 9057 9057 9057
+Encoding: 9057 9057 2376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68471,8 +70852,9 @@ SplineSet
  533 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2362
-Encoding: 9058 9058 9058
+Encoding: 9058 9058 2377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68499,35 +70881,39 @@ SplineSet
  616 211 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2363
-Encoding: 9059 9059 9059
+Encoding: 9059 9059 2378
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8902 8902 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -250 2
+Refer: 2275 8902 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 -250 2
 EndChar
+
 StartChar: uni2364
-Encoding: 9060 9060 9060
+Encoding: 9060 9060 2379
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 3105 -1 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni2365
-Encoding: 9061 9061 9061
+Encoding: 9061 9061 2380
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9675 9675 N 1 0 0 1 0 200 2
-Refer: 1114132 -1 N 1 0 0 1 0 150 2
+Refer: 2638 9675 N 1 0 0 1 0 200 2
+Refer: 3106 -1 N 1 0 0 1 0 150 2
 EndChar
+
 StartChar: uni2366
-Encoding: 9062 9062 9062
+Encoding: 9062 9062 2381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68564,8 +70950,9 @@ SplineSet
  164 376 164 376 164 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2367
-Encoding: 9063 9063 9063
+Encoding: 9063 9063 2382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68597,26 +70984,29 @@ SplineSet
  420 314 420 314 540 314 c 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2368
-Encoding: 9064 9064 9064
+Encoding: 9064 9064 2383
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 126 126 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 95 126 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni2369
-Encoding: 9065 9065 9065
+Encoding: 9065 9065 2384
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 62 62 N 1 0 0 1 0 0 2
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
+Refer: 31 62 N 1 0 0 1 0 0 2
+Refer: 3106 -1 N 1 0 0 1 0 -200 2
 EndChar
+
 StartChar: uni236A
-Encoding: 9066 9066 9066
+Encoding: 9066 9066 2385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68636,8 +71026,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236B
-Encoding: 9067 9067 9067
+Encoding: 9067 9067 2386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68676,8 +71067,9 @@ SplineSet
  474.095 714.191 474.095 714.191 464.707 715.983 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236C
-Encoding: 9068 9068 9068
+Encoding: 9068 9068 2387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68722,8 +71114,9 @@ SplineSet
  358.197 724 358.197 724 336.101 721.542 c 1,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni236D
-Encoding: 9069 9069 9069
+Encoding: 9069 9069 2388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68754,8 +71147,9 @@ SplineSet
  1071 828 1071 828 1145 890 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236E
-Encoding: 9070 9070 9070
+Encoding: 9070 9070 2389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68783,8 +71177,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236F
-Encoding: 9071 9071 9071
+Encoding: 9071 9071 2390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68823,8 +71218,9 @@ SplineSet
  193.7 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2370
-Encoding: 9072 9072 9072
+Encoding: 9072 9072 2391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68871,8 +71267,9 @@ SplineSet
  487 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2371
-Encoding: 9073 9073 9073
+Encoding: 9073 9073 2392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68904,8 +71301,9 @@ SplineSet
  574 575 574 575 520 592 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2372
-Encoding: 9074 9074 9074
+Encoding: 9074 9074 2393
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68937,8 +71335,9 @@ SplineSet
  669 705 669 705 683 699 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2373
-Encoding: 9075 9075 9075
+Encoding: 9075 9075 2394
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68959,8 +71358,9 @@ SplineSet
  708.5 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2374
-Encoding: 9076 9076 9076
+Encoding: 9076 9076 2395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68989,8 +71389,9 @@ SplineSet
  915 345 915 345 915 559 c 128,-1,18
 EndSplineSet
 EndChar
+
 StartChar: uni2375
-Encoding: 9077 9077 9077
+Encoding: 9077 9077 2396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69022,17 +71423,19 @@ SplineSet
  1033 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2376
-Encoding: 9078 9078 9078
+Encoding: 9078 9078 2397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9082 9082 N 1 0 0 1 0 0 2
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
+Refer: 2401 9082 N 1 0 0 1 0 0 2
+Refer: 3103 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2377
-Encoding: 9079 9079 9079
+Encoding: 9079 9079 2398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69067,26 +71470,29 @@ SplineSet
  1077 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2378
-Encoding: 9080 9080 9080
+Encoding: 9080 9080 2399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9075 9075 N 1 0 0 1 0 0 2
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
+Refer: 2394 9075 N 1 0 0 1 0 0 2
+Refer: 3104 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2379
-Encoding: 9081 9081 9081
+Encoding: 9081 9081 2400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 9077 9077 N 1 0 0 1 0 0 2
+Refer: 3103 -1 N 1 0 0 1 0 0 2
+Refer: 2396 9077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237A
-Encoding: 9082 9082 9082
+Encoding: 9082 9082 2401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69122,8 +71528,9 @@ SplineSet
  809.801 1150.23 809.801 1150.23 869.15 826.833 c 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni237D
-Encoding: 9085 9085 9085
+Encoding: 9085 9085 2402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69144,8 +71551,9 @@ SplineSet
  225 -466 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2380
-Encoding: 9088 9088 9088
+Encoding: 9088 9088 2403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69193,8 +71601,9 @@ SplineSet
  874 880 874 880 874 798 c 2,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2381
-Encoding: 9089 9089 9089
+Encoding: 9089 9089 2404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69255,8 +71664,9 @@ SplineSet
  588 880 588 880 588 798 c 2,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2382
-Encoding: 9090 9090 9090
+Encoding: 9090 9090 2405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69340,8 +71750,9 @@ SplineSet
  1174 880 1174 880 1174 798 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2383
-Encoding: 9091 9091 9091
+Encoding: 9091 9091 2406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69412,8 +71823,9 @@ SplineSet
  306 624 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2388
-Encoding: 9096 9096 9096
+Encoding: 9096 9096 2407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69493,8 +71905,9 @@ SplineSet
  902 695.508 902 695.508 885.367 741.284 c 1,91,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2389
-Encoding: 9097 9097 9097
+Encoding: 9097 9097 2408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69546,8 +71959,9 @@ SplineSet
  498.478 216.579 498.478 216.579 554.11 208.772 c 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238A
-Encoding: 9098 9098 9098
+Encoding: 9098 9098 2409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69600,8 +72014,9 @@ SplineSet
  1013.7 817.67 1013.7 817.67 1009.82 825.874 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238B
-Encoding: 9099 9099 9099
+Encoding: 9099 9099 2410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69648,8 +72063,9 @@ SplineSet
  70 528.7 70 528.7 70 640 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2395
-Encoding: 9109 9109 9109
+Encoding: 9109 9109 2411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69667,8 +72083,9 @@ SplineSet
  6 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni239B
-Encoding: 9115 9115 9115
+Encoding: 9115 9115 2412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69685,8 +72102,9 @@ SplineSet
  475 -528 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239C
-Encoding: 9116 9116 9116
+Encoding: 9116 9116 2413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69699,8 +72117,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni239D
-Encoding: 9117 9117 9117
+Encoding: 9117 9117 2414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69717,8 +72136,9 @@ SplineSet
  475 1929 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239E
-Encoding: 9118 9118 9118
+Encoding: 9118 9118 2415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69735,8 +72155,9 @@ SplineSet
  758 -528 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239F
-Encoding: 9119 9119 9119
+Encoding: 9119 9119 2416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69749,8 +72170,9 @@ SplineSet
  953 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A0
-Encoding: 9120 9120 9120
+Encoding: 9120 9120 2417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69767,8 +72189,9 @@ SplineSet
  758 1929 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A1
-Encoding: 9121 9121 9121
+Encoding: 9121 9121 2418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69783,8 +72206,9 @@ SplineSet
  475 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A2
-Encoding: 9122 9122 9122
+Encoding: 9122 9122 2419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69797,8 +72221,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A3
-Encoding: 9123 9123 9123
+Encoding: 9123 9123 2420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69813,8 +72238,9 @@ SplineSet
  475 1929 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A4
-Encoding: 9124 9124 9124
+Encoding: 9124 9124 2421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69829,8 +72255,9 @@ SplineSet
  757 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A5
-Encoding: 9125 9125 9125
+Encoding: 9125 9125 2422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69843,8 +72270,9 @@ SplineSet
  757 1914 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A6
-Encoding: 9126 9126 9126
+Encoding: 9126 9126 2423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69859,8 +72287,9 @@ SplineSet
  757 1914 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A7
-Encoding: 9127 9127 9127
+Encoding: 9127 9127 2424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69879,8 +72308,9 @@ SplineSet
  710 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23A8
-Encoding: 9128 9128 9128
+Encoding: 9128 9128 2425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69906,8 +72336,9 @@ SplineSet
  569 738 569 738 509 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23A9
-Encoding: 9129 9129 9129
+Encoding: 9129 9129 2426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69926,8 +72357,9 @@ SplineSet
  710 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AA
-Encoding: 9130 9130 9130
+Encoding: 9130 9130 2427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69940,8 +72372,9 @@ SplineSet
  710 -524 l 25,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23AB
-Encoding: 9131 9131 9131
+Encoding: 9131 9131 2428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69960,8 +72393,9 @@ SplineSet
  523 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AC
-Encoding: 9132 9132 9132
+Encoding: 9132 9132 2429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69987,8 +72421,9 @@ SplineSet
  665.971 673.084 665.971 673.084 724 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23AD
-Encoding: 9133 9133 9133
+Encoding: 9133 9133 2430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70007,8 +72442,9 @@ SplineSet
  523 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AE
-Encoding: 9134 9134 9134
+Encoding: 9134 9134 2431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70021,8 +72457,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CE
-Encoding: 9166 9166 9166
+Encoding: 9166 9166 2432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70050,8 +72487,9 @@ SplineSet
  893 663 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CF
-Encoding: 9167 9167 9167
+Encoding: 9167 9167 2433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70068,8 +72506,9 @@ SplineSet
  1227 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2423
-Encoding: 9251 9251 9251
+Encoding: 9251 9251 2434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70086,8 +72525,9 @@ SplineSet
  58.4131 -466 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF100000
-Encoding: 9472 9472 9472
+Encoding: 9472 9472 2435
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70100,8 +72540,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2501
-Encoding: 9473 9473 9473
+Encoding: 9473 9473 2436
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70114,8 +72555,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF110000
-Encoding: 9474 9474 9474
+Encoding: 9474 9474 2437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70128,8 +72570,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2503
-Encoding: 9475 9475 9475
+Encoding: 9475 9475 2438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70142,8 +72585,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2504
-Encoding: 9476 9476 9476
+Encoding: 9476 9476 2439
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70166,8 +72610,9 @@ SplineSet
  60 618 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2505
-Encoding: 9477 9477 9477
+Encoding: 9477 9477 2440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70190,8 +72635,9 @@ SplineSet
  60 532 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2506
-Encoding: 9478 9478 9478
+Encoding: 9478 9478 2441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70214,8 +72660,9 @@ SplineSet
  536 1193 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2507
-Encoding: 9479 9479 9479
+Encoding: 9479 9479 2442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70238,8 +72685,9 @@ SplineSet
  456 1193 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2508
-Encoding: 9480 9480 9480
+Encoding: 9480 9480 2443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70267,8 +72715,9 @@ SplineSet
  984 618 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2509
-Encoding: 9481 9481 9481
+Encoding: 9481 9481 2444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70296,8 +72745,9 @@ SplineSet
  984 532 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250A
-Encoding: 9482 9482 9482
+Encoding: 9482 9482 2445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70325,8 +72775,9 @@ SplineSet
  536 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250B
-Encoding: 9483 9483 9483
+Encoding: 9483 9483 2446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70354,8 +72805,9 @@ SplineSet
  456 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF010000
-Encoding: 9484 9484 9484
+Encoding: 9484 9484 2447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70370,8 +72822,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250D
-Encoding: 9485 9485 9485
+Encoding: 9485 9485 2448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70386,8 +72839,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250E
-Encoding: 9486 9486 9486
+Encoding: 9486 9486 2449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70402,8 +72856,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250F
-Encoding: 9487 9487 9487
+Encoding: 9487 9487 2450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70418,8 +72873,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF030000
-Encoding: 9488 9488 9488
+Encoding: 9488 9488 2451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70434,8 +72890,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2511
-Encoding: 9489 9489 9489
+Encoding: 9489 9489 2452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70450,8 +72907,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2512
-Encoding: 9490 9490 9490
+Encoding: 9490 9490 2453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70466,8 +72924,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2513
-Encoding: 9491 9491 9491
+Encoding: 9491 9491 2454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70482,8 +72941,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF020000
-Encoding: 9492 9492 9492
+Encoding: 9492 9492 2455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70498,8 +72958,9 @@ SplineSet
  536 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2515
-Encoding: 9493 9493 9493
+Encoding: 9493 9493 2456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70514,8 +72975,9 @@ SplineSet
  536 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2516
-Encoding: 9494 9494 9494
+Encoding: 9494 9494 2457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70530,8 +72992,9 @@ SplineSet
  456 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2517
-Encoding: 9495 9495 9495
+Encoding: 9495 9495 2458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70546,8 +73009,9 @@ SplineSet
  456 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF040000
-Encoding: 9496 9496 9496
+Encoding: 9496 9496 2459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70562,8 +73026,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2519
-Encoding: 9497 9497 9497
+Encoding: 9497 9497 2460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70578,8 +73043,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251A
-Encoding: 9498 9498 9498
+Encoding: 9498 9498 2461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70594,8 +73060,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251B
-Encoding: 9499 9499 9499
+Encoding: 9499 9499 2462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70610,8 +73077,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF080000
-Encoding: 9500 9500 9500
+Encoding: 9500 9500 2463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70628,8 +73096,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251D
-Encoding: 9501 9501 9501
+Encoding: 9501 9501 2464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70646,8 +73115,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251E
-Encoding: 9502 9502 9502
+Encoding: 9502 9502 2465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70666,8 +73136,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251F
-Encoding: 9503 9503 9503
+Encoding: 9503 9503 2466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70686,8 +73157,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2520
-Encoding: 9504 9504 9504
+Encoding: 9504 9504 2467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70704,8 +73176,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2521
-Encoding: 9505 9505 9505
+Encoding: 9505 9505 2468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70724,8 +73197,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2522
-Encoding: 9506 9506 9506
+Encoding: 9506 9506 2469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70744,8 +73218,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2523
-Encoding: 9507 9507 9507
+Encoding: 9507 9507 2470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70762,8 +73237,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF090000
-Encoding: 9508 9508 9508
+Encoding: 9508 9508 2471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70780,8 +73256,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2525
-Encoding: 9509 9509 9509
+Encoding: 9509 9509 2472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70798,8 +73275,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2526
-Encoding: 9510 9510 9510
+Encoding: 9510 9510 2473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70818,8 +73296,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2527
-Encoding: 9511 9511 9511
+Encoding: 9511 9511 2474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70838,8 +73317,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2528
-Encoding: 9512 9512 9512
+Encoding: 9512 9512 2475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70856,8 +73336,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2529
-Encoding: 9513 9513 9513
+Encoding: 9513 9513 2476
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70876,8 +73357,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252A
-Encoding: 9514 9514 9514
+Encoding: 9514 9514 2477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70896,8 +73378,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252B
-Encoding: 9515 9515 9515
+Encoding: 9515 9515 2478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70914,8 +73397,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF060000
-Encoding: 9516 9516 9516
+Encoding: 9516 9516 2479
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70932,8 +73416,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252D
-Encoding: 9517 9517 9517
+Encoding: 9517 9517 2480
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70952,8 +73437,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252E
-Encoding: 9518 9518 9518
+Encoding: 9518 9518 2481
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70972,8 +73458,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252F
-Encoding: 9519 9519 9519
+Encoding: 9519 9519 2482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70990,8 +73477,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2530
-Encoding: 9520 9520 9520
+Encoding: 9520 9520 2483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71008,8 +73496,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2531
-Encoding: 9521 9521 9521
+Encoding: 9521 9521 2484
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71028,8 +73517,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2532
-Encoding: 9522 9522 9522
+Encoding: 9522 9522 2485
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71048,8 +73538,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2533
-Encoding: 9523 9523 9523
+Encoding: 9523 9523 2486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71066,8 +73557,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF070000
-Encoding: 9524 9524 9524
+Encoding: 9524 9524 2487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71084,8 +73576,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2535
-Encoding: 9525 9525 9525
+Encoding: 9525 9525 2488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71104,8 +73597,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2536
-Encoding: 9526 9526 9526
+Encoding: 9526 9526 2489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71124,8 +73618,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2537
-Encoding: 9527 9527 9527
+Encoding: 9527 9527 2490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71142,8 +73637,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2538
-Encoding: 9528 9528 9528
+Encoding: 9528 9528 2491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71160,8 +73656,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2539
-Encoding: 9529 9529 9529
+Encoding: 9529 9529 2492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71180,8 +73677,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253A
-Encoding: 9530 9530 9530
+Encoding: 9530 9530 2493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71200,8 +73698,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253B
-Encoding: 9531 9531 9531
+Encoding: 9531 9531 2494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71218,8 +73717,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF050000
-Encoding: 9532 9532 9532
+Encoding: 9532 9532 2495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71240,8 +73740,9 @@ SplineSet
  696 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253D
-Encoding: 9533 9533 9533
+Encoding: 9533 9533 2496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71262,8 +73763,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253E
-Encoding: 9534 9534 9534
+Encoding: 9534 9534 2497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71284,8 +73786,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253F
-Encoding: 9535 9535 9535
+Encoding: 9535 9535 2498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71306,8 +73809,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2540
-Encoding: 9536 9536 9536
+Encoding: 9536 9536 2499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71328,8 +73832,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2541
-Encoding: 9537 9537 9537
+Encoding: 9537 9537 2500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71350,8 +73855,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2542
-Encoding: 9538 9538 9538
+Encoding: 9538 9538 2501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71372,8 +73878,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2543
-Encoding: 9539 9539 9539
+Encoding: 9539 9539 2502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71396,8 +73903,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2544
-Encoding: 9540 9540 9540
+Encoding: 9540 9540 2503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71420,8 +73928,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2545
-Encoding: 9541 9541 9541
+Encoding: 9541 9541 2504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71444,8 +73953,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2546
-Encoding: 9542 9542 9542
+Encoding: 9542 9542 2505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71468,8 +73978,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2547
-Encoding: 9543 9543 9543
+Encoding: 9543 9543 2506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71490,8 +74001,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2548
-Encoding: 9544 9544 9544
+Encoding: 9544 9544 2507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71512,8 +74024,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2549
-Encoding: 9545 9545 9545
+Encoding: 9545 9545 2508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71534,8 +74047,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254A
-Encoding: 9546 9546 9546
+Encoding: 9546 9546 2509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71556,8 +74070,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254B
-Encoding: 9547 9547 9547
+Encoding: 9547 9547 2510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71578,8 +74093,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254C
-Encoding: 9548 9548 9548
+Encoding: 9548 9548 2511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71597,8 +74113,9 @@ SplineSet
  677 618 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254D
-Encoding: 9549 9549 9549
+Encoding: 9549 9549 2512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71616,8 +74133,9 @@ SplineSet
  60 532 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254E
-Encoding: 9550 9550 9550
+Encoding: 9550 9550 2513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71635,8 +74153,9 @@ SplineSet
  536 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254F
-Encoding: 9551 9551 9551
+Encoding: 9551 9551 2514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71654,8 +74173,9 @@ SplineSet
  456 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF430000
-Encoding: 9552 9552 9552
+Encoding: 9552 9552 2515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71673,8 +74193,9 @@ SplineSet
  -20 446 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF240000
-Encoding: 9553 9553 9553
+Encoding: 9553 9553 2516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71692,8 +74213,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF510000
-Encoding: 9554 9554 9554
+Encoding: 9554 9554 2517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71712,8 +74234,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF520000
-Encoding: 9555 9555 9555
+Encoding: 9555 9555 2518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71732,8 +74255,9 @@ SplineSet
  376 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF390000
-Encoding: 9556 9556 9556
+Encoding: 9556 9556 2519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71755,8 +74279,9 @@ SplineSet
  696 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF220000
-Encoding: 9557 9557 9557
+Encoding: 9557 9557 2520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71775,8 +74300,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF210000
-Encoding: 9558 9558 9558
+Encoding: 9558 9558 2521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71795,8 +74321,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF250000
-Encoding: 9559 9559 9559
+Encoding: 9559 9559 2522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71818,8 +74345,9 @@ SplineSet
  376 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF500000
-Encoding: 9560 9560 9560
+Encoding: 9560 9560 2523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71838,8 +74366,9 @@ SplineSet
  536 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF490000
-Encoding: 9561 9561 9561
+Encoding: 9561 9561 2524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71858,8 +74387,9 @@ SplineSet
  376 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF380000
-Encoding: 9562 9562 9562
+Encoding: 9562 9562 2525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71881,8 +74411,9 @@ SplineSet
  376 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF280000
-Encoding: 9563 9563 9563
+Encoding: 9563 9563 2526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71901,8 +74432,9 @@ SplineSet
  -20 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF270000
-Encoding: 9564 9564 9564
+Encoding: 9564 9564 2527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71921,8 +74453,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF260000
-Encoding: 9565 9565 9565
+Encoding: 9565 9565 2528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71944,8 +74477,9 @@ SplineSet
  -20 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF360000
-Encoding: 9566 9566 9566
+Encoding: 9566 9566 2529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71966,8 +74500,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF370000
-Encoding: 9567 9567 9567
+Encoding: 9567 9567 2530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71989,8 +74524,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF420000
-Encoding: 9568 9568 9568
+Encoding: 9568 9568 2531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72017,8 +74553,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF190000
-Encoding: 9569 9569 9569
+Encoding: 9569 9569 2532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72039,8 +74576,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF200000
-Encoding: 9570 9570 9570
+Encoding: 9570 9570 2533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72062,8 +74600,9 @@ SplineSet
  696 -512 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF230000
-Encoding: 9571 9571 9571
+Encoding: 9571 9571 2534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72090,8 +74629,9 @@ SplineSet
  696 -512 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF470000
-Encoding: 9572 9572 9572
+Encoding: 9572 9572 2535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72113,8 +74653,9 @@ SplineSet
  -20 790 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF480000
-Encoding: 9573 9573 9573
+Encoding: 9573 9573 2536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72135,8 +74676,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF410000
-Encoding: 9574 9574 9574
+Encoding: 9574 9574 2537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72163,8 +74705,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF450000
-Encoding: 9575 9575 9575
+Encoding: 9575 9575 2538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72186,8 +74729,9 @@ SplineSet
  -20 790 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF460000
-Encoding: 9576 9576 9576
+Encoding: 9576 9576 2539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72208,8 +74752,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF400000
-Encoding: 9577 9577 9577
+Encoding: 9577 9577 2540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72236,8 +74781,9 @@ SplineSet
  696 790 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF540000
-Encoding: 9578 9578 9578
+Encoding: 9578 9578 2541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72266,8 +74812,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF530000
-Encoding: 9579 9579 9579
+Encoding: 9579 9579 2542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72296,8 +74843,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF440000
-Encoding: 9580 9580 9580
+Encoding: 9580 9580 2543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72333,8 +74881,9 @@ SplineSet
  696 790 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256D
-Encoding: 9581 9581 9581
+Encoding: 9581 9581 2544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72353,8 +74902,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256E
-Encoding: 9582 9582 9582
+Encoding: 9582 9582 2545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72373,8 +74923,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256F
-Encoding: 9583 9583 9583
+Encoding: 9583 9583 2546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72393,8 +74944,9 @@ SplineSet
  -20 618 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2570
-Encoding: 9584 9584 9584
+Encoding: 9584 9584 2547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72413,8 +74965,9 @@ SplineSet
  1253 618 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2571
-Encoding: 9585 9585 9585
+Encoding: 9585 9585 2548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72427,8 +74980,9 @@ SplineSet
  -89 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2572
-Encoding: 9586 9586 9586
+Encoding: 9586 9586 2549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72441,8 +74995,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2573
-Encoding: 9587 9587 9587
+Encoding: 9587 9587 2550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72463,8 +75018,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2574
-Encoding: 9588 9588 9588
+Encoding: 9588 9588 2551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72477,8 +75033,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2575
-Encoding: 9589 9589 9589
+Encoding: 9589 9589 2552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72491,8 +75048,9 @@ SplineSet
  536 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2576
-Encoding: 9590 9590 9590
+Encoding: 9590 9590 2553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72505,8 +75063,9 @@ SplineSet
  616 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2577
-Encoding: 9591 9591 9591
+Encoding: 9591 9591 2554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72519,8 +75078,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2578
-Encoding: 9592 9592 9592
+Encoding: 9592 9592 2555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72533,8 +75093,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2579
-Encoding: 9593 9593 9593
+Encoding: 9593 9593 2556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72547,8 +75108,9 @@ SplineSet
  456 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257A
-Encoding: 9594 9594 9594
+Encoding: 9594 9594 2557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72561,8 +75123,9 @@ SplineSet
  616 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257B
-Encoding: 9595 9595 9595
+Encoding: 9595 9595 2558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72575,8 +75138,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257C
-Encoding: 9596 9596 9596
+Encoding: 9596 9596 2559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72593,8 +75157,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257D
-Encoding: 9597 9597 9597
+Encoding: 9597 9597 2560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72611,8 +75176,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257E
-Encoding: 9598 9598 9598
+Encoding: 9598 9598 2561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72629,8 +75195,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257F
-Encoding: 9599 9599 9599
+Encoding: 9599 9599 2562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72647,16 +75214,18 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: upblock
-Encoding: 9600 9600 9600
+Encoding: 9600 9600 2563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9604 9604 N 1 0 0 1 0 1216 2
+Refer: 2567 9604 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2581
-Encoding: 9601 9601 9601
+Encoding: 9601 9601 2564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72669,8 +75238,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2582
-Encoding: 9602 9602 9602
+Encoding: 9602 9602 2565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72683,8 +75253,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2583
-Encoding: 9603 9603 9603
+Encoding: 9603 9603 2566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72697,8 +75268,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dnblock
-Encoding: 9604 9604 9604
+Encoding: 9604 9604 2567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72711,8 +75283,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2585
-Encoding: 9605 9605 9605
+Encoding: 9605 9605 2568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72725,8 +75298,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2586
-Encoding: 9606 9606 9606
+Encoding: 9606 9606 2569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72739,8 +75313,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2587
-Encoding: 9607 9607 9607
+Encoding: 9607 9607 2570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72753,8 +75328,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: block
-Encoding: 9608 9608 9608
+Encoding: 9608 9608 2571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72767,8 +75343,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2589
-Encoding: 9609 9609 9609
+Encoding: 9609 9609 2572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72781,8 +75358,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258A
-Encoding: 9610 9610 9610
+Encoding: 9610 9610 2573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72795,8 +75373,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258B
-Encoding: 9611 9611 9611
+Encoding: 9611 9611 2574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72809,8 +75388,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lfblock
-Encoding: 9612 9612 9612
+Encoding: 9612 9612 2575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72823,8 +75403,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258D
-Encoding: 9613 9613 9613
+Encoding: 9613 9613 2576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72837,8 +75418,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258E
-Encoding: 9614 9614 9614
+Encoding: 9614 9614 2577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72851,8 +75433,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258F
-Encoding: 9615 9615 9615
+Encoding: 9615 9615 2578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72865,16 +75448,18 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rtblock
-Encoding: 9616 9616 9616
+Encoding: 9616 9616 2579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9612 9612 N 1 0 0 1 637 0 2
+Refer: 2575 9612 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: ltshade
-Encoding: 9617 9617 9617
+Encoding: 9617 9617 2580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72962,8 +75547,9 @@ SplineSet
  0 1059 l 25,60,-1
 EndSplineSet
 EndChar
+
 StartChar: shade
-Encoding: 9618 9618 9618
+Encoding: 9618 9618 2581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73121,8 +75707,9 @@ SplineSet
  0 1661 l 1,116,-1
 EndSplineSet
 EndChar
+
 StartChar: dkshade
-Encoding: 9619 9619 9619
+Encoding: 9619 9619 2582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73206,24 +75793,27 @@ SplineSet
  770 1901 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2594
-Encoding: 9620 9620 9620
+Encoding: 9620 9620 2583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9601 9601 N 1 0 0 1 0 2114 2
+Refer: 2564 9601 N 1 0 0 1 0 2114 2
 EndChar
+
 StartChar: uni2595
-Encoding: 9621 9621 9621
+Encoding: 9621 9621 2584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9615 9615 N 1 0 0 1 1114 0 2
+Refer: 2578 9615 N 1 0 0 1 1114 0 2
 EndChar
+
 StartChar: uni2596
-Encoding: 9622 9622 9622
+Encoding: 9622 9622 2585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73236,24 +75826,27 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2597
-Encoding: 9623 9623 9623
+Encoding: 9623 9623 2586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 0 2
+Refer: 2585 9622 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: uni2598
-Encoding: 9624 9624 9624
+Encoding: 9624 9624 2587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 1216 2
+Refer: 2585 9622 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2599
-Encoding: 9625 9625 9625
+Encoding: 9625 9625 2588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73268,17 +75861,19 @@ SplineSet
  -20 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259A
-Encoding: 9626 9626 9626
+Encoding: 9626 9626 2589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9624 9624 N 1 0 0 1 0 0 2
-Refer: 9623 9623 N 1 0 0 1 0 0 2
+Refer: 2587 9624 N 1 0 0 1 0 0 2
+Refer: 2586 9623 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259B
-Encoding: 9627 9627 9627
+Encoding: 9627 9627 2590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73293,8 +75888,9 @@ SplineSet
  -20 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259C
-Encoding: 9628 9628 9628
+Encoding: 9628 9628 2591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73309,25 +75905,28 @@ SplineSet
  1254 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259D
-Encoding: 9629 9629 9629
+Encoding: 9629 9629 2592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 1216 2
+Refer: 2585 9622 N 1 0 0 1 637 1216 2
 EndChar
+
 StartChar: uni259E
-Encoding: 9630 9630 9630
+Encoding: 9630 9630 2593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 0 2
-Refer: 9629 9629 N 1 0 0 1 0 0 2
+Refer: 2585 9622 N 1 0 0 1 0 0 2
+Refer: 2592 9629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259F
-Encoding: 9631 9631 9631
+Encoding: 9631 9631 2594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73342,8 +75941,9 @@ SplineSet
  1254 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: filledbox
-Encoding: 9632 9632 9632
+Encoding: 9632 9632 2595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73356,8 +75956,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H22073
-Encoding: 9633 9633 9633
+Encoding: 9633 9633 2596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73375,8 +75976,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A2
-Encoding: 9634 9634 9634
+Encoding: 9634 9634 2597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73402,17 +76004,19 @@ SplineSet
  6 -78.5 6 -78.5 6 263.5 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A3
-Encoding: 9635 9635 9635
+Encoding: 9635 9635 2598
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9642 9642 N 1 0 0 1 0 0 2
-Refer: 9633 9633 N 1 0 0 1 0 0 2
+Refer: 2605 9642 N 1 0 0 1 0 0 2
+Refer: 2596 9633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni25A4
-Encoding: 9636 9636 9636
+Encoding: 9636 9636 2599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73450,8 +76054,9 @@ SplineSet
  120 922 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A5
-Encoding: 9637 9637 9637
+Encoding: 9637 9637 2600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73489,8 +76094,9 @@ SplineSet
  120 36 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A6
-Encoding: 9638 9638 9638
+Encoding: 9638 9638 2601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73628,8 +76234,9 @@ SplineSet
  6 -78.5 l 1,100,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A7
-Encoding: 9639 9639 9639
+Encoding: 9639 9639 2602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73677,8 +76284,9 @@ SplineSet
  120 182 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A8
-Encoding: 9640 9640 9640
+Encoding: 9640 9640 2603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73726,8 +76334,9 @@ SplineSet
  967 36 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A9
-Encoding: 9641 9641 9641
+Encoding: 9641 9641 2604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73877,8 +76486,9 @@ SplineSet
  6 -78.5 l 1,112,-1
 EndSplineSet
 EndChar
+
 StartChar: H18543
-Encoding: 9642 9642 9642
+Encoding: 9642 9642 2605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73891,8 +76501,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H18551
-Encoding: 9643 9643 9643
+Encoding: 9643 9643 2606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73910,8 +76521,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: filledrect
-Encoding: 9644 9644 9644
+Encoding: 9644 9644 2607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73924,8 +76536,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AD
-Encoding: 9645 9645 9645
+Encoding: 9645 9645 2608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73943,8 +76556,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AE
-Encoding: 9646 9646 9646
+Encoding: 9646 9646 2609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73957,8 +76571,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AF
-Encoding: 9647 9647 9647
+Encoding: 9647 9647 2610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73976,8 +76591,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B0
-Encoding: 9648 9648 9648
+Encoding: 9648 9648 2611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73990,8 +76606,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B1
-Encoding: 9649 9649 9649
+Encoding: 9649 9649 2612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74009,8 +76626,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagup
-Encoding: 9650 9650 9650
+Encoding: 9650 9650 2613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74022,8 +76640,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B3
-Encoding: 9651 9651 9651
+Encoding: 9651 9651 2614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74039,8 +76658,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B4
-Encoding: 9652 9652 9652
+Encoding: 9652 9652 2615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74052,8 +76672,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B5
-Encoding: 9653 9653 9653
+Encoding: 9653 9653 2616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74069,8 +76690,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B6
-Encoding: 9654 9654 9654
+Encoding: 9654 9654 2617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74082,8 +76704,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B7
-Encoding: 9655 9655 9655
+Encoding: 9655 9655 2618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74099,8 +76722,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B8
-Encoding: 9656 9656 9656
+Encoding: 9656 9656 2619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74112,8 +76736,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B9
-Encoding: 9657 9657 9657
+Encoding: 9657 9657 2620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74129,8 +76754,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagrt
-Encoding: 9658 9658 9658
+Encoding: 9658 9658 2621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74142,8 +76768,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BB
-Encoding: 9659 9659 9659
+Encoding: 9659 9659 2622
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74159,8 +76786,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagdn
-Encoding: 9660 9660 9660
+Encoding: 9660 9660 2623
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74172,8 +76800,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BD
-Encoding: 9661 9661 9661
+Encoding: 9661 9661 2624
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74189,8 +76818,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BE
-Encoding: 9662 9662 9662
+Encoding: 9662 9662 2625
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74202,8 +76832,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BF
-Encoding: 9663 9663 9663
+Encoding: 9663 9663 2626
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74219,8 +76850,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C0
-Encoding: 9664 9664 9664
+Encoding: 9664 9664 2627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74232,8 +76864,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C1
-Encoding: 9665 9665 9665
+Encoding: 9665 9665 2628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74249,8 +76882,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C2
-Encoding: 9666 9666 9666
+Encoding: 9666 9666 2629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74262,8 +76896,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C3
-Encoding: 9667 9667 9667
+Encoding: 9667 9667 2630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74279,8 +76914,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triaglf
-Encoding: 9668 9668 9668
+Encoding: 9668 9668 2631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74292,8 +76928,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C5
-Encoding: 9669 9669 9669
+Encoding: 9669 9669 2632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74309,8 +76946,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C6
-Encoding: 9670 9670 9670
+Encoding: 9670 9670 2633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74323,8 +76961,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C7
-Encoding: 9671 9671 9671
+Encoding: 9671 9671 2634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74342,8 +76981,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C8
-Encoding: 9672 9672 9672
+Encoding: 9672 9672 2635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74366,8 +77006,9 @@ SplineSet
  6 532 l 25,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25C9
-Encoding: 9673 9673 9673
+Encoding: 9673 9673 2636
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74402,8 +77043,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: lozenge
-Encoding: 9674 9674 9674
+Encoding: 9674 9674 2637
 Width: 1233
 Flags: W
 TtInstrs:
@@ -74457,8 +77099,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: circle
-Encoding: 9675 9675 9675
+Encoding: 9675 9675 2638
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74484,8 +77127,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25CC
-Encoding: 9676 9676 9676
+Encoding: 9676 9676 2639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74549,8 +77193,9 @@ SplineSet
  141 652 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25CD
-Encoding: 9677 9677 9677
+Encoding: 9677 9677 2640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74596,8 +77241,9 @@ SplineSet
  1105 714 1105 714 1002 838 c 1,51,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25CE
-Encoding: 9678 9678 9678
+Encoding: 9678 9678 2641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74641,8 +77287,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: H18533
-Encoding: 9679 9679 9679
+Encoding: 9679 9679 2642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74659,8 +77306,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D0
-Encoding: 9680 9680 9680
+Encoding: 9680 9680 2643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74683,8 +77331,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D1
-Encoding: 9681 9681 9681
+Encoding: 9681 9681 2644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74707,8 +77356,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D2
-Encoding: 9682 9682 9682
+Encoding: 9682 9682 2645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74731,8 +77381,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D3
-Encoding: 9683 9683 9683
+Encoding: 9683 9683 2646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74755,8 +77406,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D4
-Encoding: 9684 9684 9684
+Encoding: 9684 9684 2647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74782,8 +77434,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D5
-Encoding: 9685 9685 9685
+Encoding: 9685 9685 2648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74805,8 +77458,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D6
-Encoding: 9686 9686 9686
+Encoding: 9686 9686 2649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74820,8 +77474,9 @@ SplineSet
  921.5 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25D7
-Encoding: 9687 9687 9687
+Encoding: 9687 9687 2650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74835,8 +77490,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: invbullet
-Encoding: 9688 9688 9688
+Encoding: 9688 9688 2651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74858,8 +77514,9 @@ SplineSet
  -20 -20 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: invcircle
-Encoding: 9689 9689 9689
+Encoding: 9689 9689 2652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74890,8 +77547,9 @@ SplineSet
  -20 -512 l 25,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DA
-Encoding: 9690 9690 9690
+Encoding: 9690 9690 2653
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74915,8 +77573,9 @@ SplineSet
  1104.9 813.293 1104.9 813.293 1104.9 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DB
-Encoding: 9691 9691 9691
+Encoding: 9691 9691 2654
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74940,8 +77599,9 @@ SplineSet
  128.1 250.631 128.1 250.631 128.1 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DC
-Encoding: 9692 9692 9692
+Encoding: 9692 9692 2655
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74956,8 +77616,9 @@ SplineSet
  311.45 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25DD
-Encoding: 9693 9693 9693
+Encoding: 9693 9693 2656
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74972,8 +77633,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DE
-Encoding: 9694 9694 9694
+Encoding: 9694 9694 2657
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74988,8 +77650,9 @@ SplineSet
  462.5 -84 462.5 -84 311.5 -84 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DF
-Encoding: 9695 9695 9695
+Encoding: 9695 9695 2658
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75004,8 +77667,9 @@ SplineSet
  921.45 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E0
-Encoding: 9696 9696 9696
+Encoding: 9696 9696 2659
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75024,8 +77688,9 @@ SplineSet
  6 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E1
-Encoding: 9697 9697 9697
+Encoding: 9697 9697 2660
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75044,8 +77709,9 @@ SplineSet
  6 180 6 180 6 532 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E2
-Encoding: 9698 9698 9698
+Encoding: 9698 9698 2661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75057,8 +77723,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E3
-Encoding: 9699 9699 9699
+Encoding: 9699 9699 2662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75070,8 +77737,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E4
-Encoding: 9700 9700 9700
+Encoding: 9700 9700 2663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75083,8 +77751,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E5
-Encoding: 9701 9701 9701
+Encoding: 9701 9701 2664
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75096,8 +77765,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: openbullet
-Encoding: 9702 9702 9702
+Encoding: 9702 9702 2665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75123,8 +77793,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E7
-Encoding: 9703 9703 9703
+Encoding: 9703 9703 2666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75142,8 +77813,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E8
-Encoding: 9704 9704 9704
+Encoding: 9704 9704 2667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75161,8 +77833,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E9
-Encoding: 9705 9705 9705
+Encoding: 9705 9705 2668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75179,8 +77852,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EA
-Encoding: 9706 9706 9706
+Encoding: 9706 9706 2669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75197,8 +77871,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EB
-Encoding: 9707 9707 9707
+Encoding: 9707 9707 2670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75221,8 +77896,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EC
-Encoding: 9708 9708 9708
+Encoding: 9708 9708 2671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75247,8 +77923,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25ED
-Encoding: 9709 9709 9709
+Encoding: 9709 9709 2672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75264,8 +77941,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EE
-Encoding: 9710 9710 9710
+Encoding: 9710 9710 2673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75281,8 +77959,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EF
-Encoding: 9711 9711 9711
+Encoding: 9711 9711 2674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75308,8 +77987,9 @@ SplineSet
  -20 165 -20 165 -20 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25F0
-Encoding: 9712 9712 9712
+Encoding: 9712 9712 2675
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75334,8 +78014,9 @@ SplineSet
  120 35.5 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F1
-Encoding: 9713 9713 9713
+Encoding: 9713 9713 2676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75360,8 +78041,9 @@ SplineSet
  120 588.5 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F2
-Encoding: 9714 9714 9714
+Encoding: 9714 9714 2677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75386,8 +78068,9 @@ SplineSet
  120 35.5 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F3
-Encoding: 9715 9715 9715
+Encoding: 9715 9715 2678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75412,8 +78095,9 @@ SplineSet
  120 35.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F4
-Encoding: 9716 9716 9716
+Encoding: 9716 9716 2679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75444,8 +78128,9 @@ SplineSet
  130.784 474.5 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni25F5
-Encoding: 9717 9717 9717
+Encoding: 9717 9717 2680
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75476,8 +78161,9 @@ SplineSet
  130.784 474.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F6
-Encoding: 9718 9718 9718
+Encoding: 9718 9718 2681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75508,8 +78194,9 @@ SplineSet
  673 43.0479 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F7
-Encoding: 9719 9719 9719
+Encoding: 9719 9719 2682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75540,8 +78227,9 @@ SplineSet
  1102.3 588.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F8
-Encoding: 9720 9720 9720
+Encoding: 9720 9720 2683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75557,8 +78245,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25F9
-Encoding: 9721 9721 9721
+Encoding: 9721 9721 2684
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75574,8 +78263,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FA
-Encoding: 9722 9722 9722
+Encoding: 9722 9722 2685
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75591,8 +78281,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FB
-Encoding: 9723 9723 9723
+Encoding: 9723 9723 2686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75610,8 +78301,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FC
-Encoding: 9724 9724 9724
+Encoding: 9724 9724 2687
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75624,8 +78316,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FD
-Encoding: 9725 9725 9725
+Encoding: 9725 9725 2688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75643,8 +78336,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FE
-Encoding: 9726 9726 9726
+Encoding: 9726 9726 2689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75657,8 +78351,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FF
-Encoding: 9727 9727 9727
+Encoding: 9727 9727 2690
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75674,8 +78369,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2600
-Encoding: 9728 9728 9728
+Encoding: 9728 9728 2691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75757,8 +78453,9 @@ SplineSet
  590 446 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2638
-Encoding: 9784 9784 9784
+Encoding: 9784 9784 2692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75848,8 +78545,9 @@ SplineSet
  563 548 l 1,106,107
 EndSplineSet
 EndChar
+
 StartChar: uni2639
-Encoding: 9785 9785 9785
+Encoding: 9785 9785 2693
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75892,8 +78590,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: smileface
-Encoding: 9786 9786 9786
+Encoding: 9786 9786 2694
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75936,8 +78635,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: invsmileface
-Encoding: 9787 9787 9787
+Encoding: 9787 9787 2695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75971,8 +78671,9 @@ SplineSet
  496 860 496 860 501 970 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: sun
-Encoding: 9788 9788 9788
+Encoding: 9788 9788 2696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76063,8 +78764,9 @@ SplineSet
  592 924 592 924 556 910 c 0,74,75
 EndSplineSet
 EndChar
+
 StartChar: uni263F
-Encoding: 9791 9791 9791
+Encoding: 9791 9791 2697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76117,8 +78819,9 @@ SplineSet
  744 1012 744 1012 635 1018 c 2,50,-1
 EndSplineSet
 EndChar
+
 StartChar: female
-Encoding: 9792 9792 9792
+Encoding: 9792 9792 2698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76155,8 +78858,9 @@ SplineSet
  397 443 397 443 284 548 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2641
-Encoding: 9793 9793 9793
+Encoding: 9793 9793 2699
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76193,8 +78897,9 @@ SplineSet
  397 798 397 798 550 811 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: male
-Encoding: 9794 9794 9794
+Encoding: 9794 9794 2700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76230,8 +78935,9 @@ SplineSet
  910 411 910 411 781 282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2643
-Encoding: 9795 9795 9795
+Encoding: 9795 9795 2701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76263,8 +78969,9 @@ SplineSet
  488 543 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2644
-Encoding: 9796 9796 9796
+Encoding: 9796 9796 2702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76299,8 +79006,9 @@ SplineSet
  274 1141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2645
-Encoding: 9797 9797 9797
+Encoding: 9797 9797 2703
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76353,8 +79061,9 @@ SplineSet
  679 553 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2646
-Encoding: 9798 9798 9798
+Encoding: 9798 9798 2704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76416,8 +79125,9 @@ SplineSet
  679 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2647
-Encoding: 9799 9799 9799
+Encoding: 9799 9799 2705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76449,8 +79159,9 @@ SplineSet
  352 1322 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: spade
-Encoding: 9824 9824 9824
+Encoding: 9824 9824 2706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76483,8 +79194,9 @@ SplineSet
  619 1359 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2661
-Encoding: 9825 9825 9825
+Encoding: 9825 9825 2707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76524,8 +79236,9 @@ SplineSet
  56 1112 56 1112 56 1053 c 2,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2662
-Encoding: 9826 9826 9826
+Encoding: 9826 9826 2708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76546,8 +79259,9 @@ SplineSet
  614 1293 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: club
-Encoding: 9827 9827 9827
+Encoding: 9827 9827 2709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76591,8 +79305,9 @@ SplineSet
  586 1359 586 1359 618 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2664
-Encoding: 9828 9828 9828
+Encoding: 9828 9828 2710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76645,8 +79360,9 @@ SplineSet
  592 176 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: heart
-Encoding: 9829 9829 9829
+Encoding: 9829 9829 2711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76669,8 +79385,9 @@ SplineSet
  244 1359 244 1359 315 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: diamond
-Encoding: 9830 9830 9830
+Encoding: 9830 9830 2712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76685,8 +79402,9 @@ SplineSet
  617 1359 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2667
-Encoding: 9831 9831 9831
+Encoding: 9831 9831 2713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76761,8 +79479,9 @@ SplineSet
  617 277 l 1,97,98
 EndSplineSet
 EndChar
+
 StartChar: uni2669
-Encoding: 9833 9833 9833
+Encoding: 9833 9833 2714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76785,8 +79504,9 @@ SplineSet
  789 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnote
-Encoding: 9834 9834 9834
+Encoding: 9834 9834 2715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76815,8 +79535,9 @@ SplineSet
  566 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnotedbl
-Encoding: 9835 9835 9835
+Encoding: 9835 9835 2716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76848,8 +79569,9 @@ SplineSet
  473 1445 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266C
-Encoding: 9836 9836 9836
+Encoding: 9836 9836 2717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76880,8 +79602,9 @@ SplineSet
  438 1189 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266D
-Encoding: 9837 9837 9837
+Encoding: 9837 9837 2718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76905,8 +79628,9 @@ SplineSet
  519 658 519 658 376 441 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266E
-Encoding: 9838 9838 9838
+Encoding: 9838 9838 2719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76936,8 +79660,9 @@ SplineSet
  483 870 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266F
-Encoding: 9839 9839 9839
+Encoding: 9839 9839 2720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76989,16 +79714,18 @@ SplineSet
  482 867 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27C2
-Encoding: 10178 10178 10178
+Encoding: 10178 10178 2721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8869 8869 N 1 0 0 1 0 0 2
+Refer: 2265 8869 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni27C5
-Encoding: 10181 10181 10181
+Encoding: 10181 10181 2722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77023,8 +79750,9 @@ SplineSet
  736 -334 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27C6
-Encoding: 10182 10182 10182
+Encoding: 10182 10182 2723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77049,8 +79777,9 @@ SplineSet
  135 -334 135 -334 126 -334 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27DC
-Encoding: 10204 10204 10204
+Encoding: 10204 10204 2724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77079,8 +79808,9 @@ SplineSet
  176 589 176 589 215.5 549 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni27E0
-Encoding: 10208 10208 10208
+Encoding: 10208 10208 2725
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77101,8 +79831,9 @@ SplineSet
  616 -233 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E6
-Encoding: 10214 10214 10214
+Encoding: 10214 10214 2726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77124,8 +79855,9 @@ SplineSet
  474 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E7
-Encoding: 10215 10215 10215
+Encoding: 10215 10215 2727
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77147,8 +79879,9 @@ SplineSet
  1113 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E8
-Encoding: 10216 10216 10216
+Encoding: 10216 10216 2728
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77163,8 +79896,9 @@ SplineSet
  390.609 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E9
-Encoding: 10217 10217 10217
+Encoding: 10217 10217 2729
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77179,26 +79913,29 @@ SplineSet
  842.391 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27EA
-Encoding: 10218 10218 10218
+Encoding: 10218 10218 2730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10216 10216 N 1 0 0 1 -200 0 2
-Refer: 10216 10216 N 1 0 0 1 190 0 2
+Refer: 2728 10216 N 1 0 0 1 -200 0 2
+Refer: 2728 10216 N 1 0 0 1 190 0 2
 EndChar
+
 StartChar: uni27EB
-Encoding: 10219 10219 10219
+Encoding: 10219 10219 2731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10217 10217 N 1 0 0 1 -200 0 2
-Refer: 10217 10217 N 1 0 0 1 200 0 2
+Refer: 2729 10217 N 1 0 0 1 -200 0 2
+Refer: 2729 10217 N 1 0 0 1 200 0 2
 EndChar
+
 StartChar: uni27F5
-Encoding: 10229 10229 10229
+Encoding: 10229 10229 2732
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77217,8 +79954,9 @@ SplineSet
  -100 602 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F6
-Encoding: 10230 10230 10230
+Encoding: 10230 10230 2733
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77237,8 +79975,9 @@ SplineSet
  1333 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F7
-Encoding: 10231 10231 10231
+Encoding: 10231 10231 2734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77263,1544 +80002,1801 @@ SplineSet
  1333 520 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2800
-Encoding: 10240 10240 10240
+Encoding: 10240 10240 2735
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2801
-Encoding: 10241 10241 10241
+Encoding: 10241 10241 2736
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2802
-Encoding: 10242 10242 10242
+Encoding: 10242 10242 2737
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2803
-Encoding: 10243 10243 10243
+Encoding: 10243 10243 2738
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2804
-Encoding: 10244 10244 10244
+Encoding: 10244 10244 2739
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2805
-Encoding: 10245 10245 10245
+Encoding: 10245 10245 2740
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2806
-Encoding: 10246 10246 10246
+Encoding: 10246 10246 2741
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2807
-Encoding: 10247 10247 10247
+Encoding: 10247 10247 2742
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2808
-Encoding: 10248 10248 10248
+Encoding: 10248 10248 2743
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2809
-Encoding: 10249 10249 10249
+Encoding: 10249 10249 2744
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280A
-Encoding: 10250 10250 10250
+Encoding: 10250 10250 2745
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280B
-Encoding: 10251 10251 10251
+Encoding: 10251 10251 2746
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280C
-Encoding: 10252 10252 10252
+Encoding: 10252 10252 2747
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280D
-Encoding: 10253 10253 10253
+Encoding: 10253 10253 2748
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280E
-Encoding: 10254 10254 10254
+Encoding: 10254 10254 2749
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280F
-Encoding: 10255 10255 10255
+Encoding: 10255 10255 2750
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2810
-Encoding: 10256 10256 10256
+Encoding: 10256 10256 2751
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2811
-Encoding: 10257 10257 10257
+Encoding: 10257 10257 2752
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2812
-Encoding: 10258 10258 10258
+Encoding: 10258 10258 2753
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2813
-Encoding: 10259 10259 10259
+Encoding: 10259 10259 2754
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2814
-Encoding: 10260 10260 10260
+Encoding: 10260 10260 2755
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2815
-Encoding: 10261 10261 10261
+Encoding: 10261 10261 2756
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2816
-Encoding: 10262 10262 10262
+Encoding: 10262 10262 2757
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2817
-Encoding: 10263 10263 10263
+Encoding: 10263 10263 2758
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2818
-Encoding: 10264 10264 10264
+Encoding: 10264 10264 2759
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2819
-Encoding: 10265 10265 10265
+Encoding: 10265 10265 2760
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281A
-Encoding: 10266 10266 10266
+Encoding: 10266 10266 2761
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281B
-Encoding: 10267 10267 10267
+Encoding: 10267 10267 2762
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281C
-Encoding: 10268 10268 10268
+Encoding: 10268 10268 2763
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281D
-Encoding: 10269 10269 10269
+Encoding: 10269 10269 2764
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281E
-Encoding: 10270 10270 10270
+Encoding: 10270 10270 2765
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281F
-Encoding: 10271 10271 10271
+Encoding: 10271 10271 2766
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2820
-Encoding: 10272 10272 10272
+Encoding: 10272 10272 2767
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2821
-Encoding: 10273 10273 10273
+Encoding: 10273 10273 2768
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2822
-Encoding: 10274 10274 10274
+Encoding: 10274 10274 2769
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2823
-Encoding: 10275 10275 10275
+Encoding: 10275 10275 2770
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2824
-Encoding: 10276 10276 10276
+Encoding: 10276 10276 2771
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2825
-Encoding: 10277 10277 10277
+Encoding: 10277 10277 2772
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2826
-Encoding: 10278 10278 10278
+Encoding: 10278 10278 2773
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2827
-Encoding: 10279 10279 10279
+Encoding: 10279 10279 2774
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2828
-Encoding: 10280 10280 10280
+Encoding: 10280 10280 2775
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2829
-Encoding: 10281 10281 10281
+Encoding: 10281 10281 2776
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282A
-Encoding: 10282 10282 10282
+Encoding: 10282 10282 2777
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282B
-Encoding: 10283 10283 10283
+Encoding: 10283 10283 2778
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282C
-Encoding: 10284 10284 10284
+Encoding: 10284 10284 2779
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282D
-Encoding: 10285 10285 10285
+Encoding: 10285 10285 2780
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282E
-Encoding: 10286 10286 10286
+Encoding: 10286 10286 2781
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282F
-Encoding: 10287 10287 10287
+Encoding: 10287 10287 2782
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2830
-Encoding: 10288 10288 10288
+Encoding: 10288 10288 2783
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2831
-Encoding: 10289 10289 10289
+Encoding: 10289 10289 2784
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2832
-Encoding: 10290 10290 10290
+Encoding: 10290 10290 2785
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2833
-Encoding: 10291 10291 10291
+Encoding: 10291 10291 2786
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2834
-Encoding: 10292 10292 10292
+Encoding: 10292 10292 2787
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2835
-Encoding: 10293 10293 10293
+Encoding: 10293 10293 2788
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2836
-Encoding: 10294 10294 10294
+Encoding: 10294 10294 2789
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2837
-Encoding: 10295 10295 10295
+Encoding: 10295 10295 2790
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2838
-Encoding: 10296 10296 10296
+Encoding: 10296 10296 2791
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2839
-Encoding: 10297 10297 10297
+Encoding: 10297 10297 2792
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283A
-Encoding: 10298 10298 10298
+Encoding: 10298 10298 2793
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283B
-Encoding: 10299 10299 10299
+Encoding: 10299 10299 2794
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283C
-Encoding: 10300 10300 10300
+Encoding: 10300 10300 2795
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283D
-Encoding: 10301 10301 10301
+Encoding: 10301 10301 2796
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283E
-Encoding: 10302 10302 10302
+Encoding: 10302 10302 2797
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283F
-Encoding: 10303 10303 10303
+Encoding: 10303 10303 2798
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2840
-Encoding: 10304 10304 10304
+Encoding: 10304 10304 2799
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2841
-Encoding: 10305 10305 10305
+Encoding: 10305 10305 2800
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2842
-Encoding: 10306 10306 10306
+Encoding: 10306 10306 2801
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2843
-Encoding: 10307 10307 10307
+Encoding: 10307 10307 2802
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2844
-Encoding: 10308 10308 10308
+Encoding: 10308 10308 2803
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2845
-Encoding: 10309 10309 10309
+Encoding: 10309 10309 2804
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2846
-Encoding: 10310 10310 10310
+Encoding: 10310 10310 2805
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2847
-Encoding: 10311 10311 10311
+Encoding: 10311 10311 2806
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2848
-Encoding: 10312 10312 10312
+Encoding: 10312 10312 2807
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2849
-Encoding: 10313 10313 10313
+Encoding: 10313 10313 2808
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284A
-Encoding: 10314 10314 10314
+Encoding: 10314 10314 2809
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284B
-Encoding: 10315 10315 10315
+Encoding: 10315 10315 2810
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284C
-Encoding: 10316 10316 10316
+Encoding: 10316 10316 2811
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284D
-Encoding: 10317 10317 10317
+Encoding: 10317 10317 2812
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284E
-Encoding: 10318 10318 10318
+Encoding: 10318 10318 2813
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284F
-Encoding: 10319 10319 10319
+Encoding: 10319 10319 2814
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2850
-Encoding: 10320 10320 10320
+Encoding: 10320 10320 2815
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2851
-Encoding: 10321 10321 10321
+Encoding: 10321 10321 2816
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2852
-Encoding: 10322 10322 10322
+Encoding: 10322 10322 2817
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2853
-Encoding: 10323 10323 10323
+Encoding: 10323 10323 2818
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2854
-Encoding: 10324 10324 10324
+Encoding: 10324 10324 2819
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2855
-Encoding: 10325 10325 10325
+Encoding: 10325 10325 2820
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2856
-Encoding: 10326 10326 10326
+Encoding: 10326 10326 2821
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2857
-Encoding: 10327 10327 10327
+Encoding: 10327 10327 2822
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2858
-Encoding: 10328 10328 10328
+Encoding: 10328 10328 2823
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2859
-Encoding: 10329 10329 10329
+Encoding: 10329 10329 2824
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285A
-Encoding: 10330 10330 10330
+Encoding: 10330 10330 2825
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285B
-Encoding: 10331 10331 10331
+Encoding: 10331 10331 2826
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285C
-Encoding: 10332 10332 10332
+Encoding: 10332 10332 2827
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285D
-Encoding: 10333 10333 10333
+Encoding: 10333 10333 2828
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285E
-Encoding: 10334 10334 10334
+Encoding: 10334 10334 2829
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285F
-Encoding: 10335 10335 10335
+Encoding: 10335 10335 2830
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2860
-Encoding: 10336 10336 10336
+Encoding: 10336 10336 2831
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2861
-Encoding: 10337 10337 10337
+Encoding: 10337 10337 2832
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2862
-Encoding: 10338 10338 10338
+Encoding: 10338 10338 2833
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2863
-Encoding: 10339 10339 10339
+Encoding: 10339 10339 2834
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2864
-Encoding: 10340 10340 10340
+Encoding: 10340 10340 2835
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2865
-Encoding: 10341 10341 10341
+Encoding: 10341 10341 2836
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2866
-Encoding: 10342 10342 10342
+Encoding: 10342 10342 2837
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2867
-Encoding: 10343 10343 10343
+Encoding: 10343 10343 2838
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2868
-Encoding: 10344 10344 10344
+Encoding: 10344 10344 2839
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2869
-Encoding: 10345 10345 10345
+Encoding: 10345 10345 2840
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286A
-Encoding: 10346 10346 10346
+Encoding: 10346 10346 2841
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286B
-Encoding: 10347 10347 10347
+Encoding: 10347 10347 2842
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286C
-Encoding: 10348 10348 10348
+Encoding: 10348 10348 2843
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286D
-Encoding: 10349 10349 10349
+Encoding: 10349 10349 2844
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286E
-Encoding: 10350 10350 10350
+Encoding: 10350 10350 2845
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286F
-Encoding: 10351 10351 10351
+Encoding: 10351 10351 2846
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2870
-Encoding: 10352 10352 10352
+Encoding: 10352 10352 2847
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2871
-Encoding: 10353 10353 10353
+Encoding: 10353 10353 2848
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2872
-Encoding: 10354 10354 10354
+Encoding: 10354 10354 2849
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2873
-Encoding: 10355 10355 10355
+Encoding: 10355 10355 2850
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2874
-Encoding: 10356 10356 10356
+Encoding: 10356 10356 2851
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2875
-Encoding: 10357 10357 10357
+Encoding: 10357 10357 2852
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2876
-Encoding: 10358 10358 10358
+Encoding: 10358 10358 2853
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2877
-Encoding: 10359 10359 10359
+Encoding: 10359 10359 2854
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2878
-Encoding: 10360 10360 10360
+Encoding: 10360 10360 2855
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2879
-Encoding: 10361 10361 10361
+Encoding: 10361 10361 2856
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287A
-Encoding: 10362 10362 10362
+Encoding: 10362 10362 2857
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287B
-Encoding: 10363 10363 10363
+Encoding: 10363 10363 2858
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287C
-Encoding: 10364 10364 10364
+Encoding: 10364 10364 2859
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287D
-Encoding: 10365 10365 10365
+Encoding: 10365 10365 2860
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287E
-Encoding: 10366 10366 10366
+Encoding: 10366 10366 2861
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287F
-Encoding: 10367 10367 10367
+Encoding: 10367 10367 2862
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2880
-Encoding: 10368 10368 10368
+Encoding: 10368 10368 2863
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2881
-Encoding: 10369 10369 10369
+Encoding: 10369 10369 2864
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2882
-Encoding: 10370 10370 10370
+Encoding: 10370 10370 2865
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2883
-Encoding: 10371 10371 10371
+Encoding: 10371 10371 2866
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2884
-Encoding: 10372 10372 10372
+Encoding: 10372 10372 2867
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2885
-Encoding: 10373 10373 10373
+Encoding: 10373 10373 2868
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2886
-Encoding: 10374 10374 10374
+Encoding: 10374 10374 2869
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2887
-Encoding: 10375 10375 10375
+Encoding: 10375 10375 2870
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2888
-Encoding: 10376 10376 10376
+Encoding: 10376 10376 2871
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2889
-Encoding: 10377 10377 10377
+Encoding: 10377 10377 2872
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288A
-Encoding: 10378 10378 10378
+Encoding: 10378 10378 2873
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288B
-Encoding: 10379 10379 10379
+Encoding: 10379 10379 2874
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288C
-Encoding: 10380 10380 10380
+Encoding: 10380 10380 2875
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288D
-Encoding: 10381 10381 10381
+Encoding: 10381 10381 2876
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288E
-Encoding: 10382 10382 10382
+Encoding: 10382 10382 2877
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288F
-Encoding: 10383 10383 10383
+Encoding: 10383 10383 2878
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2890
-Encoding: 10384 10384 10384
+Encoding: 10384 10384 2879
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2891
-Encoding: 10385 10385 10385
+Encoding: 10385 10385 2880
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2892
-Encoding: 10386 10386 10386
+Encoding: 10386 10386 2881
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2893
-Encoding: 10387 10387 10387
+Encoding: 10387 10387 2882
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2894
-Encoding: 10388 10388 10388
+Encoding: 10388 10388 2883
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2895
-Encoding: 10389 10389 10389
+Encoding: 10389 10389 2884
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2896
-Encoding: 10390 10390 10390
+Encoding: 10390 10390 2885
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2897
-Encoding: 10391 10391 10391
+Encoding: 10391 10391 2886
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2898
-Encoding: 10392 10392 10392
+Encoding: 10392 10392 2887
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2899
-Encoding: 10393 10393 10393
+Encoding: 10393 10393 2888
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289A
-Encoding: 10394 10394 10394
+Encoding: 10394 10394 2889
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289B
-Encoding: 10395 10395 10395
+Encoding: 10395 10395 2890
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289C
-Encoding: 10396 10396 10396
+Encoding: 10396 10396 2891
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289D
-Encoding: 10397 10397 10397
+Encoding: 10397 10397 2892
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289E
-Encoding: 10398 10398 10398
+Encoding: 10398 10398 2893
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289F
-Encoding: 10399 10399 10399
+Encoding: 10399 10399 2894
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A0
-Encoding: 10400 10400 10400
+Encoding: 10400 10400 2895
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A1
-Encoding: 10401 10401 10401
+Encoding: 10401 10401 2896
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A2
-Encoding: 10402 10402 10402
+Encoding: 10402 10402 2897
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A3
-Encoding: 10403 10403 10403
+Encoding: 10403 10403 2898
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A4
-Encoding: 10404 10404 10404
+Encoding: 10404 10404 2899
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A5
-Encoding: 10405 10405 10405
+Encoding: 10405 10405 2900
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A6
-Encoding: 10406 10406 10406
+Encoding: 10406 10406 2901
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A7
-Encoding: 10407 10407 10407
+Encoding: 10407 10407 2902
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A8
-Encoding: 10408 10408 10408
+Encoding: 10408 10408 2903
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A9
-Encoding: 10409 10409 10409
+Encoding: 10409 10409 2904
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AA
-Encoding: 10410 10410 10410
+Encoding: 10410 10410 2905
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AB
-Encoding: 10411 10411 10411
+Encoding: 10411 10411 2906
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AC
-Encoding: 10412 10412 10412
+Encoding: 10412 10412 2907
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AD
-Encoding: 10413 10413 10413
+Encoding: 10413 10413 2908
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AE
-Encoding: 10414 10414 10414
+Encoding: 10414 10414 2909
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AF
-Encoding: 10415 10415 10415
+Encoding: 10415 10415 2910
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B0
-Encoding: 10416 10416 10416
+Encoding: 10416 10416 2911
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B1
-Encoding: 10417 10417 10417
+Encoding: 10417 10417 2912
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B2
-Encoding: 10418 10418 10418
+Encoding: 10418 10418 2913
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B3
-Encoding: 10419 10419 10419
+Encoding: 10419 10419 2914
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B4
-Encoding: 10420 10420 10420
+Encoding: 10420 10420 2915
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B5
-Encoding: 10421 10421 10421
+Encoding: 10421 10421 2916
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B6
-Encoding: 10422 10422 10422
+Encoding: 10422 10422 2917
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B7
-Encoding: 10423 10423 10423
+Encoding: 10423 10423 2918
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B8
-Encoding: 10424 10424 10424
+Encoding: 10424 10424 2919
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B9
-Encoding: 10425 10425 10425
+Encoding: 10425 10425 2920
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BA
-Encoding: 10426 10426 10426
+Encoding: 10426 10426 2921
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BB
-Encoding: 10427 10427 10427
+Encoding: 10427 10427 2922
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BC
-Encoding: 10428 10428 10428
+Encoding: 10428 10428 2923
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BD
-Encoding: 10429 10429 10429
+Encoding: 10429 10429 2924
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BE
-Encoding: 10430 10430 10430
+Encoding: 10430 10430 2925
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BF
-Encoding: 10431 10431 10431
+Encoding: 10431 10431 2926
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C0
-Encoding: 10432 10432 10432
+Encoding: 10432 10432 2927
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C1
-Encoding: 10433 10433 10433
+Encoding: 10433 10433 2928
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C2
-Encoding: 10434 10434 10434
+Encoding: 10434 10434 2929
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C3
-Encoding: 10435 10435 10435
+Encoding: 10435 10435 2930
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C4
-Encoding: 10436 10436 10436
+Encoding: 10436 10436 2931
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C5
-Encoding: 10437 10437 10437
+Encoding: 10437 10437 2932
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C6
-Encoding: 10438 10438 10438
+Encoding: 10438 10438 2933
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C7
-Encoding: 10439 10439 10439
+Encoding: 10439 10439 2934
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C8
-Encoding: 10440 10440 10440
+Encoding: 10440 10440 2935
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C9
-Encoding: 10441 10441 10441
+Encoding: 10441 10441 2936
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CA
-Encoding: 10442 10442 10442
+Encoding: 10442 10442 2937
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CB
-Encoding: 10443 10443 10443
+Encoding: 10443 10443 2938
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CC
-Encoding: 10444 10444 10444
+Encoding: 10444 10444 2939
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CD
-Encoding: 10445 10445 10445
+Encoding: 10445 10445 2940
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CE
-Encoding: 10446 10446 10446
+Encoding: 10446 10446 2941
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CF
-Encoding: 10447 10447 10447
+Encoding: 10447 10447 2942
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D0
-Encoding: 10448 10448 10448
+Encoding: 10448 10448 2943
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D1
-Encoding: 10449 10449 10449
+Encoding: 10449 10449 2944
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D2
-Encoding: 10450 10450 10450
+Encoding: 10450 10450 2945
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D3
-Encoding: 10451 10451 10451
+Encoding: 10451 10451 2946
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D4
-Encoding: 10452 10452 10452
+Encoding: 10452 10452 2947
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D5
-Encoding: 10453 10453 10453
+Encoding: 10453 10453 2948
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D6
-Encoding: 10454 10454 10454
+Encoding: 10454 10454 2949
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D7
-Encoding: 10455 10455 10455
+Encoding: 10455 10455 2950
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D8
-Encoding: 10456 10456 10456
+Encoding: 10456 10456 2951
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D9
-Encoding: 10457 10457 10457
+Encoding: 10457 10457 2952
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DA
-Encoding: 10458 10458 10458
+Encoding: 10458 10458 2953
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DB
-Encoding: 10459 10459 10459
+Encoding: 10459 10459 2954
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DC
-Encoding: 10460 10460 10460
+Encoding: 10460 10460 2955
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DD
-Encoding: 10461 10461 10461
+Encoding: 10461 10461 2956
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DE
-Encoding: 10462 10462 10462
+Encoding: 10462 10462 2957
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DF
-Encoding: 10463 10463 10463
+Encoding: 10463 10463 2958
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E0
-Encoding: 10464 10464 10464
+Encoding: 10464 10464 2959
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E1
-Encoding: 10465 10465 10465
+Encoding: 10465 10465 2960
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E2
-Encoding: 10466 10466 10466
+Encoding: 10466 10466 2961
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E3
-Encoding: 10467 10467 10467
+Encoding: 10467 10467 2962
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E4
-Encoding: 10468 10468 10468
+Encoding: 10468 10468 2963
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E5
-Encoding: 10469 10469 10469
+Encoding: 10469 10469 2964
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E6
-Encoding: 10470 10470 10470
+Encoding: 10470 10470 2965
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E7
-Encoding: 10471 10471 10471
+Encoding: 10471 10471 2966
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E8
-Encoding: 10472 10472 10472
+Encoding: 10472 10472 2967
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E9
-Encoding: 10473 10473 10473
+Encoding: 10473 10473 2968
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EA
-Encoding: 10474 10474 10474
+Encoding: 10474 10474 2969
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EB
-Encoding: 10475 10475 10475
+Encoding: 10475 10475 2970
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EC
-Encoding: 10476 10476 10476
+Encoding: 10476 10476 2971
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28ED
-Encoding: 10477 10477 10477
+Encoding: 10477 10477 2972
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EE
-Encoding: 10478 10478 10478
+Encoding: 10478 10478 2973
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EF
-Encoding: 10479 10479 10479
+Encoding: 10479 10479 2974
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F0
-Encoding: 10480 10480 10480
+Encoding: 10480 10480 2975
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F1
-Encoding: 10481 10481 10481
+Encoding: 10481 10481 2976
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F2
-Encoding: 10482 10482 10482
+Encoding: 10482 10482 2977
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F3
-Encoding: 10483 10483 10483
+Encoding: 10483 10483 2978
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F4
-Encoding: 10484 10484 10484
+Encoding: 10484 10484 2979
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F5
-Encoding: 10485 10485 10485
+Encoding: 10485 10485 2980
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F6
-Encoding: 10486 10486 10486
+Encoding: 10486 10486 2981
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F7
-Encoding: 10487 10487 10487
+Encoding: 10487 10487 2982
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F8
-Encoding: 10488 10488 10488
+Encoding: 10488 10488 2983
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F9
-Encoding: 10489 10489 10489
+Encoding: 10489 10489 2984
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FA
-Encoding: 10490 10490 10490
+Encoding: 10490 10490 2985
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FB
-Encoding: 10491 10491 10491
+Encoding: 10491 10491 2986
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FC
-Encoding: 10492 10492 10492
+Encoding: 10492 10492 2987
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FD
-Encoding: 10493 10493 10493
+Encoding: 10493 10493 2988
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FE
-Encoding: 10494 10494 10494
+Encoding: 10494 10494 2989
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FF
-Encoding: 10495 10495 10495
+Encoding: 10495 10495 2990
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2987
-Encoding: 10631 10631 10631
+Encoding: 10631 10631 2991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78820,8 +81816,9 @@ SplineSet
  975 1373 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2988
-Encoding: 10632 10632 10632
+Encoding: 10632 10632 2992
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78841,8 +81838,9 @@ SplineSet
  258 -89 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2997
-Encoding: 10647 10647 10647
+Encoding: 10647 10647 2993
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78859,8 +81857,9 @@ SplineSet
  619 -322 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2998
-Encoding: 10648 10648 10648
+Encoding: 10648 10648 2994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78877,8 +81876,9 @@ SplineSet
  614 1608 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29EB
-Encoding: 10731 10731 10731
+Encoding: 10731 10731 2995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78891,8 +81891,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FA
-Encoding: 10746 10746 10746
+Encoding: 10746 10746 2996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78921,8 +81922,9 @@ SplineSet
  732 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FB
-Encoding: 10747 10747 10747
+Encoding: 10747 10747 2997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78959,8 +81961,9 @@ SplineSet
  202 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2A00
-Encoding: 10752 10752 10752
+Encoding: 10752 10752 2998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78983,35 +81986,39 @@ SplineSet
  80 1547 80 1547 616 1547 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2A2F
-Encoding: 10799 10799 10799
+Encoding: 10799 10799 2999
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 215 215 N 1 0 0 1 0 0 2
+Refer: 151 215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6A
-Encoding: 10858 10858 10858
+Encoding: 10858 10858 3000
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 2 292 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 2 292 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6B
-Encoding: 10859 10859 10859
+Encoding: 10859 10859 3001
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -239 -425 2
-Refer: 8901 8901 N 1 0 0 1 242 292 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 -239 -425 2
+Refer: 2274 8901 N 1 0 0 1 242 292 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2B05
-Encoding: 11013 11013 11013
+Encoding: 11013 11013 3002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79027,8 +82034,9 @@ SplineSet
  395 842 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B06
-Encoding: 11014 11014 11014
+Encoding: 11014 11014 3003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79044,8 +82052,9 @@ SplineSet
  759 921 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B07
-Encoding: 11015 11015 11015
+Encoding: 11015 11015 3004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79061,8 +82070,9 @@ SplineSet
  474 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B08
-Encoding: 11016 11016 11016
+Encoding: 11016 11016 3005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79078,8 +82088,9 @@ SplineSet
  874 756 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B09
-Encoding: 11017 11017 11017
+Encoding: 11017 11017 3006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79095,8 +82106,9 @@ SplineSet
  560 957 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0A
-Encoding: 11018 11018 11018
+Encoding: 11018 11018 3007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79112,8 +82124,9 @@ SplineSet
  773 342 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0B
-Encoding: 11019 11019 11019
+Encoding: 11019 11019 3008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79129,8 +82142,9 @@ SplineSet
  259 543 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0C
-Encoding: 11020 11020 11020
+Encoding: 11020 11020 3009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79149,8 +82163,9 @@ SplineSet
  395 842 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0D
-Encoding: 11021 11021 11021
+Encoding: 11021 11021 3010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79169,8 +82184,9 @@ SplineSet
  474 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B12
-Encoding: 11026 11026 11026
+Encoding: 11026 11026 3011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79188,8 +82204,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B13
-Encoding: 11027 11027 11027
+Encoding: 11027 11027 3012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79207,8 +82224,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B14
-Encoding: 11028 11028 11028
+Encoding: 11028 11028 3013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79225,8 +82243,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B15
-Encoding: 11029 11029 11029
+Encoding: 11029 11029 3014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79243,8 +82262,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B16
-Encoding: 11030 11030 11030
+Encoding: 11030 11030 3015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79261,8 +82281,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B17
-Encoding: 11031 11031 11031
+Encoding: 11031 11031 3016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79279,8 +82300,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B18
-Encoding: 11032 11032 11032
+Encoding: 11032 11032 3017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79297,8 +82319,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B19
-Encoding: 11033 11033 11033
+Encoding: 11033 11033 3018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79315,8 +82338,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B1A
-Encoding: 11034 11034 11034
+Encoding: 11034 11034 3019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79392,8 +82416,9 @@ SplineSet
  206 1142.5 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C64
-Encoding: 11364 11364 11364
+Encoding: 11364 11364 3020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79433,8 +82458,9 @@ SplineSet
  471.733 1327 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6D
-Encoding: 11373 11373 11373
+Encoding: 11373 11373 3021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79464,8 +82490,9 @@ SplineSet
  955 914 955 914 955 1035 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C6E
-Encoding: 11374 11374 11374
+Encoding: 11374 11374 3022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79493,8 +82520,9 @@ SplineSet
  1069.39 1319 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6F
-Encoding: 11375 11375 11375
+Encoding: 11375 11375 3023
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79515,8 +82543,9 @@ SplineSet
  594 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C70
-Encoding: 11376 11376 11376
+Encoding: 11376 11376 3024
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79546,8 +82575,9 @@ SplineSet
  257 578 257 578 257 456 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C75
-Encoding: 11381 11381 11381
+Encoding: 11381 11381 3025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79564,8 +82594,9 @@ SplineSet
  282 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C76
-Encoding: 11382 11382 11382
+Encoding: 11382 11382 3026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79582,8 +82613,9 @@ SplineSet
  370 515 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C77
-Encoding: 11383 11383 11383
+Encoding: 11383 11383 3027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79615,8 +82647,9 @@ SplineSet
  637 1128 637 1128 885 1128 c 8,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni2C79
-Encoding: 11385 11385 11385
+Encoding: 11385 11385 3028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79645,8 +82678,9 @@ SplineSet
  796 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7A
-Encoding: 11386 11386 11386
+Encoding: 11386 11386 3029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79681,16 +82715,18 @@ SplineSet
  889 498 889 498 901 559 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C7C
-Encoding: 11388 11388 11388
+Encoding: 11388 11388 3030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 690 690 N 1 0 0 1 0 -668 3
+Refer: 604 690 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2C7D
-Encoding: 11389 11389 11389
+Encoding: 11389 11389 3031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79706,8 +82742,9 @@ SplineSet
  553 763 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7E
-Encoding: 11390 11390 11390
+Encoding: 11390 11390 3032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79758,8 +82795,9 @@ SplineSet
  632.987 -162 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7F
-Encoding: 11391 11391 11391
+Encoding: 11391 11391 3033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79791,8 +82829,9 @@ SplineSet
  -7 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18
-Encoding: 11800 11800 11800
+Encoding: 11800 11800 3034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79829,17 +82868,19 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" uni2E18.case
 EndChar
+
 StartChar: uni2E1F
-Encoding: 11807 11807 11807
+Encoding: 11807 11807 3035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
-Refer: 8764 8764 N 1 0 0 1 0 0 2
+Refer: 2274 8901 N 1 0 0 1 1 -425 2
+Refer: 2167 8764 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2E22
-Encoding: 11810 11810 11810
+Encoding: 11810 11810 3036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79854,8 +82895,9 @@ SplineSet
  621 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E23
-Encoding: 11811 11811 11811
+Encoding: 11811 11811 3037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79870,8 +82912,9 @@ SplineSet
  715 1413 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E24
-Encoding: 11812 11812 11812
+Encoding: 11812 11812 3038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79886,8 +82929,9 @@ SplineSet
  477 -127 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E25
-Encoding: 11813 11813 11813
+Encoding: 11813 11813 3039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79902,8 +82946,9 @@ SplineSet
  571 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E2E
-Encoding: 11822 11822 11822
+Encoding: 11822 11822 3040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79941,8 +82986,9 @@ SplineSet
  504 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA708
-Encoding: 42760 42760 42760
+Encoding: 42760 42760 3041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79960,8 +83006,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA709
-Encoding: 42761 42761 42761
+Encoding: 42761 42761 3042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79979,8 +83026,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70A
-Encoding: 42762 42762 42762
+Encoding: 42762 42762 3043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79998,8 +83046,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70B
-Encoding: 42763 42763 42763
+Encoding: 42763 42763 3044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80017,8 +83066,9 @@ SplineSet
  664 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70C
-Encoding: 42764 42764 42764
+Encoding: 42764 42764 3045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80036,8 +83086,9 @@ SplineSet
  930 1368 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70D
-Encoding: 42765 42765 42765
+Encoding: 42765 42765 3046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80055,8 +83106,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70E
-Encoding: 42766 42766 42766
+Encoding: 42766 42766 3047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80074,8 +83126,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70F
-Encoding: 42767 42767 42767
+Encoding: 42767 42767 3048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80093,8 +83146,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA710
-Encoding: 42768 42768 42768
+Encoding: 42768 42768 3049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80112,8 +83166,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA711
-Encoding: 42769 42769 42769
+Encoding: 42769 42769 3050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80131,8 +83186,9 @@ SplineSet
  303 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA712
-Encoding: 42770 42770 42770
+Encoding: 42770 42770 3051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80147,8 +83203,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA713
-Encoding: 42771 42771 42771
+Encoding: 42771 42771 3052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80165,8 +83222,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA714
-Encoding: 42772 42772 42772
+Encoding: 42772 42772 3053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80183,8 +83241,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA715
-Encoding: 42773 42773 42773
+Encoding: 42773 42773 3054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80201,8 +83260,9 @@ SplineSet
  303 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA716
-Encoding: 42774 42774 42774
+Encoding: 42774 42774 3055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80217,8 +83277,9 @@ SplineSet
  329 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71B
-Encoding: 42779 42779 42779
+Encoding: 42779 42779 3056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80237,8 +83298,9 @@ SplineSet
  670 1508 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71C
-Encoding: 42780 42780 42780
+Encoding: 42780 42780 3057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80257,8 +83319,9 @@ SplineSet
  564 664 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71D
-Encoding: 42781 42781 42781
+Encoding: 42781 42781 3058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80278,8 +83341,9 @@ SplineSet
  633 1504 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71E
-Encoding: 42782 42782 42782
+Encoding: 42782 42782 3059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80299,16 +83363,18 @@ SplineSet
  599 668 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71F
-Encoding: 42783 42783 42783
+Encoding: 42783 42783 3060
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42782 42782 N 1 0 0 1 -130 -668 2
+Refer: 3059 42782 N 1 0 0 1 -130 -668 2
 EndChar
+
 StartChar: uniA722
-Encoding: 42786 42786 42786
+Encoding: 42786 42786 3061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80328,8 +83394,9 @@ SplineSet
  816 0 816 0 246 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA723
-Encoding: 42787 42787 42787
+Encoding: 42787 42787 3062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80349,8 +83416,9 @@ SplineSet
  827 0 827 0 307 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA724
-Encoding: 42788 42788 42788
+Encoding: 42788 42788 3063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80365,8 +83433,9 @@ SplineSet
  482 1301 482 1301 418 973 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA725
-Encoding: 42789 42789 42789
+Encoding: 42789 42789 3064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80381,8 +83450,9 @@ SplineSet
  488 958 488 958 418 600 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA726
-Encoding: 42790 42790 42790
+Encoding: 42790 42790 3065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80409,8 +83479,9 @@ SplineSet
  1241 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA727
-Encoding: 42791 42791 42791
+Encoding: 42791 42791 3066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80444,16 +83515,18 @@ SplineSet
  936 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA789
-Encoding: 42889 42889 42889
+Encoding: 42889 42889 3067
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 3
+Refer: 27 58 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78A
-Encoding: 42890 42890 42890
+Encoding: 42890 42890 3068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80471,8 +83544,9 @@ SplineSet
  857 629 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78B
-Encoding: 42891 42891 42891
+Encoding: 42891 42891 3069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80487,8 +83561,9 @@ SplineSet
  662 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78C
-Encoding: 42892 42892 42892
+Encoding: 42892 42892 3070
 Width: 1233
 Flags: W
 TtInstrs:
@@ -80521,16 +83596,18 @@ SplineSet
  756 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78D
-Encoding: 42893 42893 42893
+Encoding: 42893 42893 3071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1063 1063 N 1 0 0 1 0 0 3
+Refer: 874 1063 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78E
-Encoding: 42894 42894 42894
+Encoding: 42894 42894 3072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80565,8 +83642,9 @@ SplineSet
  525 -20 l 2,7,8
 EndSplineSet
 EndChar
+
 StartChar: uniA790
-Encoding: 42896 42896 42896
+Encoding: 42896 42896 3073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80589,8 +83667,9 @@ SplineSet
  281 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA791
-Encoding: 42897 42897 42897
+Encoding: 42897 42897 3074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80623,8 +83702,9 @@ SplineSet
  260 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7AA
-Encoding: 42922 42922 42922
+Encoding: 42922 42922 3075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80652,8 +83732,9 @@ SplineSet
  450 1327 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F8
-Encoding: 43000 43000 43000
+Encoding: 43000 43000 3076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80687,8 +83768,9 @@ SplineSet
  481 1287 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F9
-Encoding: 43001 43001 43001
+Encoding: 43001 43001 3077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80736,8 +83818,9 @@ SplineSet
  1065 1038 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uniF6C5
-Encoding: 63173 63173 63173
+Encoding: 63173 63173 3078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80773,8 +83856,9 @@ SplineSet
  552.436 1146.41 552.436 1146.41 690.449 1147 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: fi
-Encoding: 64257 64257 64257
+Encoding: 64257 64257 3079
 Width: 1233
 Flags: W
 TtInstrs:
@@ -80986,11 +84070,12 @@ SplineSet
  573 1556 573 1556 760 1556 c 2,25,-1
  952 1556 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 3" f i
 EndChar
+
 StartChar: fl
-Encoding: 64258 64258 64258
+Encoding: 64258 64258 3080
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81157,35 +84242,40 @@ SplineSet
  380 1391 380 1391 476.5 1473.5 c 128,-1,21
  573 1556 573 1556 760 1556 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 3" f l
 EndChar
+
 StartChar: uniFFF9
-Encoding: 65529 65529 65529
+Encoding: 65529 65529 3081
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFA
-Encoding: 65530 65530 65530
+Encoding: 65530 65530 3082
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFB
-Encoding: 65531 65531 65531
+Encoding: 65531 65531 3083
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFC
-Encoding: 65532 65532 65532
+Encoding: 65532 65532 3084
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFD
-Encoding: 65533 65533 65533
+Encoding: 65533 65533 3085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81228,8 +84318,9 @@ SplineSet
  792 1816 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: u1D55A
-Encoding: 120154 120154 120154
+Encoding: 120154 120154 3086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81258,8 +84349,9 @@ SplineSet
  542 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dlLtcaron
-Encoding: 1114113 -1 1114113
+Encoding: 1114113 -1 3087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81272,8 +84364,9 @@ SplineSet
  720 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Dieresis
-Encoding: 1114114 -1 1114114
+Encoding: 1114114 -1 3088
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81415,8 +84508,9 @@ SplineSet
  455 1497 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Acute
-Encoding: 1114115 -1 1114115
+Encoding: 1114115 -1 3089
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81510,8 +84604,9 @@ SplineSet
  834 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tilde
-Encoding: 1114116 -1 1114116
+Encoding: 1114116 -1 3090
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81744,8 +84839,9 @@ SplineSet
  770 1315 770 1315 739 1337 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Grave
-Encoding: 1114117 -1 1114117
+Encoding: 1114117 -1 3091
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81837,8 +84933,9 @@ SplineSet
  682 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Circumflex
-Encoding: 1114118 -1 1114118
+Encoding: 1114118 -1 3092
 Width: 1233
 Flags: W
 TtInstrs:
@@ -81937,8 +85034,9 @@ SplineSet
  653 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Caron
-Encoding: 1114119 -1 1114119
+Encoding: 1114119 -1 3093
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82043,8 +85141,9 @@ SplineSet
  813 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: fractionslash
-Encoding: 1114120 -1 1114120
+Encoding: 1114120 -1 3094
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82084,8 +85183,9 @@ SplineSet
  70 504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0311.case
-Encoding: 1114121 -1 1114121
+Encoding: 1114121 -1 3095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82105,8 +85205,9 @@ SplineSet
  481.477 1659 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0306.case
-Encoding: 1114122 -1 1114122
+Encoding: 1114122 -1 3096
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82149,13 +85250,14 @@ SplineSet
  1010.63 1845 1010.63 1845 1036.52 1901 c 1,7,-1
  1155.52 1901 l 1,8,9
  1121.39 1782 1121.39 1782 1029.93 1720.5 c 128,-1,10
- 938.477 1659 938.477 1659 794.477 1659 c 0,11,12
+ 938.477 1659 938.477 1659 794.477 1659 c 256,11,12
  650.477 1659 650.477 1659 583.334 1720 c 128,-1,13
  516.191 1781 516.191 1781 528.517 1901 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307.case
-Encoding: 1114123 -1 1114123
+Encoding: 1114123 -1 3097
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82204,8 +85306,9 @@ SplineSet
  732.88 1872 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030B.case
-Encoding: 1114124 -1 1114124
+Encoding: 1114124 -1 3098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82223,8 +85326,9 @@ SplineSet
  766.128 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030F.case
-Encoding: 1114125 -1 1114125
+Encoding: 1114125 -1 3099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82242,8 +85346,9 @@ SplineSet
  917.128 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: thinquestion
-Encoding: 1114126 -1 1114126
+Encoding: 1114126 -1 3100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82283,8 +85388,9 @@ SplineSet
  332 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0304.case
-Encoding: 1114127 -1 1114127
+Encoding: 1114127 -1 3101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82321,8 +85427,9 @@ SplineSet
  530.66 1840 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar
-Encoding: 1114128 -1 1114128
+Encoding: 1114128 -1 3102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82335,8 +85442,9 @@ SplineSet
  1077 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.wide
-Encoding: 1114129 -1 1114129
+Encoding: 1114129 -1 3103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82349,8 +85457,9 @@ SplineSet
  1227 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.small
-Encoding: 1114130 -1 1114130
+Encoding: 1114130 -1 3104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82363,8 +85472,9 @@ SplineSet
  977 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: jot
-Encoding: 1114131 -1 1114131
+Encoding: 1114131 -1 3105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82391,8 +85501,9 @@ SplineSet
  675.36 876.6 675.36 876.6 615.96 876.6 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: diaeresis.symbols
-Encoding: 1114132 -1 1114132
+Encoding: 1114132 -1 3106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82410,8 +85521,9 @@ SplineSet
  711 1552 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Eng.alt
-Encoding: 1114133 -1 1114133
+Encoding: 1114133 -1 3107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82436,8 +85548,9 @@ SplineSet
  295 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdown.case
-Encoding: 1114134 -1 1114134
+Encoding: 1114134 -1 3108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82553,8 +85666,9 @@ SplineSet
  592 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: questiondown.case
-Encoding: 1114135 -1 1114135
+Encoding: 1114135 -1 3109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -82721,13 +85835,474 @@ SplineSet
  881 1239 l 1,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18.case
-Encoding: 1114136 -1 1114136
+Encoding: 1114136 -1 3110
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 11800 11800 N 1 0 0 1 0 373 3
+Refer: 3034 11800 N 1 0 0 1 0 373 3
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3111
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3112
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 184 37 2
+Refer: 66 97 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3113
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 464.409 571 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3114
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 436.409 308 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3115
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -280.091 591 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3116
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -283.091 319 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3117
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 581 532 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3118
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 477 304 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3119
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 107.193 729 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3120
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 90.7052 453 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3121
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 N 1 0 0 1 210.927 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3122
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 N 1 0 0 1 155.909 468 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3123
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 294 686 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3124
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3125
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 138.711 729 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3126
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 81.2052 423 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3127
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 38 69 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3128
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 199 57 2
+Refer: 70 101 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3129
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 529.409 586 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3130
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 411.409 299 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3131
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -260.091 566 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3132
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -275.091 319 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3133
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 637 546 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3134
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 548 224 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3135
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 152.193 729 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3136
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 86.7052 453 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3137
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 42 73 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3138
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 189 42 2
+Refer: 241 305 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3139
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 48 79 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3140
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 42 2
+Refer: 80 111 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3141
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3089 -1 S 1 0 0 1 471.409 561 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3142
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 653 769 S 1 0 0 1 396.409 299 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3143
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3091 -1 S 1 0 0 1 -298.091 586 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3144
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 652 768 S 1 0 0 1 -292.091 303 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3145
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 576 560 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3146
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 499 284 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3147
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3090 -1 N 1 0 0 1 99.1934 729 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3148
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 637 732 N 1 0 0 1 86.7052 453 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3149
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 124 392 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3150
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 88 57 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3151
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 54 85 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3152
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 174 7 2
+Refer: 86 117 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3153
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 116 398 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3154
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 -1 42 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3155
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 224 392 2
+Refer: 58 89 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3156
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 661 777 S 1 0 0 1 146 -4 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont

--- a/src/DejaVuSansMono.sfd
+++ b/src/DejaVuSansMono.sfd
@@ -10,13 +10,16 @@ UnderlinePosition: -85
 UnderlineWidth: 90
 Ascent: 1556
 Descent: 492
+InvalidEm: 0
 LayerCount: 2
-Layer: 0 1 "Back"  1
-Layer: 1 1 "Fore"  0
+Layer: 0 1 "Back" 1
+Layer: 1 1 "Fore" 0
 FSType: 0
 OS2Version: 0
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
+CreationTime: 1470372098
+ModificationTime: 1492777380
 PfmFamily: 17
 TTFWeight: 400
 TTFWidth: 5
@@ -37,29 +40,29 @@ HheadAOffset: 0
 HheadDescent: -483
 HheadDOffset: 0
 OS2Vendor: 'PfEd'
-Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0"  {"'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
-Lookup: 6 0 0 "'ccmp' Glyph Composition/Decomposition lookup 0"  {"'ccmp' Glyph Composition/Decomposition lookup 0"  } ['ccmp' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 1"  {"'locl' Localized Forms in Cyrillic lookup 1"  } ['locl' ('cyrl' <'SRB ' > ) ]
-Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 3"  {"'fina' Terminal Forms in Arabic lookup 3"  } ['fina' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 4"  {"'medi' Medial Forms in Arabic lookup 4"  } ['medi' ('arab' <'dflt' > ) ]
-Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 5"  {"'init' Initial Forms in Arabic lookup 5"  } ['init' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 6"  {"'rlig' Required Ligatures in Arabic lookup 6"  } ['rlig' ('arab' <'dflt' > ) ]
-Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 7"  {"'liga' Standard Ligatures in Arabic lookup 7"  } ['liga' ('arab' <'dflt' > ) ]
-Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 10"  {"'dlig' Discretionary Ligatures in Latin lookup 10"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 1 0 0 "Single Substitution - Dotless Form"  {"Single Substitution - Dotless Form"  } []
-Lookup: 1 0 0 "'case' Case-Sensitive Forms"  {"'case' Case-Sensitive Forms" ("case" ) } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0"  {"'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1"  {"'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2"  {"'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3"  {"'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4"  {"'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5"  {"'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark to Base in Basic"  {"'mark' cedilla"  "'mark' above, below"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 257 0 0 "'mark' Zero-Width Marks in Basic"  {"'mark' Zero-Width Marks lookup"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
-Lookup: 260 0 0 "'mark' Mark positioning in Lao"  {"'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
-Lookup: 257 8 0 "'rtbd' Mark width in Lao"  {"'rtbd' Mark width in Lao-2"  } ['rtbd' ('lao ' <'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Latin lookup 0" { "'locl' Localized Forms in Latin lookup 0-1"  } ['locl' ('latn' <'ISM ' 'KSM ' 'LSM ' 'NSM ' 'SKS ' 'SSM ' > ) ]
+Lookup: 6 0 0 "'ccmp' Glyph Composition/Decomposition lookup 0" { "'ccmp' Glyph Composition/Decomposition lookup 0"  } ['ccmp' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "'locl' Localized Forms in Cyrillic lookup 1" { "'locl' Localized Forms in Cyrillic lookup 1"  } ['locl' ('cyrl' <'SRB ' > ) ]
+Lookup: 1 9 0 "'fina' Terminal Forms in Arabic lookup 3" { "'fina' Terminal Forms in Arabic lookup 3"  } ['fina' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'medi' Medial Forms in Arabic lookup 4" { "'medi' Medial Forms in Arabic lookup 4"  } ['medi' ('arab' <'dflt' > ) ]
+Lookup: 1 9 0 "'init' Initial Forms in Arabic lookup 5" { "'init' Initial Forms in Arabic lookup 5"  } ['init' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'rlig' Required Ligatures in Arabic lookup 6" { "'rlig' Required Ligatures in Arabic lookup 6"  } ['rlig' ('arab' <'dflt' > ) ]
+Lookup: 4 9 1 "'liga' Standard Ligatures in Arabic lookup 7" { "'liga' Standard Ligatures in Arabic lookup 7"  } ['liga' ('arab' <'dflt' > ) ]
+Lookup: 4 0 0 "'dlig' Discretionary Ligatures in Latin lookup 10" { "'dlig' Discretionary Ligatures in Latin lookup 10"  } ['dlig' ('latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 1 0 0 "Single Substitution - Dotless Form" { "Single Substitution - Dotless Form"  } []
+Lookup: 1 0 0 "'case' Case-Sensitive Forms" { "'case' Case-Sensitive Forms" ("case") } ['case' ('DFLT' <'dflt' > 'latn' <'CAT ' 'ESP ' 'GAL ' 'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 0" { "'mkmk' Mark to Mark in Arabic lookup 0"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 262 1 0 "'mkmk' Mark to Mark in Arabic lookup 1" { "'mkmk' Mark to Mark in Arabic lookup 1"  } ['mkmk' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 2" { "'mark' Mark Positioning in Arabic lookup 2"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 3" { "'mark' Mark Positioning in Arabic lookup 3"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 261 1 0 "'mark' Mark Positioning in Arabic lookup 4" { "'mark' Mark Positioning in Arabic lookup 4"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 1 0 "'mark' Mark Positioning in Arabic lookup 5" { "'mark' Mark Positioning in Arabic lookup 5"  } ['mark' ('arab' <'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark to Base in Basic" { "'mark' cedilla"  "'mark' above, below"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 257 0 0 "'mark' Zero-Width Marks in Basic" { "'mark' Zero-Width Marks lookup"  } ['mark' ('DFLT' <> 'cyrl' <'SRB ' 'dflt' > 'grek' <'dflt' > 'latn' <'ISM ' 'KSM ' 'LSM ' 'MOL ' 'NSM ' 'ROM ' 'SKS ' 'SSM ' 'dflt' > ) ]
+Lookup: 260 0 0 "'mark' Mark positioning in Lao" { "'mark' Mark positioning in Lao"  } ['mark' ('lao ' <'dflt' > ) ]
+Lookup: 257 8 0 "'rtbd' Mark width in Lao" { "'rtbd' Mark width in Lao-2"  } ['rtbd' ('lao ' <'dflt' > ) ]
 DEI: 91125
-ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0"  4 1 4 3
+ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0" 4 1 4 3
   Class: 3 i j
   Class: 227 gravecomb acutecomb uni0302 tildecomb uni0304 uni0305 uni0306 uni0307 uni0308 hookabovecomb uni030A uni030B uni030C uni030D uni030E uni030F uni0310 uni0311 uni0312 uni0313 uni0314 uni0315 uni033D uni033E uni033F uni0343 uni0374
   Class: 244 uni0316 uni0317 uni0318 uni0319 uni031C uni031D uni031E uni031F uni0320 dotbelowcomb uni0324 uni0325 uni0326 uni0327 uni0328 uni0329 uni032A uni032B uni032C uni032D uni032E uni032F uni0330 uni0331 uni0332 uni0333 uni0339 uni033A uni033B uni033C
@@ -71,22 +74,22 @@ ChainSub2: class "'ccmp' Glyph Composition/Decomposition lookup 0"  4 1 4 3
   BClsList:
   FClsList: 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
+  SeqLookup: 0 "Single Substitution - Dotless Form"
  1 0 2
   ClsList: 1
   BClsList:
   FClsList: 3 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
+  SeqLookup: 0 "Single Substitution - Dotless Form"
  1 0 3
   ClsList: 1
   BClsList:
   FClsList: 3 3 2
  1
-  SeqLookup: 0 "Single Substitution - Dotless Form" 
-  ClassNames: "0"  "1"  "2"  "3"  
-  BClassNames: "0"  
-  FClassNames: "0"  "1"  "2"  "3"  
+  SeqLookup: 0 "Single Substitution - Dotless Form"
+  ClassNames: "0" "1" "2" "3"
+  BClassNames: "0"
+  FClassNames: "0" "1" "2" "3"
 EndFPST
 TtTable: prep
 PUSHW_2
@@ -2298,12 +2301,14 @@ ShortTable: maxp 16
   3
   1
 EndShort
-LangName: 1033 "" "" "" "DejaVu Sans Mono" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License" 
+LangName: 1033 "" "" "" "DejaVu Sans Mono" "" "Version 2.37" "" "" "DejaVu fonts team" "" "" "http://dejavu.sourceforge.net" "" "Fonts are (c) Bitstream (see below). DejaVu changes are in public domain.+AAoACgAA-Bitstream Vera Fonts Copyright+AAoA-------------------------------+AAoACgAA-Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.+AAoACgAA-Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license (+ACIA-Fonts+ACIA) and associated documentation files (the +ACIA-Font Software+ACIA), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:+AAoACgAA-The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.+AAoACgAA-The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words +ACIA-Bitstream+ACIA or the word +ACIA-Vera+ACIA.+AAoACgAA-This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the +ACIA-Bitstream Vera+ACIA names.+AAoACgAA-The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.+AAoACgAA-THE FONT SOFTWARE IS PROVIDED +ACIA-AS IS+ACIA, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.+AAoACgAA-Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. +AAoA" "http://dejavu.sourceforge.net/wiki/index.php/License"
 Encoding: UnicodeFull
 UnicodeInterp: none
 NameList: AGL without afii
+DisplaySize: -48
 AntiAlias: 1
 FitToEm: 1
+WinInfo: 7803 27 9
 GridOrder2: 1
 Grid
 1 740 m 25,0,-1
@@ -2313,50 +2318,50 @@ Grid
  1 894 l 25,1,-1
  -139 1034 l 25,0,0
 1 1510 m 9,0,-1
- -139 1650 l 17,0,0
+ -139 1650 l 1041,0,0
 1 1202 m 9,1,-1
- -139 1342 l 17,0,0
+ -139 1342 l 1041,0,0
 1 1818 m 9,1,-1
- -139 1958 l 17,0,0
+ -139 1958 l 1041,0,0
 1 1048 m 9,1,-1
- -139 1188 l 17,0,0
+ -139 1188 l 1041,0,0
 1 1664 m 9,1,-1
- -139 1804 l 17,0,0
+ -139 1804 l 1041,0,0
 1 1356 m 9,1,-1
- -139 1496 l 17,0,0
+ -139 1496 l 1041,0,0
 -139 -352 m 9,0,0
  1 -492 l 25,1,-1
- 141 -632 l 17
+ 141 -632 l 1041
 -139 -198 m 25,0,0
  1 -338 l 25,1,-1
  -139 -198 l 25,0,0
 1 278 m 9,0,-1
- -139 418 l 17,0,0
+ -139 418 l 1041,0,0
 1 -30 m 9,1,-1
- -139 110 l 17,0,0
+ -139 110 l 1041,0,0
 1 586 m 9,1,-1
- -139 726 l 17,0,0
+ -139 726 l 1041,0,0
 1 -184 m 9,1,-1
- -139 -44 l 17,0,0
+ -139 -44 l 1041,0,0
 1 432 m 9,1,-1
- -139 572 l 17,0,0
+ -139 572 l 1041,0,0
 1 124 m 9,1,-1
- -139 264 l 17,0,0
+ -139 264 l 1041,0,0
 1232 -409 m 25,0,0
  1372 -549 l 25,1,-1
  1232 -409 l 25,0,0
 1372 67 m 9,0,-1
- 1232 207 l 17,0,0
+ 1232 207 l 1041,0,0
 1372 -241 m 9,1,-1
- 1232 -101 l 17,0,0
+ 1232 -101 l 1041,0,0
 1372 375 m 9,1,-1
- 1232 515 l 17,0,0
+ 1232 515 l 1041,0,0
 1372 -395 m 9,1,-1
- 1232 -255 l 17,0,0
+ 1232 -255 l 1041,0,0
 1372 221 m 9,1,-1
- 1232 361 l 17,0,0
+ 1232 361 l 1041,0,0
 1372 -87 m 9,1,-1
- 1232 53 l 17,0,0
+ 1232 53 l 1041,0,0
 1232 669 m 25,0,0
  1372 529 l 25,1,-1
  1232 669 l 25,0,0
@@ -2364,56 +2369,56 @@ Grid
  1372 683 l 25,1,-1
  1232 823 l 25,0,0
 1372 1299 m 9,0,-1
- 1232 1439 l 17,0,0
+ 1232 1439 l 1041,0,0
 1372 991 m 9,1,-1
- 1232 1131 l 17,0,0
+ 1232 1131 l 1041,0,0
 1372 1607 m 9,1,-1
- 1232 1747 l 17,0,0
+ 1232 1747 l 1041,0,0
 1372 837 m 9,1,-1
- 1232 977 l 17,0,0
+ 1232 977 l 1041,0,0
 1372 1453 m 9,1,-1
- 1232 1593 l 17,0,0
+ 1232 1593 l 1041,0,0
 1372 1145 m 9,1,-1
- 1232 1285 l 17,0,0
+ 1232 1285 l 1041,0,0
 1372 1761 m 9,1,-1
  1232 1901 l 25,0,0
- 1092 2041 l 17,0,0
+ 1092 2041 l 1041,0,0
 1373 -632 m 9,1,-1
- 1233 -492 l 17,0,0
+ 1233 -492 l 1041,0,0
 1079 -492 m 25,0,0
  1219 -632 l 25,1,-1
  1079 -492 l 25,0,0
 603 -632 m 9,0,-1
- 463 -492 l 17,0,0
+ 463 -492 l 1041,0,0
 911 -632 m 9,1,-1
- 771 -492 l 17,0,0
+ 771 -492 l 1041,0,0
 295 -632 m 9,1,-1
- 155 -492 l 17,0,0
+ 155 -492 l 1041,0,0
 1065 -632 m 9,1,-1
- 925 -492 l 17,0,0
+ 925 -492 l 1041,0,0
 449 -632 m 9,1,-1
- 309 -492 l 17,0,0
+ 309 -492 l 1041,0,0
 757 -632 m 9,1,-1
- 617 -492 l 17,0,0
+ 617 -492 l 1041,0,0
 1386 1901 m 9,1,-1
- 1246 2041 l 17,0,0
+ 1246 2041 l 1041,0,0
 938 2041 m 25,0,0
  1078 1901 l 25,1,-1
  938 2041 l 25,0,0
 462 1901 m 9,0,-1
- 322 2041 l 17,0,0
+ 322 2041 l 1041,0,0
 770 1901 m 9,1,-1
- 630 2041 l 17,0,0
+ 630 2041 l 1041,0,0
 154 1901 m 9,1,-1
- 14 2041 l 17,0,0
+ 14 2041 l 1041,0,0
 924 1901 m 9,1,-1
- 784 2041 l 17,0,0
+ 784 2041 l 1041,0,0
 308 1901 m 9,1,-1
- 168 2041 l 17,0,0
+ 168 2041 l 1041,0,0
 616 1901 m 9,1,-1
- 476 2041 l 17,0,0
+ 476 2041 l 1041,0,0
 0 1901 m 9,1,-1
- -140 2041 l 17,0,0
+ -140 2041 l 1041,0,0
 -140 2041 m 1,1,-1
  1373 2041 l 1,2,-1
  1373 -632 l 1,3,-1
@@ -2425,8 +2430,9 @@ Grid
  0 -492 l 1,8,-1
  0 1901 l 1,5,-1
 EndSplineSet
-AnchorClass2: "cedilla"  "'mark' cedilla" "lao-below"  "'mark' Mark positioning in Lao" "lao-above"  "'mark' Mark positioning in Lao" "above"  "'mark' above, below" "below"  "'mark' above, below" "rtl-above"  "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above"  "'mark' Mark Positioning in Arabic lookup 4" "rtl-below"  "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below"  "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark"  "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark"  "'mkmk' Mark to Mark in Arabic lookup 0" 
-BeginChars: 1114165 0
+AnchorClass2: "cedilla" "'mark' cedilla" "lao-below" "'mark' Mark positioning in Lao" "lao-above" "'mark' Mark positioning in Lao" "above" "'mark' above, below" "below" "'mark' above, below" "rtl-above" "'mark' Mark Positioning in Arabic lookup 5" "Ligature rtl-above" "'mark' Mark Positioning in Arabic lookup 4" "rtl-below" "'mark' Mark Positioning in Arabic lookup 3" "Ligature rtl-below" "'mark' Mark Positioning in Arabic lookup 2" "rtl-above-mark" "'mkmk' Mark to Mark in Arabic lookup 1" "rtl-below-mark" "'mkmk' Mark to Mark in Arabic lookup 0"
+BeginChars: 1114165 3824
+
 StartChar: .notdef
 Encoding: 0 -1 0
 Width: 1233
@@ -2474,14 +2480,16 @@ SplineSet
  219 -248 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: space
-Encoding: 32 32 32
+Encoding: 32 32 1
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclam
-Encoding: 33 33 33
+Encoding: 33 33 2
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2534,8 +2542,9 @@ SplineSet
  516 254 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedbl
-Encoding: 34 34 34
+Encoding: 34 34 3
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2584,8 +2593,9 @@ SplineSet
  512 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: numbersign
-Encoding: 35 35 35
+Encoding: 35 35 4
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2703,8 +2713,9 @@ SplineSet
  788 901 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: dollar
-Encoding: 36 36 36
+Encoding: 36 36 5
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2847,14 +2858,15 @@ SplineSet
  772 1177 772 1177 692 1181 c 1,40,-1
  692 750 l 1,41,42
  898 719 898 719 1006 622 c 128,-1,43
- 1114 525 1114 525 1114 371 c 0,44,45
+ 1114 525 1114 525 1114 371 c 256,44,45
  1114 217 1114 217 997.5 114 c 128,-1,46
  881 11 881 11 693 2 c 1,47,-1
  692 -301 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: percent
-Encoding: 37 37 37
+Encoding: 37 37 6
 Width: 1233
 Flags: W
 TtInstrs:
@@ -2952,7 +2964,7 @@ SplineSet
  696 241 696 241 748.5 188 c 128,-1,2
  801 135 801 135 879 135 c 0,3,4
  956 135 956 135 1009.5 188.5 c 128,-1,5
- 1063 242 1063 242 1063 319 c 0,6,7
+ 1063 242 1063 242 1063 319 c 256,6,7
  1063 396 1063 396 1009 450 c 128,-1,8
  955 504 955 504 879 504 c 0,9,10
  801 504 801 504 748.5 451 c 128,-1,11
@@ -2977,26 +2989,27 @@ SplineSet
  168 1033 168 1033 220.5 980.5 c 128,-1,33
  273 928 273 928 352 928 c 0,34,35
  429 928 429 928 483 981.5 c 128,-1,36
- 537 1035 537 1035 537 1112 c 0,37,38
+ 537 1035 537 1035 537 1112 c 256,37,38
  537 1189 537 1189 483 1242.5 c 128,-1,39
- 429 1296 429 1296 352 1296 c 0,40,41
+ 429 1296 429 1296 352 1296 c 256,40,41
  275 1296 275 1296 221.5 1243 c 128,-1,42
  168 1190 168 1190 168 1112 c 0,31,32
-33 1112 m 0,43,44
+33 1112 m 256,43,44
  33 1247 33 1247 125 1339.5 c 128,-1,45
  217 1432 217 1432 352 1432 c 0,46,47
  416 1432 416 1432 474.5 1408 c 128,-1,48
- 533 1384 533 1384 578 1339 c 0,49,50
+ 533 1384 533 1384 578 1339 c 256,49,50
  623 1294 623 1294 647.5 1235.5 c 128,-1,51
  672 1177 672 1177 672 1112 c 0,52,53
  672 978 672 978 579 885.5 c 128,-1,54
  486 793 486 793 352 793 c 0,55,56
  217 793 217 793 125 885 c 128,-1,57
- 33 977 33 977 33 1112 c 0,43,44
+ 33 977 33 977 33 1112 c 256,43,44
 EndSplineSet
 EndChar
+
 StartChar: ampersand
-Encoding: 38 38 38
+Encoding: 38 38 7
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3227,8 +3240,9 @@ SplineSet
  416 803 l 1,43,44
 EndSplineSet
 EndChar
+
 StartChar: quotesingle
-Encoding: 39 39 39
+Encoding: 39 39 8
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3261,8 +3275,9 @@ SplineSet
  702 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: parenleft
-Encoding: 40 40 40
+Encoding: 40 40 9
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3314,8 +3329,9 @@ SplineSet
  885 1554 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: parenright
-Encoding: 41 41 41
+Encoding: 41 41 10
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3367,8 +3383,9 @@ SplineSet
  481 1325 481 1325 348 1554 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asterisk
-Encoding: 42 42 42
+Encoding: 42 42 11
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3475,8 +3492,9 @@ SplineSet
  1067 1247 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: plus
-Encoding: 43 43 43
+Encoding: 43 43 12
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3538,8 +3556,9 @@ SplineSet
  700 1171 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: comma
-Encoding: 44 44 44
+Encoding: 44 44 13
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3580,8 +3599,9 @@ SplineSet
  502 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: hyphen
-Encoding: 45 45 45
+Encoding: 45 45 14
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3613,8 +3633,9 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: period
-Encoding: 46 46 46
+Encoding: 46 46 15
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3645,8 +3666,9 @@ SplineSet
  489 305 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: slash
-Encoding: 47 47 47
+Encoding: 47 47 16
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3685,8 +3707,9 @@ SplineSet
  889 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: zero
-Encoding: 48 48 48
+Encoding: 48 48 17
 Width: 1233
 Flags: W
 TtInstrs:
@@ -3978,19 +4001,20 @@ SplineSet
  897 435 897 435 897 745 c 0,21,22
  897 1056 897 1056 827.5 1208 c 128,-1,23
  758 1360 758 1360 616 1360 c 0,12,13
-616 1520 m 0,24,25
+616 1520 m 256,24,25
  855 1520 855 1520 977.5 1324 c 128,-1,26
  1100 1128 1100 1128 1100 745 c 0,27,28
  1100 363 1100 363 977.5 167 c 128,-1,29
- 855 -29 855 -29 616 -29 c 0,30,31
+ 855 -29 855 -29 616 -29 c 256,30,31
  377 -29 377 -29 255 167 c 128,-1,32
  133 363 133 363 133 745 c 0,33,34
  133 1128 133 1128 255 1324 c 128,-1,35
- 377 1520 377 1520 616 1520 c 0,24,25
+ 377 1520 377 1520 616 1520 c 256,24,25
 EndSplineSet
 EndChar
+
 StartChar: one
-Encoding: 49 49 49
+Encoding: 49 49 18
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4050,8 +4074,9 @@ SplineSet
  270 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: two
-Encoding: 50 50 50
+Encoding: 50 50 19
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4164,8 +4189,9 @@ SplineSet
  591 399 591 399 373 170 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: three
-Encoding: 51 51 51
+Encoding: 51 51 20
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4276,8 +4302,9 @@ SplineSet
  907 833 907 833 776 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: four
-Encoding: 52 52 52
+Encoding: 52 52 21
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4369,8 +4396,9 @@ SplineSet
  702 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: five
-Encoding: 53 53 53
+Encoding: 53 53 22
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4464,8 +4492,9 @@ SplineSet
  207 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: six
-Encoding: 54 54 54
+Encoding: 54 54 23
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4554,7 +4583,7 @@ SplineSet
  922 1489 922 1489 991 1460 c 1,0,-1
 631 829 m 0,25,26
  502 829 502 829 428 736 c 128,-1,27
- 354 643 354 643 354 479 c 0,28,29
+ 354 643 354 643 354 479 c 256,28,29
  354 315 354 315 428 222 c 128,-1,30
  502 129 502 129 631 129 c 0,31,32
  765 129 765 129 833 217.5 c 128,-1,33
@@ -4563,8 +4592,9 @@ SplineSet
  765 829 765 829 631 829 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: seven
-Encoding: 55 55 55
+Encoding: 55 55 24
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4635,8 +4665,9 @@ SplineSet
  139 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: eight
-Encoding: 56 56 56
+Encoding: 56 56 25
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4713,7 +4744,7 @@ Fore
 SplineSet
 616 709 m 0,0,1
  481 709 481 709 407.5 633.5 c 128,-1,2
- 334 558 334 558 334 420 c 0,3,4
+ 334 558 334 558 334 420 c 256,3,4
  334 282 334 282 408.5 205.5 c 128,-1,5
  483 129 483 129 616 129 c 0,6,7
  752 129 752 129 825.5 204.5 c 128,-1,8
@@ -4732,7 +4763,7 @@ SplineSet
  943 760 943 760 1022.5 660 c 128,-1,26
  1102 560 1102 560 1102 401 c 0,27,28
  1102 199 1102 199 973 85 c 128,-1,29
- 844 -29 844 -29 616 -29 c 0,30,31
+ 844 -29 844 -29 616 -29 c 256,30,31
  388 -29 388 -29 259.5 84.5 c 128,-1,32
  131 198 131 198 131 399 c 0,33,34
  131 559 131 559 210.5 659.5 c 128,-1,35
@@ -4748,8 +4779,9 @@ SplineSet
  367 1235 367 1235 367 1114 c 0,36,37
 EndSplineSet
 EndChar
+
 StartChar: nine
-Encoding: 57 57 57
+Encoding: 57 57 26
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4818,7 +4850,7 @@ Fore
 SplineSet
 596 662 m 0,0,1
  725 662 725 662 798.5 755 c 128,-1,2
- 872 848 872 848 872 1012 c 0,3,4
+ 872 848 872 848 872 1012 c 256,3,4
  872 1176 872 1176 798.5 1269 c 128,-1,5
  725 1362 725 1362 596 1362 c 0,6,7
  462 1362 462 1362 394 1273.5 c 128,-1,8
@@ -4845,8 +4877,9 @@ SplineSet
  305 2 305 2 236 31 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: colon
-Encoding: 58 58 58
+Encoding: 58 58 27
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4893,8 +4926,9 @@ SplineSet
  489 305 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: semicolon
-Encoding: 59 59 59
+Encoding: 59 59 28
 Width: 1233
 Flags: W
 TtInstrs:
@@ -4953,8 +4987,9 @@ SplineSet
  489 1063 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: less
-Encoding: 60 60 60
+Encoding: 60 60 29
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5005,8 +5040,9 @@ SplineSet
  1145 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equal
-Encoding: 61 61 61
+Encoding: 61 61 30
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5053,8 +5089,9 @@ SplineSet
  88 930 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: greater
-Encoding: 62 62 62
+Encoding: 62 62 31
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5105,8 +5142,9 @@ SplineSet
  88 961 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: question
-Encoding: 63 63 63
+Encoding: 63 63 32
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5268,8 +5306,9 @@ SplineSet
  487 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: at
-Encoding: 64 64 64
+Encoding: 64 64 33
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5391,11 +5430,11 @@ Fore
 SplineSet
 1038 545 m 0,0,1
  1038 674 1038 674 974 751.5 c 128,-1,2
- 910 829 910 829 803 829 c 0,3,4
+ 910 829 910 829 803 829 c 256,3,4
  696 829 696 829 631.5 751.5 c 128,-1,5
  567 674 567 674 567 545 c 0,6,7
  567 415 567 415 631.5 337.5 c 128,-1,8
- 696 260 696 260 803 260 c 0,9,10
+ 696 260 696 260 803 260 c 256,9,10
  910 260 910 260 974 337.5 c 128,-1,11
  1038 415 1038 415 1038 545 c 0,0,1
 1178 135 m 1,12,-1
@@ -5404,7 +5443,7 @@ SplineSet
  997 183 997 183 931.5 149 c 128,-1,16
  866 115 866 115 784 115 c 0,17,18
  623 115 623 115 517.5 236 c 128,-1,19
- 412 357 412 357 412 545 c 0,20,21
+ 412 357 412 357 412 545 c 256,20,21
  412 733 412 733 517.5 854 c 128,-1,22
  623 975 623 975 784 975 c 0,23,24
  864 975 864 975 931 940 c 128,-1,25
@@ -5430,8 +5469,9 @@ SplineSet
  1178 135 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: A
-Encoding: 65 65 65
+Encoding: 65 65 34
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5609,8 +5649,9 @@ SplineSet
  494 1493 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: B
-Encoding: 66 66 66
+Encoding: 66 66 35
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5712,8 +5753,9 @@ SplineSet
  166 1493 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: C
-Encoding: 67 67 67
+Encoding: 67 67 36
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5791,8 +5833,9 @@ SplineSet
  1073 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: D
-Encoding: 68 68 68
+Encoding: 68 68 37
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5861,8 +5904,9 @@ SplineSet
  440 1493 l 2,9,10
 EndSplineSet
 EndChar
+
 StartChar: E
-Encoding: 69 69 69
+Encoding: 69 69 38
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5929,8 +5973,9 @@ SplineSet
  197 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: F
-Encoding: 70 70 70
+Encoding: 70 70 39
 Width: 1233
 Flags: W
 TtInstrs:
@@ -5990,8 +6035,9 @@ SplineSet
  233 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: G
-Encoding: 71 71 71
+Encoding: 71 71 40
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6087,8 +6133,9 @@ SplineSet
  1104 123 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: H
-Encoding: 72 72 72
+Encoding: 72 72 41
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6152,8 +6199,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: I
-Encoding: 73 73 73
+Encoding: 73 73 42
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6216,8 +6264,9 @@ SplineSet
  201 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: J
-Encoding: 74 74 74
+Encoding: 74 74 43
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6289,8 +6338,9 @@ SplineSet
  212 15 212 15 109 61 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: K
-Encoding: 75 75 75
+Encoding: 75 75 44
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6467,8 +6517,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: L
-Encoding: 76 76 76
+Encoding: 76 76 45
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6512,8 +6563,9 @@ SplineSet
  215 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: M
-Encoding: 77 77 77
+Encoding: 77 77 46
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6673,8 +6725,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: N
-Encoding: 78 78 78
+Encoding: 78 78 47
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6807,8 +6860,9 @@ SplineSet
  139 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: O
-Encoding: 79 79 79
+Encoding: 79 79 48
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6854,7 +6908,7 @@ AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-905 745 m 0,0,1
+905 745 m 256,0,1
  905 1074 905 1074 837.5 1215 c 128,-1,2
  770 1356 770 1356 616 1356 c 0,3,4
  463 1356 463 1356 395.5 1215 c 128,-1,5
@@ -6862,10 +6916,10 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,8
  463 135 463 135 616 135 c 0,9,10
  770 135 770 135 837.5 275.5 c 128,-1,11
- 905 416 905 416 905 745 c 0,0,1
+ 905 416 905 416 905 745 c 256,0,1
 1116 745 m 0,12,13
  1116 355 1116 355 992.5 163 c 128,-1,14
- 869 -29 869 -29 616 -29 c 0,15,16
+ 869 -29 869 -29 616 -29 c 256,15,16
  363 -29 363 -29 240 162 c 128,-1,17
  117 353 117 353 117 745 c 0,18,19
  117 1136 117 1136 240.5 1328 c 128,-1,20
@@ -6874,8 +6928,9 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: P
-Encoding: 80 80 80
+Encoding: 80 80 49
 Width: 1233
 Flags: W
 TtInstrs:
@@ -6933,7 +6988,7 @@ SplineSet
  399 766 l 1,1,-1
  633 766 l 2,2,3
  773 766 773 766 851.5 840 c 128,-1,4
- 930 914 930 914 930 1047 c 0,5,6
+ 930 914 930 914 930 1047 c 256,5,6
  930 1180 930 1180 852 1253.5 c 128,-1,7
  774 1327 774 1327 633 1327 c 2,8,-1
  399 1327 l 1,0,-1
@@ -6949,8 +7004,9 @@ SplineSet
  197 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: Q
-Encoding: 81 81 81
+Encoding: 81 81 50
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7036,7 +7092,7 @@ SplineSet
  1040 -170 l 1,16,-1
  889 -270 l 1,17,-1
  655 -27 l 1,0,1
-905 745 m 0,18,19
+905 745 m 256,18,19
  905 1074 905 1074 837.5 1215 c 128,-1,20
  770 1356 770 1356 616 1356 c 0,21,22
  463 1356 463 1356 395.5 1215 c 128,-1,23
@@ -7044,11 +7100,12 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,26
  463 135 463 135 616 135 c 0,27,28
  770 135 770 135 837.5 275.5 c 128,-1,29
- 905 416 905 416 905 745 c 0,18,19
+ 905 416 905 416 905 745 c 256,18,19
 EndSplineSet
 EndChar
+
 StartChar: R
-Encoding: 82 82 82
+Encoding: 82 82 51
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7192,8 +7249,9 @@ SplineSet
  346 1327 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: S
-Encoding: 83 83 83
+Encoding: 83 83 52
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7367,8 +7425,9 @@ SplineSet
  907 1481 907 1481 1012 1442 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: T
-Encoding: 84 84 84
+Encoding: 84 84 53
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7418,8 +7477,9 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: U
-Encoding: 85 85 85
+Encoding: 85 85 54
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7496,8 +7556,9 @@ SplineSet
  147 347 147 347 147 573 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: V
-Encoding: 86 86 86
+Encoding: 86 86 55
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7594,8 +7655,9 @@ SplineSet
  616 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: W
-Encoding: 87 87 87
+Encoding: 87 87 56
 Width: 1233
 Flags: W
 TtInstrs:
@@ -7847,8 +7909,9 @@ SplineSet
  0 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: X
-Encoding: 88 88 88
+Encoding: 88 88 57
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8072,8 +8135,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Y
-Encoding: 89 89 89
+Encoding: 89 89 58
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8185,8 +8249,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Z
-Encoding: 90 90 90
+Encoding: 90 90 59
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8279,8 +8344,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketleft
-Encoding: 91 91 91
+Encoding: 91 91 60
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8329,8 +8395,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: backslash
-Encoding: 92 92 92
+Encoding: 92 92 61
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8369,8 +8436,9 @@ SplineSet
  293 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bracketright
-Encoding: 93 93 93
+Encoding: 93 93 62
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8419,8 +8487,9 @@ SplineSet
  770 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciicircum
-Encoding: 94 94 94
+Encoding: 94 94 63
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8462,8 +8531,9 @@ SplineSet
  705 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underscore
-Encoding: 95 95 95
+Encoding: 95 95 64
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8493,8 +8563,9 @@ SplineSet
  1233 -403 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: grave
-Encoding: 96 96 96
+Encoding: 96 96 65
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8544,8 +8615,9 @@ SplineSet
  477 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: a
-Encoding: 97 97 97
+Encoding: 97 97 66
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8701,8 +8773,9 @@ SplineSet
  1059 786 1059 786 1059 639 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: b
-Encoding: 98 98 98
+Encoding: 98 98 67
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8761,7 +8834,7 @@ AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-918 559 m 0,0,1
+918 559 m 256,0,1
  918 773 918 773 850 882 c 128,-1,2
  782 991 782 991 649 991 c 0,3,4
  515 991 515 991 446 881.5 c 128,-1,5
@@ -8769,7 +8842,7 @@ SplineSet
  377 347 377 347 446 237 c 128,-1,8
  515 127 515 127 649 127 c 0,9,10
  782 127 782 127 850 236 c 128,-1,11
- 918 345 918 345 918 559 c 0,0,1
+ 918 345 918 345 918 559 c 256,0,1
 377 977 m 1,12,13
  421 1059 421 1059 498.5 1103 c 128,-1,14
  576 1147 576 1147 678 1147 c 0,15,16
@@ -8786,8 +8859,9 @@ SplineSet
  377 977 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: c
-Encoding: 99 99 99
+Encoding: 99 99 68
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8849,7 +8923,7 @@ SplineSet
  987 14 987 14 908.5 -7.5 c 128,-1,2
  830 -29 830 -29 748 -29 c 0,3,4
  488 -29 488 -29 341.5 127 c 128,-1,5
- 195 283 195 283 195 559 c 0,6,7
+ 195 283 195 283 195 559 c 256,6,7
  195 835 195 835 341.5 991 c 128,-1,8
  488 1147 488 1147 748 1147 c 0,9,10
  829 1147 829 1147 906 1126 c 128,-1,11
@@ -8866,8 +8940,9 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: d
-Encoding: 100 100 100
+Encoding: 100 100 69
 Width: 1233
 Flags: W
 TtInstrs:
@@ -8940,19 +9015,20 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,14,15
  660 1147 660 1147 737 1103.5 c 128,-1,16
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,17,18
+317 559 m 256,17,18
  317 345 317 345 385 236 c 128,-1,19
- 453 127 453 127 586 127 c 0,20,21
+ 453 127 453 127 586 127 c 256,20,21
  719 127 719 127 788.5 237 c 128,-1,22
  858 347 858 347 858 559 c 0,23,24
  858 772 858 772 788.5 881.5 c 128,-1,25
- 719 991 719 991 586 991 c 0,26,27
+ 719 991 719 991 586 991 c 256,26,27
  453 991 453 991 385 882 c 128,-1,28
- 317 773 317 773 317 559 c 0,17,18
+ 317 773 317 773 317 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: e
-Encoding: 101 101 101
+Encoding: 101 101 70
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9057,10 +9133,13 @@ SplineSet
  928 660 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: f
-Encoding: 102 102 102
+Encoding: 102 102 71
 Width: 1233
 Flags: W
+HStem: 0 21G<494 678> 977 143<195 494 678 1063> 1403 153<717.718 1063>
+VStem: 494 184<0 977 1120 1361.22>
 TtInstrs:
 NPUSHB
  26
@@ -9142,8 +9221,9 @@ SplineSet
  1063 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: g
-Encoding: 103 103 103
+Encoding: 103 103 72
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9230,7 +9310,7 @@ SplineSet
  858 776 858 776 790.5 883.5 c 128,-1,2
  723 991 723 991 594 991 c 0,3,4
  459 991 459 991 388 883.5 c 128,-1,5
- 317 776 317 776 317 569 c 0,6,7
+ 317 776 317 776 317 569 c 256,6,7
  317 362 317 362 388.5 253.5 c 128,-1,8
  460 145 460 145 596 145 c 0,9,10
  723 145 723 145 790.5 254 c 128,-1,11
@@ -9260,8 +9340,9 @@ SplineSet
  1042 72 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: h
-Encoding: 104 104 104
+Encoding: 104 104 73
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9335,10 +9416,13 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: i
-Encoding: 105 105 105
+Encoding: 105 105 74
 Width: 1233
 Flags: W
+HStem: 0 143<178 543 727 1092> 977 143<256 543> 1323 233<543 727>
+VStem: 543 184<143 977 1323 1556>
 TtInstrs:
 NPUSHB
  25
@@ -9411,8 +9495,9 @@ SplineSet
 EndSplineSet
 Substitution2: "Single Substitution - Dotless Form" dotlessi
 EndChar
+
 StartChar: j
-Encoding: 106 106 106
+Encoding: 106 106 75
 Width: 1233
 Flags: W
 TtInstrs:
@@ -9499,10 +9584,14 @@ SplineSet
 EndSplineSet
 Substitution2: "Single Substitution - Dotless Form" dotlessj
 EndChar
+
 StartChar: k
-Encoding: 107 107 107
+Encoding: 107 107 76
 Width: 1233
 Flags: W
+HStem: 0 21G<236 426 962.675 1202> 1100 20G<888.226 1133>
+VStem: 236 190<0 449 655 1556>
+DStem2: 426 655 563 578 0.725332 0.688399<0 46.3638 222.54 670.441> 692 698 563 578 0.589959 -0.807434<20.7874 731.727>
 TtInstrs:
 NPUSHB
  58
@@ -9723,10 +9812,13 @@ SplineSet
  236 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: l
-Encoding: 108 108 108
+Encoding: 108 108 77
 Width: 1233
 Flags: W
+HStem: 0 156<700.74 1034> 1423 144<160 455>
+VStem: 455 184<220.984 1423>
 TtInstrs:
 NPUSHB
  19
@@ -9788,10 +9880,13 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: m
-Encoding: 109 109 109
+Encoding: 109 109 78
 Width: 1233
 Flags: W
+HStem: 0 21G<109 276 537 705 967 1135> 993 154<340.757 501.272 748.334 933.127> 1100 20G<109 276>
+VStem: 109 167<0 956.95 1024 1120> 537 168<0 935.205> 967 168<0 933.659>
 TtInstrs:
 NPUSHB
  39
@@ -9991,8 +10086,9 @@ SplineSet
  648 1077 648 1077 676 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: n
-Encoding: 110 110 110
+Encoding: 110 110 79
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10066,8 +10162,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: o
-Encoding: 111 111 111
+Encoding: 111 111 80
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10122,7 +10219,7 @@ SplineSet
  901 346 901 346 901 559 c 0,9,10
  901 773 901 773 829 882 c 128,-1,11
  757 991 757 991 616 991 c 0,0,1
-616 1147 m 0,12,13
+616 1147 m 256,12,13
  849 1147 849 1147 972.5 996 c 128,-1,14
  1096 845 1096 845 1096 559 c 0,15,16
  1096 272 1096 272 973 121.5 c 128,-1,17
@@ -10130,11 +10227,12 @@ SplineSet
  383 -29 383 -29 260 121.5 c 128,-1,20
  137 272 137 272 137 559 c 0,21,22
  137 845 137 845 260 996 c 128,-1,23
- 383 1147 383 1147 616 1147 c 0,12,13
+ 383 1147 383 1147 616 1147 c 256,12,13
 EndSplineSet
 EndChar
+
 StartChar: p
-Encoding: 112 112 112
+Encoding: 112 112 81
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10210,7 +10308,7 @@ SplineSet
  876 -29 876 -29 674 -29 c 0,14,15
  572 -29 572 -29 495.5 14.5 c 128,-1,16
  419 58 419 58 375 141 c 1,0,-1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -10218,11 +10316,12 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: q
-Encoding: 113 113 113
+Encoding: 113 113 82
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10284,15 +10383,15 @@ AnchorPoint: "below" 616 -426 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-332 555 m 0,0,1
+332 555 m 256,0,1
  332 341 332 341 399.5 232 c 128,-1,2
- 467 123 467 123 600 123 c 0,3,4
+ 467 123 467 123 600 123 c 256,3,4
  733 123 733 123 801.5 232.5 c 128,-1,5
- 870 342 870 342 870 555 c 0,6,7
+ 870 342 870 342 870 555 c 256,6,7
  870 768 870 768 801.5 877.5 c 128,-1,8
- 733 987 733 987 600 987 c 0,9,10
+ 733 987 733 987 600 987 c 256,9,10
  467 987 467 987 399.5 878 c 128,-1,11
- 332 769 332 769 332 555 c 0,0,1
+ 332 769 332 769 332 555 c 256,0,1
 870 139 m 1,12,13
  825 56 825 56 748.5 11.5 c 128,-1,14
  672 -33 672 -33 571 -33 c 0,15,16
@@ -10309,8 +10408,9 @@ SplineSet
  870 139 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: r
-Encoding: 114 114 114
+Encoding: 114 114 83
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10417,8 +10517,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: s
-Encoding: 115 115 115
+Encoding: 115 115 84
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10577,8 +10678,9 @@ SplineSet
  893 1114 893 1114 973 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: t
-Encoding: 116 116 116
+Encoding: 116 116 85
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10659,8 +10761,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: u
-Encoding: 117 117 117
+Encoding: 117 117 86
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10734,8 +10837,9 @@ SplineSet
  195 196 195 196 195 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: v
-Encoding: 118 118 118
+Encoding: 118 118 87
 Width: 1233
 Flags: W
 TtInstrs:
@@ -10857,8 +10961,9 @@ SplineSet
  100 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: w
-Encoding: 119 119 119
+Encoding: 119 119 88
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11158,8 +11263,9 @@ SplineSet
  0 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: x
-Encoding: 120 120 120
+Encoding: 120 120 89
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11354,8 +11460,9 @@ SplineSet
  1118 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: y
-Encoding: 121 121 121
+Encoding: 121 121 90
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11544,8 +11651,9 @@ SplineSet
  858 360 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: z
-Encoding: 122 122 122
+Encoding: 122 122 91
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11657,8 +11765,9 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceleft
-Encoding: 123 123 123
+Encoding: 123 123 92
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11800,8 +11909,9 @@ SplineSet
  1012 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bar
-Encoding: 124 124 124
+Encoding: 124 124 93
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11834,8 +11944,9 @@ SplineSet
  702 1565 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: braceright
-Encoding: 125 125 125
+Encoding: 125 125 94
 Width: 1233
 Flags: W
 TtInstrs:
@@ -11981,8 +12092,9 @@ SplineSet
  221 -190 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: asciitilde
-Encoding: 126 126 126
+Encoding: 126 126 95
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12049,14 +12161,16 @@ SplineSet
  1071 718 1071 718 1145 780 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: nonbreakingspace
-Encoding: 160 160 160
+Encoding: 160 160 96
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: exclamdown
-Encoding: 161 161 161
+Encoding: 161 161 97
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12112,8 +12226,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" exclamdown.case
 EndChar
+
 StartChar: cent
-Encoding: 162 162 162
+Encoding: 162 162 98
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12224,13 +12339,14 @@ SplineSet
 698 127 m 1,27,-1
  698 991 l 1,28,29
  566 979 566 979 486 861 c 128,-1,30
- 406 743 406 743 406 559 c 0,31,32
+ 406 743 406 743 406 559 c 256,31,32
  406 375 406 375 486 257.5 c 128,-1,33
  566 140 566 140 698 127 c 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: sterling
-Encoding: 163 163 163
+Encoding: 163 163 99
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12327,8 +12443,9 @@ SplineSet
  1019 1491 1019 1491 1092 1462 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: currency
-Encoding: 164 164 164
+Encoding: 164 164 100
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12504,8 +12621,9 @@ SplineSet
  793 954 793 954 844 924 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: yen
-Encoding: 165 165 165
+Encoding: 165 165 101
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12668,8 +12786,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: brokenbar
-Encoding: 166 166 166
+Encoding: 166 166 102
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12717,8 +12836,9 @@ SplineSet
  702 408 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: section
-Encoding: 167 167 167
+Encoding: 167 167 103
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12878,8 +12998,9 @@ SplineSet
  729 804 729 804 485 936 c 1,51,52
 EndSplineSet
 EndChar
+
 StartChar: dieresis
-Encoding: 168 168 168
+Encoding: 168 168 104
 Width: 1233
 Flags: W
 TtInstrs:
@@ -12927,10 +13048,11 @@ SplineSet
  711 1350 l 1,7,-1
  711 1552 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: copyright
-Encoding: 169 169 169
+Encoding: 169 169 105
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13027,7 +13149,7 @@ SplineSet
  812 1094 812 1094 864 1071 c 1,0,-1
 616 1255 m 0,26,27
  510 1255 510 1255 419.5 1218 c 128,-1,28
- 329 1181 329 1181 254 1106 c 0,29,30
+ 329 1181 329 1181 254 1106 c 256,29,30
  179 1031 179 1031 140.5 939 c 128,-1,31
  102 847 102 847 102 741 c 0,32,33
  102 637 102 637 140.5 545.5 c 128,-1,34
@@ -13035,11 +13157,11 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,37
  511 227 511 227 616 227 c 0,38,39
  722 227 722 227 812.5 265 c 128,-1,40
- 903 303 903 303 979 379 c 0,41,42
+ 903 303 903 303 979 379 c 256,41,42
  1055 455 1055 455 1092.5 545.5 c 128,-1,43
  1130 636 1130 636 1130 741 c 0,44,45
  1130 847 1130 847 1092 939 c 128,-1,46
- 1054 1031 1054 1031 979 1106 c 0,47,48
+ 1054 1031 1054 1031 979 1106 c 256,47,48
  904 1181 904 1181 813.5 1218 c 128,-1,49
  723 1255 723 1255 616 1255 c 0,26,27
 616 1358 m 0,50,51
@@ -13048,11 +13170,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,55
  1233 867 1233 867 1233 741 c 0,56,57
  1233 616 1233 616 1187.5 507 c 128,-1,58
- 1142 398 1142 398 1051 307 c 0,59,60
+ 1142 398 1142 398 1051 307 c 256,59,60
  960 216 960 216 851 170.5 c 128,-1,61
  742 125 742 125 616 125 c 0,62,63
  491 125 491 125 382 170.5 c 128,-1,64
- 273 216 273 216 182 307 c 0,65,66
+ 273 216 273 216 182 307 c 256,65,66
  91 398 91 398 45.5 507 c 128,-1,67
  0 616 0 616 0 741 c 0,68,69
  0 867 0 867 46 977 c 128,-1,70
@@ -13061,8 +13183,9 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,50,51
 EndSplineSet
 EndChar
+
 StartChar: ordfeminine
-Encoding: 170 170 170
+Encoding: 170 170 106
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13207,8 +13330,9 @@ SplineSet
  293 592 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotleft
-Encoding: 171 171 171
+Encoding: 171 171 107
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13281,8 +13405,9 @@ SplineSet
  1042 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalnot
-Encoding: 172 172 172
+Encoding: 172 172 108
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13323,8 +13448,9 @@ SplineSet
  88 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: sfthyphen
-Encoding: 173 173 173
+Encoding: 173 173 109
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13356,8 +13482,9 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: registered
-Encoding: 174 174 174
+Encoding: 174 174 110
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13529,11 +13656,11 @@ SplineSet
  1141 1087 1141 1087 1187 977 c 128,-1,34
  1233 867 1233 867 1233 741 c 0,35,36
  1233 616 1233 616 1187.5 507 c 128,-1,37
- 1142 398 1142 398 1051 307 c 0,38,39
+ 1142 398 1142 398 1051 307 c 256,38,39
  960 216 960 216 851 170.5 c 128,-1,40
  742 125 742 125 616 125 c 0,41,42
  491 125 491 125 382 170.5 c 128,-1,43
- 273 216 273 216 182 307 c 0,44,45
+ 273 216 273 216 182 307 c 256,44,45
  91 398 91 398 45.5 507 c 128,-1,46
  0 616 0 616 0 741 c 0,47,48
  0 867 0 867 46 977 c 128,-1,49
@@ -13542,7 +13669,7 @@ SplineSet
  490 1358 490 1358 616 1358 c 0,29,30
 616 1255 m 0,53,54
  510 1255 510 1255 419.5 1218 c 128,-1,55
- 329 1181 329 1181 254 1106 c 0,56,57
+ 329 1181 329 1181 254 1106 c 256,56,57
  179 1031 179 1031 140.5 939 c 128,-1,58
  102 847 102 847 102 741 c 0,59,60
  102 637 102 637 140.5 545.5 c 128,-1,61
@@ -13550,17 +13677,18 @@ SplineSet
  330 303 330 303 420.5 265 c 128,-1,64
  511 227 511 227 616 227 c 0,65,66
  722 227 722 227 812.5 265 c 128,-1,67
- 903 303 903 303 979 379 c 0,68,69
+ 903 303 903 303 979 379 c 256,68,69
  1055 455 1055 455 1092.5 545.5 c 128,-1,70
  1130 636 1130 636 1130 741 c 0,71,72
  1130 847 1130 847 1092 939 c 128,-1,73
- 1054 1031 1054 1031 979 1106 c 0,74,75
+ 1054 1031 1054 1031 979 1106 c 256,74,75
  904 1181 904 1181 813.5 1218 c 128,-1,76
  723 1255 723 1255 616 1255 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: macron
-Encoding: 175 175 175
+Encoding: 175 175 111
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13591,10 +13719,11 @@ SplineSet
  317 1378 l 1,3,-1
  317 1526 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: degree
-Encoding: 176 176 176
+Encoding: 176 176 112
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13645,19 +13774,20 @@ SplineSet
  299 1065 299 1065 299 1200 c 0,12,13
  299 1334 299 1334 391 1427 c 128,-1,14
  483 1520 483 1520 616 1520 c 0,0,1
-616 1391 m 0,15,16
+616 1391 m 256,15,16
  537 1391 537 1391 481.5 1335.5 c 128,-1,17
- 426 1280 426 1280 426 1200 c 0,18,19
+ 426 1280 426 1280 426 1200 c 256,18,19
  426 1120 426 1120 480.5 1066 c 128,-1,20
  535 1012 535 1012 614 1012 c 0,21,22
  694 1012 694 1012 750.5 1067 c 128,-1,23
  807 1122 807 1122 807 1200 c 0,24,25
  807 1279 807 1279 751 1335 c 128,-1,26
- 695 1391 695 1391 616 1391 c 0,15,16
+ 695 1391 695 1391 616 1391 c 256,15,16
 EndSplineSet
 EndChar
+
 StartChar: plusminus
-Encoding: 177 177 177
+Encoding: 177 177 113
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13731,8 +13861,9 @@ SplineSet
  700 1171 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: twosuperior
-Encoding: 178 178 178
+Encoding: 178 178 114
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13850,8 +13981,9 @@ SplineSet
  483 782 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: threesuperior
-Encoding: 179 179 179
+Encoding: 179 179 115
 Width: 1233
 Flags: W
 TtInstrs:
@@ -13963,8 +14095,9 @@ SplineSet
  815 1139 815 1139 731 1120 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: acute
-Encoding: 180 180 180
+Encoding: 180 180 116
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14013,10 +14146,11 @@ SplineSet
  475 1262 l 1,3,-1
  756 1638 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: mu
-Encoding: 181 181 181
+Encoding: 181 181 117
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14128,8 +14262,9 @@ SplineSet
  195 -428 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: paragraph
-Encoding: 182 182 182
+Encoding: 182 182 118
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14187,8 +14322,9 @@ SplineSet
  367 1493 367 1493 582 1493 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: periodcentered
-Encoding: 183 183 183
+Encoding: 183 183 119
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14222,17 +14358,19 @@ SplineSet
  489 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: cedilla
-Encoding: 184 184 184
+Encoding: 184 184 120
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: onesuperior
-Encoding: 185 185 185
+Encoding: 185 185 121
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14300,8 +14438,9 @@ SplineSet
  362 778 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: ordmasculine
-Encoding: 186 186 186
+Encoding: 186 186 122
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14362,7 +14501,7 @@ Fore
 SplineSet
 616 1403 m 0,0,1
  514 1403 514 1403 456.5 1325 c 128,-1,2
- 399 1247 399 1247 399 1108 c 0,3,4
+ 399 1247 399 1247 399 1108 c 256,3,4
  399 969 399 969 456.5 892 c 128,-1,5
  514 815 514 815 616 815 c 0,6,7
  717 815 717 815 775.5 893.5 c 128,-1,8
@@ -14385,8 +14524,9 @@ SplineSet
  276 592 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: guillemotright
-Encoding: 187 187 187
+Encoding: 187 187 123
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14459,41 +14599,45 @@ SplineSet
  193 1059 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: onequarter
-Encoding: 188 188 188
+Encoding: 188 188 124
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: onehalf
-Encoding: 189 189 189
+Encoding: 189 189 125
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 201 -938 2
-LCarets2: 2 0 0 
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 201 -938 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: threequarters
-Encoding: 190 190 190
+Encoding: 190 190 126
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 184 -938 2
-Refer: 179 179 N 1 0 0 1 -227 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-LCarets2: 2 0 0 
+Refer: 2009 8308 N 1 0 0 1 184 -938 2
+Refer: 115 179 N 1 0 0 1 -227 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: questiondown
-Encoding: 191 191 191
+Encoding: 191 191 127
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14664,8 +14808,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" questiondown.case
 EndChar
+
 StartChar: Agrave
-Encoding: 192 192 192
+Encoding: 192 192 128
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14681,12 +14826,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aacute
-Encoding: 193 193 193
+Encoding: 193 193 129
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14702,12 +14848,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Acircumflex
-Encoding: 194 194 194
+Encoding: 194 194 130
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14736,12 +14883,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Atilde
-Encoding: 195 195 195
+Encoding: 195 195 131
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14766,12 +14914,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Adieresis
-Encoding: 196 196 196
+Encoding: 196 196 132
 Width: 1233
 Flags: W
 TtInstrs:
@@ -14808,12 +14957,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Aring
-Encoding: 197 197 197
+Encoding: 197 197 133
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15016,15 +15166,15 @@ AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-768 1626 m 0,0,1
+768 1626 m 256,0,1
  768 1689 768 1689 723.5 1733.5 c 128,-1,2
  679 1778 679 1778 616 1778 c 0,3,4
  552 1778 552 1778 508.5 1734.5 c 128,-1,5
  465 1691 465 1691 465 1626 c 0,6,7
  465 1563 465 1563 509 1519 c 128,-1,8
- 553 1475 553 1475 616 1475 c 0,9,10
+ 553 1475 553 1475 616 1475 c 256,9,10
  679 1475 679 1475 723.5 1519 c 128,-1,11
- 768 1563 768 1563 768 1626 c 0,0,1
+ 768 1563 768 1563 768 1626 c 256,0,1
 616 1311 m 1,12,-1
  403 551 l 1,13,-1
  829 551 l 1,14,-1
@@ -15033,7 +15183,7 @@ SplineSet
  407 1432 407 1432 374.5 1492.5 c 128,-1,17
  342 1553 342 1553 342 1626 c 0,18,19
  342 1740 342 1740 422 1820.5 c 128,-1,20
- 502 1901 502 1901 616 1901 c 0,21,22
+ 502 1901 502 1901 616 1901 c 256,21,22
  730 1901 730 1901 810.5 1820.5 c 128,-1,23
  891 1740 891 1740 891 1626 c 0,24,25
  891 1553 891 1553 859 1494 c 128,-1,26
@@ -15046,10 +15196,11 @@ SplineSet
  37 0 l 1,33,-1
  465 1399 l 1,15,16
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: AE
-Encoding: 198 198 198
+Encoding: 198 198 134
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15186,91 +15337,99 @@ SplineSet
  530 1323 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: Ccedilla
-Encoding: 199 199 199
+Encoding: 199 199 135
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Egrave
-Encoding: 200 200 200
+Encoding: 200 200 136
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eacute
-Encoding: 201 201 201
+Encoding: 201 201 137
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ecircumflex
-Encoding: 202 202 202
+Encoding: 202 202 138
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Edieresis
-Encoding: 203 203 203
+Encoding: 203 203 139
 Width: 1233
 Flags: W
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 18 373 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 18 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Igrave
-Encoding: 204 204 204
+Encoding: 204 204 140
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Iacute
-Encoding: 205 205 205
+Encoding: 205 205 141
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Icircumflex
-Encoding: 206 206 206
+Encoding: 206 206 142
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15290,12 +15449,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Idieresis
-Encoding: 207 207 207
+Encoding: 207 207 143
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15312,12 +15472,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eth
-Encoding: 208 208 208
+Encoding: 208 208 144
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15413,8 +15574,9 @@ SplineSet
  436 166 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: Ntilde
-Encoding: 209 209 209
+Encoding: 209 209 145
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15439,12 +15601,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 377 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 377 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ograve
-Encoding: 210 210 210
+Encoding: 210 210 146
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15460,12 +15623,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Oacute
-Encoding: 211 211 211
+Encoding: 211 211 147
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15481,12 +15645,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ocircumflex
-Encoding: 212 212 212
+Encoding: 212 212 148
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15515,12 +15680,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Otilde
-Encoding: 213 213 213
+Encoding: 213 213 149
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15545,12 +15711,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Odieresis
-Encoding: 214 214 214
+Encoding: 214 214 150
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15587,12 +15754,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: multiply
-Encoding: 215 215 215
+Encoding: 215 215 151
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15661,8 +15829,9 @@ SplineSet
  150 293 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Oslash
-Encoding: 216 216 216
+Encoding: 216 216 152
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15817,8 +15986,9 @@ SplineSet
  1032 1247 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: Ugrave
-Encoding: 217 217 217
+Encoding: 217 217 153
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15834,12 +16004,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uacute
-Encoding: 218 218 218
+Encoding: 218 218 154
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15855,12 +16026,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ucircumflex
-Encoding: 219 219 219
+Encoding: 219 219 155
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15889,12 +16061,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Udieresis
-Encoding: 220 220 220
+Encoding: 220 220 156
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15931,12 +16104,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Yacute
-Encoding: 221 221 221
+Encoding: 221 221 157
 Width: 1233
 Flags: W
 TtInstrs:
@@ -15952,12 +16126,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Thorn
-Encoding: 222 222 222
+Encoding: 222 222 158
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16023,7 +16198,7 @@ SplineSet
  403 532 l 1,1,-1
  637 532 l 2,2,3
  795 532 795 532 873.5 598 c 128,-1,4
- 952 664 952 664 952 795 c 0,5,6
+ 952 664 952 664 952 795 c 256,5,6
  952 926 952 926 873.5 991.5 c 128,-1,7
  795 1057 795 1057 637 1057 c 2,8,-1
  403 1057 l 1,0,-1
@@ -16041,8 +16216,9 @@ SplineSet
  201 1493 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: germandbls
-Encoding: 223 223 223
+Encoding: 223 223 159
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16176,80 +16352,87 @@ SplineSet
  188 1137 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: agrave
-Encoding: 224 224 224
+Encoding: 224 224 160
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aacute
-Encoding: 225 225 225
+Encoding: 225 225 161
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: acircumflex
-Encoding: 226 226 226
+Encoding: 226 226 162
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: atilde
-Encoding: 227 227 227
+Encoding: 227 227 163
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: adieresis
-Encoding: 228 228 228
+Encoding: 228 228 164
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: aring
-Encoding: 229 229 229
+Encoding: 229 229 165
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ae
-Encoding: 230 230 230
+Encoding: 230 230 166
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16414,7 +16597,7 @@ SplineSet
 1036 657 m 1,11,-1
  1036 709 l 2,12,13
  1036 860 1036 860 997.5 926.5 c 128,-1,14
- 959 993 959 993 872 993 c 0,15,16
+ 959 993 959 993 872 993 c 256,15,16
  785 993 785 993 747 925 c 128,-1,17
  709 857 709 857 709 700 c 2,18,-1
  709 657 l 1,19,-1
@@ -16456,55 +16639,60 @@ SplineSet
  1200 514 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: ccedilla
-Encoding: 231 231 231
+Encoding: 231 231 167
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: egrave
-Encoding: 232 232 232
+Encoding: 232 232 168
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eacute
-Encoding: 233 233 233
+Encoding: 233 233 169
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecircumflex
-Encoding: 234 234 234
+Encoding: 234 234 170
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: edieresis
-Encoding: 235 235 235
+Encoding: 235 235 171
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16520,36 +16708,39 @@ AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 14 0 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 14 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: igrave
-Encoding: 236 236 236
+Encoding: 236 236 172
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 S 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: iacute
-Encoding: 237 237 237
+Encoding: 237 237 173
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: icircumflex
-Encoding: 238 238 238
+Encoding: 238 238 174
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16567,12 +16758,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: idieresis
-Encoding: 239 239 239
+Encoding: 239 239 175
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16589,12 +16781,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 24 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 24 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: eth
-Encoding: 240 240 240
+Encoding: 240 240 176
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16778,44 +16971,48 @@ SplineSet
  843 848 843 848 793 918 c 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: ntilde
-Encoding: 241 241 241
+Encoding: 241 241 177
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ograve
-Encoding: 242 242 242
+Encoding: 242 242 178
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: oacute
-Encoding: 243 243 243
+Encoding: 243 243 179
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ocircumflex
-Encoding: 244 244 244
+Encoding: 244 244 180
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16840,12 +17037,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: otilde
-Encoding: 245 245 245
+Encoding: 245 245 181
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16878,12 +17076,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: odieresis
-Encoding: 246 246 246
+Encoding: 246 246 182
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16916,12 +17115,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: divide
-Encoding: 247 247 247
+Encoding: 247 247 183
 Width: 1233
 Flags: W
 TtInstrs:
@@ -16985,8 +17185,9 @@ SplineSet
  88 727 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: oslash
-Encoding: 248 248 248
+Encoding: 248 248 184
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17149,32 +17350,35 @@ SplineSet
  217 180 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: ugrave
-Encoding: 249 249 249
+Encoding: 249 249 185
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uacute
-Encoding: 250 250 250
+Encoding: 250 250 186
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ucircumflex
-Encoding: 251 251 251
+Encoding: 251 251 187
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17199,12 +17403,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 710 710 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: udieresis
-Encoding: 252 252 252
+Encoding: 252 252 188
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17237,24 +17442,26 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: yacute
-Encoding: 253 253 253
+Encoding: 253 253 189
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: thorn
-Encoding: 254 254 254
+Encoding: 254 254 190
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17330,7 +17537,7 @@ SplineSet
  876 -29 876 -29 674 -29 c 0,14,15
  572 -29 572 -29 495.5 14.5 c 128,-1,16
  419 58 419 58 375 141 c 1,0,-1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -17338,23 +17545,25 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: ydieresis
-Encoding: 255 255 255
+Encoding: 255 255 191
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 90 121 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Amacron
-Encoding: 256 256 256
+Encoding: 256 256 192
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17382,19 +17591,21 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: amacron
-Encoding: 257 257 257
+Encoding: 257 257 193
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Abreve
-Encoding: 258 258 258
+Encoding: 258 258 194
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17427,142 +17638,155 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: abreve
-Encoding: 259 259 259
+Encoding: 259 259 195
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 966 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Aogonek
-Encoding: 260 260 260
+Encoding: 260 260 196
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 455 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 455 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aogonek
-Encoding: 261 261 261
+Encoding: 261 261 197
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 345 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 345 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cacute
-Encoding: 262 262 262
+Encoding: 262 262 198
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: cacute
-Encoding: 263 263 263
+Encoding: 263 263 199
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ccircumflex
-Encoding: 264 264 264
+Encoding: 264 264 200
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 126.5 380 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 126.5 380 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ccircumflex
-Encoding: 265 265 265
+Encoding: 265 265 201
 Width: 1233
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 90 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 90 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Cdotaccent
-Encoding: 266 266 266
+Encoding: 266 266 202
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 75 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 75 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: cdotaccent
-Encoding: 267 267 267
+Encoding: 267 267 203
 Width: 1233
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 75 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 75 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ccaron
-Encoding: 268 268 268
+Encoding: 268 268 204
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 691 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 90 373 2
-LCarets2: 1 0 
+Refer: 36 67 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 90 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ccaron
-Encoding: 269 269 269
+Encoding: 269 269 205
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
 AnchorPoint: "cedilla" 720 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 68 99 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcaron
-Encoding: 270 270 270
+Encoding: 270 270 206
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -78 367 2
-LCarets2: 1 0 
+Refer: 37 68 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 -78 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dcaron
-Encoding: 271 271 271
+Encoding: 271 271 207
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17582,12 +17806,13 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 570 -81 2
-Refer: 100 100 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 570 -81 2
+Refer: 69 100 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Dcroat
-Encoding: 272 272 272
+Encoding: 272 272 208
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -17595,10 +17820,11 @@ AnchorPoint: "above" 566 1493 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dcroat
-Encoding: 273 273 273
+Encoding: 273 273 209
 Width: 1233
 Flags: W
 TtInstrs:
@@ -17702,208 +17928,227 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,22,23
  660 1147 660 1147 737 1103.5 c 128,-1,24
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,25,26
+317 559 m 256,25,26
  317 345 317 345 385 236 c 128,-1,27
- 453 127 453 127 586 127 c 0,28,29
+ 453 127 453 127 586 127 c 256,28,29
  719 127 719 127 788.5 237 c 128,-1,30
  858 347 858 347 858 559 c 0,31,32
  858 772 858 772 788.5 881.5 c 128,-1,33
- 719 991 719 991 586 991 c 0,34,35
+ 719 991 719 991 586 991 c 256,34,35
  453 991 453 991 385 882 c 128,-1,36
- 317 773 317 773 317 559 c 0,25,26
+ 317 773 317 773 317 559 c 256,25,26
 EndSplineSet
 EndChar
+
 StartChar: Emacron
-Encoding: 274 274 274
+Encoding: 274 274 210
 Width: 1233
 AnchorPoint: "below" 634 0 basechar 0
 AnchorPoint: "cedilla" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: emacron
-Encoding: 275 275 275
+Encoding: 275 275 211
 Width: 1233
 AnchorPoint: "below" 630 0 basechar 0
 AnchorPoint: "cedilla" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 35 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 35 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ebreve
-Encoding: 276 276 276
+Encoding: 276 276 212
 Width: 1233
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ebreve
-Encoding: 277 277 277
+Encoding: 277 277 213
 Width: 1233
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Edotaccent
-Encoding: 278 278 278
+Encoding: 278 278 214
 Width: 1233
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: edotaccent
-Encoding: 279 279 279
+Encoding: 279 279 215
 Width: 1233
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eogonek
-Encoding: 280 280 280
+Encoding: 280 280 216
 Width: 1233
 Flags: W
 AnchorPoint: "above" 634 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 305 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 305 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: eogonek
-Encoding: 281 281 281
+Encoding: 281 281 217
 Width: 1233
 Flags: W
 AnchorPoint: "above" 630 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 246 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 246 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ecaron
-Encoding: 282 282 282
+Encoding: 282 282 218
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 634 0 basechar 0
 AnchorPoint: "below" 634 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 36 367 2
-LCarets2: 1 0 
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 36 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ecaron
-Encoding: 283 283 283
+Encoding: 283 283 219
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 630 0 basechar 0
 AnchorPoint: "below" 630 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 35 -5 2
-LCarets2: 1 0 
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 35 -5 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gcircumflex
-Encoding: 284 284 284
+Encoding: 284 284 220
 Width: 1233
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcircumflex
-Encoding: 285 285 285
+Encoding: 285 285 221
 Width: 1233
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gbreve
-Encoding: 286 286 286
+Encoding: 286 286 222
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3735 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: gbreve
-Encoding: 287 287 287
+Encoding: 287 287 223
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Gdotaccent
-Encoding: 288 288 288
+Encoding: 288 288 224
 Width: 1233
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gdotaccent
-Encoding: 289 289 289
+Encoding: 289 289 225
 Width: 1233
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcommaaccent
-Encoding: 290 290 290
+Encoding: 290 290 226
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 127.5 -31 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 127.5 -31 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcommaaccent
-Encoding: 291 291 291
+Encoding: 291 291 227
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 786 786 N 1 0 0 1 17 302 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 673 786 N 1 0 0 1 17 302 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hcircumflex
-Encoding: 292 292 292
+Encoding: 292 292 228
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -17931,11 +18176,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 994 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: hcircumflex
-Encoding: 293 293 293
+Encoding: 293 293 229
 Width: 1233
 TtInstrs:
 SVTCA[y-axis]
@@ -17965,11 +18211,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Hbar
-Encoding: 294 294 294
+Encoding: 294 294 230
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18071,8 +18318,9 @@ SplineSet
  339 1105 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: hbar
-Encoding: 295 295 295
+Encoding: 295 295 231
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18173,8 +18421,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Itilde
-Encoding: 296 296 296
+Encoding: 296 296 232
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18206,21 +18455,23 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: itilde
-Encoding: 297 297 297
+Encoding: 297 297 233
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Imacron
-Encoding: 298 298 298
+Encoding: 298 298 234
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18244,21 +18495,23 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: imacron
-Encoding: 299 299 299
+Encoding: 299 299 235
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ibreve
-Encoding: 300 300 300
+Encoding: 300 300 236
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -18282,52 +18535,57 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ibreve
-Encoding: 301 301 301
+Encoding: 301 301 237
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Iogonek
-Encoding: 302 302 302
+Encoding: 302 302 238
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 70 -0.000325203 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 70 -0.000325203 2
 EndChar
+
 StartChar: iogonek
-Encoding: 303 303 303
+Encoding: 303 303 239
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 80.0029 0.0016284 2
+Refer: 74 105 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 80.0029 0.0016284 2
 EndChar
+
 StartChar: Idotaccent
-Encoding: 304 304 304
+Encoding: 304 304 240
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotlessi
-Encoding: 305 305 305
+Encoding: 305 305 241
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18385,8 +18643,9 @@ SplineSet
  256 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: IJ
-Encoding: 306 306 306
+Encoding: 306 306 242
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18459,16 +18718,16 @@ SplineSet
  651.6 300 l 1,1,2
  713.48 219 713.48 219 779.44 178.5 c 128,-1,3
  845.4 138 845.4 138 916.12 138 c 0,4,5
- 1013.36 138 1013.36 138 1051.78 212.5 c 0,6,7
+ 1013.36 138 1013.36 138 1051.78 212.5 c 256,6,7
  1090.2 287 1090.2 287 1090.2 490 c 2,8,-1
  1090.2 1326 l 1,9,-1
  831.12 1326 l 1,10,-1
  831.12 1496 l 1,11,-1
  1227.56 1496 l 1,12,-1
  1227.56 490 l 2,13,14
- 1227.56 208 1227.56 208 1155.82 91 c 0,15,16
+ 1227.56 208 1227.56 208 1155.82 91 c 256,15,16
  1084.08 -26 1084.08 -26 916.12 -26 c 0,17,18
- 850.84 -26 850.84 -26 786.24 -4 c 0,19,20
+ 850.84 -26 850.84 -26 786.24 -4 c 256,19,20
  721.64 18 721.64 18 651.6 64 c 1,0,-1
 -1 1493 m 1,21,-1
  604.17 1493 l 1,22,-1
@@ -18484,10 +18743,11 @@ SplineSet
  -1 1323 l 1,32,-1
  -1 1493 l 1,21,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ij
-Encoding: 307 307 307
+Encoding: 307 307 243
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18603,51 +18863,56 @@ SplineSet
  294.42 1323 l 1,31,-1
  294.42 1556 l 1,28,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: Jcircumflex
-Encoding: 308 308 308
+Encoding: 308 308 244
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 48 373 2
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 48 373 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: jcircumflex
-Encoding: 309 309 309
+Encoding: 309 309 245
 Width: 1233
 AnchorPoint: "cedilla" 441 -423 basechar 0
 AnchorPoint: "below" 616 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 493 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kcommaaccent
-Encoding: 310 310 310
+Encoding: 310 310 246
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 106.5 -2 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 106.5 -2 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kcommaaccent
-Encoding: 311 311 311
+Encoding: 311 311 247
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 144.5 -2 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 144.5 -2 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: kgreenlandic
-Encoding: 312 312 312
+Encoding: 312 312 248
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18869,8 +19134,9 @@ SplineSet
  236 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Lacute
-Encoding: 313 313 313
+Encoding: 313 313 249
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18886,12 +19152,13 @@ AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -275 374 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -275 374 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lacute
-Encoding: 314 314 314
+Encoding: 314 314 250
 Width: 1233
 Flags: W
 TtInstrs:
@@ -18922,68 +19189,74 @@ AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -95 374 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -95 374 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lcommaaccent
-Encoding: 315 315 315
+Encoding: 315 315 251
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 102.5 -2 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 102.5 -2 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: lcommaaccent
-Encoding: 316 316 316
+Encoding: 316 316 252
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -5 -2 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 -5 -2 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lcaron
-Encoding: 317 317 317
+Encoding: 317 317 253
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 174 -147 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 174 -147 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: lcaron
-Encoding: 318 318 318
+Encoding: 318 318 254
 Width: 1233
 Flags: W
 AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114113 -1 N 1 0 0 1 416 -71 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3726 -1 N 1 0 0 1 416 -71 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Ldot
-Encoding: 319 319 319
+Encoding: 319 319 255
 Width: 1233
 AnchorPoint: "above" 666 1493 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 352 133.5 2
-Refer: 76 76 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 352 133.5 2
+Refer: 45 76 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ldot
-Encoding: 320 320 320
+Encoding: 320 320 256
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
@@ -18991,12 +19264,13 @@ AnchorPoint: "below" 562 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 471 144 2
-Refer: 108 108 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 119 183 N 1 0 0 1 471 144 2
+Refer: 77 108 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Lslash
-Encoding: 321 321 321
+Encoding: 321 321 257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19079,8 +19353,9 @@ SplineSet
  215 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lslash
-Encoding: 322 322 322
+Encoding: 322 322 258
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19176,86 +19451,94 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: Nacute
-Encoding: 323 323 323
+Encoding: 323 323 259
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 33 373 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 33 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nacute
-Encoding: 324 324 324
+Encoding: 324 324 260
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 20.5 7 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 20.5 7 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncommaaccent
-Encoding: 325 325 325
+Encoding: 325 325 261
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 42 -2 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 42 -2 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ncommaaccent
-Encoding: 326 326 326
+Encoding: 326 326 262
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 48.5 -2 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 48.5 -2 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ncaron
-Encoding: 327 327 327
+Encoding: 327 327 263
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 996 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 42 373 2
-LCarets2: 1 0 
+Refer: 47 78 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 42 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ncaron
-Encoding: 328 328 328
+Encoding: 328 328 264
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 958 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 -12 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 -12 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: napostrophe
-Encoding: 329 329 329
+Encoding: 329 329 265
 Width: 1233
 Flags: W
 AnchorPoint: "below" 739 0 basechar 0
 AnchorPoint: "cedilla" 1081 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 123 0 2
-Refer: 700 700 N 1 0 0 1 -439 0 2
-LCarets2: 1 0 
+Refer: 79 110 N 1 0 0 1 123 0 2
+Refer: 616 700 N 1 0 0 1 -439 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Eng
-Encoding: 330 330 330
+Encoding: 330 330 266
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19342,8 +19625,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Latin lookup 0-1" Eng.alt
 EndChar
+
 StartChar: eng
-Encoding: 331 331 331
+Encoding: 331 331 267
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19429,8 +19713,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omacron
-Encoding: 332 332 332
+Encoding: 332 332 268
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19458,11 +19743,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omacron
-Encoding: 333 333 333
+Encoding: 333 333 269
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19478,11 +19764,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Obreve
-Encoding: 334 334 334
+Encoding: 334 334 270
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19506,11 +19793,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: obreve
-Encoding: 335 335 335
+Encoding: 335 335 271
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -19534,31 +19822,34 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ohungarumlaut
-Encoding: 336 336 336
+Encoding: 336 336 272
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ohungarumlaut
-Encoding: 337 337 337
+Encoding: 337 337 273
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: OE
-Encoding: 338 338 338
+Encoding: 338 338 274
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19653,8 +19944,9 @@ SplineSet
  590 1323 l 2,17,18
 EndSplineSet
 EndChar
+
 StartChar: oe
-Encoding: 339 339 339
+Encoding: 339 339 275
 Width: 1233
 Flags: W
 TtInstrs:
@@ -19784,7 +20076,7 @@ SplineSet
  557 821 557 821 517 908 c 128,-1,16
  477 995 477 995 373 995 c 0,17,18
  270 995 270 995 230 911.5 c 128,-1,19
- 190 828 190 828 190 559 c 0,20,21
+ 190 828 190 828 190 559 c 256,20,21
  190 290 190 290 230 206.5 c 128,-1,22
  270 123 270 123 373 123 c 0,11,12
 1210 514 m 1,23,-1
@@ -19802,7 +20094,7 @@ SplineSet
  585 36 585 36 521 3.5 c 128,-1,40
  457 -29 457 -29 373 -29 c 0,41,42
  184 -29 184 -29 99 109 c 128,-1,43
- 14 247 14 247 14 559 c 0,44,45
+ 14 247 14 247 14 559 c 256,44,45
  14 871 14 871 99 1009 c 128,-1,46
  184 1147 184 1147 373 1147 c 0,47,48
  462 1147 462 1147 526 1116 c 128,-1,49
@@ -19814,63 +20106,69 @@ SplineSet
  1210 514 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: Racute
-Encoding: 340 340 340
+Encoding: 340 340 276
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -75 373 2
-Refer: 82 82 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 3728 -1 N 1 0 0 1 -75 373 2
+Refer: 51 82 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: racute
-Encoding: 341 341 341
+Encoding: 341 341 277
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 454 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 206 7 2
-Refer: 114 114 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 116 180 N 1 0 0 1 206 7 2
+Refer: 83 114 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Rcommaaccent
-Encoding: 342 342 342
+Encoding: 342 342 278
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 113.5 -2 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 113.5 -2 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: rcommaaccent
-Encoding: 343 343 343
+Encoding: 343 343 279
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 -120 -2 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 -120 -2 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rcaron
-Encoding: 344 344 344
+Encoding: 344 344 280
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
 AnchorPoint: "cedilla" 1092 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 -60 367 2
-LCarets2: 1 0 
+Refer: 51 82 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 -60 367 2
+LCarets2: 1 0
 EndChar
+
 StartChar: rcaron
-Encoding: 345 345 345
+Encoding: 345 345 281
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -19878,120 +20176,131 @@ AnchorPoint: "above" 616 1120 basechar 0
 AnchorPoint: "cedilla" 454 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 90 0 2
-LCarets2: 1 0 
+Refer: 83 114 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 90 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Sacute
-Encoding: 346 346 346
+Encoding: 346 346 282
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 25 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 25 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: sacute
-Encoding: 347 347 347
+Encoding: 347 347 283
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 26.5 7 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 26.5 7 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scircumflex
-Encoding: 348 348 348
+Encoding: 348 348 284
 Width: 1233
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 373 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 373 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scircumflex
-Encoding: 349 349 349
+Encoding: 349 349 285
 Width: 1233
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scedilla
-Encoding: 350 350 350
+Encoding: 350 350 286
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scedilla
-Encoding: 351 351 351
+Encoding: 351 351 287
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Scaron
-Encoding: 352 352 352
+Encoding: 352 352 288
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: scaron
-Encoding: 353 353 353
+Encoding: 353 353 289
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tcommaaccent
-Encoding: 354 354 354
+Encoding: 354 354 290
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: tcommaaccent
-Encoding: 355 355 355
+Encoding: 355 355 291
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 121 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 121 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Tcaron
-Encoding: 356 356 356
+Encoding: 356 356 292
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20008,24 +20317,26 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 6 373 2
-LCarets2: 1 0 
+Refer: 53 84 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 6 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: tcaron
-Encoding: 357 357 357
+Encoding: 357 357 293
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 888 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
-Refer: 1114113 -1 N 1 0 0 1 276 24 2
-LCarets2: 1 0 
+Refer: 85 116 N 1 0 0 1 0 0 2
+Refer: 3726 -1 N 1 0 0 1 276 24 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Tbar
-Encoding: 358 358 358
+Encoding: 358 358 294
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20100,8 +20411,9 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tbar
-Encoding: 359 359 359
+Encoding: 359 359 295
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20207,8 +20519,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Utilde
-Encoding: 360 360 360
+Encoding: 360 360 296
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20233,11 +20546,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: utilde
-Encoding: 361 361 361
+Encoding: 361 361 297
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20261,11 +20575,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Umacron
-Encoding: 362 362 362
+Encoding: 362 362 298
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20294,11 +20609,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: umacron
-Encoding: 363 363 363
+Encoding: 363 363 299
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20315,11 +20631,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ubreve
-Encoding: 364 364 364
+Encoding: 364 364 300
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20343,11 +20660,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ubreve
-Encoding: 365 365 365
+Encoding: 365 365 301
 Width: 1233
 TtInstrs:
 PUSHB_5
@@ -20371,75 +20689,82 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uring
-Encoding: 366 366 366
+Encoding: 366 366 302
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 10 103 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 10 103 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uring
-Encoding: 367 367 367
+Encoding: 367 367 303
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 730 730 N 1 0 0 1 15 -45 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 15 -45 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Uhungarumlaut
-Encoding: 368 368 368
+Encoding: 368 368 304
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uhungarumlaut
-Encoding: 369 369 369
+Encoding: 369 369 305
 Width: 1233
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Uogonek
-Encoding: 370 370 370
+Encoding: 370 370 306
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
 EndChar
+
 StartChar: uogonek
-Encoding: 371 371 371
+Encoding: 371 371 307
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 731 731 N 1 0 0 1 407 0.166702 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 407 0.166702 2
 EndChar
+
 StartChar: Wcircumflex
-Encoding: 372 372 372
+Encoding: 372 372 308
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20456,11 +20781,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 915 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wcircumflex
-Encoding: 373 373 373
+Encoding: 373 373 309
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20477,11 +20803,12 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 883 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ycircumflex
-Encoding: 374 374 374
+Encoding: 374 374 310
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20498,22 +20825,24 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ycircumflex
-Encoding: 375 375 375
+Encoding: 375 375 311
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
 AnchorPoint: "cedilla" 282 -426 basechar 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 12 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 12 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Ydieresis
-Encoding: 376 376 376
+Encoding: 376 376 312
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20530,80 +20859,87 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 58 89 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: Zacute
-Encoding: 377 377 377
+Encoding: 377 377 313
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 27 373 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 27 373 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zacute
-Encoding: 378 378 378
+Encoding: 378 378 314
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 86 7 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 86 7 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zdotaccent
-Encoding: 379 379 379
+Encoding: 379 379 315
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 666 0 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zdotaccent
-Encoding: 380 380 380
+Encoding: 380 380 316
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zcaron
-Encoding: 381 381 381
+Encoding: 381 381 317
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 666 0 basechar 0
 AnchorPoint: "below" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 59 90 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: zcaron
-Encoding: 382 382 382
+Encoding: 382 382 318
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 91 122 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: longs
-Encoding: 383 383 383
+Encoding: 383 383 319
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20675,8 +21011,9 @@ SplineSet
  678 1322 678 1322 678.005 1219 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0180
-Encoding: 384 384 384
+Encoding: 384 384 320
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20720,8 +21057,9 @@ SplineSet
  918 345 918 345 918 559 c 128,-1,28
 EndSplineSet
 EndChar
+
 StartChar: uni0181
-Encoding: 385 385 385
+Encoding: 385 385 321
 Width: 1233
 Flags: W
 TtInstrs:
@@ -20832,8 +21170,9 @@ SplineSet
  189 1493 189 1493 338 1493 c 2,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0182
-Encoding: 386 386 386
+Encoding: 386 386 322
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20841,10 +21180,11 @@ AnchorPoint: "above" 616 1493 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 1041 1041 N 1 0 0 1 0 0 2
+Refer: 855 1041 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0183
-Encoding: 387 387 387
+Encoding: 387 387 323
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -20880,8 +21220,9 @@ SplineSet
  918 345 918 345 918 559 c 128,-1,20
 EndSplineSet
 EndChar
+
 StartChar: uni0184
-Encoding: 388 388 388
+Encoding: 388 388 324
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -20911,8 +21252,9 @@ SplineSet
  417 877 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0185
-Encoding: 389 389 389
+Encoding: 389 389 325
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 616 0 basechar 0
@@ -20947,8 +21289,9 @@ SplineSet
  438 977 l 1,13,14
 EndSplineSet
 EndChar
+
 StartChar: uni0186
-Encoding: 390 390 390
+Encoding: 390 390 326
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21027,8 +21370,9 @@ SplineSet
  139 1438 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0187
-Encoding: 391 391 391
+Encoding: 391 391 327
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -21063,8 +21407,9 @@ SplineSet
  994 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0188
-Encoding: 392 392 392
+Encoding: 392 392 328
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -21099,8 +21444,9 @@ SplineSet
  960 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0189
-Encoding: 393 393 393
+Encoding: 393 393 329
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -21108,10 +21454,11 @@ AnchorPoint: "above" 566 1493 basechar 0
 AnchorPoint: "cedilla" 566 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 208 208 N 1 0 0 1 0 0 2
+Refer: 144 208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni018A
-Encoding: 394 394 394
+Encoding: 394 394 330
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 0 basechar 0
@@ -21145,8 +21492,9 @@ SplineSet
  555 166 l 2,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni018B
-Encoding: 395 395 395
+Encoding: 395 395 331
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21177,8 +21525,9 @@ SplineSet
  200 1327 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018C
-Encoding: 396 396 396
+Encoding: 396 396 332
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -21214,8 +21563,9 @@ SplineSet
  324 1372 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018D
-Encoding: 397 397 397
+Encoding: 397 397 333
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -21261,8 +21611,9 @@ SplineSet
  941 84 941 84 898 51.4697 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni018E
-Encoding: 398 398 398
+Encoding: 398 398 334
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21331,8 +21682,9 @@ SplineSet
  1102 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni018F
-Encoding: 399 399 399
+Encoding: 399 399 335
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21418,19 +21770,20 @@ SplineSet
  869 1520 869 1520 992.5 1328 c 128,-1,15
  1116 1136 1116 1136 1116 745 c 0,16,17
  1116 355 1116 355 992.5 163 c 128,-1,18
- 869 -29 869 -29 616 -29 c 0,19,20
+ 869 -29 869 -29 616 -29 c 256,19,20
  363 -29 363 -29 240 162 c 128,-1,21
  117 353 117 353 117 745 c 2,0,-1
 332 644 m 1,22,23
  332 395.594 332 395.594 402 265.257 c 128,-1,24
- 471.915 135 471.915 135 619.958 135 c 0,25,26
+ 471.915 135 471.915 135 619.958 135 c 256,25,26
  768 135 768 135 831 262.5 c 128,-1,27
  894 390 894 390 903 644 c 1,28,-1
  332 644 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0190
-Encoding: 400 400 400
+Encoding: 400 400 336
 Width: 1233
 Flags: W
 TtInstrs:
@@ -21535,8 +21888,9 @@ SplineSet
  293 760 293 760 440 799 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0191
-Encoding: 401 401 401
+Encoding: 401 401 337
 Width: 1233
 Flags: W
 AnchorPoint: "below" 770 -426 basechar 0
@@ -21564,8 +21918,9 @@ SplineSet
  380 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: florin
-Encoding: 402 402 402
+Encoding: 402 402 338
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -21605,8 +21960,9 @@ SplineSet
  1063 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0193
-Encoding: 403 403 403
+Encoding: 403 403 339
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
@@ -21646,8 +22002,9 @@ SplineSet
  1053.5 123 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0194
-Encoding: 404 404 404
+Encoding: 404 404 340
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -21674,8 +22031,9 @@ SplineSet
  822 194.575 822 194.575 600.5 495 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0195
-Encoding: 405 405 405
+Encoding: 405 405 341
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21714,8 +22072,9 @@ SplineSet
  754.875 922.002 754.875 922.002 754.875 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0196
-Encoding: 406 406 406
+Encoding: 406 406 342
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21741,8 +22100,9 @@ SplineSet
  514 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0197
-Encoding: 407 407 407
+Encoding: 407 407 343
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -21776,8 +22136,9 @@ SplineSet
  201 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0198
-Encoding: 408 408 408
+Encoding: 408 408 344
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21809,8 +22170,9 @@ SplineSet
  646.556 1180 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0199
-Encoding: 409 409 409
+Encoding: 409 409 345
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1556 basechar 0
@@ -21842,8 +22204,9 @@ SplineSet
  236 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019A
-Encoding: 410 410 410
+Encoding: 410 410 346
 Width: 1233
 Flags: W
 AnchorPoint: "above" 562 1556 basechar 0
@@ -21877,8 +22240,9 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019B
-Encoding: 411 411 411
+Encoding: 411 411 347
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 1032 0 basechar 0
@@ -21906,8 +22270,9 @@ SplineSet
  578.858 1213.1 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019C
-Encoding: 412 412 412
+Encoding: 412 412 348
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21946,8 +22311,9 @@ SplineSet
  596 43 596 43 568 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni019D
-Encoding: 413 413 413
+Encoding: 413 413 349
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -21974,8 +22340,9 @@ SplineSet
  190 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019E
-Encoding: 414 414 414
+Encoding: 414 414 350
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -22003,8 +22370,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni019F
-Encoding: 415 415 415
+Encoding: 415 415 351
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22036,8 +22404,9 @@ SplineSet
  329.758 644 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: Ohorn
-Encoding: 416 416 416
+Encoding: 416 416 352
 Width: 1233
 Flags: W
 AnchorPoint: "above" 505 1493 basechar 0
@@ -22045,11 +22414,12 @@ AnchorPoint: "below" 505 0 basechar 0
 AnchorPoint: "cedilla" 505 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 377 420 2
-Refer: 79 79 N 1 0 0 1 -111 0 2
+Refer: 682 795 N 1 0 0 1 377 420 2
+Refer: 48 79 N 1 0 0 1 -111 0 2
 EndChar
+
 StartChar: ohorn
-Encoding: 417 417 417
+Encoding: 417 417 353
 Width: 1233
 Flags: W
 AnchorPoint: "below" 511 0 basechar 0
@@ -22057,11 +22427,12 @@ AnchorPoint: "above" 511 1120 basechar 0
 AnchorPoint: "cedilla" 511 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 387.5 0 2
-Refer: 111 111 N 1 0 0 1 -105 0 2
+Refer: 682 795 N 1 0 0 1 387.5 0 2
+Refer: 80 111 N 1 0 0 1 -105 0 2
 EndChar
+
 StartChar: uni01A2
-Encoding: 418 418 418
+Encoding: 418 418 354
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22094,8 +22465,9 @@ SplineSet
  693.225 1215 l 1,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni01A3
-Encoding: 419 419 419
+Encoding: 419 419 355
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -22129,8 +22501,9 @@ SplineSet
  261.588 639.325 261.588 639.325 261.588 559 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni01A4
-Encoding: 420 420 420
+Encoding: 420 420 356
 Width: 1233
 Flags: W
 AnchorPoint: "above" 748 1493 basechar 0
@@ -22166,8 +22539,9 @@ SplineSet
  669.25 766 l 2,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni01A5
-Encoding: 421 421 421
+Encoding: 421 421 357
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -22207,8 +22581,9 @@ SplineSet
  375 977 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni01A6
-Encoding: 422 422 422
+Encoding: 422 422 358
 Width: 1233
 Flags: W
 AnchorPoint: "cedilla" 1130 -264 basechar 0
@@ -22246,8 +22621,9 @@ SplineSet
  346 1063 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01A7
-Encoding: 423 423 423
+Encoding: 423 423 359
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22287,8 +22663,9 @@ SplineSet
  225 1442 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A8
-Encoding: 424 424 424
+Encoding: 424 424 360
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -22328,8 +22705,9 @@ SplineSet
  270 1081 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01A9
-Encoding: 425 425 425
+Encoding: 425 425 361
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -22337,10 +22715,11 @@ AnchorPoint: "below" 616 0 basechar 0
 AnchorPoint: "cedilla" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 931 931 N 1 0 0 1 0 0 2
+Refer: 760 931 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01AA
-Encoding: 426 426 426
+Encoding: 426 426 362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22372,8 +22751,9 @@ SplineSet
  765 1130 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AB
-Encoding: 427 427 427
+Encoding: 427 427 363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22409,8 +22789,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AC
-Encoding: 428 428 428
+Encoding: 428 428 364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22433,8 +22814,9 @@ SplineSet
  453 1327 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01AD
-Encoding: 429 429 429
+Encoding: 429 429 365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22467,8 +22849,9 @@ SplineSet
  614 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01AE
-Encoding: 430 430 430
+Encoding: 430 430 366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22491,26 +22874,29 @@ SplineSet
  47 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Uhorn
-Encoding: 431 431 431
+Encoding: 431 431 367
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 410 424 2
-Refer: 85 85 N 1 0 0 1 -138 0 2
+Refer: 682 795 N 1 0 0 1 410 424 2
+Refer: 54 85 N 1 0 0 1 -138 0 2
 EndChar
+
 StartChar: uhorn
-Encoding: 432 432 432
+Encoding: 432 432 368
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 795 795 N 1 0 0 1 380 0 2
-Refer: 117 117 N 1 0 0 1 -156 0 2
+Refer: 682 795 N 1 0 0 1 380 0 2
+Refer: 86 117 N 1 0 0 1 -156 0 2
 EndChar
+
 StartChar: uni01B1
-Encoding: 433 433 433
+Encoding: 433 433 369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22543,8 +22929,9 @@ SplineSet
  1159 1460 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B2
-Encoding: 434 434 434
+Encoding: 434 434 370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22569,8 +22956,9 @@ SplineSet
  775.09 0 775.09 0 505.5 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B3
-Encoding: 435 435 435
+Encoding: 435 435 371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22596,8 +22984,9 @@ SplineSet
  951 1285 951 1285 875 1140 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B4
-Encoding: 436 436 436
+Encoding: 436 436 372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22627,8 +23016,9 @@ SplineSet
  622 -104 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B5
-Encoding: 437 437 437
+Encoding: 437 437 373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22656,8 +23046,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B6
-Encoding: 438 438 438
+Encoding: 438 438 374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22685,8 +23076,9 @@ SplineSet
  222 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B7
-Encoding: 439 439 439
+Encoding: 439 439 375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22717,8 +23109,9 @@ SplineSet
  227.5 435 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01B8
-Encoding: 440 440 440
+Encoding: 440 440 376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22749,8 +23142,9 @@ SplineSet
  1005.5 292.378 1005.5 292.378 1005.5 435 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01B9
-Encoding: 441 441 441
+Encoding: 441 441 377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22781,8 +23175,9 @@ SplineSet
  518 476 518 476 624 476 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni01BA
-Encoding: 442 442 442
+Encoding: 442 442 378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22811,8 +23206,9 @@ SplineSet
  370 -274 370 -274 699 -274 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BB
-Encoding: 443 443 443
+Encoding: 443 443 379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22845,8 +23241,9 @@ SplineSet
  164 1421 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BC
-Encoding: 444 444 444
+Encoding: 444 444 380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22876,8 +23273,9 @@ SplineSet
  476.552 142 476.552 142 616 142 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BD
-Encoding: 445 445 445
+Encoding: 445 445 381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22905,8 +23303,9 @@ SplineSet
  294.714 -266 294.714 -266 518 -266 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BE
-Encoding: 446 446 446
+Encoding: 446 446 382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22938,8 +23337,9 @@ SplineSet
  844.003 306.321 844.003 306.321 845 439 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01BF
-Encoding: 447 447 447
+Encoding: 447 447 383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22964,8 +23364,9 @@ SplineSet
  310 60 l 17,15,16
 EndSplineSet
 EndChar
+
 StartChar: uni01C0
-Encoding: 448 448 448
+Encoding: 448 448 384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -22978,17 +23379,19 @@ SplineSet
  515.5 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C1
-Encoding: 449 449 449
+Encoding: 449 449 385
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 448 448 N 1 0 0 1 -202 0 2
-Refer: 448 448 N 1 0 0 1 202 0 2
+Refer: 384 448 N 1 0 0 1 -202 0 2
+Refer: 384 448 N 1 0 0 1 202 0 2
 EndChar
+
 StartChar: uni01C2
-Encoding: 450 450 450
+Encoding: 450 450 386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23017,131 +23420,148 @@ SplineSet
  515.5 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni01C3
-Encoding: 451 451 451
+Encoding: 451 451 387
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -1 0 2
+Refer: 2 33 N 1 0 0 1 -1 0 2
 EndChar
+
 StartChar: uni01C4
-Encoding: 452 452 452
+Encoding: 452 452 388
 Width: 2048
 LayerCount: 2
-LCarets2: 1 0 
+LCarets2: 1 0
 Colour: ffff00
 EndChar
+
 StartChar: uni01C5
-Encoding: 453 453 453
+Encoding: 453 453 389
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C6
-Encoding: 454 454 454
+Encoding: 454 454 390
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C7
-Encoding: 455 455 455
+Encoding: 455 455 391
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C8
-Encoding: 456 456 456
+Encoding: 456 456 392
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01C9
-Encoding: 457 457 457
+Encoding: 457 457 393
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CA
-Encoding: 458 458 458
+Encoding: 458 458 394
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CB
-Encoding: 459 459 459
+Encoding: 459 459 395
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CC
-Encoding: 460 460 460
+Encoding: 460 460 396
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni01CD
-Encoding: 461 461 461
+Encoding: 461 461 397
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CE
-Encoding: 462 462 462
+Encoding: 462 462 398
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01CF
-Encoding: 463 463 463
+Encoding: 463 463 399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 42 73 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D0
-Encoding: 464 464 464
+Encoding: 464 464 400
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D1
-Encoding: 465 465 465
+Encoding: 465 465 401
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D2
-Encoding: 466 466 466
+Encoding: 466 466 402
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D3
-Encoding: 467 467 467
+Encoding: 467 467 403
 Width: 1233
 Flags: W
 TtInstrs:
@@ -23168,263 +23588,293 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-LCarets2: 1 0 
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D4
-Encoding: 468 468 468
+Encoding: 468 468 404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 711 711 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni01D5
-Encoding: 469 469 469
+Encoding: 469 469 405
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 713 713 N 1 0 0 1 0 426 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
 EndChar
+
 StartChar: uni01D6
-Encoding: 470 470 470
+Encoding: 470 470 406
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 175 175 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01D7
-Encoding: 471 471 471
+Encoding: 471 471 407
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114115 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01D8
-Encoding: 472 472 472
+Encoding: 472 472 408
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 769 769 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01D9
-Encoding: 473 473 473
+Encoding: 473 473 409
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114119 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01DA
-Encoding: 474 474 474
+Encoding: 474 474 410
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 776 776 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
-Refer: 780 780 N 1 0 0 1 0 316 2
+Refer: 663 776 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+Refer: 667 780 N 1 0 0 1 0 316 2
 EndChar
+
 StartChar: uni01DB
-Encoding: 475 475 475
+Encoding: 475 475 411
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 85 85 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 515 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni01DC
-Encoding: 476 476 476
+Encoding: 476 476 412
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 0 316 2
-Refer: 252 252 N 1 0 0 1 0 0 2
+Refer: 655 768 N 1 0 0 1 0 316 2
+Refer: 188 252 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DD
-Encoding: 477 477 477
+Encoding: 477 477 413
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01DE
-Encoding: 478 478 478
+Encoding: 478 478 414
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01DF
-Encoding: 479 479 479
+Encoding: 479 479 415
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 228 228 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 164 228 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E0
-Encoding: 480 480 480
+Encoding: 480 480 416
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 1114123 -1 N 1 0 0 1 0 -124 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 3736 -1 N 1 0 0 1 0 -124 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E1
-Encoding: 481 481 481
+Encoding: 481 481 417
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 551 551 N 1 0 0 1 0 0 3
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 477 551 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni01E2
-Encoding: 482 482 482
+Encoding: 482 482 418
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 170 0 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 170 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E3
-Encoding: 483 483 483
+Encoding: 483 483 419
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gcaron
-Encoding: 486 486 486
+Encoding: 486 486 420
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gcaron
-Encoding: 487 487 487
+Encoding: 487 487 421
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E8
-Encoding: 488 488 488
+Encoding: 488 488 422
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01E9
-Encoding: 489 489 489
+Encoding: 489 489 423
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EA
-Encoding: 490 490 490
+Encoding: 490 490 424
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EB
-Encoding: 491 491 491
+Encoding: 491 491 425
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 28.5 -15.8333 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 639 731 N 1 0 0 1 28.5 -15.8333 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EC
-Encoding: 492 492 492
+Encoding: 492 492 426
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 490 490 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 424 490 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01ED
-Encoding: 493 493 493
+Encoding: 493 493 427
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 491 491 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 425 491 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EE
-Encoding: 494 494 494
+Encoding: 494 494 428
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01EF
-Encoding: 495 495 495
+Encoding: 495 495 429
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F0
-Encoding: 496 496 496
+Encoding: 496 496 430
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 35 -5 2
-Refer: 567 567 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 35 -5 2
+Refer: 493 567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F4
-Encoding: 500 500 500
+Encoding: 500 500 431
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F5
-Encoding: 501 501 501
+Encoding: 501 501 432
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F6
-Encoding: 502 502 502
+Encoding: 502 502 433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23455,310 +23905,345 @@ SplineSet
  830.749 135 830.749 135 877.05 135 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni01F8
-Encoding: 504 504 504
+Encoding: 504 504 434
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni01F9
-Encoding: 505 505 505
+Encoding: 505 505 435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: AEacute
-Encoding: 508 508 508
+Encoding: 508 508 436
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 240 373 2
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 240 373 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: aeacute
-Encoding: 509 509 509
+Encoding: 509 509 437
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Oslashacute
-Encoding: 510 510 510
+Encoding: 510 510 438
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 216 216 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 152 216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: oslashacute
-Encoding: 511 511 511
+Encoding: 511 511 439
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 248 248 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 184 248 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0200
-Encoding: 512 512 512
+Encoding: 512 512 440
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0201
-Encoding: 513 513 513
+Encoding: 513 513 441
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0202
-Encoding: 514 514 514
+Encoding: 514 514 442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0203
-Encoding: 515 515 515
+Encoding: 515 515 443
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0204
-Encoding: 516 516 516
+Encoding: 516 516 444
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0205
-Encoding: 517 517 517
+Encoding: 517 517 445
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0206
-Encoding: 518 518 518
+Encoding: 518 518 446
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0207
-Encoding: 519 519 519
+Encoding: 519 519 447
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0208
-Encoding: 520 520 520
+Encoding: 520 520 448
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0209
-Encoding: 521 521 521
+Encoding: 521 521 449
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020A
-Encoding: 522 522 522
+Encoding: 522 522 450
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020B
-Encoding: 523 523 523
+Encoding: 523 523 451
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 305 305 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020C
-Encoding: 524 524 524
+Encoding: 524 524 452
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020D
-Encoding: 525 525 525
+Encoding: 525 525 453
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020E
-Encoding: 526 526 526
+Encoding: 526 526 454
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni020F
-Encoding: 527 527 527
+Encoding: 527 527 455
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0210
-Encoding: 528 528 528
+Encoding: 528 528 456
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0211
-Encoding: 529 529 529
+Encoding: 529 529 457
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 150 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0212
-Encoding: 530 530 530
+Encoding: 530 530 458
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0213
-Encoding: 531 531 531
+Encoding: 531 531 459
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 150 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 150 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0214
-Encoding: 532 532 532
+Encoding: 532 532 460
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114125 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3738 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0215
-Encoding: 533 533 533
+Encoding: 533 533 461
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 783 783 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 670 783 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0216
-Encoding: 534 534 534
+Encoding: 534 534 462
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114121 -1 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3734 -1 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0217
-Encoding: 535 535 535
+Encoding: 535 535 463
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 785 785 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 672 785 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Scommaaccent
-Encoding: 536 536 536
+Encoding: 536 536 464
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: scommaaccent
-Encoding: 537 537 537
+Encoding: 537 537 465
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021A
-Encoding: 538 538 538
+Encoding: 538 538 466
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021B
-Encoding: 539 539 539
+Encoding: 539 539 467
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 806 806 N 1 0 0 1 89 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 693 806 N 1 0 0 1 89 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021C
-Encoding: 540 540 540
+Encoding: 540 540 468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23803,8 +24288,9 @@ SplineSet
  882 733 882 733 800 674 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021D
-Encoding: 541 541 541
+Encoding: 541 541 469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23855,24 +24341,27 @@ SplineSet
  924 570 924 570 782 461 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni021E
-Encoding: 542 542 542
+Encoding: 542 542 470
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni021F
-Encoding: 543 543 543
+Encoding: 543 543 471
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114119 -1 N 1 0 0 1 0 373 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3732 -1 N 1 0 0 1 0 373 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0220
-Encoding: 544 544 544
+Encoding: 544 544 472
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -23899,8 +24388,9 @@ SplineSet
  1085 1260.95 1085 1260.95 1085 998.75 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0221
-Encoding: 545 545 545
+Encoding: 545 545 473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23944,8 +24434,9 @@ SplineSet
  172.715 773 172.715 773 172.715 559 c 128,-1,42
 EndSplineSet
 EndChar
+
 StartChar: uni0224
-Encoding: 548 548 548
+Encoding: 548 548 474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23966,7 +24457,7 @@ SplineSet
  806 -270 l 2,14,15
  896 -270 896 -270 941 -208 c 0,16,17
  985 -146 985 -146 985 -20 c 2,18,-1
- 985 5.55112e-16 l 1,19,-1
+ 985 5.55112e-016 l 1,19,-1
  156 0 l 1,20,-1
  156 154 l 1,21,-1
  915 1323 l 1,22,-1
@@ -23974,8 +24465,9 @@ SplineSet
  178 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0225
-Encoding: 549 549 549
+Encoding: 549 549 475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -23987,7 +24479,7 @@ SplineSet
  397 150 l 1,3,-1
  1040 150 l 1,4,-1
  1040 0 l 1,5,-1
- 1032 -3.55271e-15 l 1,6,-1
+ 1032 -3.55271e-015 l 1,6,-1
  1032 -20 l 2,7,8
  1032 -215 1032 -215 943 -320 c 0,9,10
  853 -426 853 -426 688 -426 c 2,11,-1
@@ -23996,7 +24488,7 @@ SplineSet
  668 -270 l 2,14,15
  758 -270 758 -270 803 -208 c 0,16,17
  847 -146 847 -146 847 -20 c 2,18,-1
- 847 5.55112e-16 l 1,19,-1
+ 847 5.55112e-016 l 1,19,-1
  203 0 l 1,20,-1
  203 170 l 1,21,-1
  846 975 l 1,22,-1
@@ -24004,129 +24496,144 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0226
-Encoding: 550 550 550
+Encoding: 550 550 476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0227
-Encoding: 551 551 551
+Encoding: 551 551 477
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0228
-Encoding: 552 552 552
+Encoding: 552 552 478
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0229
-Encoding: 553 553 553
+Encoding: 553 553 479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 50 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022A
-Encoding: 554 554 554
+Encoding: 554 554 480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 249 2
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 249 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022B
-Encoding: 555 555 555
+Encoding: 555 555 481
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 246 246 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 182 246 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022C
-Encoding: 556 556 556
+Encoding: 556 556 482
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 245 2
-Refer: 713 713 N 1 0 0 1 0 426 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 245 2
+Refer: 625 713 N 1 0 0 1 0 426 2
 EndChar
+
 StartChar: uni022D
-Encoding: 557 557 557
+Encoding: 557 557 483
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 3.5 316 2
-Refer: 245 245 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 3.5 316 2
+Refer: 181 245 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022E
-Encoding: 558 558 558
+Encoding: 558 558 484
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni022F
-Encoding: 559 559 559
+Encoding: 559 559 485
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0230
-Encoding: 560 560 560
+Encoding: 560 560 486
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 713 713 N 1 0 0 1 0 426 2
-Refer: 1114123 -1 N 1 0 0 1 0 -124 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 625 713 N 1 0 0 1 0 426 2
+Refer: 3736 -1 N 1 0 0 1 0 -124 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0231
-Encoding: 561 561 561
+Encoding: 561 561 487
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 175 175 N 1 0 0 1 0 316 2
-Refer: 559 559 N 1 0 0 1 0 0 2
+Refer: 111 175 N 1 0 0 1 0 316 2
+Refer: 485 559 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0232
-Encoding: 562 562 562
+Encoding: 562 562 488
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0233
-Encoding: 563 563 563
+Encoding: 563 563 489
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0234
-Encoding: 564 564 564
+Encoding: 564 564 490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24155,8 +24662,9 @@ SplineSet
  713.5 -29 713.5 -29 664.5 -12 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0235
-Encoding: 565 565 565
+Encoding: 565 565 491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24196,8 +24704,9 @@ SplineSet
  714.999 406 l 2,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0236
-Encoding: 566 566 566
+Encoding: 566 566 492
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24232,8 +24741,9 @@ SplineSet
  614 406 l 2,5,6
 EndSplineSet
 EndChar
+
 StartChar: dotlessj
-Encoding: 567 567 567
+Encoding: 567 567 493
 Width: 1233
 Flags: W
 TtInstrs:
@@ -24302,8 +24812,9 @@ SplineSet
  600 -145 600 -145 600 -20 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0238
-Encoding: 568 568 568
+Encoding: 568 568 494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24352,8 +24863,9 @@ SplineSet
  671.7 977 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0239
-Encoding: 569 569 569
+Encoding: 569 569 495
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24402,8 +24914,9 @@ SplineSet
  561.3 141 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni023A
-Encoding: 570 570 570
+Encoding: 570 570 496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24421,7 +24934,7 @@ SplineSet
  432.448 389 l 1,9,-1
  302.473 203.407 l 1,10,-1
  246 0 l 1,11,-1
- 160.023 -4.44089e-15 l 1,12,-1
+ 160.023 -4.44089e-015 l 1,12,-1
  111 -70 l 1,13,-1
  8 0 l 1,14,-1
  59.5096 73.538 l 1,15,-1
@@ -24436,8 +24949,9 @@ SplineSet
  705.138 995.274 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023B
-Encoding: 571 571 571
+Encoding: 571 571 497
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24476,8 +24990,9 @@ SplineSet
  1073 53 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023C
-Encoding: 572 572 572
+Encoding: 572 572 498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24515,8 +25030,9 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni023D
-Encoding: 573 573 573
+Encoding: 573 573 499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24539,8 +25055,9 @@ SplineSet
  288 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023E
-Encoding: 574 574 574
+Encoding: 574 574 500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24569,8 +25086,9 @@ SplineSet
  514 686.702 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni023F
-Encoding: 575 575 575
+Encoding: 575 575 501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24615,8 +25133,9 @@ SplineSet
  893 1114 893 1114 973 1081 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0240
-Encoding: 576 576 576
+Encoding: 576 576 502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24644,8 +25163,9 @@ SplineSet
  227 1122 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0241
-Encoding: 577 577 577
+Encoding: 577 577 503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24675,8 +25195,9 @@ SplineSet
  373.75 1327 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0243
-Encoding: 579 579 579
+Encoding: 579 579 504
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -24723,8 +25244,9 @@ SplineSet
  369 366 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0244
-Encoding: 580 580 580
+Encoding: 580 580 505
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -24771,8 +25293,9 @@ SplineSet
  883 577 l 1,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0245
-Encoding: 581 581 581
+Encoding: 581 581 506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -24788,8 +25311,9 @@ SplineSet
  617 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024C
-Encoding: 588 588 588
+Encoding: 588 588 507
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
@@ -24829,8 +25353,9 @@ SplineSet
  430 1327 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni024D
-Encoding: 589 589 589
+Encoding: 589 589 508
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -24863,8 +25388,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0250
-Encoding: 592 592 592
+Encoding: 592 592 509
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -24907,8 +25433,9 @@ SplineSet
  154 332 154 332 154 479 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0251
-Encoding: 593 593 593
+Encoding: 593 593 510
 Width: 1233
 Flags: W
 TtInstrs:
@@ -24980,19 +25507,20 @@ SplineSet
  357 1147 357 1147 559 1147 c 0,14,15
  660 1147 660 1147 737 1103.5 c 128,-1,16
  814 1060 814 1060 858 977 c 1,0,-1
-317 559 m 0,17,18
+317 559 m 256,17,18
  317 345 317 345 385 236 c 128,-1,19
- 453 127 453 127 586 127 c 0,20,21
+ 453 127 453 127 586 127 c 256,20,21
  719 127 719 127 788.5 237 c 128,-1,22
  858 347 858 347 858 559 c 0,23,24
  858 772 858 772 788.5 881.5 c 128,-1,25
- 719 991 719 991 586 991 c 0,26,27
+ 719 991 719 991 586 991 c 256,26,27
  453 991 453 991 385 882 c 128,-1,28
- 317 773 317 773 317 559 c 0,17,18
+ 317 773 317 773 317 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0252
-Encoding: 594 594 594
+Encoding: 594 594 511
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25050,15 +25578,15 @@ AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-917 557 m 0,0,1
+917 557 m 256,0,1
  917 771 917 771 849 880 c 128,-1,2
- 781 989 781 989 648 989 c 0,3,4
+ 781 989 781 989 648 989 c 256,3,4
  515 989 515 989 445.5 879 c 128,-1,5
  376 769 376 769 376 557 c 0,6,7
  376 344 376 344 445.5 234.5 c 128,-1,8
- 515 125 515 125 648 125 c 0,9,10
+ 515 125 515 125 648 125 c 256,9,10
  781 125 781 125 849 234 c 128,-1,11
- 917 343 917 343 917 557 c 0,0,1
+ 917 343 917 343 917 557 c 256,0,1
 376 975 m 1,12,13
  422 1058 422 1058 498.5 1101.5 c 128,-1,14
  575 1145 575 1145 675 1145 c 0,15,16
@@ -25075,8 +25603,9 @@ SplineSet
  376 975 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0253
-Encoding: 595 595 595
+Encoding: 595 595 512
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25143,7 +25672,7 @@ AnchorPoint: "above" 652 1556 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-918 559 m 0,0,1
+918 559 m 256,0,1
  918 773 918 773 850 882 c 128,-1,2
  782 991 782 991 649 991 c 0,3,4
  515 991 515 991 446 881.5 c 128,-1,5
@@ -25151,7 +25680,7 @@ SplineSet
  377 347 377 347 446 237 c 128,-1,8
  515 127 515 127 649 127 c 0,9,10
  782 127 782 127 850 236 c 128,-1,11
- 918 345 918 345 918 559 c 0,0,1
+ 918 345 918 345 918 559 c 256,0,1
 377 977 m 1,12,13
  421 1059 421 1059 498.5 1103 c 128,-1,14
  576 1147 576 1147 678 1147 c 24,15,16
@@ -25174,8 +25703,9 @@ SplineSet
  377 977 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0254
-Encoding: 596 596 596
+Encoding: 596 596 513
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25237,7 +25767,7 @@ SplineSet
  258 1104 258 1104 336 1125.5 c 128,-1,2
  414 1147 414 1147 496 1147 c 0,3,4
  756 1147 756 1147 903 991 c 128,-1,5
- 1050 835 1050 835 1050 559 c 0,6,7
+ 1050 835 1050 835 1050 559 c 256,6,7
  1050 283 1050 283 903 127 c 128,-1,8
  756 -29 756 -29 496 -29 c 0,9,10
  416 -29 416 -29 339 -8 c 128,-1,11
@@ -25254,8 +25784,9 @@ SplineSet
  184 1061 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0255
-Encoding: 597 597 597
+Encoding: 597 597 514
 Width: 1233
 Flags: W
 AnchorPoint: "below" 691 0 basechar 0
@@ -25291,8 +25822,9 @@ SplineSet
  679 259 679 259 632 146 c 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni0256
-Encoding: 598 598 598
+Encoding: 598 598 515
 Width: 1233
 Flags: W
 AnchorPoint: "above" 601 1556 basechar 0
@@ -25331,8 +25863,9 @@ SplineSet
  714 1060 714 1060 750 977 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0257
-Encoding: 599 599 599
+Encoding: 599 599 516
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -25372,8 +25905,9 @@ SplineSet
  748 1002 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0258
-Encoding: 600 600 600
+Encoding: 600 600 517
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
@@ -25406,8 +25940,9 @@ SplineSet
  306 821 306 821 306 659 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0259
-Encoding: 601 601 601
+Encoding: 601 601 518
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25505,8 +26040,9 @@ SplineSet
  306 459 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni025A
-Encoding: 602 602 602
+Encoding: 602 602 519
 Width: 1233
 Flags: W
 AnchorPoint: "below" 410 0 basechar 0
@@ -25547,8 +26083,9 @@ SplineSet
  207.571 1147 207.571 1147 368 1147 c 0,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni025B
-Encoding: 603 603 603
+Encoding: 603 603 520
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25647,8 +26184,9 @@ SplineSet
  317 584 317 584 449 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025C
-Encoding: 604 604 604
+Encoding: 604 604 521
 Width: 1233
 Flags: W
 TtInstrs:
@@ -25750,8 +26288,9 @@ SplineSet
  902 632 902 632 783 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025D
-Encoding: 605 605 605
+Encoding: 605 605 522
 Width: 1233
 Flags: W
 AnchorPoint: "below" 370 0 basechar 0
@@ -25803,8 +26342,9 @@ SplineSet
  606.375 631.999 606.375 631.999 517.125 607 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni025E
-Encoding: 606 606 606
+Encoding: 606 606 523
 Width: 1233
 Flags: W
 AnchorPoint: "below" 630 0 basechar 0
@@ -25841,8 +26381,9 @@ SplineSet
  176 950.176 176 950.176 451 1099 c 0,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni025F
-Encoding: 607 607 607
+Encoding: 607 607 524
 Width: 1233
 Flags: W
 AnchorPoint: "below" 689 -426 basechar 0
@@ -25873,8 +26414,9 @@ SplineSet
  1137 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0260
-Encoding: 608 608 608
+Encoding: 608 608 525
 Width: 1233
 Flags: W
 AnchorPoint: "below" 574 -426 basechar 0
@@ -25921,8 +26463,9 @@ SplineSet
  752 363 752 363 752 569 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0261
-Encoding: 609 609 609
+Encoding: 609 609 526
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -25961,8 +26504,9 @@ SplineSet
  1076 72 l 2,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni0262
-Encoding: 610 610 610
+Encoding: 610 610 527
 Width: 1233
 Flags: W
 AnchorPoint: "below" 661 0 basechar 0
@@ -25994,8 +26538,9 @@ SplineSet
  866 156 866 156 946 178 c 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0263
-Encoding: 611 611 611
+Encoding: 611 611 528
 Width: 1233
 Flags: W
 AnchorPoint: "below" 622 -426 basechar 0
@@ -26029,8 +26574,9 @@ SplineSet
  497.246 -267.998 497.246 -267.998 610.469 -267.998 c 24,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0264
-Encoding: 612 612 612
+Encoding: 612 612 529
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26056,8 +26602,9 @@ SplineSet
  727 286 727 286 608 440 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0265
-Encoding: 613 613 613
+Encoding: 613 613 530
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26084,8 +26631,9 @@ SplineSet
  188.5 196 188.5 196 188.5 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0266
-Encoding: 614 614 614
+Encoding: 614 614 531
 Width: 1233
 Flags: W
 AnchorPoint: "above" 623 1556 basechar 0
@@ -26120,8 +26668,9 @@ SplineSet
  381 962 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0267
-Encoding: 615 615 615
+Encoding: 615 615 532
 Width: 1233
 Flags: W
 AnchorPoint: "above" 623 1556 basechar 0
@@ -26162,8 +26711,9 @@ SplineSet
  381 962 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0268
-Encoding: 616 616 616
+Encoding: 616 616 533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26195,8 +26745,9 @@ SplineSet
  238 1118 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0269
-Encoding: 617 617 617
+Encoding: 617 617 534
 Width: 1233
 Flags: W
 AnchorPoint: "above" 580 1120 basechar 0
@@ -26219,8 +26770,9 @@ SplineSet
  1034 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026A
-Encoding: 618 618 618
+Encoding: 618 618 535
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26243,8 +26795,9 @@ SplineSet
  160 1118 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni026B
-Encoding: 619 619 619
+Encoding: 619 619 536
 Width: 1233
 Flags: W
 AnchorPoint: "above" 568 1556 basechar 0
@@ -26283,8 +26836,9 @@ SplineSet
  658.5 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026C
-Encoding: 620 620 620
+Encoding: 620 620 537
 Width: 1233
 Flags: W
 AnchorPoint: "above" 592 1556 basechar 0
@@ -26321,8 +26875,9 @@ SplineSet
  498 786 l 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni026D
-Encoding: 621 621 621
+Encoding: 621 621 538
 Width: 1233
 Flags: W
 AnchorPoint: "above" 574 1556 basechar 0
@@ -26345,8 +26900,9 @@ SplineSet
  639 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026E
-Encoding: 622 622 622
+Encoding: 622 622 539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -26389,8 +26945,9 @@ SplineSet
  424 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni026F
-Encoding: 623 623 623
+Encoding: 623 623 540
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26428,8 +26985,9 @@ SplineSet
  590 41 590 41 562 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0270
-Encoding: 624 624 624
+Encoding: 624 624 541
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26467,8 +27025,9 @@ SplineSet
  590 41 590 41 562 112 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0271
-Encoding: 625 625 625
+Encoding: 625 625 542
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26512,8 +27071,9 @@ SplineSet
  645.122 1069.08 645.122 1069.08 670 1006 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0272
-Encoding: 626 626 626
+Encoding: 626 626 543
 Width: 1233
 Flags: W
 AnchorPoint: "below" 694 -426 basechar 0
@@ -26546,8 +27106,9 @@ SplineSet
  490 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0273
-Encoding: 627 627 627
+Encoding: 627 627 544
 Width: 1233
 Flags: W
 AnchorPoint: "below" 550 -426 basechar 0
@@ -26580,8 +27141,9 @@ SplineSet
  744 -234 744 -234 744 -20 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0274
-Encoding: 628 628 628
+Encoding: 628 628 545
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26602,8 +27164,9 @@ SplineSet
  144 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0275
-Encoding: 629 629 629
+Encoding: 629 629 546
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26634,8 +27197,9 @@ SplineSet
  880.677 315.092 880.677 315.092 895.263 447 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0276
-Encoding: 630 630 630
+Encoding: 630 630 547
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26669,8 +27233,9 @@ SplineSet
  596 973 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0277
-Encoding: 631 631 631
+Encoding: 631 631 548
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26707,8 +27272,9 @@ SplineSet
  1062 733.594 1062 733.594 1062 435 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0278
-Encoding: 632 632 632
+Encoding: 632 632 549
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -26753,8 +27319,9 @@ SplineSet
  452.544 162.672 452.544 162.672 532 138.621 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0279
-Encoding: 633 633 633
+Encoding: 633 633 550
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26779,8 +27346,9 @@ SplineSet
  152 231 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027A
-Encoding: 634 634 634
+Encoding: 634 634 551
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26805,8 +27373,9 @@ SplineSet
  152 231 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027B
-Encoding: 635 635 635
+Encoding: 635 635 552
 Width: 1233
 Flags: W
 AnchorPoint: "below" 566 -426 basechar 0
@@ -26837,8 +27406,9 @@ SplineSet
  895 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027C
-Encoding: 636 636 636
+Encoding: 636 636 553
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -26863,8 +27433,9 @@ SplineSet
  1155 889 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027D
-Encoding: 637 637 637
+Encoding: 637 637 554
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -26895,8 +27466,9 @@ SplineSet
  547 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027E
-Encoding: 638 638 638
+Encoding: 638 638 555
 Width: 1233
 Flags: W
 AnchorPoint: "below" 611.5 0 basechar 0
@@ -26921,8 +27493,9 @@ SplineSet
  520 741 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni027F
-Encoding: 639 639 639
+Encoding: 639 639 556
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -26947,8 +27520,9 @@ SplineSet
  712 953 712 953 712 741 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0280
-Encoding: 640 640 640
+Encoding: 640 640 557
 Width: 1233
 Flags: W
 AnchorPoint: "below" 512.5 0 basechar 0
@@ -26983,8 +27557,9 @@ SplineSet
  307 965 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0281
-Encoding: 641 641 641
+Encoding: 641 641 558
 Width: 1233
 Flags: W
 AnchorPoint: "above" 512.5 1120 basechar 0
@@ -27019,8 +27594,9 @@ SplineSet
  307 155 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0282
-Encoding: 642 642 642
+Encoding: 642 642 559
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27065,8 +27641,9 @@ SplineSet
  909 1117 909 1117 984 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0283
-Encoding: 643 643 643
+Encoding: 643 643 560
 Width: 1233
 Flags: W
 AnchorPoint: "below" 627 -426 basechar 0
@@ -27093,8 +27670,9 @@ SplineSet
  723 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0284
-Encoding: 644 644 644
+Encoding: 644 644 561
 Width: 1233
 Flags: W
 AnchorPoint: "above" 627 1556 basechar 0
@@ -27133,8 +27711,9 @@ SplineSet
  1076.5 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0285
-Encoding: 645 645 645
+Encoding: 645 645 562
 Width: 1233
 Flags: W
 AnchorPoint: "below" 632.5 -426 basechar 0
@@ -27161,8 +27740,9 @@ SplineSet
  723 906.938 723 906.938 723 712 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0286
-Encoding: 646 646 646
+Encoding: 646 646 563
 Width: 1233
 Flags: W
 AnchorPoint: "above" 627 1556 basechar 0
@@ -27196,8 +27776,9 @@ SplineSet
  763 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0287
-Encoding: 647 647 647
+Encoding: 647 647 564
 Width: 1233
 Flags: W
 AnchorPoint: "below" 676 -426 basechar 0
@@ -27226,8 +27807,9 @@ SplineSet
  584 -318 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0288
-Encoding: 648 648 648
+Encoding: 648 648 565
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -27256,8 +27838,9 @@ SplineSet
  614 1438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0289
-Encoding: 649 649 649
+Encoding: 649 649 566
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27296,8 +27879,9 @@ SplineSet
  886.656 311.231 886.656 311.231 894.591 452 c 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028A
-Encoding: 650 650 650
+Encoding: 650 650 567
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27332,8 +27916,9 @@ SplineSet
  95 956 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028B
-Encoding: 651 651 651
+Encoding: 651 651 568
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27365,8 +27950,9 @@ SplineSet
  643 974 643 974 597 986 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028C
-Encoding: 652 652 652
+Encoding: 652 652 569
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27384,8 +27970,9 @@ SplineSet
  1162 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028D
-Encoding: 653 653 653
+Encoding: 653 653 570
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27409,8 +27996,9 @@ SplineSet
  1218 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni028E
-Encoding: 654 654 654
+Encoding: 654 654 571
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27435,8 +28023,9 @@ SplineSet
  564 1224 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni028F
-Encoding: 655 655 655
+Encoding: 655 655 572
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27456,8 +28045,9 @@ SplineSet
  102 1149 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0290
-Encoding: 656 656 656
+Encoding: 656 656 573
 Width: 1233
 Flags: W
 AnchorPoint: "above" 540 1120 basechar 0
@@ -27486,8 +28076,9 @@ SplineSet
  213 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0291
-Encoding: 657 657 657
+Encoding: 657 657 574
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -114 basechar 0
@@ -27519,8 +28110,9 @@ SplineSet
  739 290 739 290 703 147 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0292
-Encoding: 658 658 658
+Encoding: 658 658 575
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27553,8 +28145,9 @@ SplineSet
  609 476 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0293
-Encoding: 659 659 659
+Encoding: 659 659 576
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -27594,8 +28187,9 @@ SplineSet
  773 -186 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0294
-Encoding: 660 660 660
+Encoding: 660 660 577
 Width: 1233
 Flags: W
 AnchorPoint: "below" 548 0 basechar 0
@@ -27623,8 +28217,9 @@ SplineSet
  446 798 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0295
-Encoding: 661 661 661
+Encoding: 661 661 578
 Width: 1233
 Flags: W
 AnchorPoint: "below" 682 0 basechar 0
@@ -27652,8 +28247,9 @@ SplineSet
  786 798 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0296
-Encoding: 662 662 662
+Encoding: 662 662 579
 Width: 1233
 Flags: W
 AnchorPoint: "above" 548 1556 basechar 0
@@ -27681,8 +28277,9 @@ SplineSet
  446 756 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0297
-Encoding: 663 663 663
+Encoding: 663 663 580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27711,8 +28308,9 @@ SplineSet
  194 1086 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0298
-Encoding: 664 664 664
+Encoding: 664 664 581
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
@@ -27749,8 +28347,9 @@ SplineSet
  503 520 503 520 503 567 c 0,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni0299
-Encoding: 665 665 665
+Encoding: 665 665 582
 Width: 1233
 Flags: W
 TtInstrs:
@@ -27835,8 +28434,9 @@ SplineSet
  209 1149 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029A
-Encoding: 666 666 666
+Encoding: 666 666 583
 Width: 1233
 Flags: W
 AnchorPoint: "above" 574 1120 basechar 0
@@ -27873,8 +28473,9 @@ SplineSet
  699 1145 699 1145 782 1099 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni029B
-Encoding: 667 667 667
+Encoding: 667 667 584
 Width: 1233
 Flags: W
 AnchorPoint: "above" 538 1556 basechar 0
@@ -27916,8 +28517,9 @@ SplineSet
  659 156 659 156 718 178 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029C
-Encoding: 668 668 668
+Encoding: 668 668 585
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -27940,8 +28542,9 @@ SplineSet
  144 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029D
-Encoding: 669 669 669
+Encoding: 669 669 586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -27953,15 +28556,15 @@ SplineSet
  665.5 1323 l 1,3,-1
  665.5 1556 l 1,0,-1
 849.5 1120 m 1,4,-1
- 849.5 -5.55112e-16 l 1,5,-1
+ 849.5 -5.55112e-016 l 1,5,-1
  1030.5 0 l 1,6,-1
  1030.5 -155 l 1,7,-1
  839.63 -154.657 l 1,8,9
  821.138 -267.409 821.138 -267.409 768 -330 c 0,10,11
  686.751 -425.707 686.751 -425.707 505.5 -426 c 0,12,13
  202.5 -426 202.5 -426 202.5 -205 c 0,14,15
- 202.5 -4.34885e-14 202.5 -4.34885e-14 472.5 0 c 2,16,-1
- 665.5 3.10862e-14 l 1,17,-1
+ 202.5 -4.34885e-014 202.5 -4.34885e-014 472.5 0 c 2,16,-1
+ 665.5 3.10862e-014 l 1,17,-1
  665.5 977 l 1,18,-1
  348.5 977 l 1,19,-1
  348.5 1120 l 1,20,-1
@@ -27974,8 +28577,9 @@ SplineSet
  645.067 -199.079 645.067 -199.079 654.513 -154.325 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029E
-Encoding: 670 670 670
+Encoding: 670 670 587
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -27997,8 +28601,9 @@ SplineSet
  1113.5 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni029F
-Encoding: 671 671 671
+Encoding: 671 671 588
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -28015,8 +28620,9 @@ SplineSet
  245 1147 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A0
-Encoding: 672 672 672
+Encoding: 672 672 589
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -28055,8 +28661,9 @@ SplineSet
  228.375 762 228.375 762 228.375 559 c 128,-1,31
 EndSplineSet
 EndChar
+
 StartChar: uni02A1
-Encoding: 673 673 673
+Encoding: 673 673 590
 Width: 1233
 Flags: W
 AnchorPoint: "above" 548 1556 basechar 0
@@ -28092,8 +28699,9 @@ SplineSet
  446 798 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A2
-Encoding: 674 674 674
+Encoding: 674 674 591
 Width: 1233
 Flags: W
 AnchorPoint: "above" 682 1556 basechar 0
@@ -28129,8 +28737,9 @@ SplineSet
  584 440 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A3
-Encoding: 675 675 675
+Encoding: 675 675 592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28172,8 +28781,9 @@ SplineSet
  654.301 973 l 1,44,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A4
-Encoding: 676 676 676
+Encoding: 676 676 593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28227,8 +28837,9 @@ SplineSet
  627 973 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A5
-Encoding: 677 677 677
+Encoding: 677 677 594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28256,7 +28867,7 @@ SplineSet
  902 435 902 435 1033.6 435 c 0,26,27
  1169.8 435 1169.8 435 1170.4 189 c 0,28,29
  1171 0 1171 0 970.6 0 c 2,30,-1
- 946.195 -4.99378e-06 l 1,31,32
+ 946.195 -4.99378e-006 l 1,31,32
  944.199 -51.0396 944.199 -51.0396 944.199 -111 c 1,33,-1
  852.4 -111 l 1,34,35
  852.4 -28.3187 852.4 -28.3187 853.491 -1 c 1,36,-1
@@ -28281,8 +28892,9 @@ SplineSet
  980.001 290.209 980.001 290.209 958.633 147 c 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A6
-Encoding: 678 678 678
+Encoding: 678 678 595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28337,8 +28949,9 @@ SplineSet
  998.399 1117 998.399 1117 1044 1087 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02A7
-Encoding: 679 679 679
+Encoding: 679 679 596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28382,8 +28995,9 @@ SplineSet
  675 154 l 1,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni02A8
-Encoding: 680 680 680
+Encoding: 680 680 597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28436,8 +29050,9 @@ SplineSet
  587.061 154 l 1,57,58
 EndSplineSet
 EndChar
+
 StartChar: uni02A9
-Encoding: 681 681 681
+Encoding: 681 681 598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28486,8 +29101,9 @@ SplineSet
  1095.1 908.004 1095.1 908.004 1095.1 676 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AA
-Encoding: 682 682 682
+Encoding: 682 682 599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28530,8 +29146,9 @@ SplineSet
  374.106 676.569 374.106 676.569 368 788 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AB
-Encoding: 683 683 683
+Encoding: 683 683 600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28555,8 +29172,9 @@ SplineSet
  357.375 973 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AC
-Encoding: 684 684 684
+Encoding: 684 684 601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28592,8 +29210,9 @@ SplineSet
  143.055 1311.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AD
-Encoding: 685 685 685
+Encoding: 685 685 602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28619,8 +29238,9 @@ SplineSet
  143 1311 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02AE
-Encoding: 686 686 686
+Encoding: 686 686 603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28648,8 +29268,9 @@ SplineSet
  817.242 -29 817.242 -29 644.25 -29 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni02AF
-Encoding: 687 687 687
+Encoding: 687 687 604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28683,8 +29304,9 @@ SplineSet
  445.5 448 l 2,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni02B0
-Encoding: 688 688 688
+Encoding: 688 688 605
 Width: 1233
 Flags: W
 TtInstrs:
@@ -28743,8 +29365,9 @@ SplineSet
  911.97 1176.48 911.97 1176.48 911.97 1046.56 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B1
-Encoding: 689 689 689
+Encoding: 689 689 606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28777,8 +29400,9 @@ SplineSet
  436.95 1196.38 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B2
-Encoding: 690 690 690
+Encoding: 690 690 607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28802,8 +29426,9 @@ SplineSet
  630.99 1539.36 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B3
-Encoding: 691 691 691
+Encoding: 691 691 608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28826,8 +29451,9 @@ SplineSet
  823.14 1198.88 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B4
-Encoding: 692 692 692
+Encoding: 692 692 609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28850,8 +29476,9 @@ SplineSet
  409.86 764.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B5
-Encoding: 693 693 693
+Encoding: 693 693 610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28884,8 +29511,9 @@ SplineSet
  337.41 764.32 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B6
-Encoding: 694 694 694
+Encoding: 694 694 611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28918,8 +29546,9 @@ SplineSet
  421.515 754.8 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B7
-Encoding: 695 695 695
+Encoding: 695 695 612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28941,8 +29570,9 @@ SplineSet
  143.055 1295.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02B8
-Encoding: 696 696 696
+Encoding: 696 696 613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -28965,39 +29595,44 @@ SplineSet
  649.891 609.76 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02B9
-Encoding: 697 697 697
+Encoding: 697 697 614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 884 884 N 1 0 0 1 0 0 2
+Refer: 722 884 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BB
-Encoding: 699 699 699
+Encoding: 699 699 615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8216 8216 N 1 0 0 1 0 0 2
+Refer: 1970 8216 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BC
-Encoding: 700 700 700
+Encoding: 700 700 616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8217 8217 N 1 0 0 1 0 0 2
+Refer: 1971 8217 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BD
-Encoding: 701 701 701
+Encoding: 701 701 617
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 788 788 N 1 0 0 1 0 0 2
+Refer: 675 788 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02BE
-Encoding: 702 702 702
+Encoding: 702 702 618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29016,8 +29651,9 @@ SplineSet
  594.5 1007 594.5 1007 479.5 1007 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02BF
-Encoding: 703 703 703
+Encoding: 703 703 619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29036,8 +29672,9 @@ SplineSet
  753.5 1068 753.5 1068 753.5 1007 c 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02C0
-Encoding: 704 704 704
+Encoding: 704 704 620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29063,8 +29700,9 @@ SplineSet
  509.085 1356.88 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C1
-Encoding: 705 705 705
+Encoding: 705 705 621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29090,8 +29728,9 @@ SplineSet
  723.285 1356.88 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circumflex
-Encoding: 710 710 710
+Encoding: 710 710 622
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29158,8 +29797,9 @@ SplineSet
  543 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: caron
-Encoding: 711 711 711
+Encoding: 711 711 623
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29226,8 +29866,9 @@ SplineSet
  543 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C8
-Encoding: 712 712 712
+Encoding: 712 712 624
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29261,16 +29902,18 @@ SplineSet
  684.5 1554 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02C9
-Encoding: 713 713 713
+Encoding: 713 713 625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CC
-Encoding: 716 716 716
+Encoding: 716 716 626
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29304,32 +29947,36 @@ SplineSet
  684.5 252 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02CD
-Encoding: 717 717 717
+Encoding: 717 717 627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni02CE
-Encoding: 718 718 718
+Encoding: 718 718 628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 EndChar
+
 StartChar: uni02CF
-Encoding: 719 719 719
+Encoding: 719 719 629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 EndChar
+
 StartChar: uni02D0
-Encoding: 720 720 720
+Encoding: 720 720 630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29345,8 +29992,9 @@ SplineSet
  616.5 330.199 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D1
-Encoding: 721 721 721
+Encoding: 721 721 631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29358,24 +30006,27 @@ SplineSet
  616.5 728.801 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D2
-Encoding: 722 722 722
+Encoding: 722 722 632
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 702 702 N 1 0 0 1 0 -497 2
+Refer: 618 702 N 1 0 0 1 0 -497 2
 EndChar
+
 StartChar: uni02D3
-Encoding: 723 723 723
+Encoding: 723 723 633
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 -497 2
+Refer: 619 703 N 1 0 0 1 0 -497 2
 EndChar
+
 StartChar: uni02D6
-Encoding: 726 726 726
+Encoding: 726 726 634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29396,8 +30047,9 @@ SplineSet
  542 629 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02D7
-Encoding: 727 727 727
+Encoding: 727 727 635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29410,26 +30062,29 @@ SplineSet
  842 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: breve
-Encoding: 728 728 728
+Encoding: 728 728 636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 661 774 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: dotaccent
-Encoding: 729 729 729
+Encoding: 729 729 637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 662 775 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: ring
-Encoding: 730 730 730
+Encoding: 730 730 638
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29511,29 +30166,30 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-891 1524 m 0,0,1
+891 1524 m 256,0,1
  891 1409 891 1409 811.5 1329 c 128,-1,2
  732 1249 732 1249 616 1249 c 0,3,4
  501 1249 501 1249 421.5 1329 c 128,-1,5
- 342 1409 342 1409 342 1524 c 0,6,7
+ 342 1409 342 1409 342 1524 c 256,6,7
  342 1639 342 1639 421.5 1718.5 c 128,-1,8
  501 1798 501 1798 616 1798 c 0,9,10
  732 1798 732 1798 811.5 1718.5 c 128,-1,11
- 891 1639 891 1639 891 1524 c 0,0,1
+ 891 1639 891 1639 891 1524 c 256,0,1
 768 1524 m 0,12,13
  768 1587 768 1587 724 1631 c 128,-1,14
- 680 1675 680 1675 616 1675 c 0,15,16
+ 680 1675 680 1675 616 1675 c 256,15,16
  552 1675 552 1675 508.5 1631.5 c 128,-1,17
  465 1588 465 1588 465 1524 c 0,18,19
  465 1459 465 1459 508.5 1415.5 c 128,-1,20
- 552 1372 552 1372 616 1372 c 0,21,22
+ 552 1372 552 1372 616 1372 c 256,21,22
  680 1372 680 1372 724 1416 c 128,-1,23
  768 1460 768 1460 768 1524 c 0,12,13
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: ogonek
-Encoding: 731 731 731
+Encoding: 731 731 639
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29591,8 +30247,9 @@ SplineSet
  473 -62 473 -62 528 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: tilde
-Encoding: 732 732 732
+Encoding: 732 732 640
 Width: 1233
 Flags: W
 TtInstrs:
@@ -29797,19 +30454,21 @@ SplineSet
  713 1309 713 1309 681 1323 c 128,-1,27
  649 1337 649 1337 612 1370 c 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: hungarumlaut
-Encoding: 733 733 733
+Encoding: 733 733 641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-LCarets2: 1 0 
+Refer: 666 779 N 1 0 0 1 0 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni02DE
-Encoding: 734 734 734
+Encoding: 734 734 642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29830,8 +30489,9 @@ SplineSet
  -351 868 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E0
-Encoding: 736 736 736
+Encoding: 736 736 643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29855,8 +30515,9 @@ SplineSet
  745 735 745 735 616 921 c 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni02E1
-Encoding: 737 737 737
+Encoding: 737 737 644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29877,8 +30538,9 @@ SplineSet
  644 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni02E2
-Encoding: 738 738 738
+Encoding: 738 738 645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29915,8 +30577,9 @@ SplineSet
  800 1310 800 1310 848 1293 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E3
-Encoding: 739 739 739
+Encoding: 739 739 646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29937,8 +30600,9 @@ SplineSet
  945 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E4
-Encoding: 740 740 740
+Encoding: 740 740 647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29964,8 +30628,9 @@ SplineSet
  723 1115 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E5
-Encoding: 741 741 741
+Encoding: 741 741 648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29980,8 +30645,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E6
-Encoding: 742 742 742
+Encoding: 742 742 649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -29998,8 +30664,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E7
-Encoding: 743 743 743
+Encoding: 743 743 650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30016,8 +30683,9 @@ SplineSet
  797 752 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E8
-Encoding: 744 744 744
+Encoding: 744 744 651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30034,8 +30702,9 @@ SplineSet
  797 444 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02E9
-Encoding: 745 745 745
+Encoding: 745 745 652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30050,64 +30719,71 @@ SplineSet
  797 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni02EE
-Encoding: 750 750 750
+Encoding: 750 750 653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8221 8221 N 1 0 0 1 0 0 3
+Refer: 1975 8221 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni02F3
-Encoding: 755 755 755
+Encoding: 755 755 654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: gravecomb
-Encoding: 768 768 768
+Encoding: 768 768 655
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: acutecomb
-Encoding: 769 769 769
+Encoding: 769 769 656
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0302
-Encoding: 770 770 770
+Encoding: 770 770 657
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 0 0 2
+Refer: 622 710 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: tildecomb
-Encoding: 771 771 771
+Encoding: 771 771 658
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0304
-Encoding: 772 772 772
+Encoding: 772 772 659
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30141,18 +30817,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0305
-Encoding: 773 773 773
+Encoding: 773 773 660
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0306
-Encoding: 774 774 774
+Encoding: 774 774 661
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30205,8 +30883,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0307
-Encoding: 775 775 775
+Encoding: 775 775 662
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30243,18 +30922,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0308
-Encoding: 776 776 776
+Encoding: 776 776 663
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: hookabovecomb
-Encoding: 777 777 777
+Encoding: 777 777 664
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30278,18 +30959,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030A
-Encoding: 778 778 778
+Encoding: 778 778 665
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 0 2
+Refer: 638 730 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030B
-Encoding: 779 779 779
+Encoding: 779 779 666
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30348,18 +31031,20 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030C
-Encoding: 780 780 780
+Encoding: 780 780 667
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 711 711 N 1 0 0 1 0 0 2
+Refer: 623 711 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030D
-Encoding: 781 781 781
+Encoding: 781 781 668
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30374,19 +31059,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030E
-Encoding: 782 782 782
+Encoding: 782 782 669
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 781 781 N 1 0 0 1 204 0 2
-Refer: 781 781 N 1 0 0 1 -204 0 2
+Refer: 668 781 N 1 0 0 1 204 0 2
+Refer: 668 781 N 1 0 0 1 -204 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni030F
-Encoding: 783 783 783
+Encoding: 783 783 670
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30406,19 +31093,21 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0310
-Encoding: 784 784 784
+Encoding: 784 784 671
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 0 204 2
-Refer: 728 728 N 1 0 0 1 0 0 2
+Refer: 637 729 N 1 0 0 1 0 204 2
+Refer: 636 728 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0311
-Encoding: 785 785 785
+Encoding: 785 785 672
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30439,8 +31128,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0312
-Encoding: 786 786 786
+Encoding: 786 786 673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30453,8 +31143,9 @@ SplineSet
  708 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0313
-Encoding: 787 787 787
+Encoding: 787 787 674
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30472,8 +31163,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0314
-Encoding: 788 788 788
+Encoding: 788 788 675
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30491,8 +31183,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0315
-Encoding: 789 789 789
+Encoding: 789 789 676
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -30507,28 +31200,31 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0316
-Encoding: 790 790 790
+Encoding: 790 790 677
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 -1846 2
+Refer: 65 96 N 1 0 0 1 98 -1846 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0317
-Encoding: 791 791 791
+Encoding: 791 791 678
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -98 -1846 2
+Refer: 116 180 N 1 0 0 1 -98 -1846 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0318
-Encoding: 792 792 792
+Encoding: 792 792 679
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30547,8 +31243,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0319
-Encoding: 793 793 793
+Encoding: 793 793 680
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30567,8 +31264,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031A
-Encoding: 794 794 794
+Encoding: 794 794 681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30583,8 +31281,9 @@ SplineSet
  725.5 1768 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031B
-Encoding: 795 795 795
+Encoding: 795 795 682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30607,8 +31306,9 @@ SplineSet
  481 817 481 817 419 872 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni031C
-Encoding: 796 796 796
+Encoding: 796 796 683
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30629,8 +31329,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031D
-Encoding: 797 797 797
+Encoding: 797 797 684
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30649,8 +31350,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031E
-Encoding: 798 798 798
+Encoding: 798 798 685
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30669,8 +31371,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni031F
-Encoding: 799 799 799
+Encoding: 799 799 686
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30693,8 +31396,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0320
-Encoding: 800 800 800
+Encoding: 800 800 687
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -30709,8 +31413,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0321
-Encoding: 801 801 801
+Encoding: 801 801 688
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30729,8 +31434,9 @@ SplineSet
  1051 128 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0322
-Encoding: 802 802 802
+Encoding: 802 802 689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -30749,8 +31455,9 @@ SplineSet
  182 128 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dotbelowcomb
-Encoding: 803 803 803
+Encoding: 803 803 690
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30786,8 +31493,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0324
-Encoding: 804 804 804
+Encoding: 804 804 691
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30837,8 +31545,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0325
-Encoding: 805 805 805
+Encoding: 805 805 692
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30876,29 +31585,30 @@ AnchorPoint: "below" 616 0 mark 0
 LayerCount: 2
 Fore
 SplineSet
-836 -282 m 0,0,1
+836 -282 m 256,0,1
  836 -374 836 -374 772.5 -438 c 128,-1,2
  709 -502 709 -502 616 -502 c 0,3,4
  524 -502 524 -502 460.5 -438 c 128,-1,5
- 397 -374 397 -374 397 -282 c 0,6,7
+ 397 -374 397 -374 397 -282 c 256,6,7
  397 -190 397 -190 460.5 -126.5 c 128,-1,8
  524 -63 524 -63 616 -63 c 0,9,10
  709 -63 709 -63 772.5 -126.5 c 128,-1,11
- 836 -190 836 -190 836 -282 c 0,0,1
+ 836 -190 836 -190 836 -282 c 256,0,1
 738 -282 m 0,12,13
  738 -232 738 -232 702.5 -196.5 c 128,-1,14
- 667 -161 667 -161 616 -161 c 0,15,16
+ 667 -161 667 -161 616 -161 c 256,15,16
  565 -161 565 -161 530 -196 c 128,-1,17
  495 -231 495 -231 495 -282 c 0,18,19
  495 -334 495 -334 530 -369 c 128,-1,20
- 565 -404 565 -404 616 -404 c 0,21,22
+ 565 -404 565 -404 616 -404 c 256,21,22
  667 -404 667 -404 702.5 -368.5 c 128,-1,23
  738 -333 738 -333 738 -282 c 0,12,13
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0326
-Encoding: 806 806 806
+Encoding: 806 806 693
 Width: 1233
 Flags: W
 TtInstrs:
@@ -30932,8 +31642,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0327
-Encoding: 807 807 807
+Encoding: 807 807 694
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31013,17 +31724,19 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0328
-Encoding: 808 808 808
+Encoding: 808 808 695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 731 731 N 1 0 0 1 10 0 2
+Refer: 639 731 N 1 0 0 1 10 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0329
-Encoding: 809 809 809
+Encoding: 809 809 696
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31038,8 +31751,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032A
-Encoding: 810 810 810
+Encoding: 810 810 697
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31058,8 +31772,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032B
-Encoding: 811 811 811
+Encoding: 811 811 698
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31082,8 +31797,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032C
-Encoding: 812 812 812
+Encoding: 812 812 699
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31128,8 +31844,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032D
-Encoding: 813 813 813
+Encoding: 813 813 700
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31174,8 +31891,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032E
-Encoding: 814 814 814
+Encoding: 814 814 701
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31228,8 +31946,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni032F
-Encoding: 815 815 815
+Encoding: 815 815 702
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31250,8 +31969,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0330
-Encoding: 816 816 816
+Encoding: 816 816 703
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31418,8 +32138,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0331
-Encoding: 817 817 817
+Encoding: 817 817 704
 Width: 1233
 Flags: W
 TtInstrs:
@@ -31453,32 +32174,36 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0332
-Encoding: 818 818 818
+Encoding: 818 818 705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0333
-Encoding: 819 819 819
+Encoding: 819 819 706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8215 8215 N 1 0 0 1 0 0 2
+Refer: 1969 8215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0334
-Encoding: 820 820 820
+Encoding: 820 820 707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0335
-Encoding: 821 821 821
+Encoding: 821 821 708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31491,8 +32216,9 @@ SplineSet
  1062 616 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0336
-Encoding: 822 822 822
+Encoding: 822 822 709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31505,8 +32231,9 @@ SplineSet
  0 452 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0337
-Encoding: 823 823 823
+Encoding: 823 823 710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31519,8 +32246,9 @@ SplineSet
  139 -96 l 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0338
-Encoding: 824 824 824
+Encoding: 824 824 711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31533,8 +32261,9 @@ SplineSet
  111 -70 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0339
-Encoding: 825 825 825
+Encoding: 825 825 712
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31555,8 +32284,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033A
-Encoding: 826 826 826
+Encoding: 826 826 713
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31575,8 +32305,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033B
-Encoding: 827 827 827
+Encoding: 827 827 714
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31596,8 +32327,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033C
-Encoding: 828 828 828
+Encoding: 828 828 715
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 mark 0
@@ -31620,8 +32352,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033D
-Encoding: 829 829 829
+Encoding: 829 829 716
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -31644,8 +32377,9 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033E
-Encoding: 830 830 830
+Encoding: 830 830 717
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
@@ -31676,35 +32410,39 @@ SplineSet
 EndSplineSet
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni033F
-Encoding: 831 831 831
+Encoding: 831 831 718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8254 8254 N 1 0 0 1 0 0 2
-Refer: 8254 8254 N 1 0 0 1 0 -240 2
+Refer: 1998 8254 N 1 0 0 1 0 0 2
+Refer: 1998 8254 N 1 0 0 1 0 -240 2
 EndChar
+
 StartChar: uni0343
-Encoding: 835 835 835
+Encoding: 835 835 719
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 mark 0
 LayerCount: 2
 Fore
-Refer: 787 787 N 1 0 0 1 0 0 2
+Refer: 674 787 N 1 0 0 1 0 0 2
 Position2: "'mark' Zero-Width Marks lookup" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0358
-Encoding: 856 856 856
+Encoding: 856 856 720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 729 729 N 1 0 0 1 513 0 2
+Refer: 637 729 N 1 0 0 1 513 0 2
 EndChar
+
 StartChar: uni0361
-Encoding: 865 865 865
+Encoding: 865 865 721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31723,8 +32461,9 @@ SplineSet
  671.5 1710 671.5 1710 616.5 1710 c 24,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0374
-Encoding: 884 884 884
+Encoding: 884 884 722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31737,8 +32476,9 @@ SplineSet
  492 1140 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0375
-Encoding: 885 885 885
+Encoding: 885 885 723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31751,24 +32491,27 @@ SplineSet
  741 72 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0376
-Encoding: 886 886 886
+Encoding: 886 886 724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1048 1048 N 1 0 0 1 0 0 3
+Refer: 862 1048 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0377
-Encoding: 887 887 887
+Encoding: 887 887 725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 3
+Refer: 894 1080 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037A
-Encoding: 890 890 890
+Encoding: 890 890 726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -31785,42 +32528,47 @@ SplineSet
  762 -426 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni037B
-Encoding: 891 891 891
+Encoding: 891 891 727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
+Refer: 513 596 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni037C
-Encoding: 892 892 892
+Encoding: 892 892 728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 135 -124 2
+Refer: 68 99 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 135 -124 2
 EndChar
+
 StartChar: uni037D
-Encoding: 893 893 893
+Encoding: 893 893 729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 596 596 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 -118 -124 2
+Refer: 513 596 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 -118 -124 2
 EndChar
+
 StartChar: uni037E
-Encoding: 894 894 894
+Encoding: 894 894 730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 59 59 N 1 0 0 1 0 0 2
+Refer: 28 59 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni037F
-Encoding: 895 895 895
+Encoding: 895 895 731
 Width: 1233
 Flags: W
 AnchorPoint: "below" 666 0 basechar 0
@@ -31828,131 +32576,146 @@ AnchorPoint: "above" 666 1493 basechar 0
 AnchorPoint: "cedilla" 666 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 3
+Refer: 43 74 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: tonos
-Encoding: 900 900 900
+Encoding: 900 900 732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dieresistonos
-Encoding: 901 901 901
+Encoding: 901 901 733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 370 2
 EndChar
+
 StartChar: Alphatonos
-Encoding: 902 902 902
+Encoding: 902 902 734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -450 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -450 0 2
 EndChar
+
 StartChar: anoteleia
-Encoding: 903 903 903
+Encoding: 903 903 735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Epsilontonos
-Encoding: 904 904 904
+Encoding: 904 904 736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -700 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: Etatonos
-Encoding: 905 905 905
+Encoding: 905 905 737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -750 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -750 0 2
 EndChar
+
 StartChar: Iotatonos
-Encoding: 906 906 906
+Encoding: 906 906 738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -700 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: Omicrontonos
-Encoding: 908 908 908
+Encoding: 908 908 739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -550 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: Upsilontonos
-Encoding: 910 910 910
+Encoding: 910 910 740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -875 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: Omegatonos
-Encoding: 911 911 911
+Encoding: 911 911 741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -525 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: iotadieresistonos
-Encoding: 912 912 912
+Encoding: 912 912 742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Alpha
-Encoding: 913 913 913
+Encoding: 913 913 743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Beta
-Encoding: 914 914 914
+Encoding: 914 914 744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Gamma
-Encoding: 915 915 915
+Encoding: 915 915 745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0394
-Encoding: 916 916 916
+Encoding: 916 916 746
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32020,32 +32783,36 @@ SplineSet
  1196 0 l 9,3,-1
 EndSplineSet
 EndChar
+
 StartChar: Epsilon
-Encoding: 917 917 917
+Encoding: 917 917 747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Zeta
-Encoding: 918 918 918
+Encoding: 918 918 748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Eta
-Encoding: 919 919 919
+Encoding: 919 919 749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Theta
-Encoding: 920 920 920
+Encoding: 920 920 750
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32112,7 +32879,7 @@ SplineSet
  417.42 881 l 1,2,-1
  815.58 881 l 9,3,-1
  815.58 711 l 17,0,-1
-905 745 m 0,4,5
+905 745 m 256,4,5
  905 1074 905 1074 837.5 1215 c 128,-1,6
  770 1356 770 1356 616 1356 c 0,7,8
  463 1356 463 1356 395.5 1215 c 128,-1,9
@@ -32120,10 +32887,10 @@ SplineSet
  328 417 328 417 395.5 276 c 128,-1,12
  463 135 463 135 616 135 c 0,13,14
  770 135 770 135 837.5 275.5 c 128,-1,15
- 905 416 905 416 905 745 c 0,4,5
+ 905 416 905 416 905 745 c 256,4,5
 1116 745 m 0,16,17
  1116 355 1116 355 992.5 163 c 128,-1,18
- 869 -29 869 -29 616 -29 c 0,19,20
+ 869 -29 869 -29 616 -29 c 256,19,20
  363 -29 363 -29 240 162 c 128,-1,21
  117 353 117 353 117 745 c 0,22,23
  117 1136 117 1136 240.5 1328 c 128,-1,24
@@ -32132,24 +32899,27 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: Iota
-Encoding: 921 921 921
+Encoding: 921 921 751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Kappa
-Encoding: 922 922 922
+Encoding: 922 922 752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Lambda
-Encoding: 923 923 923
+Encoding: 923 923 753
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32215,24 +32985,27 @@ SplineSet
  246 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Mu
-Encoding: 924 924 924
+Encoding: 924 924 754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Nu
-Encoding: 925 925 925
+Encoding: 925 925 755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Xi
-Encoding: 926 926 926
+Encoding: 926 926 756
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32297,32 +33070,36 @@ SplineSet
  1096 170 l 25,8,-1
 EndSplineSet
 EndChar
+
 StartChar: Omicron
-Encoding: 927 927 927
+Encoding: 927 927 757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Pi
-Encoding: 928 928 928
+Encoding: 928 928 758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1055 1055 N 1 0 0 1 0 0 2
+Refer: 869 1055 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Rho
-Encoding: 929 929 929
+Encoding: 929 929 759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Sigma
-Encoding: 931 931 931
+Encoding: 931 931 760
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32405,24 +33182,27 @@ SplineSet
  786 747 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tau
-Encoding: 932 932 932
+Encoding: 932 932 761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilon
-Encoding: 933 933 933
+Encoding: 933 933 762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Phi
-Encoding: 934 934 934
+Encoding: 934 934 763
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32544,16 +33324,18 @@ SplineSet
  437.89 477.637 437.89 477.637 514 461.826 c 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: Chi
-Encoding: 935 935 935
+Encoding: 935 935 764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Psi
-Encoding: 936 936 936
+Encoding: 936 936 765
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32645,8 +33427,9 @@ SplineSet
  717 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Omega
-Encoding: 937 937 937
+Encoding: 937 937 766
 Width: 1233
 Flags: W
 TtInstrs:
@@ -32736,7 +33519,7 @@ SplineSet
  816 248 816 248 883 412.5 c 128,-1,20
  950 577 950 577 950 799 c 0,21,22
  950 1029 950 1029 860 1161.5 c 128,-1,23
- 770 1294 770 1294 616 1294 c 0,24,25
+ 770 1294 770 1294 616 1294 c 256,24,25
  462 1294 462 1294 372.5 1161.5 c 128,-1,26
  283 1029 283 1029 283 799 c 0,27,28
  283 577 283 577 350 412.5 c 128,-1,29
@@ -32745,71 +33528,79 @@ SplineSet
  74 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Iotadieresis
-Encoding: 938 938 938
+Encoding: 938 938 767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Upsilondieresis
-Encoding: 939 939 939
+Encoding: 939 939 768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alphatonos
-Encoding: 940 940 940
+Encoding: 940 940 769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: epsilontonos
-Encoding: 941 941 941
+Encoding: 941 941 770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: etatonos
-Encoding: 942 942 942
+Encoding: 942 942 771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: iotatonos
-Encoding: 943 943 943
+Encoding: 943 943 772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresistonos
-Encoding: 944 944 944
+Encoding: 944 944 773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: alpha
-Encoding: 945 945 945
+Encoding: 945 945 774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32845,8 +33636,9 @@ SplineSet
  809.801 1150.23 809.801 1150.23 869.15 826.833 c 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: beta
-Encoding: 946 946 946
+Encoding: 946 946 775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32873,8 +33665,9 @@ SplineSet
  336.7 342 l 1,15,16
 EndSplineSet
 EndChar
+
 StartChar: gamma
-Encoding: 947 947 947
+Encoding: 947 947 776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32896,8 +33689,9 @@ SplineSet
  220.5 836 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: delta
-Encoding: 948 948 948
+Encoding: 948 948 777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32939,16 +33733,18 @@ SplineSet
  291 1034 291 1034 334 1066.53 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: epsilon
-Encoding: 949 949 949
+Encoding: 949 949 778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 603 603 N 1 0 0 1 0 0 2
+Refer: 520 603 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: zeta
-Encoding: 950 950 950
+Encoding: 950 950 779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -32974,8 +33770,9 @@ SplineSet
  382 127 382 127 760 127 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: eta
-Encoding: 951 951 951
+Encoding: 951 951 780
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33048,8 +33845,9 @@ SplineSet
  1051 922 1051 922 1051 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: theta
-Encoding: 952 952 952
+Encoding: 952 952 781
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33126,7 +33924,7 @@ SplineSet
  476 129.072 476 129.072 616 129.072 c 0,14,15
  757 129.072 757 129.072 829 282.81 c 24,16,17
  893.082 419.641 893.082 419.641 899 644 c 9,9,-1
-616 1500 m 0,18,19
+616 1500 m 256,18,19
  849 1500 849 1500 972.5 1303.7 c 128,-1,20
  1096 1107.4 1096 1107.4 1096 735.6 c 0,21,22
  1096 362.5 1096 362.5 973 166.85 c 128,-1,23
@@ -33134,13 +33932,16 @@ SplineSet
  383 -28.7998 383 -28.7998 260 166.85 c 128,-1,26
  137 362.5 137 362.5 137 735.6 c 0,27,28
  137 1107.4 137 1107.4 260 1303.7 c 128,-1,29
- 383 1500 383 1500 616 1500 c 0,18,19
+ 383 1500 383 1500 616 1500 c 256,18,19
 EndSplineSet
 EndChar
+
 StartChar: iota
-Encoding: 953 953 953
+Encoding: 953 953 782
 Width: 1233
 Flags: W
+HStem: 0 156<747.782 975> 977 143<310 520>
+VStem: 520.5 188<194.322 977>
 TtInstrs:
 NPUSHB
  6
@@ -33190,16 +33991,18 @@ SplineSet
  708.5 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: kappa
-Encoding: 954 954 954
+Encoding: 954 954 783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 3
+Refer: 248 312 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: lambda
-Encoding: 955 955 955
+Encoding: 955 955 784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33220,16 +34023,18 @@ SplineSet
  579.251 1547.44 579.251 1547.44 641.5 1381 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03BC
-Encoding: 956 956 956
+Encoding: 956 956 785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 181 181 N 1 0 0 1 0 0 2
+Refer: 117 181 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: nu
-Encoding: 957 957 957
+Encoding: 957 957 786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33251,8 +34056,9 @@ SplineSet
  458 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: xi
-Encoding: 958 958 958
+Encoding: 958 958 787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33283,18 +34089,22 @@ SplineSet
  348.957 131.096 348.957 131.096 785 127 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: omicron
-Encoding: 959 959 959
+Encoding: 959 959 788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: pi
-Encoding: 960 960 960
+Encoding: 960 960 789
 Width: 1233
 Flags: W
+HStem: -39 152<1036 1180.91> 0 21G<223 403> 936 184<80 223 403 831 1012 1153>
+VStem: 223 180<0 936> 831 181<145.494 936>
 LayerCount: 2
 Fore
 SplineSet
@@ -33321,8 +34131,9 @@ SplineSet
  80 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rho
-Encoding: 961 961 961
+Encoding: 961 961 790
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33388,7 +34199,7 @@ SplineSet
  190 540 l 2,13,14
  190 856 190 856 300 990 c 24,15,16
  431.259 1146.98 431.259 1146.98 644 1147 c 0,0,1
-915 559 m 0,17,18
+915 559 m 256,17,18
  915 773 915 773 847.5 882 c 128,-1,19
  780 991 780 991 647 991 c 0,20,21
  513 991 513 991 444 881.5 c 128,-1,22
@@ -33396,11 +34207,12 @@ SplineSet
  375 347 375 347 444 237 c 128,-1,25
  513 127 513 127 647 127 c 0,26,27
  780 127 780 127 847.5 236 c 128,-1,28
- 915 345 915 345 915 559 c 0,17,18
+ 915 345 915 345 915 559 c 256,17,18
 EndSplineSet
 EndChar
+
 StartChar: sigma1
-Encoding: 962 962 962
+Encoding: 962 962 791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33431,8 +34243,9 @@ SplineSet
  576.192 128.789 576.192 128.789 748 127 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: sigma
-Encoding: 963 963 963
+Encoding: 963 963 792
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33512,8 +34325,9 @@ SplineSet
  890 936 l 1,14,15
 EndSplineSet
 EndChar
+
 StartChar: tau
-Encoding: 964 964 964
+Encoding: 964 964 793
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33571,8 +34385,9 @@ SplineSet
  708.5 249.652 708.5 249.652 742.5 204 c 16,0,1
 EndSplineSet
 EndChar
+
 StartChar: upsilon
-Encoding: 965 965 965
+Encoding: 965 965 794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33599,8 +34414,9 @@ SplineSet
  520 156 520 156 628 156 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: phi
-Encoding: 966 966 966
+Encoding: 966 966 795
 Width: 1233
 Flags: W
 TtInstrs:
@@ -33715,8 +34531,9 @@ SplineSet
  525 1128 525 1128 773 1128 c 8,11,12
 EndSplineSet
 EndChar
+
 StartChar: chi
-Encoding: 967 967 967
+Encoding: 967 967 796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33745,8 +34562,9 @@ SplineSet
  816.646 -426 816.646 -426 750.5 -250.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: psi
-Encoding: 968 968 968
+Encoding: 968 968 797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33775,8 +34593,9 @@ SplineSet
  708 140 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: omega
-Encoding: 969 969 969
+Encoding: 969 969 798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33808,53 +34627,59 @@ SplineSet
  1033 1120 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: iotadieresis
-Encoding: 970 970 970
+Encoding: 970 970 799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilondieresis
-Encoding: 971 971 971
+Encoding: 971 971 800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omicrontonos
-Encoding: 972 972 972
+Encoding: 972 972 801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: upsilontonos
-Encoding: 973 973 973
+Encoding: 973 973 802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: omegatonos
-Encoding: 974 974 974
+Encoding: 974 974 803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni03D0
-Encoding: 976 976 976
+Encoding: 976 976 804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33883,8 +34708,9 @@ SplineSet
  969.09 590 969.09 590 653 730 c 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: theta1
-Encoding: 977 977 977
+Encoding: 977 977 805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33913,8 +34739,9 @@ SplineSet
  904.93 471.523 904.93 471.523 909.758 710 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: Upsilon1
-Encoding: 978 978 978
+Encoding: 978 978 806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33939,26 +34766,29 @@ SplineSet
  954.966 1181.53 954.966 1181.53 941.079 1296.95 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D3
-Encoding: 979 979 979
+Encoding: 979 979 807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 900 900 N 1 0 0 1 -875 0 2
+Refer: 806 978 N 1 0 0 1 0 0 2
+Refer: 732 900 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni03D4
-Encoding: 980 980 980
+Encoding: 980 980 808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 978 978 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 806 978 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: phi1
-Encoding: 981 981 981
+Encoding: 981 981 809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -33993,8 +34823,9 @@ SplineSet
  425.166 168.092 425.166 168.092 524 141.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: omega1
-Encoding: 982 982 982
+Encoding: 982 982 810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34023,8 +34854,9 @@ SplineSet
  1110.5 936 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D7
-Encoding: 983 983 983
+Encoding: 983 983 811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34059,8 +34891,9 @@ SplineSet
  888 -372 888 -372 957 -10 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D8
-Encoding: 984 984 984
+Encoding: 984 984 812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34089,8 +34922,9 @@ SplineSet
  514 -426 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03D9
-Encoding: 985 985 985
+Encoding: 985 985 813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34119,8 +34953,9 @@ SplineSet
  877.709 3.50293 877.709 3.50293 708 -23 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DA
-Encoding: 986 986 986
+Encoding: 986 986 814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34149,8 +34984,9 @@ SplineSet
  743 1323 l 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DB
-Encoding: 987 987 987
+Encoding: 987 987 815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34179,16 +35015,18 @@ SplineSet
  1065 964 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03DC
-Encoding: 988 988 988
+Encoding: 988 988 816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 3
+Refer: 39 70 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03DD
-Encoding: 989 989 989
+Encoding: 989 989 817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34221,8 +35059,9 @@ SplineSet
  430 -113.331 430 -113.331 430 0 c 10,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DE
-Encoding: 990 990 990
+Encoding: 990 990 818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34247,8 +35086,9 @@ SplineSet
  502.216 1340.82 502.216 1340.82 483 1159 c 26,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03DF
-Encoding: 991 991 991
+Encoding: 991 991 819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34265,8 +35105,9 @@ SplineSet
  1101 880 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E0
-Encoding: 992 992 992
+Encoding: 992 992 820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34296,8 +35137,9 @@ SplineSet
  460 1355 460 1355 385 1355 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03E1
-Encoding: 993 993 993
+Encoding: 993 993 821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34322,8 +35164,9 @@ SplineSet
  848 308 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03F0
-Encoding: 1008 1008 1008
+Encoding: 1008 1008 822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34360,8 +35203,9 @@ SplineSet
  492 409 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni03F1
-Encoding: 1009 1009 1009
+Encoding: 1009 1009 823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34393,24 +35237,27 @@ SplineSet
  915 345 915 345 915 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03F2
-Encoding: 1010 1010 1010
+Encoding: 1010 1010 824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 3
+Refer: 68 99 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F3
-Encoding: 1011 1011 1011
+Encoding: 1011 1011 825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 3
+Refer: 75 106 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F4
-Encoding: 1012 1012 1012
+Encoding: 1012 1012 826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34439,8 +35286,9 @@ SplineSet
  1116 1136 1116 1136 1116 745 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni03F5
-Encoding: 1013 1013 1013
+Encoding: 1013 1013 827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34470,8 +35318,9 @@ SplineSet
  1033 942 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F6
-Encoding: 1014 1014 1014
+Encoding: 1014 1014 828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34501,32 +35350,36 @@ SplineSet
  198.992 954.997 198.992 954.997 162 942 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni03F7
-Encoding: 1015 1015 1015
+Encoding: 1015 1015 829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 222 222 N 1 0 0 1 0 0 3
+Refer: 158 222 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F8
-Encoding: 1016 1016 1016
+Encoding: 1016 1016 830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 254 254 N 1 0 0 1 0 0 3
+Refer: 190 254 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03F9
-Encoding: 1017 1017 1017
+Encoding: 1017 1017 831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 3
+Refer: 36 67 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni03FA
-Encoding: 1018 1018 1018
+Encoding: 1018 1018 832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34548,8 +35401,9 @@ SplineSet
  86 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FB
-Encoding: 1019 1019 1019
+Encoding: 1019 1019 833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34571,8 +35425,9 @@ SplineSet
  127 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FC
-Encoding: 1020 1020 1020
+Encoding: 1020 1020 834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34609,8 +35464,9 @@ SplineSet
  915 345 915 345 915 559 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni03FD
-Encoding: 1021 1021 1021
+Encoding: 1021 1021 835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34637,44 +35493,49 @@ SplineSet
  216 12 216 12 139 53 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni03FE
-Encoding: 1022 1022 1022
+Encoding: 1022 1022 836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1017 1017 N 1 0 0 1 0 0 3
-Refer: 183 183 N 1 0 0 1 139 0 2
+Refer: 831 1017 N 1 0 0 1 0 0 3
+Refer: 119 183 N 1 0 0 1 139 0 2
 EndChar
+
 StartChar: uni03FF
-Encoding: 1023 1023 1023
+Encoding: 1023 1023 837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 183 183 N 1 0 0 1 -157 0 2
-Refer: 1021 1021 N 1 0 0 1 0 0 2
+Refer: 119 183 N 1 0 0 1 -157 0 2
+Refer: 835 1021 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0400
-Encoding: 1024 1024 1024
+Encoding: 1024 1024 838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0401
-Encoding: 1025 1025 1025
+Encoding: 1025 1025 839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 56 373 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 56 373 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0402
-Encoding: 1026 1026 1026
+Encoding: 1026 1026 840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34714,17 +35575,19 @@ SplineSet
  576 -466 576 -466 573 -287 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0403
-Encoding: 1027 1027 1027
+Encoding: 1027 1027 841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 72 373 2
-Refer: 1043 1043 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 72 373 2
+Refer: 857 1043 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0404
-Encoding: 1028 1028 1028
+Encoding: 1028 1028 842
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34810,17 +35673,17 @@ Fore
 SplineSet
 350 661 m 1,0,1
  354 433 354 433 450 284 c 128,-1,2
- 546 135 546 135 734.705 135 c 0,3,4
+ 546 135 546 135 734.705 135 c 256,3,4
  923.41 135 923.41 135 1073 260 c 1,5,-1
  1073 53 l 1,6,7
  919 -29 919 -29 743 -29 c 0,8,9
  456 -29 456 -29 297.5 174 c 128,-1,10
- 139 377 139 377 139 744 c 0,11,12
+ 139 377 139 377 139 744 c 256,11,12
  139 1111 139 1111 298.5 1315.5 c 128,-1,13
  458 1520 458 1520 743 1520 c 0,14,15
  919 1520 919 1520 1073 1438 c 1,16,-1
  1073 1231 l 1,17,18
- 921.361 1356 921.361 1356 731.18 1356 c 0,19,20
+ 921.361 1356 921.361 1356 731.18 1356 c 256,19,20
  541 1356 541 1356 459.5 1222 c 128,-1,21
  378 1088 378 1088 355 831 c 1,22,-1
  982 831 l 1,23,-1
@@ -34828,24 +35691,27 @@ SplineSet
  350 661 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0405
-Encoding: 1029 1029 1029
+Encoding: 1029 1029 843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0406
-Encoding: 1030 1030 1030
+Encoding: 1030 1030 844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0407
-Encoding: 1031 1031 1031
+Encoding: 1031 1031 845
 Width: 1233
 Flags: W
 TtInstrs:
@@ -34860,19 +35726,21 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1030 1030 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 844 1030 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni0408
-Encoding: 1032 1032 1032
+Encoding: 1032 1032 846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0409
-Encoding: 1033 1033 1033
+Encoding: 1033 1033 847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34908,8 +35776,9 @@ SplineSet
  801 1493 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040A
-Encoding: 1034 1034 1034
+Encoding: 1034 1034 848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34943,8 +35812,9 @@ SplineSet
  615 0 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040B
-Encoding: 1035 1035 1035
+Encoding: 1035 1035 849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -34977,35 +35847,39 @@ SplineSet
  383 1325 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni040C
-Encoding: 1036 1036 1036
+Encoding: 1036 1036 850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 27 373 2
-Refer: 1050 1050 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 27 373 2
+Refer: 864 1050 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040D
-Encoding: 1037 1037 1037
+Encoding: 1037 1037 851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040E
-Encoding: 1038 1038 1038
+Encoding: 1038 1038 852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni040F
-Encoding: 1039 1039 1039
+Encoding: 1039 1039 853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -35026,16 +35900,18 @@ SplineSet
  137 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0410
-Encoding: 1040 1040 1040
+Encoding: 1040 1040 854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0411
-Encoding: 1041 1041 1041
+Encoding: 1041 1041 855
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35107,7 +35983,7 @@ SplineSet
  604 877 l 1,12,13
  982.571 862.441 982.571 862.441 1084 671 c 0,14,15
  1137 570.76 1137 570.76 1137 410 c 0,16,17
- 1137 206.996 1137 206.996 1004 103.5 c 0,18,19
+ 1137 206.996 1137 206.996 1004 103.5 c 256,18,19
  871 0 871 0 608 0 c 2,20,-1
  166 0 l 1,21,-1
  166 1493 l 1,22,-1
@@ -35115,16 +35991,18 @@ SplineSet
  1068 1327 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0412
-Encoding: 1042 1042 1042
+Encoding: 1042 1042 856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0413
-Encoding: 1043 1043 1043
+Encoding: 1043 1043 857
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35165,8 +36043,9 @@ SplineSet
  215 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0414
-Encoding: 1044 1044 1044
+Encoding: 1044 1044 858
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35248,16 +36127,18 @@ SplineSet
  876 1323 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0415
-Encoding: 1045 1045 1045
+Encoding: 1045 1045 859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0416
-Encoding: 1046 1046 1046
+Encoding: 1046 1046 860
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35408,16 +36289,18 @@ SplineSet
  523 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0417
-Encoding: 1047 1047 1047
+Encoding: 1047 1047 861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0418
-Encoding: 1048 1048 1048
+Encoding: 1048 1048 862
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35498,25 +36381,28 @@ SplineSet
  139 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0419
-Encoding: 1049 1049 1049
+Encoding: 1049 1049 863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041A
-Encoding: 1050 1050 1050
+Encoding: 1050 1050 864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041B
-Encoding: 1051 1051 1051
+Encoding: 1051 1051 865
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35577,32 +36463,36 @@ SplineSet
  483 1323 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni041C
-Encoding: 1052 1052 1052
+Encoding: 1052 1052 866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041D
-Encoding: 1053 1053 1053
+Encoding: 1053 1053 867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041E
-Encoding: 1054 1054 1054
+Encoding: 1054 1054 868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni041F
-Encoding: 1055 1055 1055
+Encoding: 1055 1055 869
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35651,32 +36541,36 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0420
-Encoding: 1056 1056 1056
+Encoding: 1056 1056 870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0421
-Encoding: 1057 1057 1057
+Encoding: 1057 1057 871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0422
-Encoding: 1058 1058 1058
+Encoding: 1058 1058 872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0423
-Encoding: 1059 1059 1059
+Encoding: 1059 1059 873
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35765,8 +36659,9 @@ SplineSet
  741 425 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0424
-Encoding: 1060 1060 1060
+Encoding: 1060 1060 874
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35898,16 +36793,18 @@ SplineSet
  718 316 l 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0425
-Encoding: 1061 1061 1061
+Encoding: 1061 1061 875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0426
-Encoding: 1062 1062 1062
+Encoding: 1062 1062 876
 Width: 1233
 Flags: W
 TtInstrs:
@@ -35966,8 +36863,9 @@ SplineSet
  80 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0427
-Encoding: 1063 1063 1063
+Encoding: 1063 1063 877
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36026,8 +36924,9 @@ SplineSet
  137 773 137 773 137 980 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0428
-Encoding: 1064 1064 1064
+Encoding: 1064 1064 878
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36088,8 +36987,9 @@ SplineSet
  1120 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0429
-Encoding: 1065 1065 1065
+Encoding: 1065 1065 879
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36163,8 +37063,9 @@ SplineSet
  60 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042A
-Encoding: 1066 1066 1066
+Encoding: 1066 1066 880
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36217,7 +37118,7 @@ SplineSet
 495 166 m 1,0,-1
  633 166 l 2,1,2
  774 166 774 166 852 239.5 c 128,-1,3
- 930 313 930 313 930 446 c 0,4,5
+ 930 313 930 313 930 446 c 256,4,5
  930 579 930 579 851.5 653 c 128,-1,6
  773 727 773 727 633 727 c 2,7,-1
  495 727 l 1,8,-1
@@ -36236,8 +37137,9 @@ SplineSet
  293 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042B
-Encoding: 1067 1067 1067
+Encoding: 1067 1067 881
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36314,8 +37216,9 @@ SplineSet
  65 0 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042C
-Encoding: 1068 1068 1068
+Encoding: 1068 1068 882
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36369,7 +37272,7 @@ SplineSet
 399 166 m 1,0,-1
  633 166 l 2,1,2
  774 166 774 166 852 239.5 c 128,-1,3
- 930 313 930 313 930 446 c 0,4,5
+ 930 313 930 313 930 446 c 256,4,5
  930 579 930 579 851.5 653 c 128,-1,6
  773 727 773 727 633 727 c 2,7,-1
  399 727 l 1,8,-1
@@ -36379,15 +37282,16 @@ SplineSet
  399 1493 l 1,11,-1
  399 893 l 1,12,-1
  633 893 l 2,13,14
- 884 893 884 893 1012.5 780 c 0,15,16
+ 884 893 884 893 1012.5 780 c 256,15,16
  1141 667.005 1141 667.005 1141 446 c 0,17,18
- 1141 227.005 1141 227.005 1012 113.5 c 0,19,20
+ 1141 227.005 1141 227.005 1012 113.5 c 256,19,20
  883.005 0 883.005 0 633 0 c 2,21,-1
  197 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042D
-Encoding: 1069 1069 1069
+Encoding: 1069 1069 883
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36492,8 +37396,9 @@ SplineSet
  756 -29 756 -29 469 -29 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni042E
-Encoding: 1070 1070 1070
+Encoding: 1070 1070 884
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36573,19 +37478,19 @@ EndTTInstrs
 LayerCount: 2
 Fore
 SplineSet
-975 745 m 0,0,1
+975 745 m 256,0,1
  975 1074 975 1074 927.5 1215 c 128,-1,2
- 880 1356 880 1356 773 1356 c 0,3,4
+ 880 1356 880 1356 773 1356 c 256,3,4
  666 1356 666 1356 618.5 1215 c 128,-1,5
  571 1074 571 1074 571 745 c 0,6,7
  571 417 571 417 618.5 276 c 128,-1,8
- 666 135 666 135 773 135 c 0,9,10
+ 666 135 666 135 773 135 c 256,9,10
  880 135 880 135 927.5 275.5 c 128,-1,11
- 975 416 975 416 975 745 c 0,0,1
+ 975 416 975 416 975 745 c 256,0,1
 263 836 m 9,12,-1
  374 836 l 17,13,14
  383.936 1159 383.936 1159 477.468 1339.5 c 128,-1,15
- 571 1520 571 1520 773 1520 c 0,16,17
+ 571 1520 571 1520 773 1520 c 256,16,17
  975 1520 975 1520 1074 1328 c 128,-1,18
  1173 1136 1173 1136 1173 745 c 0,19,20
  1173 355 1173 355 1074 163 c 128,-1,21
@@ -36600,8 +37505,9 @@ SplineSet
  263 836 l 9,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni042F
-Encoding: 1071 1071 1071
+Encoding: 1071 1071 885
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36699,17 +37605,19 @@ SplineSet
  76 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0430
-Encoding: 1072 1072 1072
+Encoding: 1072 1072 886
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0431
-Encoding: 1073 1073 1073
+Encoding: 1073 1073 887
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36772,18 +37680,18 @@ AnchorPoint: "above" 616 1556 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-901 559 m 0,0,1
- 901 991 901 991 616.5 991 c 0,2,3
+901 559 m 256,0,1
+ 901 991 901 991 616.5 991 c 256,2,3
  332 991 332 991 332 559 c 0,4,5
  332 346 332 346 404 236.5 c 128,-1,6
  476 127 476 127 616 127 c 0,7,8
- 901 127 901 127 901 559 c 0,0,1
+ 901 127 901 127 901 559 c 256,0,1
 285 1024 m 1,9,10
- 405 1147 405 1147 627 1147 c 0,11,12
+ 405 1147 405 1147 627 1147 c 256,11,12
  849 1147 849 1147 972.5 996 c 128,-1,13
- 1096 845 1096 845 1096 558.5 c 0,14,15
+ 1096 845 1096 845 1096 558.5 c 256,14,15
  1096 272 1096 272 973 121.5 c 128,-1,16
- 850 -29 850 -29 616.5 -29 c 0,17,18
+ 850 -29 850 -29 616.5 -29 c 256,17,18
  383 -29 383 -29 257.73 124.277 c 128,-1,19
  132.461 277.555 132.461 277.555 137 559 c 0,20,21
  137.722 603.772 137.722 603.772 137 621 c 2,22,-1
@@ -36803,8 +37711,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'locl' Localized Forms in Cyrillic lookup 1" uniF6C5
 EndChar
+
 StartChar: uni0432
-Encoding: 1074 1074 1074
+Encoding: 1074 1074 888
 Width: 1233
 Flags: W
 TtInstrs:
@@ -36862,7 +37771,7 @@ SplineSet
  393 150 l 1,1,-1
  632 150 l 2,2,3
  727 150 727 150 777.5 206 c 128,-1,4
- 828 262 828 262 828 341.5 c 0,5,6
+ 828 262 828 262 828 341.5 c 256,5,6
  828 421 828 421 785.5 468 c 128,-1,7
  743 515 743 515 636 515 c 2,8,-1
  393 515 l 1,0,-1
@@ -36870,7 +37779,7 @@ SplineSet
  393 665 l 1,10,-1
  621 665 l 2,11,12
  706 665 706 665 748 707.5 c 128,-1,13
- 790 750 790 750 790 817 c 0,14,15
+ 790 750 790 750 790 817 c 256,14,15
  790 884 790 884 748 927 c 128,-1,16
  706 970 706 970 620 970 c 2,17,-1
  393 970 l 1,9,-1
@@ -36888,10 +37797,13 @@ SplineSet
  209 1120 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0433
-Encoding: 1075 1075 1075
+Encoding: 1075 1075 889
 Width: 1233
 Flags: W
+HStem: 0 21G<257 441> 970 150<441 1009>
+VStem: 257 184<0 970>
 TtInstrs:
 NPUSHB
  10
@@ -36929,8 +37841,9 @@ SplineSet
  441 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0434
-Encoding: 1076 1076 1076
+Encoding: 1076 1076 890
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37013,17 +37926,19 @@ SplineSet
  822 150 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0435
-Encoding: 1077 1077 1077
+Encoding: 1077 1077 891
 Width: 1233
 Flags: W
 AnchorPoint: "above" 630 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0436
-Encoding: 1078 1078 1078
+Encoding: 1078 1078 892
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37175,17 +38090,19 @@ SplineSet
  533 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0437
-Encoding: 1079 1079 1079
+Encoding: 1079 1079 893
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 604 604 N 1 0 0 1 0 0 2
+Refer: 521 604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0438
-Encoding: 1080 1080 1080
+Encoding: 1080 1080 894
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37268,26 +38185,29 @@ SplineSet
  866 809 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0439
-Encoding: 1081 1081 1081
+Encoding: 1081 1081 895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043A
-Encoding: 1082 1082 1082
+Encoding: 1082 1082 896
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 312 312 N 1 0 0 1 0 0 3
+Refer: 248 312 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni043B
-Encoding: 1083 1083 1083
+Encoding: 1083 1083 897
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37349,8 +38269,9 @@ SplineSet
  265 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043C
-Encoding: 1084 1084 1084
+Encoding: 1084 1084 898
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37453,8 +38374,9 @@ SplineSet
  61 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043D
-Encoding: 1085 1085 1085
+Encoding: 1085 1085 899
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37514,19 +38436,23 @@ SplineSet
  866 515 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni043E
-Encoding: 1086 1086 1086
+Encoding: 1086 1086 900
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni043F
-Encoding: 1087 1087 1087
+Encoding: 1087 1087 901
 Width: 1233
 Flags: W
+HStem: 0 21G<195 379 866 1050> 970 150<379 866>
+VStem: 195 184<0 970> 866 184<0 970>
 TtInstrs:
 NPUSHB
  14
@@ -37572,28 +38498,33 @@ SplineSet
  866 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0440
-Encoding: 1088 1088 1088
+Encoding: 1088 1088 902
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0441
-Encoding: 1089 1089 1089
+Encoding: 1089 1089 903
 Width: 1233
 Flags: W
 AnchorPoint: "above" 691 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0442
-Encoding: 1090 1090 1090
+Encoding: 1090 1090 904
 Width: 1233
 Flags: W
+HStem: 0 21G<536 720> 970 150<225 536 720 1031>
+VStem: 536 184<0 970>
 TtInstrs:
 NPUSHB
  13
@@ -37639,19 +38570,24 @@ SplineSet
  720 970 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0443
-Encoding: 1091 1091 1091
+Encoding: 1091 1091 905
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0444
-Encoding: 1092 1092 1092
+Encoding: 1092 1092 906
 Width: 1233
 Flags: W
+HStem: -426 21G<520 704> -29 156<411.557 520 704 812.443>
+VStem: 99 195<248.278 864.734> 520 184<-426 -23.895 127 982 1141.9 1556> 930 195<248.278 864.734>
+CounterMasks: 1 38
 TtInstrs:
 NPUSHB
  17
@@ -37751,20 +38687,20 @@ Fore
 SplineSet
 520 982 m 1,0,1
  400 957 400 957 347 880.5 c 128,-1,2
- 294 804 294 804 294 559 c 0,3,4
+ 294 804 294 804 294 559 c 256,3,4
  294 314 294 314 347 233 c 128,-1,5
  400 152 400 152 520 127 c 1,6,-1
  520 982 l 1,0,1
 520 -29 m 17,7,8
  300 -7 300 -7 199.5 126.5 c 128,-1,9
- 99 260 99 260 99 559 c 0,10,11
+ 99 260 99 260 99 559 c 256,10,11
  99 858 99 858 198.5 991.5 c 128,-1,12
  298 1125 298 1125 520 1147 c 1,13,-1
  520 1556 l 1,14,-1
  704 1556 l 1,15,-1
  704 1147 l 1,16,17
  926 1125 926 1125 1025.5 991.5 c 128,-1,18
- 1125 858 1125 858 1125 559 c 0,19,20
+ 1125 858 1125 858 1125 559 c 256,19,20
  1125 260 1125 260 1024.5 126.5 c 128,-1,21
  924 -7 924 -7 704 -29 c 1,22,-1
  704 -426 l 1,23,-1
@@ -37773,22 +38709,24 @@ SplineSet
 704 982 m 1,25,-1
  704 127 l 1,26,27
  824 152 824 152 877 233 c 128,-1,28
- 930 314 930 314 930 559 c 0,29,30
+ 930 314 930 314 930 559 c 256,29,30
  930 804 930 804 877 880.5 c 128,-1,31
  824 957 824 957 704 982 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0445
-Encoding: 1093 1093 1093
+Encoding: 1093 1093 907
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0446
-Encoding: 1094 1094 1094
+Encoding: 1094 1094 908
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37848,8 +38786,9 @@ SplineSet
  1118 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0447
-Encoding: 1095 1095 1095
+Encoding: 1095 1095 909
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37910,8 +38849,9 @@ SplineSet
  195 565 195 565 195 755 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0448
-Encoding: 1096 1096 1096
+Encoding: 1096 1096 910
 Width: 1233
 Flags: W
 TtInstrs:
@@ -37971,8 +38911,9 @@ SplineSet
  1109 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0449
-Encoding: 1097 1097 1097
+Encoding: 1097 1097 911
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38045,8 +38986,9 @@ SplineSet
  1058 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044A
-Encoding: 1098 1098 1098
+Encoding: 1098 1098 912
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38099,7 +39041,7 @@ SplineSet
 462 156 m 1,0,-1
  710 156 l 2,1,2
  834 156 834 156 901 200 c 128,-1,3
- 968 244 968 244 968 334 c 0,4,5
+ 968 244 968 244 968 334 c 256,4,5
  968 424 968 424 899.5 469 c 128,-1,6
  831 514 831 514 710 514 c 2,7,-1
  462 514 l 1,8,-1
@@ -38112,14 +39054,15 @@ SplineSet
  462 667 l 1,14,-1
  718 667 l 2,15,16
  927 667 927 667 1045.5 583.5 c 128,-1,17
- 1164 500 1164 500 1164 332 c 0,18,19
+ 1164 500 1164 500 1164 332 c 256,18,19
  1164 164 1164 164 1048 82 c 128,-1,20
  932 0 932 0 718 0 c 2,21,-1
  278 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044B
-Encoding: 1099 1099 1099
+Encoding: 1099 1099 913
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38179,7 +39122,7 @@ SplineSet
 286 154 m 1,4,-1
  369 154 l 2,5,6
  493 154 493 154 560 198.5 c 128,-1,7
- 627 243 627 243 627 334 c 0,8,9
+ 627 243 627 243 627 334 c 256,8,9
  627 425 627 425 558.5 470.5 c 128,-1,10
  490 516 490 516 369 516 c 2,11,-1
  286 516 l 1,12,-1
@@ -38190,14 +39133,15 @@ SplineSet
  286 667 l 1,16,-1
  377 667 l 2,17,18
  586 667 586 667 704.5 583.5 c 128,-1,19
- 823 500 823 500 823 332 c 0,20,21
+ 823 500 823 500 823 332 c 256,20,21
  823 164 823 164 707 82 c 128,-1,22
  591 0 591 0 377 0 c 2,23,-1
  104 0 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044C
-Encoding: 1100 1100 1100
+Encoding: 1100 1100 914
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38262,14 +39206,15 @@ SplineSet
  379 667 l 1,12,-1
  635 667 l 2,13,14
  843.321 667 843.321 667 961.66 583.498 c 128,-1,15
- 1080 499.996 1080 499.996 1080 332 c 0,16,17
+ 1080 499.996 1080 499.996 1080 332 c 256,16,17
  1080 164.004 1080 164.004 964.5 82.002 c 128,-1,18
  849 0 849 0 635 0 c 2,19,-1
  195 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044D
-Encoding: 1101 1101 1101
+Encoding: 1101 1101 915
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38370,15 +39315,16 @@ SplineSet
  273 1105 273 1105 350 1126 c 128,-1,21
  427 1147 427 1147 508 1147 c 0,22,23
  768 1147 768 1147 914.5 991 c 128,-1,24
- 1061 835 1061 835 1061 559 c 0,25,26
+ 1061 835 1061 835 1061 559 c 256,25,26
  1061 283 1061 283 914 127 c 0,27,28
  768 -29 768 -29 508 -29 c 0,29,30
  426 -29 426 -29 347.5 -7.5 c 128,-1,31
  269 14 269 14 195 57 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044E
-Encoding: 1102 1102 1102
+Encoding: 1102 1102 916
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38462,11 +39408,11 @@ SplineSet
 262 634 m 1,12,-1
  404 634 l 1,13,14
  421 890 421 890 526 1018.5 c 128,-1,15
- 631 1147 631 1147 788 1147 c 0,16,17
+ 631 1147 631 1147 788 1147 c 256,16,17
  945 1147 945 1147 1056.5 1001 c 128,-1,18
- 1168 855 1168 855 1168 553.5 c 0,19,20
+ 1168 855 1168 855 1168 553.5 c 256,19,20
  1168 252 1168 252 1053 111.5 c 128,-1,21
- 938 -29 938 -29 784.5 -29 c 0,22,23
+ 938 -29 938 -29 784.5 -29 c 256,22,23
  631 -29 631 -29 525.5 109 c 128,-1,24
  420 247 420 247 404 484 c 1,25,-1
  262 484 l 1,26,-1
@@ -38477,8 +39423,9 @@ SplineSet
  262 634 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni044F
-Encoding: 1103 1103 1103
+Encoding: 1103 1103 917
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38553,14 +39500,14 @@ AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-403 787 m 0,0,1
+403 787 m 256,0,1
  403 690 403 690 460 647.5 c 128,-1,2
  517 605 517 605 572 605 c 2,3,-1
  800 605 l 1,4,-1
  800 970 l 1,5,-1
  573 970 l 2,6,7
  517 970 517 970 460 927 c 128,-1,8
- 403 884 403 884 403 787 c 0,0,1
+ 403 884 403 884 403 787 c 256,0,1
 168 0 m 1,9,-1
  440 479 l 1,10,11
  387 501 387 501 302 566 c 128,-1,12
@@ -38576,26 +39523,29 @@ SplineSet
  168 0 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0450
-Encoding: 1104 1104 1104
+Encoding: 1104 1104 918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 -30 7 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -30 7 2
 EndChar
+
 StartChar: uni0451
-Encoding: 1105 1105 1105
+Encoding: 1105 1105 919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1077 1077 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 35 -81 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 35 -81 2
 EndChar
+
 StartChar: uni0452
-Encoding: 1106 1106 1106
+Encoding: 1106 1106 920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38630,17 +39580,19 @@ SplineSet
  35 977 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0453
-Encoding: 1107 1107 1107
+Encoding: 1107 1107 921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1075 1075 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 81 7 2
+Refer: 889 1075 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 81 7 2
 EndChar
+
 StartChar: uni0454
-Encoding: 1108 1108 1108
+Encoding: 1108 1108 922
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38749,25 +39701,28 @@ SplineSet
  1061 57 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0455
-Encoding: 1109 1109 1109
+Encoding: 1109 1109 923
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1120 basechar 0
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0456
-Encoding: 1110 1110 1110
+Encoding: 1110 1110 924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0457
-Encoding: 1111 1111 1111
+Encoding: 1111 1111 925
 Width: 1233
 Flags: W
 TtInstrs:
@@ -38782,19 +39737,21 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 305 305 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 24 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 24 0 2
 EndChar
+
 StartChar: uni0458
-Encoding: 1112 1112 1112
+Encoding: 1112 1112 926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0459
-Encoding: 1113 1113 1113
+Encoding: 1113 1113 927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38830,8 +39787,9 @@ SplineSet
  995 0 995 0 831 0 c 2,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni045A
-Encoding: 1114 1114 1114
+Encoding: 1114 1114 928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38863,8 +39821,9 @@ SplineSet
  765 667 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045B
-Encoding: 1115 1115 1115
+Encoding: 1115 1115 929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38897,35 +39856,39 @@ SplineSet
  35 977 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni045C
-Encoding: 1116 1116 1116
+Encoding: 1116 1116 930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1082 1082 N 1 0 0 1 0 0 2
-Refer: 180 180 N 1 0 0 1 48.5 7 2
+Refer: 896 1082 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 48.5 7 2
 EndChar
+
 StartChar: uni045D
-Encoding: 1117 1117 1117
+Encoding: 1117 1117 931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1080 1080 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 64.5 7 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 64.5 7 2
 EndChar
+
 StartChar: uni045E
-Encoding: 1118 1118 1118
+Encoding: 1118 1118 932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni045F
-Encoding: 1119 1119 1119
+Encoding: 1119 1119 933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38946,8 +39909,9 @@ SplineSet
  195 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0462
-Encoding: 1122 1122 1122
+Encoding: 1122 1122 934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -38981,8 +39945,9 @@ SplineSet
  495 1105 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0463
-Encoding: 1123 1123 1123
+Encoding: 1123 1123 935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39016,76 +39981,87 @@ SplineSet
  462 156 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni046A
-Encoding: 1130 1130 1130
+Encoding: 1130 1130 936
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni046B
-Encoding: 1131 1131 1131
+Encoding: 1131 1131 937
 Width: 2048
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0472
-Encoding: 1138 1138 1138
+Encoding: 1138 1138 938
 Width: 1233
 Flags: W
 AnchorPoint: "above" 807 1520 basechar 0
 AnchorPoint: "below" 807 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 415 415 N 1 0 0 1 0 0 3
+Refer: 351 415 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0473
-Encoding: 1139 1139 1139
+Encoding: 1139 1139 939
 Width: 1233
 Flags: W
 AnchorPoint: "below" 637 0 basechar 0
 AnchorPoint: "above" 637 1147 basechar 0
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 3
+Refer: 546 629 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni048A
-Encoding: 1162 1162 1162
+Encoding: 1162 1162 940
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048B
-Encoding: 1163 1163 1163
+Encoding: 1163 1163 941
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048C
-Encoding: 1164 1164 1164
+Encoding: 1164 1164 942
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048D
-Encoding: 1165 1165 1165
+Encoding: 1165 1165 943
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048E
-Encoding: 1166 1166 1166
+Encoding: 1166 1166 944
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni048F
-Encoding: 1167 1167 1167
+Encoding: 1167 1167 945
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0490
-Encoding: 1168 1168 1168
+Encoding: 1168 1168 946
 Width: 1233
 Flags: W
 TtInstrs:
@@ -39132,8 +40108,9 @@ SplineSet
  215 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0491
-Encoding: 1169 1169 1169
+Encoding: 1169 1169 947
 Width: 1233
 Flags: W
 TtInstrs:
@@ -39178,8 +40155,9 @@ SplineSet
  441 936 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0492
-Encoding: 1170 1170 1170
+Encoding: 1170 1170 948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39202,8 +40180,9 @@ SplineSet
  85 1000 l 9,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0493
-Encoding: 1171 1171 1171
+Encoding: 1171 1171 949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39226,8 +40205,9 @@ SplineSet
  257 0 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0494
-Encoding: 1172 1172 1172
+Encoding: 1172 1172 950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39258,8 +40238,9 @@ SplineSet
  418 711 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0495
-Encoding: 1173 1173 1173
+Encoding: 1173 1173 951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39290,8 +40271,9 @@ SplineSet
  441 487 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0496
-Encoding: 1174 1174 1174
+Encoding: 1174 1174 952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39324,8 +40306,9 @@ SplineSet
  15 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0497
-Encoding: 1175 1175 1175
+Encoding: 1175 1175 953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39358,26 +40341,29 @@ SplineSet
  59 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0498
-Encoding: 1176 1176 1176
+Encoding: 1176 1176 954
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -73 0 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -73 0 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0499
-Encoding: 1177 1177 1177
+Encoding: 1177 1177 955
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -67 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -67 0 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni049A
-Encoding: 1178 1178 1178
+Encoding: 1178 1178 956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39402,8 +40388,9 @@ SplineSet
  1110 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049B
-Encoding: 1179 1179 1179
+Encoding: 1179 1179 957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39428,44 +40415,51 @@ SplineSet
  1068 184 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni049C
-Encoding: 1180 1180 1180
+Encoding: 1180 1180 958
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049D
-Encoding: 1181 1181 1181
+Encoding: 1181 1181 959
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049E
-Encoding: 1182 1182 1182
+Encoding: 1182 1182 960
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni049F
-Encoding: 1183 1183 1183
+Encoding: 1183 1183 961
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A0
-Encoding: 1184 1184 1184
+Encoding: 1184 1184 962
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A1
-Encoding: 1185 1185 1185
+Encoding: 1185 1185 963
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A2
-Encoding: 1186 1186 1186
+Encoding: 1186 1186 964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39490,8 +40484,9 @@ SplineSet
  990 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04A3
-Encoding: 1187 1187 1187
+Encoding: 1187 1187 965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39516,8 +40511,9 @@ SplineSet
  953 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04A4
-Encoding: 1188 1188 1188
+Encoding: 1188 1188 966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39540,8 +40536,9 @@ SplineSet
  113 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A5
-Encoding: 1189 1189 1189
+Encoding: 1189 1189 967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39564,50 +40561,57 @@ SplineSet
  125 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04A6
-Encoding: 1190 1190 1190
+Encoding: 1190 1190 968
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A7
-Encoding: 1191 1191 1191
+Encoding: 1191 1191 969
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A8
-Encoding: 1192 1192 1192
+Encoding: 1192 1192 970
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04A9
-Encoding: 1193 1193 1193
+Encoding: 1193 1193 971
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04AA
-Encoding: 1194 1194 1194
+Encoding: 1194 1194 972
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 1057 1057 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 871 1057 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AB
-Encoding: 1195 1195 1195
+Encoding: 1195 1195 973
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 1089 1089 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 903 1089 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AC
-Encoding: 1196 1196 1196
+Encoding: 1196 1196 974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39628,8 +40632,9 @@ SplineSet
  719 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04AD
-Encoding: 1197 1197 1197
+Encoding: 1197 1197 975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39650,16 +40655,18 @@ SplineSet
  720 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04AE
-Encoding: 1198 1198 1198
+Encoding: 1198 1198 976
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04AF
-Encoding: 1199 1199 1199
+Encoding: 1199 1199 977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39677,8 +40684,9 @@ SplineSet
  92 1120 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B0
-Encoding: 1200 1200 1200
+Encoding: 1200 1200 978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39704,8 +40712,9 @@ SplineSet
  37 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B1
-Encoding: 1201 1201 1201
+Encoding: 1201 1201 979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39731,8 +40740,9 @@ SplineSet
  92 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B2
-Encoding: 1202 1202 1202
+Encoding: 1202 1202 980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39757,8 +40767,9 @@ SplineSet
  1112 170 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B3
-Encoding: 1203 1203 1203
+Encoding: 1203 1203 981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39783,44 +40794,51 @@ SplineSet
  1018 184 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04B4
-Encoding: 1204 1204 1204
+Encoding: 1204 1204 982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B5
-Encoding: 1205 1205 1205
+Encoding: 1205 1205 983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B6
-Encoding: 1206 1206 1206
+Encoding: 1206 1206 984
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B7
-Encoding: 1207 1207 1207
+Encoding: 1207 1207 985
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B8
-Encoding: 1208 1208 1208
+Encoding: 1208 1208 986
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04B9
-Encoding: 1209 1209 1209
+Encoding: 1209 1209 987
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BA
-Encoding: 1210 1210 1210
+Encoding: 1210 1210 988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39849,66 +40867,75 @@ SplineSet
  1095 727.993 1095 727.993 1095 500 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04BB
-Encoding: 1211 1211 1211
+Encoding: 1211 1211 989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04BC
-Encoding: 1212 1212 1212
+Encoding: 1212 1212 990
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BD
-Encoding: 1213 1213 1213
+Encoding: 1213 1213 991
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BE
-Encoding: 1214 1214 1214
+Encoding: 1214 1214 992
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04BF
-Encoding: 1215 1215 1215
+Encoding: 1215 1215 993
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C0
-Encoding: 1216 1216 1216
+Encoding: 1216 1216 994
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C1
-Encoding: 1217 1217 1217
+Encoding: 1217 1217 995
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C2
-Encoding: 1218 1218 1218
+Encoding: 1218 1218 996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04C3
-Encoding: 1219 1219 1219
+Encoding: 1219 1219 997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39941,8 +40968,9 @@ SplineSet
  627 881 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C4
-Encoding: 1220 1220 1220
+Encoding: 1220 1220 998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -39975,20 +41003,23 @@ SplineSet
  617.765 631 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04C5
-Encoding: 1221 1221 1221
+Encoding: 1221 1221 999
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C6
-Encoding: 1222 1222 1222
+Encoding: 1222 1222 1000
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04C7
-Encoding: 1223 1223 1223
+Encoding: 1223 1223 1001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40015,8 +41046,9 @@ SplineSet
  1096 104 l 18,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni04C8
-Encoding: 1224 1224 1224
+Encoding: 1224 1224 1002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40043,20 +41075,23 @@ SplineSet
  1050 -20 l 18,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni04C9
-Encoding: 1225 1225 1225
+Encoding: 1225 1225 1003
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CA
-Encoding: 1226 1226 1226
+Encoding: 1226 1226 1004
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CB
-Encoding: 1227 1227 1227
+Encoding: 1227 1227 1005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40089,8 +41124,9 @@ SplineSet
  892 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CC
-Encoding: 1228 1228 1228
+Encoding: 1228 1228 1006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40120,20 +41156,23 @@ SplineSet
  867 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04CD
-Encoding: 1229 1229 1229
+Encoding: 1229 1229 1007
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CE
-Encoding: 1230 1230 1230
+Encoding: 1230 1230 1008
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni04CF
-Encoding: 1231 1231 1231
+Encoding: 1231 1231 1009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40146,8 +41185,9 @@ SplineSet
  639 1567 l 17,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni04D0
-Encoding: 1232 1232 1232
+Encoding: 1232 1232 1010
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40178,20 +41218,22 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 1040 1040 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D1
-Encoding: 1233 1233 1233
+Encoding: 1233 1233 1011
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D2
-Encoding: 1234 1234 1234
+Encoding: 1234 1234 1012
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40226,176 +41268,196 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1040 1040 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 854 1040 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04D3
-Encoding: 1235 1235 1235
+Encoding: 1235 1235 1013
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1072 1072 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 886 1072 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D4
-Encoding: 1236 1236 1236
+Encoding: 1236 1236 1014
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 198 198 N 1 0 0 1 0 0 2
+Refer: 134 198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D5
-Encoding: 1237 1237 1237
+Encoding: 1237 1237 1015
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 230 230 N 1 0 0 1 0 0 2
+Refer: 166 230 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D6
-Encoding: 1238 1238 1238
+Encoding: 1238 1238 1016
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 1045 1045 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 859 1045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D7
-Encoding: 1239 1239 1239
+Encoding: 1239 1239 1017
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 1077 1077 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 891 1077 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04D8
-Encoding: 1240 1240 1240
+Encoding: 1240 1240 1018
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 399 399 N 1 0 0 1 0 0 3
+Refer: 335 399 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04D9
-Encoding: 1241 1241 1241
+Encoding: 1241 1241 1019
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 601 601 N 1 0 0 1 0 0 3
+Refer: 518 601 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni04DA
-Encoding: 1242 1242 1242
+Encoding: 1242 1242 1020
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1240 1240 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 1018 1240 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DB
-Encoding: 1243 1243 1243
+Encoding: 1243 1243 1021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1241 1241 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1019 1241 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DC
-Encoding: 1244 1244 1244
+Encoding: 1244 1244 1022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1046 1046 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 860 1046 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DD
-Encoding: 1245 1245 1245
+Encoding: 1245 1245 1023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1078 1078 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 892 1078 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DE
-Encoding: 1246 1246 1246
+Encoding: 1246 1246 1024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -17 373 2
-Refer: 1047 1047 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 -17 373 2
+Refer: 861 1047 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04DF
-Encoding: 1247 1247 1247
+Encoding: 1247 1247 1025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -15 0 2
-Refer: 1079 1079 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -15 0 2
+Refer: 893 1079 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E0
-Encoding: 1248 1248 1248
+Encoding: 1248 1248 1026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 439 439 N 1 0 0 1 0 0 2
+Refer: 375 439 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E1
-Encoding: 1249 1249 1249
+Encoding: 1249 1249 1027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 658 658 N 1 0 0 1 0 0 2
+Refer: 575 658 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E2
-Encoding: 1250 1250 1250
+Encoding: 1250 1250 1028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E3
-Encoding: 1251 1251 1251
+Encoding: 1251 1251 1029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E4
-Encoding: 1252 1252 1252
+Encoding: 1252 1252 1030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1048 1048 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 862 1048 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E5
-Encoding: 1253 1253 1253
+Encoding: 1253 1253 1031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1080 1080 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 894 1080 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E6
-Encoding: 1254 1254 1254
+Encoding: 1254 1254 1032
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40430,11 +41492,12 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1054 1054 N 1 0 0 1 0 0 2
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
+Refer: 868 1054 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
 EndChar
+
 StartChar: uni04E7
-Encoding: 1255 1255 1255
+Encoding: 1255 1255 1033
 Width: 1233
 Flags: W
 TtInstrs:
@@ -40461,135 +41524,150 @@ IUP[x]
 EndTTInstrs
 LayerCount: 2
 Fore
-Refer: 1086 1086 N 1 0 0 1 0 0 2
-Refer: 168 168 N 1 0 0 1 0 0 2
+Refer: 900 1086 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E8
-Encoding: 1256 1256 1256
+Encoding: 1256 1256 1034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1012 1012 N 1 0 0 1 0 0 2
+Refer: 826 1012 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04E9
-Encoding: 1257 1257 1257
+Encoding: 1257 1257 1035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 629 629 N 1 0 0 1 0 0 2
+Refer: 546 629 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EA
-Encoding: 1258 1258 1258
+Encoding: 1258 1258 1036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1256 1256 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 1034 1256 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EB
-Encoding: 1259 1259 1259
+Encoding: 1259 1259 1037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1257 1257 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1035 1257 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EC
-Encoding: 1260 1260 1260
+Encoding: 1260 1260 1038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 -33 373 2
-Refer: 1069 1069 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 -33 373 2
+Refer: 883 1069 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04ED
-Encoding: 1261 1261 1261
+Encoding: 1261 1261 1039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -20 0 2
-Refer: 1101 1101 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 -20 0 2
+Refer: 915 1101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EE
-Encoding: 1262 1262 1262
+Encoding: 1262 1262 1040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04EF
-Encoding: 1263 1263 1263
+Encoding: 1263 1263 1041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F0
-Encoding: 1264 1264 1264
+Encoding: 1264 1264 1042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F1
-Encoding: 1265 1265 1265
+Encoding: 1265 1265 1043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F2
-Encoding: 1266 1266 1266
+Encoding: 1266 1266 1044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114124 -1 N 1 0 0 1 0 0 2
-Refer: 1059 1059 N 1 0 0 1 0 0 2
+Refer: 3737 -1 N 1 0 0 1 0 0 2
+Refer: 873 1059 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F3
-Encoding: 1267 1267 1267
+Encoding: 1267 1267 1045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 779 779 N 1 0 0 1 0 0 2
-Refer: 1091 1091 N 1 0 0 1 0 0 2
+Refer: 666 779 N 1 0 0 1 0 0 2
+Refer: 905 1091 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F4
-Encoding: 1268 1268 1268
+Encoding: 1268 1268 1046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1063 1063 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 877 1063 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F5
-Encoding: 1269 1269 1269
+Encoding: 1269 1269 1047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1095 1095 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 909 1095 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F6
-Encoding: 1270 1270 1270
+Encoding: 1270 1270 1048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40608,8 +41686,9 @@ SplineSet
  418 170 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04F7
-Encoding: 1271 1271 1271
+Encoding: 1271 1271 1049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40628,170 +41707,195 @@ SplineSet
  441 184 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni04F8
-Encoding: 1272 1272 1272
+Encoding: 1272 1272 1050
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0 373 2
-Refer: 1067 1067 N 1 0 0 1 0 0 2
+Refer: 3727 -1 N 1 0 0 1 0 373 2
+Refer: 881 1067 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni04F9
-Encoding: 1273 1273 1273
+Encoding: 1273 1273 1051
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 1099 1099 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 913 1099 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0500
-Encoding: 1280 1280 1280
+Encoding: 1280 1280 1052
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0501
-Encoding: 1281 1281 1281
+Encoding: 1281 1281 1053
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0502
-Encoding: 1282 1282 1282
+Encoding: 1282 1282 1054
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0503
-Encoding: 1283 1283 1283
+Encoding: 1283 1283 1055
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0504
-Encoding: 1284 1284 1284
+Encoding: 1284 1284 1056
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0505
-Encoding: 1285 1285 1285
+Encoding: 1285 1285 1057
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0506
-Encoding: 1286 1286 1286
+Encoding: 1286 1286 1058
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0507
-Encoding: 1287 1287 1287
+Encoding: 1287 1287 1059
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0508
-Encoding: 1288 1288 1288
+Encoding: 1288 1288 1060
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0509
-Encoding: 1289 1289 1289
+Encoding: 1289 1289 1061
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050A
-Encoding: 1290 1290 1290
+Encoding: 1290 1290 1062
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050B
-Encoding: 1291 1291 1291
+Encoding: 1291 1291 1063
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050C
-Encoding: 1292 1292 1292
+Encoding: 1292 1292 1064
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050D
-Encoding: 1293 1293 1293
+Encoding: 1293 1293 1065
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050E
-Encoding: 1294 1294 1294
+Encoding: 1294 1294 1066
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni050F
-Encoding: 1295 1295 1295
+Encoding: 1295 1295 1067
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: uni0510
-Encoding: 1296 1296 1296
+Encoding: 1296 1296 1068
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 400 400 N 1 0 0 1 0 0 3
+Refer: 336 400 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0511
-Encoding: 1297 1297 1297
+Encoding: 1297 1297 1069
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 3
+Refer: 778 949 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni051A
-Encoding: 1306 1306 1306
+Encoding: 1306 1306 1070
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051B
-Encoding: 1307 1307 1307
+Encoding: 1307 1307 1071
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051C
-Encoding: 1308 1308 1308
+Encoding: 1308 1308 1072
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni051D
-Encoding: 1309 1309 1309
+Encoding: 1309 1309 1073
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0531
-Encoding: 1329 1329 1329
+Encoding: 1329 1329 1074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40830,8 +41934,9 @@ SplineSet
  669 458 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0532
-Encoding: 1330 1330 1330
+Encoding: 1330 1330 1075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40866,8 +41971,9 @@ SplineSet
  1066 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0533
-Encoding: 1331 1331 1331
+Encoding: 1331 1331 1076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40911,8 +42017,9 @@ SplineSet
  821 1058 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0534
-Encoding: 1332 1332 1332
+Encoding: 1332 1332 1077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40947,8 +42054,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0535
-Encoding: 1333 1333 1333
+Encoding: 1333 1333 1078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -40983,8 +42091,9 @@ SplineSet
  1066 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0536
-Encoding: 1334 1334 1334
+Encoding: 1334 1334 1079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41031,8 +42140,9 @@ SplineSet
  1137 1067 1137 1067 1137 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0537
-Encoding: 1335 1335 1335
+Encoding: 1335 1335 1080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41051,8 +42161,9 @@ SplineSet
  323 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0538
-Encoding: 1336 1336 1336
+Encoding: 1336 1336 1081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41085,8 +42196,9 @@ SplineSet
  1066 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0539
-Encoding: 1337 1337 1337
+Encoding: 1337 1337 1082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41148,8 +42260,9 @@ SplineSet
  589 499 589 499 589 415 c 0,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni053A
-Encoding: 1338 1338 1338
+Encoding: 1338 1338 1083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41193,8 +42306,9 @@ SplineSet
  552 950 l 2,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni053B
-Encoding: 1339 1339 1339
+Encoding: 1339 1339 1084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41225,8 +42339,9 @@ SplineSet
  1085 494 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053C
-Encoding: 1340 1340 1340
+Encoding: 1340 1340 1085
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41241,8 +42356,9 @@ SplineSet
  154 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053D
-Encoding: 1341 1341 1341
+Encoding: 1341 1341 1086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41279,8 +42395,9 @@ SplineSet
  648 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni053E
-Encoding: 1342 1342 1342
+Encoding: 1342 1342 1087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41345,8 +42462,9 @@ SplineSet
  307 749 307 749 307 621 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni053F
-Encoding: 1343 1343 1343
+Encoding: 1343 1343 1088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41377,8 +42495,9 @@ SplineSet
  1085 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0540
-Encoding: 1344 1344 1344
+Encoding: 1344 1344 1089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41409,8 +42528,9 @@ SplineSet
  1142 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0541
-Encoding: 1345 1345 1345
+Encoding: 1345 1345 1090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41467,8 +42587,9 @@ SplineSet
  508 408 508 408 434 408 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni0542
-Encoding: 1346 1346 1346
+Encoding: 1346 1346 1091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41501,8 +42622,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0543
-Encoding: 1347 1347 1347
+Encoding: 1347 1347 1092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41538,8 +42660,9 @@ SplineSet
  458 669 458 669 429 618 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0544
-Encoding: 1348 1348 1348
+Encoding: 1348 1348 1093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41572,8 +42695,9 @@ SplineSet
  790 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0545
-Encoding: 1349 1349 1349
+Encoding: 1349 1349 1094
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41631,8 +42755,9 @@ SplineSet
  1169 506 1169 506 1169 444 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0546
-Encoding: 1350 1350 1350
+Encoding: 1350 1350 1095
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41665,8 +42790,9 @@ SplineSet
  1179 457 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0547
-Encoding: 1351 1351 1351
+Encoding: 1351 1351 1096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41717,8 +42843,9 @@ SplineSet
  307 722 307 722 307 596 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0548
-Encoding: 1352 1352 1352
+Encoding: 1352 1352 1097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41749,8 +42876,9 @@ SplineSet
  1085 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0549
-Encoding: 1353 1353 1353
+Encoding: 1353 1353 1098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41795,8 +42923,9 @@ SplineSet
  926 769 926 769 926 895 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054A
-Encoding: 1354 1354 1354
+Encoding: 1354 1354 1099
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41830,8 +42959,9 @@ SplineSet
  798 1342 798 1342 711 1351 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054B
-Encoding: 1355 1355 1355
+Encoding: 1355 1355 1100
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41897,8 +43027,9 @@ SplineSet
  925 761 925 761 925 895 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni054C
-Encoding: 1356 1356 1356
+Encoding: 1356 1356 1101
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41933,8 +43064,9 @@ SplineSet
  54 1036 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni054D
-Encoding: 1357 1357 1357
+Encoding: 1357 1357 1102
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41965,8 +43097,9 @@ SplineSet
  147 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054E
-Encoding: 1358 1358 1358
+Encoding: 1358 1358 1103
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -41999,8 +43132,9 @@ SplineSet
  33 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni054F
-Encoding: 1359 1359 1359
+Encoding: 1359 1359 1104
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42061,8 +43195,9 @@ SplineSet
  105 340 105 340 105 447 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0550
-Encoding: 1360 1360 1360
+Encoding: 1360 1360 1105
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42093,8 +43228,9 @@ SplineSet
  1085 875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0551
-Encoding: 1361 1361 1361
+Encoding: 1361 1361 1106
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42164,8 +43300,9 @@ SplineSet
  551 1520 551 1520 658 1520 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni0552
-Encoding: 1362 1362 1362
+Encoding: 1362 1362 1107
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42182,8 +43319,9 @@ SplineSet
  338 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0553
-Encoding: 1363 1363 1363
+Encoding: 1363 1363 1108
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42234,8 +43372,9 @@ SplineSet
  518 158 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni0554
-Encoding: 1364 1364 1364
+Encoding: 1364 1364 1109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42288,16 +43427,18 @@ SplineSet
  791 1356 791 1356 713 1356 c 0,31,32
 EndSplineSet
 EndChar
+
 StartChar: uni0555
-Encoding: 1365 1365 1365
+Encoding: 1365 1365 1110
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 3
+Refer: 48 79 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0556
-Encoding: 1366 1366 1366
+Encoding: 1366 1366 1111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42360,16 +43501,18 @@ SplineSet
  964 438 964 438 964 537 c 0,53,54
 EndSplineSet
 EndChar
+
 StartChar: uni0559
-Encoding: 1369 1369 1369
+Encoding: 1369 1369 1112
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 703 703 N 1 0 0 1 0 0 3
+Refer: 619 703 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni055A
-Encoding: 1370 1370 1370
+Encoding: 1370 1370 1113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42384,16 +43527,18 @@ SplineSet
  552 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055B
-Encoding: 1371 1371 1371
+Encoding: 1371 1371 1114
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -97 7 3
+Refer: 116 180 N 1 0 0 1 -97 7 3
 EndChar
+
 StartChar: uni055C
-Encoding: 1372 1372 1372
+Encoding: 1372 1372 1115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42420,16 +43565,18 @@ SplineSet
  377 1335 377 1335 377 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055D
-Encoding: 1373 1373 1373
+Encoding: 1373 1373 1116
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 98 0 3
+Refer: 65 96 N 1 0 0 1 98 0 3
 EndChar
+
 StartChar: uni055E
-Encoding: 1374 1374 1374
+Encoding: 1374 1374 1117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42471,8 +43618,9 @@ SplineSet
  336 1422 336 1422 336 1265 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni055F
-Encoding: 1375 1375 1375
+Encoding: 1375 1375 1118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42487,8 +43635,9 @@ SplineSet
  188 1265 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0561
-Encoding: 1377 1377 1377
+Encoding: 1377 1377 1119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42526,8 +43675,9 @@ SplineSet
  617 -27 617 -27 562 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0562
-Encoding: 1378 1378 1378
+Encoding: 1378 1378 1120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42556,8 +43706,9 @@ SplineSet
  1039 923 1039 923 1039 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0563
-Encoding: 1379 1379 1379
+Encoding: 1379 1379 1121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42596,8 +43747,9 @@ SplineSet
  268 770 268 770 268 555 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni0564
-Encoding: 1380 1380 1380
+Encoding: 1380 1380 1122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42626,8 +43778,9 @@ SplineSet
  970 923 970 923 970 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0565
-Encoding: 1381 1381 1381
+Encoding: 1381 1381 1123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42656,8 +43809,9 @@ SplineSet
  164 195 164 195 164 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0566
-Encoding: 1382 1382 1382
+Encoding: 1382 1382 1124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42694,8 +43848,9 @@ SplineSet
  268 770 268 770 268 555 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni0567
-Encoding: 1383 1383 1383
+Encoding: 1383 1383 1125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42714,8 +43869,9 @@ SplineSet
  940 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0568
-Encoding: 1384 1384 1384
+Encoding: 1384 1384 1126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42742,8 +43898,9 @@ SplineSet
  1039 923 1039 923 1039 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0569
-Encoding: 1385 1385 1385
+Encoding: 1385 1385 1127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42803,8 +43960,9 @@ SplineSet
  656 107 656 107 694 107 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni056A
-Encoding: 1386 1386 1386
+Encoding: 1386 1386 1128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42848,8 +44006,9 @@ SplineSet
  991 977 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056B
-Encoding: 1387 1387 1387
+Encoding: 1387 1387 1129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42874,8 +44033,9 @@ SplineSet
  1044 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056C
-Encoding: 1388 1388 1388
+Encoding: 1388 1388 1130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42890,8 +44050,9 @@ SplineSet
  511 -283 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni056D
-Encoding: 1389 1389 1389
+Encoding: 1389 1389 1131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42932,8 +44093,9 @@ SplineSet
  700 479 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni056E
-Encoding: 1390 1390 1390
+Encoding: 1390 1390 1132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -42984,8 +44146,9 @@ SplineSet
  330 620 330 620 330 535 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni056F
-Encoding: 1391 1391 1391
+Encoding: 1391 1391 1133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43010,16 +44173,18 @@ SplineSet
  188 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0570
-Encoding: 1392 1392 1392
+Encoding: 1392 1392 1134
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 -6 0 3
+Refer: 73 104 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0571
-Encoding: 1393 1393 1393
+Encoding: 1393 1393 1135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43083,8 +44248,9 @@ SplineSet
  362 532 362 532 362 453 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni0572
-Encoding: 1394 1394 1394
+Encoding: 1394 1394 1136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43111,8 +44277,9 @@ SplineSet
  970 923 970 923 970 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0573
-Encoding: 1395 1395 1395
+Encoding: 1395 1395 1137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43172,8 +44339,9 @@ SplineSet
  379 583 379 583 379 435 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni0574
-Encoding: 1396 1396 1396
+Encoding: 1396 1396 1138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43200,8 +44368,9 @@ SplineSet
  104 195 104 195 104 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0575
-Encoding: 1397 1397 1397
+Encoding: 1397 1397 1139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43219,8 +44388,9 @@ SplineSet
  731 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0576
-Encoding: 1398 1398 1398
+Encoding: 1398 1398 1140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43247,8 +44417,9 @@ SplineSet
  272 195 272 195 272 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0577
-Encoding: 1399 1399 1399
+Encoding: 1399 1399 1141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43299,16 +44470,18 @@ SplineSet
  385 -180 385 -180 385 -207 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0578
-Encoding: 1400 1400 1400
+Encoding: 1400 1400 1142
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 -6 0 3
+Refer: 79 110 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni0579
-Encoding: 1401 1401 1401
+Encoding: 1401 1401 1143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43356,8 +44529,9 @@ SplineSet
  506 -283 506 -283 527 -283 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057A
-Encoding: 1402 1402 1402
+Encoding: 1402 1402 1144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43395,8 +44569,9 @@ SplineSet
  617 -27 617 -27 562 114 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057B
-Encoding: 1403 1403 1403
+Encoding: 1403 1403 1145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43464,8 +44639,9 @@ SplineSet
  660 994 660 994 595 994 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni057C
-Encoding: 1404 1404 1404
+Encoding: 1404 1404 1146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43505,16 +44681,18 @@ SplineSet
  644 987 644 987 571 987 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni057D
-Encoding: 1405 1405 1405
+Encoding: 1405 1405 1147
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 -6 0 3
+Refer: 86 117 N 1 0 0 1 -6 0 3
 EndChar
+
 StartChar: uni057E
-Encoding: 1406 1406 1406
+Encoding: 1406 1406 1148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43541,8 +44719,9 @@ SplineSet
  102 195 102 195 102 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni057F
-Encoding: 1407 1407 1407
+Encoding: 1407 1407 1149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43584,8 +44763,9 @@ SplineSet
  1129 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0580
-Encoding: 1408 1408 1408
+Encoding: 1408 1408 1150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43610,16 +44790,18 @@ SplineSet
  1044 923 1044 923 1044 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0581
-Encoding: 1409 1409 1409
+Encoding: 1409 1409 1151
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 34 0 3
+Refer: 72 103 N 1 0 0 1 34 0 3
 EndChar
+
 StartChar: uni0582
-Encoding: 1410 1410 1410
+Encoding: 1410 1410 1152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43634,8 +44816,9 @@ SplineSet
  433 143 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0583
-Encoding: 1411 1411 1411
+Encoding: 1411 1411 1153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43677,8 +44860,9 @@ SplineSet
  1129 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0584
-Encoding: 1412 1412 1412
+Encoding: 1412 1412 1154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43721,16 +44905,18 @@ SplineSet
  932 344 932 344 932 559 c 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni0585
-Encoding: 1413 1413 1413
+Encoding: 1413 1413 1155
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 3
+Refer: 80 111 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni0586
-Encoding: 1414 1414 1414
+Encoding: 1414 1414 1156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43786,8 +44972,9 @@ SplineSet
  1011 482 1011 482 1011 576 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni0587
-Encoding: 1415 1415 1415
+Encoding: 1415 1415 1157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43814,8 +45001,9 @@ SplineSet
  72 195 72 195 72 424 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0589
-Encoding: 1417 1417 1417
+Encoding: 1417 1417 1158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43833,8 +45021,9 @@ SplineSet
  511 850 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni058A
-Encoding: 1418 1418 1418
+Encoding: 1418 1418 1159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43849,8 +45038,9 @@ SplineSet
  356 643 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0606
-Encoding: 1542 1542 1542
+Encoding: 1542 1542 1160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43892,8 +45082,9 @@ SplineSet
  1133 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0607
-Encoding: 1543 1543 1543
+Encoding: 1543 1543 1161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43937,8 +45128,9 @@ SplineSet
  1133 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0609
-Encoding: 1545 1545 1545
+Encoding: 1545 1545 1162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -43966,8 +45158,9 @@ SplineSet
  764 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060A
-Encoding: 1546 1546 1546
+Encoding: 1546 1546 1163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44000,8 +45193,9 @@ SplineSet
  474 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni060C
-Encoding: 1548 1548 1548
+Encoding: 1548 1548 1164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44016,8 +45210,9 @@ SplineSet
  681 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0615
-Encoding: 1557 1557 1557
+Encoding: 1557 1557 1165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44045,8 +45240,9 @@ SplineSet
  759 1277 759 1277 643 1277 c 18,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni061B
-Encoding: 1563 1563 1563
+Encoding: 1563 1563 1166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44066,8 +45262,9 @@ SplineSet
  470 254 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni061F
-Encoding: 1567 1567 1567
+Encoding: 1567 1567 1167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -44105,8 +45302,9 @@ SplineSet
  574 401 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0621
-Encoding: 1569 1569 1569
+Encoding: 1569 1569 1168
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 0 basechar 0
@@ -44136,65 +45334,71 @@ SplineSet
  543 100 543 100 434 85 c 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0622
-Encoding: 1570 1570 1570
+Encoding: 1570 1570 1169
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 0 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE82
 EndChar
+
 StartChar: uni0623
-Encoding: 1571 1571 1571
+Encoding: 1571 1571 1170
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 612 2164 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 0 390 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 390 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE84
 EndChar
+
 StartChar: uni0624
-Encoding: 1572 1572 1572
+Encoding: 1572 1572 1171
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 720 1312 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 99 -450 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 99 -450 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE86
 EndChar
+
 StartChar: uni0625
-Encoding: 1573 1573 1573
+Encoding: 1573 1573 1172
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -545 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 0 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE88
 EndChar
+
 StartChar: uni0626
-Encoding: 1574 1574 1574
+Encoding: 1574 1574 1173
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 636 basechar 0
 AnchorPoint: "rtl-above" 460 1208 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -142 -540 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -142 -540 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE8A
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE8C
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE8B
 EndChar
+
 StartChar: uni0627
-Encoding: 1575 1575 1575
+Encoding: 1575 1575 1174
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -78 basechar 0
@@ -44210,76 +45414,82 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE8E
 EndChar
+
 StartChar: uni0628
-Encoding: 1576 1576 1576
+Encoding: 1576 1576 1175
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -376 basechar 0
 AnchorPoint: "rtl-above" 612 764 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 556 -312 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 556 -312 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE92
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE91
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE90
 EndChar
+
 StartChar: uni0629
-Encoding: 1577 1577 1577
+Encoding: 1577 1577 1176
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -160 basechar 0
 AnchorPoint: "rtl-above" 568 1184 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 369 900 2
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 369 900 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE94
 EndChar
+
 StartChar: uni062A
-Encoding: 1578 1578 1578
+Encoding: 1578 1578 1177
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 AnchorPoint: "rtl-above" 636 980 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 440 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 440 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE96
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE98
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE97
 EndChar
+
 StartChar: uni062B
-Encoding: 1579 1579 1579
+Encoding: 1579 1579 1178
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 AnchorPoint: "rtl-above" 548 1184 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 420 650 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 420 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE9A
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFE9C
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE9B
 EndChar
+
 StartChar: uni062C
-Encoding: 1580 1580 1580
+Encoding: 1580 1580 1179
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 508 -564 basechar 0
 AnchorPoint: "rtl-above" 500 1148 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 663 13 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 663 13 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFE9E
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFE9F
 EndChar
+
 StartChar: uni062D
-Encoding: 1581 1581 1581
+Encoding: 1581 1581 1180
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -560 basechar 0
@@ -44310,22 +45520,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEA2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEA3
 EndChar
+
 StartChar: uni062E
-Encoding: 1582 1582 1582
+Encoding: 1582 1582 1181
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -585 basechar 0
 AnchorPoint: "rtl-above" 516 1352 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 458 1050 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 458 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEA6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEA8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEA7
 EndChar
+
 StartChar: uni062F
-Encoding: 1583 1583 1583
+Encoding: 1583 1583 1182
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -132 basechar 0
@@ -44351,20 +45563,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAA
 EndChar
+
 StartChar: uni0630
-Encoding: 1584 1584 1584
+Encoding: 1584 1584 1183
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -116 basechar 0
 AnchorPoint: "rtl-above" 448 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 540 1074 2
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 540 1074 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAC
 EndChar
+
 StartChar: uni0631
-Encoding: 1585 1585 1585
+Encoding: 1585 1585 1184
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -544 basechar 0
@@ -44386,20 +45600,22 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEAE
 EndChar
+
 StartChar: uni0632
-Encoding: 1586 1586 1586
+Encoding: 1586 1586 1185
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 560 -532 basechar 0
 AnchorPoint: "rtl-above" 408 1056 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 853 800 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 853 800 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB0
 EndChar
+
 StartChar: uni0633
-Encoding: 1587 1587 1587
+Encoding: 1587 1587 1186
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -436 basechar 0
@@ -44449,22 +45665,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEB4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEB3
 EndChar
+
 StartChar: uni0634
-Encoding: 1588 1588 1588
+Encoding: 1588 1588 1187
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 672 -380 basechar 0
 AnchorPoint: "rtl-above" 476 1396 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 355 800 2
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 355 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEB6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEB8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEB7
 EndChar
+
 StartChar: uni0635
-Encoding: 1589 1589 1589
+Encoding: 1589 1589 1188
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 808 -292 basechar 0
@@ -44512,22 +45730,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEBA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEBC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEBB
 EndChar
+
 StartChar: uni0636
-Encoding: 1590 1590 1590
+Encoding: 1590 1590 1189
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 800 -320 basechar 0
 AnchorPoint: "rtl-above" 308 1096 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 335 695 2
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 335 695 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEBE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEBF
 EndChar
+
 StartChar: uni0637
-Encoding: 1591 1591 1591
+Encoding: 1591 1591 1190
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 340 -144 basechar 0
@@ -44562,22 +45782,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEC2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEC3
 EndChar
+
 StartChar: uni0638
-Encoding: 1592 1592 1592
+Encoding: 1592 1592 1191
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 364 -136 basechar 0
 AnchorPoint: "rtl-above" 236 1748 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 601 790 2
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 601 790 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEC6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEC8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEC7
 EndChar
+
 StartChar: uni0639
-Encoding: 1593 1593 1593
+Encoding: 1593 1593 1192
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 656 -564 basechar 0
@@ -44614,22 +45836,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFECA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFECC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFECB
 EndChar
+
 StartChar: uni063A
-Encoding: 1594 1594 1594
+Encoding: 1594 1594 1193
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 648 -560 basechar 0
 AnchorPoint: "rtl-above" 380 1524 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 381 1200 2
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 381 1200 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFECE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFECF
 EndChar
+
 StartChar: uni0640
-Encoding: 1600 1600 1600
+Encoding: 1600 1600 1194
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -136 basechar 0
@@ -44644,36 +45868,39 @@ SplineSet
  -20 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0641
-Encoding: 1601 1601 1601
+Encoding: 1601 1601 1195
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -188 basechar 0
 AnchorPoint: "rtl-above" 764 1412 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 764 1078 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 764 1078 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFED2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFED3
 EndChar
+
 StartChar: uni0642
-Encoding: 1602 1602 1602
+Encoding: 1602 1602 1196
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 552 -444 basechar 0
 AnchorPoint: "rtl-above" 668 1528 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 595 1150 2
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 595 1150 2
+Refer: 3762 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFED6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFED8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFED7
 EndChar
+
 StartChar: uni0643
-Encoding: 1603 1603 1603
+Encoding: 1603 1603 1197
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 508 -156 basechar 0
@@ -44722,8 +45949,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEDA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEDC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEDB
 EndChar
+
 StartChar: uni0644
-Encoding: 1604 1604 1604
+Encoding: 1604 1604 1198
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 532 -388 basechar 0
@@ -44753,8 +45981,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEDE
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE0
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEDF
 EndChar
+
 StartChar: uni0645
-Encoding: 1605 1605 1605
+Encoding: 1605 1605 1199
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
@@ -44794,22 +46023,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEE2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEE3
 EndChar
+
 StartChar: uni0646
-Encoding: 1606 1606 1606
+Encoding: 1606 1606 1200
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -420 basechar 0
 AnchorPoint: "rtl-above" 504 1132 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 490 714 2
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 490 714 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEE6
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEE8
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEE7
 EndChar
+
 StartChar: uni0647
-Encoding: 1607 1607 1607
+Encoding: 1607 1607 1201
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -216 basechar 0
@@ -44840,8 +46071,9 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEEA
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEEC
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEEB
 EndChar
+
 StartChar: uni0648
-Encoding: 1608 1608 1608
+Encoding: 1608 1608 1202
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -548 basechar 0
@@ -44874,8 +46106,9 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEEE
 EndChar
+
 StartChar: uni0649
-Encoding: 1609 1609 1609
+Encoding: 1609 1609 1203
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -332 basechar 0
@@ -44917,22 +46150,24 @@ Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEF0
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBE9
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBE8
 EndChar
+
 StartChar: uni064A
-Encoding: 1610 1610 1610
+Encoding: 1610 1610 1204
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -544 basechar 0
 AnchorPoint: "rtl-above" 664 1072 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 370 -500 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 370 -500 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFEF2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFEF4
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFEF3
 EndChar
+
 StartChar: uni064B
-Encoding: 1611 1611 1611
+Encoding: 1611 1611 1205
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -44952,8 +46187,9 @@ SplineSet
  324 1210 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064C
-Encoding: 1612 1612 1612
+Encoding: 1612 1612 1206
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -44994,8 +46230,9 @@ SplineSet
  698 1566 698 1566 724 1558 c 1,39,40
 EndSplineSet
 EndChar
+
 StartChar: uni064D
-Encoding: 1613 1613 1613
+Encoding: 1613 1613 1207
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 0 mark 0
@@ -45015,8 +46252,9 @@ SplineSet
  324 -250 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064E
-Encoding: 1614 1614 1614
+Encoding: 1614 1614 1208
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 605 1130 mark 0
@@ -45032,8 +46270,9 @@ SplineSet
  324 1210 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni064F
-Encoding: 1615 1615 1615
+Encoding: 1615 1615 1209
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 605 1130 mark 0
@@ -45071,8 +46310,9 @@ SplineSet
  698 1566 698 1566 724 1558 c 1,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni0650
-Encoding: 1616 1616 1616
+Encoding: 1616 1616 1210
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 616 0 mark 0
@@ -45088,8 +46328,9 @@ SplineSet
  324 -280 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0651
-Encoding: 1617 1617 1617
+Encoding: 1617 1617 1211
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 611 1826 basemark 0
@@ -45123,8 +46364,9 @@ SplineSet
  644 1359 644 1359 632 1412 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0652
-Encoding: 1618 1618 1618
+Encoding: 1618 1618 1212
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 610 1130 mark 0
@@ -45153,8 +46395,9 @@ SplineSet
  890 1639 890 1639 890 1524 c 128,-1,11
 EndSplineSet
 EndChar
+
 StartChar: uni0653
-Encoding: 1619 1619 1619
+Encoding: 1619 1619 1213
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 605 1130 mark 0
@@ -45177,8 +46420,9 @@ SplineSet
  256 1334 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0654
-Encoding: 1620 1620 1620
+Encoding: 1620 1620 1214
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above-mark" 611 1760 basemark 0
@@ -45186,10 +46430,11 @@ AnchorPoint: "rtl-above" 605 1130 mark 0
 AnchorPoint: "Ligature rtl-above" 605 1130 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -115 2
+Refer: 1231 1652 N 1 0 0 1 0 -115 2
 EndChar
+
 StartChar: uni0655
-Encoding: 1621 1621 1621
+Encoding: 1621 1621 1215
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below-mark" 624 -540 basemark 0
@@ -45197,10 +46442,11 @@ AnchorPoint: "rtl-below" 616 0 mark 0
 AnchorPoint: "Ligature rtl-below" 616 0 mark 0
 LayerCount: 2
 Fore
-Refer: 1652 1652 N 1 0 0 1 0 -1830 2
+Refer: 1231 1652 N 1 0 0 1 0 -1830 2
 EndChar
+
 StartChar: uni065A
-Encoding: 1626 1626 1626
+Encoding: 1626 1626 1216
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 616.5 1200 mark 0
@@ -45218,8 +46464,9 @@ SplineSet
  542 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0660
-Encoding: 1632 1632 1632
+Encoding: 1632 1632 1217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45232,8 +46479,9 @@ SplineSet
  506 700 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0661
-Encoding: 1633 1633 1633
+Encoding: 1633 1633 1218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45248,8 +46496,9 @@ SplineSet
  828 490 828 490 828 0 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0662
-Encoding: 1634 1634 1634
+Encoding: 1634 1634 1219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45272,8 +46521,9 @@ SplineSet
  577 808 577 808 493 865 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0663
-Encoding: 1635 1635 1635
+Encoding: 1635 1635 1220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45303,8 +46553,9 @@ SplineSet
  520 817 520 817 484 821 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0664
-Encoding: 1636 1636 1636
+Encoding: 1636 1636 1221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45336,8 +46587,9 @@ SplineSet
  661 1286 661 1286 864 1312 c 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0665
-Encoding: 1637 1637 1637
+Encoding: 1637 1637 1222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45363,8 +46615,9 @@ SplineSet
  427 1317 427 1317 616 1316 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0666
-Encoding: 1638 1638 1638
+Encoding: 1638 1638 1223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45383,8 +46636,9 @@ SplineSet
  709 1250 709 1250 915 1300 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni0667
-Encoding: 1639 1639 1639
+Encoding: 1639 1639 1224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45404,8 +46658,9 @@ SplineSet
  526 0 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0668
-Encoding: 1640 1640 1640
+Encoding: 1640 1640 1225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45425,8 +46680,9 @@ SplineSet
  510 1054 510 1054 526 1300 c 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0669
-Encoding: 1641 1641 1641
+Encoding: 1641 1641 1226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45455,8 +46711,9 @@ SplineSet
  591 781 591 781 748 778 c 1,21,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066A
-Encoding: 1642 1642 1642
+Encoding: 1642 1642 1227
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45479,8 +46736,9 @@ SplineSet
  874 1300 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066B
-Encoding: 1643 1643 1643
+Encoding: 1643 1643 1228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45499,8 +46757,9 @@ SplineSet
  310 -70 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni066C
-Encoding: 1644 1644 1644
+Encoding: 1644 1644 1229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45515,8 +46774,9 @@ SplineSet
  552 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066D
-Encoding: 1645 1645 1645
+Encoding: 1645 1645 1230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45535,8 +46795,9 @@ SplineSet
  146 759 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0674
-Encoding: 1652 1652 1652
+Encoding: 1652 1652 1231
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45560,174 +46821,188 @@ SplineSet
  445 1430 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0679
-Encoding: 1657 1657 1657
+Encoding: 1657 1657 1232
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 41.5 -600 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 41.5 -600 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB69
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB68
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB67
 EndChar
+
 StartChar: uni067A
-Encoding: 1658 1658 1658
+Encoding: 1658 1658 1233
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 533.5 900 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 533.5 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB61
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB60
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB5F
 EndChar
+
 StartChar: uni067B
-Encoding: 1659 1659 1659
+Encoding: 1659 1659 1234
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -536 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 528 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 528 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB55
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB54
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB53
 EndChar
+
 StartChar: uni067E
-Encoding: 1662 1662 1662
+Encoding: 1662 1662 1235
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 414 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 414 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB59
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB58
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB57
 EndChar
+
 StartChar: uni067F
-Encoding: 1663 1663 1663
+Encoding: 1663 1663 1236
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 419.5 900 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 419.5 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB65
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB64
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB63
 EndChar
+
 StartChar: uni0680
-Encoding: 1664 1664 1664
+Encoding: 1664 1664 1237
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -532 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 414 -250 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 414 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB5D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB5C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB5B
 EndChar
+
 StartChar: uni0683
-Encoding: 1667 1667 1667
+Encoding: 1667 1667 1238
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -537 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 554 81 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 554 81 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB79
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB78
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB77
 EndChar
+
 StartChar: uni0684
-Encoding: 1668 1668 1668
+Encoding: 1668 1668 1239
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -548 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 715 175 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 715 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB75
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB74
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB73
 EndChar
+
 StartChar: uni0686
-Encoding: 1670 1670 1670
+Encoding: 1670 1670 1240
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -548 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 618 150 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 618 150 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB7D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB7C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB7B
 EndChar
+
 StartChar: uni0687
-Encoding: 1671 1671 1671
+Encoding: 1671 1671 1241
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 610 175 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 610 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB81
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB80
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB7F
 EndChar
+
 StartChar: uni0691
-Encoding: 1681 1681 1681
+Encoding: 1681 1681 1242
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 558.5 -540.5 basechar 0
 AnchorPoint: "rtl-above" 700 1242.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 354.5 -585 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 354.5 -585 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8D
 EndChar
+
 StartChar: uni0698
-Encoding: 1688 1688 1688
+Encoding: 1688 1688 1243
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 529 -541.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 725 737 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 725 737 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8B
 EndChar
+
 StartChar: uni06A4
-Encoding: 1700 1700 1700
+Encoding: 1700 1700 1244
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 -188 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 624 1033 2
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 624 1033 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB6D
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB6C
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB6B
 EndChar
+
 StartChar: uni06A9
-Encoding: 1705 1705 1705
+Encoding: 1705 1705 1245
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 565 -150 basechar 0
@@ -45766,22 +47041,24 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB91
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB90
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB8F
 EndChar
+
 StartChar: uni06AF
-Encoding: 1711 1711 1711
+Encoding: 1711 1711 1246
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596.5 -150 basechar 0
 AnchorPoint: "rtl-above" 430 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 681.5 0 2
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 681.5 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFB95
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFB94
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB93
 EndChar
+
 StartChar: uni06BE
-Encoding: 1726 1726 1726
+Encoding: 1726 1726 1247
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 607.5 1120 basechar 0
@@ -45834,53 +47111,59 @@ Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBAD
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBAC
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFBAB
 EndChar
+
 StartChar: uni06CC
-Encoding: 1740 1740 1740
+Encoding: 1740 1740 1248
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -400 basechar 0
 AnchorPoint: "rtl-above" 415 780 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 Substitution2: "'medi' Medial Forms in Arabic lookup 4" uniFBFF
 Substitution2: "'init' Initial Forms in Arabic lookup 5" uniFBFE
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFBFD
 EndChar
+
 StartChar: uni06F0
-Encoding: 1776 1776 1776
+Encoding: 1776 1776 1249
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1632 1632 N 1 0 0 1 0 0 2
+Refer: 1217 1632 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F1
-Encoding: 1777 1777 1777
+Encoding: 1777 1777 1250
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1633 1633 N 1 0 0 1 0 0 2
+Refer: 1218 1633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F2
-Encoding: 1778 1778 1778
+Encoding: 1778 1778 1251
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1634 1634 N 1 0 0 1 0 0 2
+Refer: 1219 1634 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F3
-Encoding: 1779 1779 1779
+Encoding: 1779 1779 1252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1635 1635 N 1 0 0 1 0 0 2
+Refer: 1220 1635 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F4
-Encoding: 1780 1780 1780
+Encoding: 1780 1780 1253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45911,8 +47194,9 @@ SplineSet
  470 1084 470 1084 549 1044 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F5
-Encoding: 1781 1781 1781
+Encoding: 1781 1781 1254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45943,8 +47227,9 @@ SplineSet
  657 -13 657 -13 616 138 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F6
-Encoding: 1782 1782 1782
+Encoding: 1782 1782 1255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -45971,32 +47256,36 @@ SplineSet
  264 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni06F7
-Encoding: 1783 1783 1783
+Encoding: 1783 1783 1256
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1639 1639 N 1 0 0 1 0 0 2
+Refer: 1224 1639 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F8
-Encoding: 1784 1784 1784
+Encoding: 1784 1784 1257
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1640 1640 N 1 0 0 1 0 0 2
+Refer: 1225 1640 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06F9
-Encoding: 1785 1785 1785
+Encoding: 1785 1785 1258
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1641 1641 N 1 0 0 1 0 0 2
+Refer: 1226 1641 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0E3F
-Encoding: 3647 3647 3647
+Encoding: 3647 3647 1259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -46044,8 +47333,9 @@ SplineSet
  660 769 l 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni0E81
-Encoding: 3713 3713 3713
+Encoding: 3713 3713 1260
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46146,8 +47436,9 @@ SplineSet
  490 184 l 2,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni0E82
-Encoding: 3714 3714 3714
+Encoding: 3714 3714 1261
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46186,8 +47477,9 @@ SplineSet
  542 603 542 603 318.5 603 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E84
-Encoding: 3716 3716 3716
+Encoding: 3716 3716 1262
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46232,8 +47524,9 @@ SplineSet
  121 -21 121 -21 121 349 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni0E87
-Encoding: 3719 3719 3719
+Encoding: 3719 3719 1263
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46265,8 +47558,9 @@ SplineSet
  524.634 1007.93 524.634 1007.93 459.503 1006 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni0E88
-Encoding: 3720 3720 3720
+Encoding: 3720 3720 1264
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46304,8 +47598,9 @@ SplineSet
  260.25 1178 260.25 1178 612.25 1178 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8A
-Encoding: 3722 3722 3722
+Encoding: 3722 3722 1265
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 -492 basechar 0
@@ -46349,8 +47644,9 @@ SplineSet
  494 631 494 631 307 603 c 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E8D
-Encoding: 3725 3725 3725
+Encoding: 3725 3725 1266
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46389,8 +47685,9 @@ SplineSet
  309 416.021 309 416.021 309 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E94
-Encoding: 3732 3732 3732
+Encoding: 3732 3732 1267
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46444,11 +47741,11 @@ AnchorPoint: "lao-below" 1233 0 basechar 0
 LayerCount: 2
 Fore
 SplineSet
-358.25 235 m 0,0,1
- 294.25 235 294.25 235 294.25 171 c 0,2,3
- 294.25 107 294.25 107 358.25 107 c 0,4,5
- 422.25 107 422.25 107 422.25 171 c 0,6,7
- 422.25 235 422.25 235 358.25 235 c 0,0,1
+358.25 235 m 256,0,1
+ 294.25 235 294.25 235 294.25 171 c 256,2,3
+ 294.25 107 294.25 107 358.25 107 c 256,4,5
+ 422.25 107 422.25 107 422.25 171 c 256,6,7
+ 422.25 235 422.25 235 358.25 235 c 256,0,1
 925.75 0 m 1,8,-1
  925.75 799 l 2,9,10
  925.75 999.84 925.75 999.84 616 997 c 0,11,12
@@ -46466,8 +47763,9 @@ SplineSet
  925.75 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E95
-Encoding: 3733 3733 3733
+Encoding: 3733 3733 1268
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46507,8 +47805,9 @@ SplineSet
  772 747 772 747 644 747 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E96
-Encoding: 3734 3734 3734
+Encoding: 3734 3734 1269
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 -492 basechar 0
@@ -46546,8 +47845,9 @@ SplineSet
  441 351 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E97
-Encoding: 3735 3735 3735
+Encoding: 3735 3735 1270
 Width: 1233
 Flags: W
 TtInstrs:
@@ -46646,8 +47946,9 @@ SplineSet
  108 790 108 790 108 970 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni0E99
-Encoding: 3737 3737 3737
+Encoding: 3737 3737 1271
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46681,8 +47982,9 @@ SplineSet
  75 -29 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9A
-Encoding: 3738 3738 3738
+Encoding: 3738 3738 1272
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46711,8 +48013,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9B
-Encoding: 3739 3739 3739
+Encoding: 3739 3739 1273
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46741,8 +48044,9 @@ SplineSet
  125.003 -16 125.003 -16 125.003 320 c 0,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni0E9C
-Encoding: 3740 3740 3740
+Encoding: 3740 3740 1274
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46801,8 +48105,9 @@ SplineSet
  945.441 -16.5908 945.441 -16.5908 822.5 -17 c 0,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0E9D
-Encoding: 3741 3741 3741
+Encoding: 3741 3741 1275
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46845,8 +48150,9 @@ SplineSet
  342.5 1017 342.5 1017 310.5 1017 c 0,37,38
 EndSplineSet
 EndChar
+
 StartChar: uni0E9E
-Encoding: 3742 3742 3742
+Encoding: 3742 3742 1276
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46886,8 +48192,9 @@ SplineSet
  285.5 133 285.5 133 434.5 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0E9F
-Encoding: 3743 3743 3743
+Encoding: 3743 3743 1277
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1234 1552 basechar 0
@@ -46927,8 +48234,9 @@ SplineSet
  285.5 133 285.5 133 434.5 133 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA1
-Encoding: 3745 3745 3745
+Encoding: 3745 3745 1278
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -46954,8 +48262,9 @@ SplineSet
  355 1120 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EA2
-Encoding: 3746 3746 3746
+Encoding: 3746 3746 1279
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1552 basechar 0
@@ -46994,8 +48303,9 @@ SplineSet
  309 416.021 309 416.021 309 304 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA3
-Encoding: 3747 3747 3747
+Encoding: 3747 3747 1280
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47032,8 +48342,9 @@ SplineSet
  949.498 145 949.498 145 948.496 328 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA5
-Encoding: 3749 3749 3749
+Encoding: 3749 3749 1281
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47073,8 +48384,9 @@ SplineSet
  245 1165 245 1165 622 1164 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EA7
-Encoding: 3751 3751 3751
+Encoding: 3751 3751 1282
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47105,8 +48417,9 @@ SplineSet
  136 802 l 1,6,7
 EndSplineSet
 EndChar
+
 StartChar: uni0EAA
-Encoding: 3754 3754 3754
+Encoding: 3754 3754 1283
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47153,8 +48466,9 @@ SplineSet
  268 856 268 856 598 855 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni0EAB
-Encoding: 3755 3755 3755
+Encoding: 3755 3755 1284
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47199,8 +48513,9 @@ SplineSet
  853.046 -24.9417 853.046 -24.9417 445.004 -24 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni0EAD
-Encoding: 3757 3757 3757
+Encoding: 3757 3757 1285
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47239,8 +48554,9 @@ SplineSet
  940 696 940 696 940 857 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni0EAE
-Encoding: 3758 3758 3758
+Encoding: 3758 3758 1286
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1184 basechar 0
@@ -47282,8 +48598,9 @@ SplineSet
  582.935 132 582.935 132 594 132 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni0EAF
-Encoding: 3759 3759 3759
+Encoding: 3759 3759 1287
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47316,17 +48633,19 @@ SplineSet
  352.13 -217.5 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0EB0
-Encoding: 3760 3760 3760
+Encoding: 3760 3760 1288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3761 3761 N 1 0 0 1 1233 -1335 2
-Refer: 3761 3761 N 1 0 0 1 1233 -651 2
+Refer: 1289 3761 N 1 0 0 1 1233 -1335 2
+Refer: 1289 3761 N 1 0 0 1 1233 -651 2
 EndChar
+
 StartChar: uni0EB1
-Encoding: 3761 3761 3761
+Encoding: 3761 3761 1289
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" -9 1140 mark 0
@@ -47353,8 +48672,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB2
-Encoding: 3762 3762 3762
+Encoding: 3762 3762 1290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47378,17 +48698,19 @@ SplineSet
  323 772 323 772 323 717 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni0EB3
-Encoding: 3763 3763 3763
+Encoding: 3763 3763 1291
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 3762 3762 N 1 0 0 1 0 0 2
-Refer: 3789 3789 N 1 0 0 1 -1233 0 2
+Refer: 1290 3762 N 1 0 0 1 0 0 2
+Refer: 1305 3789 N 1 0 0 1 -1233 0 2
 EndChar
+
 StartChar: uni0EB4
-Encoding: 3764 3764 3764
+Encoding: 3764 3764 1292
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47409,8 +48731,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB5
-Encoding: 3765 3765 3765
+Encoding: 3765 3765 1293
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47435,8 +48758,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB6
-Encoding: 3766 3766 3766
+Encoding: 3766 3766 1294
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47462,8 +48786,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB7
-Encoding: 3767 3767 3767
+Encoding: 3767 3767 1295
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1143 mark 0
@@ -47493,8 +48818,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB8
-Encoding: 3768 3768 3768
+Encoding: 3768 3768 1296
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47519,8 +48845,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EB9
-Encoding: 3769 3769 3769
+Encoding: 3769 3769 1297
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47549,8 +48876,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EBB
-Encoding: 3771 3771 3771
+Encoding: 3771 3771 1298
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1140 mark 0
@@ -47577,8 +48905,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EBC
-Encoding: 3772 3772 3772
+Encoding: 3772 3772 1299
 Width: 1233
 Flags: W
 AnchorPoint: "lao-below" 1233 0 mark 0
@@ -47605,8 +48934,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EC8
-Encoding: 3784 3784 3784
+Encoding: 3784 3784 1300
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47621,8 +48951,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0EC9
-Encoding: 3785 3785 3785
+Encoding: 3785 3785 1301
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
@@ -47651,8 +48982,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECA
-Encoding: 3786 3786 3786
+Encoding: 3786 3786 1302
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
@@ -47692,8 +49024,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECB
-Encoding: 3787 3787 3787
+Encoding: 3787 3787 1303
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47716,18 +49049,20 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECC
-Encoding: 3788 3788 3788
+Encoding: 3788 3788 1304
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1150 mark 0
 LayerCount: 2
 Fore
-Refer: 3772 3772 N 1 0 0 1 0 1872 2
+Refer: 1299 3772 N 1 0 0 1 0 1872 2
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni0ECD
-Encoding: 3789 3789 3789
+Encoding: 3789 3789 1305
 Width: 1233
 Flags: W
 AnchorPoint: "lao-above" 1233 1120 mark 0
@@ -47747,8 +49082,9 @@ SplineSet
 EndSplineSet
 Position2: "'rtbd' Mark width in Lao-2" dx=0 dy=0 dh=-1233 dv=0
 EndChar
+
 StartChar: uni10D0
-Encoding: 4304 4304 4304
+Encoding: 4304 4304 1306
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47769,8 +49105,9 @@ SplineSet
  1075 804 1075 804 1075 495 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D1
-Encoding: 4305 4305 4305
+Encoding: 4305 4305 1307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47795,8 +49132,9 @@ SplineSet
  888 145 888 145 888 545 c 0,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni10D2
-Encoding: 4306 4306 4306
+Encoding: 4306 4306 1308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47824,8 +49162,9 @@ SplineSet
  943 -277 943 -277 943 43 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D3
-Encoding: 4307 4307 4307
+Encoding: 4307 4307 1309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47864,8 +49203,9 @@ SplineSet
  989 185 989 185 989 441 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D4
-Encoding: 4308 4308 4308
+Encoding: 4308 4308 1310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47890,8 +49230,9 @@ SplineSet
  1075 -32 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D5
-Encoding: 4309 4309 4309
+Encoding: 4309 4309 1311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47924,8 +49265,9 @@ SplineSet
  1074 -45 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D6
-Encoding: 4310 4310 4310
+Encoding: 4310 4310 1312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47954,8 +49296,9 @@ SplineSet
  686 984 686 984 684 1202 c 0,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni10D7
-Encoding: 4311 4311 4311
+Encoding: 4311 4311 1313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -47989,8 +49332,9 @@ SplineSet
  582 145 582 145 580 388 c 2,27,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10D8
-Encoding: 4312 4312 4312
+Encoding: 4312 4312 1314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48009,8 +49353,9 @@ SplineSet
  1075 1045 1075 1045 1074 547 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10D9
-Encoding: 4313 4313 4313
+Encoding: 4313 4313 1315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48039,8 +49384,9 @@ SplineSet
  1076 -30 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DA
-Encoding: 4314 4314 4314
+Encoding: 4314 4314 1316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48067,8 +49413,9 @@ SplineSet
  889 904 889 904 620 904 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DB
-Encoding: 4315 4315 4315
+Encoding: 4315 4315 1317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48096,8 +49443,9 @@ SplineSet
  888 145 888 145 888 495 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni10DC
-Encoding: 4316 4316 4316
+Encoding: 4316 4316 1318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48123,8 +49471,9 @@ SplineSet
  889 145 889 145 889 545 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10DD
-Encoding: 4317 4317 4317
+Encoding: 4317 4317 1319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48157,8 +49506,9 @@ SplineSet
  1178 454 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DE
-Encoding: 4318 4318 4318
+Encoding: 4318 4318 1320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48187,8 +49537,9 @@ SplineSet
  1076 748 1076 748 1076 474 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10DF
-Encoding: 4319 4319 4319
+Encoding: 4319 4319 1321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48213,8 +49564,9 @@ SplineSet
  1075 -18 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E0
-Encoding: 4320 4320 4320
+Encoding: 4320 4320 1322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48252,8 +49604,9 @@ SplineSet
  1178 1035 1178 1035 1178 596 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10E1
-Encoding: 4321 4321 4321
+Encoding: 4321 4321 1323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48276,8 +49629,9 @@ SplineSet
  1075 733 1075 733 1075 515 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E2
-Encoding: 4322 4322 4322
+Encoding: 4322 4322 1324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48301,8 +49655,9 @@ SplineSet
  233 777 233 777 233 290 c 0,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni10E3
-Encoding: 4323 4323 4323
+Encoding: 4323 4323 1325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48337,8 +49692,9 @@ SplineSet
  1098 -43 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E4
-Encoding: 4324 4324 4324
+Encoding: 4324 4324 1326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48385,8 +49741,9 @@ SplineSet
  578 727 l 2,46,47
 EndSplineSet
 EndChar
+
 StartChar: uni10E5
-Encoding: 4325 4325 4325
+Encoding: 4325 4325 1327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48414,8 +49771,9 @@ SplineSet
  1073 67 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E6
-Encoding: 4326 4326 4326
+Encoding: 4326 4326 1328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48454,8 +49812,9 @@ SplineSet
  237 -201 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E7
-Encoding: 4327 4327 4327
+Encoding: 4327 4327 1329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48481,8 +49840,9 @@ SplineSet
  1074 -47 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10E8
-Encoding: 4328 4328 4328
+Encoding: 4328 4328 1330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48516,8 +49876,9 @@ SplineSet
  889 145 889 145 890 515 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10E9
-Encoding: 4329 4329 4329
+Encoding: 4329 4329 1331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48545,8 +49906,9 @@ SplineSet
  778 1149 778 1149 778 1224 c 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni10EA
-Encoding: 4330 4330 4330
+Encoding: 4330 4330 1332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48577,8 +49939,9 @@ SplineSet
  1116 799 1116 799 1116 645 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10EB
-Encoding: 4331 4331 4331
+Encoding: 4331 4331 1333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48600,8 +49963,9 @@ SplineSet
  889 145 889 145 889 519 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EC
-Encoding: 4332 4332 4332
+Encoding: 4332 4332 1334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48635,8 +49999,9 @@ SplineSet
  348 904 348 904 347 565 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10ED
-Encoding: 4333 4333 4333
+Encoding: 4333 4333 1335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48674,8 +50039,9 @@ SplineSet
  372 957 372 957 372 763 c 0,38,39
 EndSplineSet
 EndChar
+
 StartChar: uni10EE
-Encoding: 4334 4334 4334
+Encoding: 4334 4334 1336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48697,8 +50063,9 @@ SplineSet
  889 145 889 145 889 525 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni10EF
-Encoding: 4335 4335 4335
+Encoding: 4335 4335 1337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48729,8 +50096,9 @@ SplineSet
  1075 234 1075 234 1076 41 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F0
-Encoding: 4336 4336 4336
+Encoding: 4336 4336 1338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48767,8 +50135,9 @@ SplineSet
  1076 497 1076 497 1076 360 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F1
-Encoding: 4337 4337 4337
+Encoding: 4337 4337 1339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48815,8 +50184,9 @@ SplineSet
  1074 81 1074 81 1075 -124 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F2
-Encoding: 4338 4338 4338
+Encoding: 4338 4338 1340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48840,8 +50210,9 @@ SplineSet
  345 902 345 902 345 519 c 0,18,19
 EndSplineSet
 EndChar
+
 StartChar: uni10F3
-Encoding: 4339 4339 4339
+Encoding: 4339 4339 1341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48872,8 +50243,9 @@ SplineSet
  1076 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F4
-Encoding: 4340 4340 4340
+Encoding: 4340 4340 1342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48905,8 +50277,9 @@ SplineSet
  1076 -20 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F5
-Encoding: 4341 4341 4341
+Encoding: 4341 4341 1343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48945,8 +50318,9 @@ SplineSet
  329 1415 329 1415 329 1218 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni10F6
-Encoding: 4342 4342 4342
+Encoding: 4342 4342 1344
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -48985,8 +50359,9 @@ SplineSet
  989 145 989 145 989 312 c 2,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F7
-Encoding: 4343 4343 4343
+Encoding: 4343 4343 1345
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49013,8 +50388,9 @@ SplineSet
  1124 174 1124 174 1126 0 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni10F8
-Encoding: 4344 4344 4344
+Encoding: 4344 4344 1346
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49041,8 +50417,9 @@ SplineSet
  161 1022 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10F9
-Encoding: 4345 4345 4345
+Encoding: 4345 4345 1347
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49069,8 +50446,9 @@ SplineSet
  301 917 301 917 301 619 c 0,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni10FA
-Encoding: 4346 4346 4346
+Encoding: 4346 4346 1348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49096,8 +50474,9 @@ SplineSet
  751 -135 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FB
-Encoding: 4347 4347 4347
+Encoding: 4347 4347 1349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49120,8 +50499,9 @@ SplineSet
  291 224 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni10FC
-Encoding: 4348 4348 4348
+Encoding: 4348 4348 1350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49146,524 +50526,611 @@ SplineSet
  734 836 734 836 734 1043 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni13A0
-Encoding: 5024 5024 5024
+Encoding: 5024 5024 1351
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A1
-Encoding: 5025 5025 5025
+Encoding: 5025 5025 1352
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A2
-Encoding: 5026 5026 5026
+Encoding: 5026 5026 1353
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A3
-Encoding: 5027 5027 5027
+Encoding: 5027 5027 1354
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A4
-Encoding: 5028 5028 5028
+Encoding: 5028 5028 1355
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A5
-Encoding: 5029 5029 5029
+Encoding: 5029 5029 1356
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A6
-Encoding: 5030 5030 5030
+Encoding: 5030 5030 1357
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A7
-Encoding: 5031 5031 5031
+Encoding: 5031 5031 1358
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A8
-Encoding: 5032 5032 5032
+Encoding: 5032 5032 1359
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13A9
-Encoding: 5033 5033 5033
+Encoding: 5033 5033 1360
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AA
-Encoding: 5034 5034 5034
+Encoding: 5034 5034 1361
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AB
-Encoding: 5035 5035 5035
+Encoding: 5035 5035 1362
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AC
-Encoding: 5036 5036 5036
+Encoding: 5036 5036 1363
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AD
-Encoding: 5037 5037 5037
+Encoding: 5037 5037 1364
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AE
-Encoding: 5038 5038 5038
+Encoding: 5038 5038 1365
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13AF
-Encoding: 5039 5039 5039
+Encoding: 5039 5039 1366
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B0
-Encoding: 5040 5040 5040
+Encoding: 5040 5040 1367
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B1
-Encoding: 5041 5041 5041
+Encoding: 5041 5041 1368
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B2
-Encoding: 5042 5042 5042
+Encoding: 5042 5042 1369
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B3
-Encoding: 5043 5043 5043
+Encoding: 5043 5043 1370
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B4
-Encoding: 5044 5044 5044
+Encoding: 5044 5044 1371
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B5
-Encoding: 5045 5045 5045
+Encoding: 5045 5045 1372
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B6
-Encoding: 5046 5046 5046
+Encoding: 5046 5046 1373
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B7
-Encoding: 5047 5047 5047
+Encoding: 5047 5047 1374
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B8
-Encoding: 5048 5048 5048
+Encoding: 5048 5048 1375
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13B9
-Encoding: 5049 5049 5049
+Encoding: 5049 5049 1376
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BA
-Encoding: 5050 5050 5050
+Encoding: 5050 5050 1377
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BB
-Encoding: 5051 5051 5051
+Encoding: 5051 5051 1378
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BC
-Encoding: 5052 5052 5052
+Encoding: 5052 5052 1379
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BD
-Encoding: 5053 5053 5053
+Encoding: 5053 5053 1380
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BE
-Encoding: 5054 5054 5054
+Encoding: 5054 5054 1381
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13BF
-Encoding: 5055 5055 5055
+Encoding: 5055 5055 1382
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C0
-Encoding: 5056 5056 5056
+Encoding: 5056 5056 1383
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C1
-Encoding: 5057 5057 5057
+Encoding: 5057 5057 1384
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C2
-Encoding: 5058 5058 5058
+Encoding: 5058 5058 1385
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C3
-Encoding: 5059 5059 5059
+Encoding: 5059 5059 1386
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C4
-Encoding: 5060 5060 5060
+Encoding: 5060 5060 1387
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C5
-Encoding: 5061 5061 5061
+Encoding: 5061 5061 1388
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C6
-Encoding: 5062 5062 5062
+Encoding: 5062 5062 1389
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C7
-Encoding: 5063 5063 5063
+Encoding: 5063 5063 1390
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C8
-Encoding: 5064 5064 5064
+Encoding: 5064 5064 1391
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13C9
-Encoding: 5065 5065 5065
+Encoding: 5065 5065 1392
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CA
-Encoding: 5066 5066 5066
+Encoding: 5066 5066 1393
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CB
-Encoding: 5067 5067 5067
+Encoding: 5067 5067 1394
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CC
-Encoding: 5068 5068 5068
+Encoding: 5068 5068 1395
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CD
-Encoding: 5069 5069 5069
+Encoding: 5069 5069 1396
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CE
-Encoding: 5070 5070 5070
+Encoding: 5070 5070 1397
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13CF
-Encoding: 5071 5071 5071
+Encoding: 5071 5071 1398
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D0
-Encoding: 5072 5072 5072
+Encoding: 5072 5072 1399
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D1
-Encoding: 5073 5073 5073
+Encoding: 5073 5073 1400
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D2
-Encoding: 5074 5074 5074
+Encoding: 5074 5074 1401
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D3
-Encoding: 5075 5075 5075
+Encoding: 5075 5075 1402
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D4
-Encoding: 5076 5076 5076
+Encoding: 5076 5076 1403
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D5
-Encoding: 5077 5077 5077
+Encoding: 5077 5077 1404
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D6
-Encoding: 5078 5078 5078
+Encoding: 5078 5078 1405
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D7
-Encoding: 5079 5079 5079
+Encoding: 5079 5079 1406
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D8
-Encoding: 5080 5080 5080
+Encoding: 5080 5080 1407
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13D9
-Encoding: 5081 5081 5081
+Encoding: 5081 5081 1408
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DA
-Encoding: 5082 5082 5082
+Encoding: 5082 5082 1409
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DB
-Encoding: 5083 5083 5083
+Encoding: 5083 5083 1410
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DC
-Encoding: 5084 5084 5084
+Encoding: 5084 5084 1411
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DD
-Encoding: 5085 5085 5085
+Encoding: 5085 5085 1412
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DE
-Encoding: 5086 5086 5086
+Encoding: 5086 5086 1413
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13DF
-Encoding: 5087 5087 5087
+Encoding: 5087 5087 1414
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E0
-Encoding: 5088 5088 5088
+Encoding: 5088 5088 1415
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E1
-Encoding: 5089 5089 5089
+Encoding: 5089 5089 1416
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E2
-Encoding: 5090 5090 5090
+Encoding: 5090 5090 1417
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E3
-Encoding: 5091 5091 5091
+Encoding: 5091 5091 1418
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E4
-Encoding: 5092 5092 5092
+Encoding: 5092 5092 1419
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E5
-Encoding: 5093 5093 5093
+Encoding: 5093 5093 1420
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E6
-Encoding: 5094 5094 5094
+Encoding: 5094 5094 1421
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E7
-Encoding: 5095 5095 5095
+Encoding: 5095 5095 1422
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E8
-Encoding: 5096 5096 5096
+Encoding: 5096 5096 1423
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13E9
-Encoding: 5097 5097 5097
+Encoding: 5097 5097 1424
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EA
-Encoding: 5098 5098 5098
+Encoding: 5098 5098 1425
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EB
-Encoding: 5099 5099 5099
+Encoding: 5099 5099 1426
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EC
-Encoding: 5100 5100 5100
+Encoding: 5100 5100 1427
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13ED
-Encoding: 5101 5101 5101
+Encoding: 5101 5101 1428
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EE
-Encoding: 5102 5102 5102
+Encoding: 5102 5102 1429
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13EF
-Encoding: 5103 5103 5103
+Encoding: 5103 5103 1430
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F0
-Encoding: 5104 5104 5104
+Encoding: 5104 5104 1431
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F1
-Encoding: 5105 5105 5105
+Encoding: 5105 5105 1432
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F2
-Encoding: 5106 5106 5106
+Encoding: 5106 5106 1433
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F3
-Encoding: 5107 5107 5107
+Encoding: 5107 5107 1434
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F4
-Encoding: 5108 5108 5108
+Encoding: 5108 5108 1435
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni13F5
-Encoding: 5109 5109 5109
+Encoding: 5109 5109 1436
 Width: 1233
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni1D02
-Encoding: 7426 7426 7426
+Encoding: 7426 7426 1437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49723,8 +51190,9 @@ SplineSet
  41 604 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D08
-Encoding: 7432 7432 7432
+Encoding: 7432 7432 1438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49762,8 +51230,9 @@ SplineSet
  916 541 916 541 784 518 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D09
-Encoding: 7433 7433 7433
+Encoding: 7433 7433 1439
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49787,8 +51256,9 @@ SplineSet
  727 -432 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D14
-Encoding: 7444 7444 7444
+Encoding: 7444 7444 1440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49839,8 +51309,9 @@ SplineSet
  14 604 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D16
-Encoding: 7446 7446 7446
+Encoding: 7446 7446 1441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49859,8 +51330,9 @@ SplineSet
  137 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D17
-Encoding: 7447 7447 7447
+Encoding: 7447 7447 1442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49879,8 +51351,9 @@ SplineSet
  1095 559 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D1D
-Encoding: 7453 7453 7453
+Encoding: 7453 7453 1443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49905,8 +51378,9 @@ SplineSet
  965 2.5 965 2.5 737 2.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1E
-Encoding: 7454 7454 7454
+Encoding: 7454 7454 1444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49941,8 +51415,9 @@ SplineSet
  1012.35 -1.5 1012.35 -1.5 852.75 -1.5 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D1F
-Encoding: 7455 7455 7455
+Encoding: 7455 7455 1445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -49978,8 +51453,9 @@ SplineSet
  1120 488 1120 488 1049 460 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2C
-Encoding: 7468 7468 7468
+Encoding: 7468 7468 1446
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.58 668 basechar 0
@@ -50002,8 +51478,9 @@ SplineSet
  540 1504 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2D
-Encoding: 7469 7469 7469
+Encoding: 7469 7469 1447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50033,8 +51510,9 @@ SplineSet
  579 1409 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D2E
-Encoding: 7470 7470 7470
+Encoding: 7470 7470 1448
 Width: 1233
 Flags: W
 AnchorPoint: "above" 594.08 1504.08 basechar 0
@@ -50072,8 +51550,9 @@ SplineSet
  311 1504 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D30
-Encoding: 7472 7472 7472
+Encoding: 7472 7472 1449
 Width: 1233
 Flags: W
 AnchorPoint: "above" 581.58 1504.08 basechar 0
@@ -50099,8 +51578,9 @@ SplineSet
  502 1504 l 2,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni1D31
-Encoding: 7473 7473 7473
+Encoding: 7473 7473 1450
 Width: 1233
 Flags: W
 AnchorPoint: "above" 606.92 1504.08 basechar 0
@@ -50123,8 +51603,9 @@ SplineSet
  332 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D32
-Encoding: 7474 7474 7474
+Encoding: 7474 7474 1451
 Width: 1233
 Flags: W
 AnchorPoint: "above" 626.45 1504.08 basechar 0
@@ -50147,8 +51628,9 @@ SplineSet
  902 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D33
-Encoding: 7475 7475 7475
+Encoding: 7475 7475 1452
 Width: 1233
 Flags: W
 AnchorPoint: "above" 656.08 1504.08 basechar 0
@@ -50181,8 +51663,9 @@ SplineSet
  932 737 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D34
-Encoding: 7476 7476 7476
+Encoding: 7476 7476 1453
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616.58 1504.08 basechar 0
@@ -50205,8 +51688,9 @@ SplineSet
  314 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D35
-Encoding: 7477 7477 7477
+Encoding: 7477 7477 1454
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616.58 1504.08 basechar 0
@@ -50229,8 +51713,9 @@ SplineSet
  356 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D36
-Encoding: 7478 7478 7478
+Encoding: 7478 7478 1455
 Width: 1233
 Flags: W
 AnchorPoint: "above" 700.58 1504.08 basechar 0
@@ -50255,8 +51740,9 @@ SplineSet
  415 676 415 676 350 702 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D37
-Encoding: 7479 7479 7479
+Encoding: 7479 7479 1456
 Width: 1233
 Flags: W
 AnchorPoint: "below" 575.58 668 basechar 0
@@ -50279,8 +51765,9 @@ SplineSet
  274 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D38
-Encoding: 7480 7480 7480
+Encoding: 7480 7480 1457
 Width: 1233
 Flags: W
 AnchorPoint: "below" 609.58 668 basechar 0
@@ -50297,8 +51784,9 @@ SplineSet
  325 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D39
-Encoding: 7481 7481 7481
+Encoding: 7481 7481 1458
 Width: 1233
 Flags: W
 AnchorPoint: "below" 617.08 668 basechar 0
@@ -50322,8 +51810,9 @@ SplineSet
  283 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3A
-Encoding: 7482 7482 7482
+Encoding: 7482 7482 1459
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50344,8 +51833,9 @@ SplineSet
  316 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3B
-Encoding: 7483 7483 7483
+Encoding: 7483 7483 1460
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.71 668 basechar 0
@@ -50366,8 +51856,9 @@ SplineSet
  917 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3C
-Encoding: 7484 7484 7484
+Encoding: 7484 7484 1461
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50395,8 +51886,9 @@ SplineSet
  931 1304 931 1304 931 1085 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D3E
-Encoding: 7486 7486 7486
+Encoding: 7486 7486 1462
 Width: 1233
 Flags: W
 AnchorPoint: "below" 583.08 668 basechar 0
@@ -50424,8 +51916,9 @@ SplineSet
  319 1504 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D3F
-Encoding: 7487 7487 7487
+Encoding: 7487 7487 1463
 Width: 1233
 Flags: W
 AnchorPoint: "below" 539.58 668 basechar 0
@@ -50460,8 +51953,9 @@ SplineSet
  401 1411 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D40
-Encoding: 7488 7488 7488
+Encoding: 7488 7488 1464
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50480,8 +51974,9 @@ SplineSet
  258 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D41
-Encoding: 7489 7489 7489
+Encoding: 7489 7489 1465
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50514,8 +52009,9 @@ SplineSet
  321 862 321 862 321 989 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D42
-Encoding: 7490 7490 7490
+Encoding: 7490 7490 1466
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616.08 668 basechar 0
@@ -50539,8 +52035,9 @@ SplineSet
  228 1504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D43
-Encoding: 7491 7491 7491
+Encoding: 7491 7491 1467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50581,8 +52078,9 @@ SplineSet
  908 1108 908 1108 908 1026 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D44
-Encoding: 7492 7492 7492
+Encoding: 7492 7492 1468
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50623,8 +52121,9 @@ SplineSet
  325 854 325 854 325 936 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D45
-Encoding: 7493 7493 7493
+Encoding: 7493 7493 1469
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50655,8 +52154,9 @@ SplineSet
  449 1101 449 1101 449 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D46
-Encoding: 7494 7494 7494
+Encoding: 7494 7494 1470
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50716,8 +52216,9 @@ SplineSet
  251 1006 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D47
-Encoding: 7495 7495 7495
+Encoding: 7495 7495 1471
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50748,8 +52249,9 @@ SplineSet
  443 1215 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D48
-Encoding: 7496 7496 7496
+Encoding: 7496 7496 1472
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50780,8 +52282,9 @@ SplineSet
  449 1101 449 1101 449 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D49
-Encoding: 7497 7497 7497
+Encoding: 7497 7497 1473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50812,8 +52315,9 @@ SplineSet
  812 1038 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni1D4A
-Encoding: 7498 7498 7498
+Encoding: 7498 7498 1474
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50844,8 +52348,9 @@ SplineSet
  421 924 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni1D4B
-Encoding: 7499 7499 7499
+Encoding: 7499 7499 1475
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50883,8 +52388,9 @@ SplineSet
  428 995 428 995 511 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4C
-Encoding: 7500 7500 7500
+Encoding: 7500 7500 1476
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50922,8 +52428,9 @@ SplineSet
  805 971 805 971 722 958 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4D
-Encoding: 7501 7501 7501
+Encoding: 7501 7501 1477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50963,8 +52470,9 @@ SplineSet
  906 708 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D4E
-Encoding: 7502 7502 7502
+Encoding: 7502 7502 1478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -50988,8 +52496,9 @@ SplineSet
  674 426 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D4F
-Encoding: 7503 7503 7503
+Encoding: 7503 7503 1479
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51010,8 +52519,9 @@ SplineSet
  312 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D50
-Encoding: 7504 7504 7504
+Encoding: 7504 7504 1480
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51047,8 +52557,9 @@ SplineSet
  633 1271 633 1271 651 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D51
-Encoding: 7505 7505 7505
+Encoding: 7505 7505 1481
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51079,8 +52590,9 @@ SplineSet
  886 1184 886 1184 886 1057 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D52
-Encoding: 7506 7506 7506
+Encoding: 7506 7506 1482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51106,8 +52618,9 @@ SplineSet
  469 1310 469 1310 616 1310 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D53
-Encoding: 7507 7507 7507
+Encoding: 7507 7507 1483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51134,8 +52647,9 @@ SplineSet
  344 1262 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D54
-Encoding: 7508 7508 7508
+Encoding: 7508 7508 1484
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51154,8 +52668,9 @@ SplineSet
  314 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D55
-Encoding: 7509 7509 7509
+Encoding: 7509 7509 1485
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51174,8 +52689,9 @@ SplineSet
  919 981 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1D56
-Encoding: 7510 7510 7510
+Encoding: 7510 7510 1486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51206,8 +52722,9 @@ SplineSet
  784 861 784 861 784 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D57
-Encoding: 7511 7511 7511
+Encoding: 7511 7511 1487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51234,8 +52751,9 @@ SplineSet
  637 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D58
-Encoding: 7512 7512 7512
+Encoding: 7512 7512 1488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51260,8 +52778,9 @@ SplineSet
  347 778 347 778 347 905 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D59
-Encoding: 7513 7513 7513
+Encoding: 7513 7513 1489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51286,8 +52805,9 @@ SplineSet
  836 669 836 669 692 669 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5A
-Encoding: 7514 7514 7514
+Encoding: 7514 7514 1490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51323,8 +52843,9 @@ SplineSet
  600 707 600 707 582 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D5B
-Encoding: 7515 7515 7515
+Encoding: 7515 7515 1491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51340,40 +52861,45 @@ SplineSet
  291 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D62
-Encoding: 7522 7522 7522
+Encoding: 7522 7522 1492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8305 8305 N 1 0 0 1 0 -668 3
+Refer: 2008 8305 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D63
-Encoding: 7523 7523 7523
+Encoding: 7523 7523 1493
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 691 691 N 1 0 0 1 0 -668 3
+Refer: 608 691 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D64
-Encoding: 7524 7524 7524
+Encoding: 7524 7524 1494
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7512 7512 N 1 0 0 1 0 -668 3
+Refer: 1488 7512 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D65
-Encoding: 7525 7525 7525
+Encoding: 7525 7525 1495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7515 7515 N 1 0 0 1 0 -668 3
+Refer: 1491 7515 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni1D77
-Encoding: 7543 7543 7543
+Encoding: 7543 7543 1496
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51413,16 +52939,18 @@ SplineSet
  123 635 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1D78
-Encoding: 7544 7544 7544
+Encoding: 7544 7544 1497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7476 7476 N 1 0 0 1 0 0 2
+Refer: 1453 7476 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1D7B
-Encoding: 7547 7547 7547
+Encoding: 7547 7547 1498
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51451,8 +52979,9 @@ SplineSet
  1076.75 616 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1D85
-Encoding: 7557 7557 7557
+Encoding: 7557 7557 1499
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51472,7 +53001,7 @@ SplineSet
  670 -270 l 2,15,16
  760 -270 760 -270 805 -208 c 0,17,18
  849 -146 849 -146 849 -20 c 2,19,-1
- 849 5.55112e-16 l 1,20,-1
+ 849 5.55112e-016 l 1,20,-1
  801 0 l 2,21,22
  636 0 636 0 545.5 106 c 0,23,24
  455 212 455 212 455 406 c 2,25,-1
@@ -51483,8 +53012,9 @@ SplineSet
  639 406 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9B
-Encoding: 7579 7579 7579
+Encoding: 7579 7579 1500
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51515,8 +53045,9 @@ SplineSet
  784 861 784 861 784 981 c 0,17,18
 EndSplineSet
 EndChar
+
 StartChar: uni1D9C
-Encoding: 7580 7580 7580
+Encoding: 7580 7580 1501
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51543,8 +53074,9 @@ SplineSet
  889 700 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1D9D
-Encoding: 7581 7581 7581
+Encoding: 7581 7581 1502
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51578,8 +53110,9 @@ SplineSet
  634 647 634 647 589 657 c 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni1D9E
-Encoding: 7582 7582 7582
+Encoding: 7582 7582 1503
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51620,8 +53153,9 @@ SplineSet
  759 1143 759 1143 728 1182 c 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni1D9F
-Encoding: 7583 7583 7583
+Encoding: 7583 7583 1504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51659,8 +53193,9 @@ SplineSet
  796 1022 796 1022 721 1008 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA0
-Encoding: 7584 7584 7584
+Encoding: 7584 7584 1505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51687,8 +53222,9 @@ SplineSet
  890 1539 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA1
-Encoding: 7585 7585 7585
+Encoding: 7585 7585 1506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51717,8 +53253,9 @@ SplineSet
  462 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA2
-Encoding: 7586 7586 7586
+Encoding: 7586 7586 1507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51755,8 +53292,9 @@ SplineSet
  906 708 l 2,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1DA3
-Encoding: 7587 7587 7587
+Encoding: 7587 7587 1508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51781,8 +53319,9 @@ SplineSet
  347 778 347 778 347 905 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA4
-Encoding: 7588 7588 7588
+Encoding: 7588 7588 1509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51814,8 +53353,9 @@ SplineSet
  383 1295 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA5
-Encoding: 7589 7589 7589
+Encoding: 7589 7589 1510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51836,8 +53376,9 @@ SplineSet
  880 668 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DA6
-Encoding: 7590 7590 7590
+Encoding: 7590 7590 1511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51858,8 +53399,9 @@ SplineSet
  329 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA7
-Encoding: 7591 7591 7591
+Encoding: 7591 7591 1512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51888,8 +53430,9 @@ SplineSet
  906 1013 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DA8
-Encoding: 7592 7592 7592
+Encoding: 7592 7592 1513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51920,8 +53463,9 @@ SplineSet
  634 557 634 557 640 582 c 1,19,20
 EndSplineSet
 EndChar
+
 StartChar: uni1DA9
-Encoding: 7593 7593 7593
+Encoding: 7593 7593 1514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51942,8 +53486,9 @@ SplineSet
  643 657 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAA
-Encoding: 7594 7594 7594
+Encoding: 7594 7594 1515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51972,8 +53517,9 @@ SplineSet
  643 895 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAB
-Encoding: 7595 7595 7595
+Encoding: 7595 7595 1516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -51988,8 +53534,9 @@ SplineSet
  382 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAC
-Encoding: 7596 7596 7596
+Encoding: 7596 7596 1517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52034,8 +53581,9 @@ SplineSet
  633 1271 633 1271 650 1231 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAD
-Encoding: 7597 7597 7597
+Encoding: 7597 7597 1518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52071,8 +53619,9 @@ SplineSet
  600 707 600 707 582 747 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAE
-Encoding: 7598 7598 7598
+Encoding: 7598 7598 1519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52103,8 +53652,9 @@ SplineSet
  536 657 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DAF
-Encoding: 7599 7599 7599
+Encoding: 7599 7599 1520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52139,8 +53689,9 @@ SplineSet
  697 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB0
-Encoding: 7600 7600 7600
+Encoding: 7600 7600 1521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52159,8 +53710,9 @@ SplineSet
  319 1310 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB1
-Encoding: 7601 7601 7601
+Encoding: 7601 7601 1522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52189,8 +53741,9 @@ SplineSet
  783 844 783 844 792 918 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB2
-Encoding: 7602 7602 7602
+Encoding: 7602 7602 1523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52233,8 +53786,9 @@ SplineSet
  513 759 513 759 563 746 c 1,43,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB3
-Encoding: 7603 7603 7603
+Encoding: 7603 7603 1524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52281,8 +53835,9 @@ SplineSet
  800 1294 800 1294 848 1277 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB4
-Encoding: 7604 7604 7604
+Encoding: 7604 7604 1525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52307,8 +53862,9 @@ SplineSet
  521 571 521 571 521 657 c 0,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB5
-Encoding: 7605 7605 7605
+Encoding: 7605 7605 1526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52343,8 +53899,9 @@ SplineSet
  637 1473 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB6
-Encoding: 7606 7606 7606
+Encoding: 7606 7606 1527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52381,8 +53938,9 @@ SplineSet
  787 842 787 842 792 921 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB7
-Encoding: 7607 7607 7607
+Encoding: 7607 7607 1528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52415,8 +53973,9 @@ SplineSet
  288 1203 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DB9
-Encoding: 7609 7609 7609
+Encoding: 7609 7609 1529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52445,8 +54004,9 @@ SplineSet
  592 1213 592 1213 563 1220 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DBA
-Encoding: 7610 7610 7610
+Encoding: 7610 7610 1530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52462,8 +54022,9 @@ SplineSet
  960 668 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBB
-Encoding: 7611 7611 7611
+Encoding: 7611 7611 1531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52482,8 +54043,9 @@ SplineSet
  368 1296 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBC
-Encoding: 7612 7612 7612
+Encoding: 7612 7612 1532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52512,8 +54074,9 @@ SplineSet
  362 1295 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni1DBD
-Encoding: 7613 7613 7613
+Encoding: 7613 7613 1533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52543,8 +54106,9 @@ SplineSet
  693 831 693 831 671 750 c 1,21,22
 EndSplineSet
 EndChar
+
 StartChar: uni1DBE
-Encoding: 7614 7614 7614
+Encoding: 7614 7614 1534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52575,8 +54139,9 @@ SplineSet
  612 935 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1DBF
-Encoding: 7615 7615 7615
+Encoding: 7615 7615 1535
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -52605,3178 +54170,3537 @@ SplineSet
  469 1508 469 1508 616 1508 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni1E00
-Encoding: 7680 7680 7680
+Encoding: 7680 7680 1536
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E01
-Encoding: 7681 7681 7681
+Encoding: 7681 7681 1537
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 805 805 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 692 805 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E02
-Encoding: 7682 7682 7682
+Encoding: 7682 7682 1538
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E03
-Encoding: 7683 7683 7683
+Encoding: 7683 7683 1539
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 50 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 50 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E04
-Encoding: 7684 7684 7684
+Encoding: 7684 7684 1540
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E05
-Encoding: 7685 7685 7685
+Encoding: 7685 7685 1541
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E06
-Encoding: 7686 7686 7686
+Encoding: 7686 7686 1542
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E07
-Encoding: 7687 7687 7687
+Encoding: 7687 7687 1543
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E08
-Encoding: 7688 7688 7688
+Encoding: 7688 7688 1544
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 90 373 2
-Refer: 807 807 N 1 0 0 1 100 0 2
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 90 373 2
+Refer: 694 807 N 1 0 0 1 100 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E09
-Encoding: 7689 7689 7689
+Encoding: 7689 7689 1545
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 90 0 2
-Refer: 807 807 N 1 0 0 1 104 0 2
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 90 0 2
+Refer: 694 807 N 1 0 0 1 104 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0A
-Encoding: 7690 7690 7690
+Encoding: 7690 7690 1546
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0B
-Encoding: 7691 7691 7691
+Encoding: 7691 7691 1547
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 -50 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 -50 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0C
-Encoding: 7692 7692 7692
+Encoding: 7692 7692 1548
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0D
-Encoding: 7693 7693 7693
+Encoding: 7693 7693 1549
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0E
-Encoding: 7694 7694 7694
+Encoding: 7694 7694 1550
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E0F
-Encoding: 7695 7695 7695
+Encoding: 7695 7695 1551
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E10
-Encoding: 7696 7696 7696
+Encoding: 7696 7696 1552
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -270 0 2
-Refer: 68 68 N 1 0 0 1 0 0 3
+Refer: 694 807 N 1 0 0 1 -270 0 2
+Refer: 37 68 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E11
-Encoding: 7697 7697 7697
+Encoding: 7697 7697 1553
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -20 0 2
-Refer: 100 100 N 1 0 0 1 0 0 3
+Refer: 694 807 N 1 0 0 1 -20 0 2
+Refer: 69 100 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E12
-Encoding: 7698 7698 7698
+Encoding: 7698 7698 1554
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 -50 0 2
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 -50 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E13
-Encoding: 7699 7699 7699
+Encoding: 7699 7699 1555
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E18
-Encoding: 7704 7704 7704
+Encoding: 7704 7704 1556
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E19
-Encoding: 7705 7705 7705
+Encoding: 7705 7705 1557
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1A
-Encoding: 7706 7706 7706
+Encoding: 7706 7706 1558
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1B
-Encoding: 7707 7707 7707
+Encoding: 7707 7707 1559
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1C
-Encoding: 7708 7708 7708
+Encoding: 7708 7708 1560
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 3735 -1 N 1 0 0 1 18 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1D
-Encoding: 7709 7709 7709
+Encoding: 7709 7709 1561
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
-Refer: 807 807 N 1 0 0 1 50 0 2
+Refer: 661 774 N 1 0 0 1 14 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 50 0 2
 EndChar
+
 StartChar: uni1E1E
-Encoding: 7710 7710 7710
+Encoding: 7710 7710 1562
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 54 0 2
-Refer: 70 70 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 54 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E1F
-Encoding: 7711 7711 7711
+Encoding: 7711 7711 1563
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 102 102 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E20
-Encoding: 7712 7712 7712
+Encoding: 7712 7712 1564
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 50 0 2
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 50 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E21
-Encoding: 7713 7713 7713
+Encoding: 7713 7713 1565
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E22
-Encoding: 7714 7714 7714
+Encoding: 7714 7714 1566
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E23
-Encoding: 7715 7715 7715
+Encoding: 7715 7715 1567
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E24
-Encoding: 7716 7716 7716
+Encoding: 7716 7716 1568
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E25
-Encoding: 7717 7717 7717
+Encoding: 7717 7717 1569
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E26
-Encoding: 7718 7718 7718
+Encoding: 7718 7718 1570
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 0.5 348 2
-Refer: 72 72 N 1 0 0 1 0 0 3
+Refer: 3727 -1 N 1 0 0 1 0.5 348 2
+Refer: 41 72 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E27
-Encoding: 7719 7719 7719
+Encoding: 7719 7719 1571
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 7 328 2
-Refer: 104 104 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 7 328 2
+Refer: 73 104 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E28
-Encoding: 7720 7720 7720
+Encoding: 7720 7720 1572
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -375 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -375 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E29
-Encoding: 7721 7721 7721
+Encoding: 7721 7721 1573
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 807 807 N 1 0 0 1 -340 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 694 807 N 1 0 0 1 -340 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2A
-Encoding: 7722 7722 7722
+Encoding: 7722 7722 1574
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2B
-Encoding: 7723 7723 7723
+Encoding: 7723 7723 1575
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 814 814 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 701 814 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2C
-Encoding: 7724 7724 7724
+Encoding: 7724 7724 1576
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E2D
-Encoding: 7725 7725 7725
+Encoding: 7725 7725 1577
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E30
-Encoding: 7728 7728 7728
+Encoding: 7728 7728 1578
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E31
-Encoding: 7729 7729 7729
+Encoding: 7729 7729 1579
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -219 373 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 -219 373 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E32
-Encoding: 7730 7730 7730
+Encoding: 7730 7730 1580
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E33
-Encoding: 7731 7731 7731
+Encoding: 7731 7731 1581
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E34
-Encoding: 7732 7732 7732
+Encoding: 7732 7732 1582
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E35
-Encoding: 7733 7733 7733
+Encoding: 7733 7733 1583
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E36
-Encoding: 7734 7734 7734
+Encoding: 7734 7734 1584
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E37
-Encoding: 7735 7735 7735
+Encoding: 7735 7735 1585
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E38
-Encoding: 7736 7736 7736
+Encoding: 7736 7736 1586
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 7734 7734 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 1584 7734 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E39
-Encoding: 7737 7737 7737
+Encoding: 7737 7737 1587
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 7735 7735 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 1585 7735 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3A
-Encoding: 7738 7738 7738
+Encoding: 7738 7738 1588
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3B
-Encoding: 7739 7739 7739
+Encoding: 7739 7739 1589
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3C
-Encoding: 7740 7740 7740
+Encoding: 7740 7740 1590
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 50 0 2
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 50 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3D
-Encoding: 7741 7741 7741
+Encoding: 7741 7741 1591
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3E
-Encoding: 7742 7742 7742
+Encoding: 7742 7742 1592
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 373 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 373 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E3F
-Encoding: 7743 7743 7743
+Encoding: 7743 7743 1593
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E40
-Encoding: 7744 7744 7744
+Encoding: 7744 7744 1594
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E41
-Encoding: 7745 7745 7745
+Encoding: 7745 7745 1595
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E42
-Encoding: 7746 7746 7746
+Encoding: 7746 7746 1596
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E43
-Encoding: 7747 7747 7747
+Encoding: 7747 7747 1597
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E44
-Encoding: 7748 7748 7748
+Encoding: 7748 7748 1598
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E45
-Encoding: 7749 7749 7749
+Encoding: 7749 7749 1599
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E46
-Encoding: 7750 7750 7750
+Encoding: 7750 7750 1600
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E47
-Encoding: 7751 7751 7751
+Encoding: 7751 7751 1601
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E48
-Encoding: 7752 7752 7752
+Encoding: 7752 7752 1602
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E49
-Encoding: 7753 7753 7753
+Encoding: 7753 7753 1603
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4A
-Encoding: 7754 7754 7754
+Encoding: 7754 7754 1604
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4B
-Encoding: 7755 7755 7755
+Encoding: 7755 7755 1605
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E4C
-Encoding: 7756 7756 7756
+Encoding: 7756 7756 1606
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 262 2
+Refer: 3728 -1 N 1 0 0 1 50 515 2
 EndChar
+
 StartChar: uni1E4D
-Encoding: 7757 7757 7757
+Encoding: 7757 7757 1607
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 404 2
-Refer: 111 111 N 1 0 0 1 0 0 2
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E54
-Encoding: 7764 7764 7764
+Encoding: 7764 7764 1608
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -137 380 2
-Refer: 80 80 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -137 380 2
+Refer: 49 80 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E55
-Encoding: 7765 7765 7765
+Encoding: 7765 7765 1609
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 0 2
-Refer: 112 112 N 1 0 0 1 0 0 3
+Refer: 656 769 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E56
-Encoding: 7766 7766 7766
+Encoding: 7766 7766 1610
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E57
-Encoding: 7767 7767 7767
+Encoding: 7767 7767 1611
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 112 112 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E58
-Encoding: 7768 7768 7768
+Encoding: 7768 7768 1612
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E59
-Encoding: 7769 7769 7769
+Encoding: 7769 7769 1613
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5A
-Encoding: 7770 7770 7770
+Encoding: 7770 7770 1614
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -50 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 -50 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5B
-Encoding: 7771 7771 7771
+Encoding: 7771 7771 1615
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5C
-Encoding: 7772 7772 7772
+Encoding: 7772 7772 1616
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 -50 0 2
-Refer: 7770 7770 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 -50 0 2
+Refer: 1614 7770 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5D
-Encoding: 7773 7773 7773
+Encoding: 7773 7773 1617
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 7771 7771 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 1615 7771 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5E
-Encoding: 7774 7774 7774
+Encoding: 7774 7774 1618
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E5F
-Encoding: 7775 7775 7775
+Encoding: 7775 7775 1619
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E60
-Encoding: 7776 7776 7776
+Encoding: 7776 7776 1620
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E61
-Encoding: 7777 7777 7777
+Encoding: 7777 7777 1621
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 3
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E62
-Encoding: 7778 7778 7778
+Encoding: 7778 7778 1622
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E63
-Encoding: 7779 7779 7779
+Encoding: 7779 7779 1623
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E68
-Encoding: 7784 7784 7784
+Encoding: 7784 7784 1624
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 83 83 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E69
-Encoding: 7785 7785 7785
+Encoding: 7785 7785 1625
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 115 115 N 1 0 0 1 0 0 2
-Refer: 803 803 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6A
-Encoding: 7786 7786 7786
+Encoding: 7786 7786 1626
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6B
-Encoding: 7787 7787 7787
+Encoding: 7787 7787 1627
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6C
-Encoding: 7788 7788 7788
+Encoding: 7788 7788 1628
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6D
-Encoding: 7789 7789 7789
+Encoding: 7789 7789 1629
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6E
-Encoding: 7790 7790 7790
+Encoding: 7790 7790 1630
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E6F
-Encoding: 7791 7791 7791
+Encoding: 7791 7791 1631
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E70
-Encoding: 7792 7792 7792
+Encoding: 7792 7792 1632
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E71
-Encoding: 7793 7793 7793
+Encoding: 7793 7793 1633
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E72
-Encoding: 7794 7794 7794
+Encoding: 7794 7794 1634
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E73
-Encoding: 7795 7795 7795
+Encoding: 7795 7795 1635
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 804 804 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 691 804 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E74
-Encoding: 7796 7796 7796
+Encoding: 7796 7796 1636
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E75
-Encoding: 7797 7797 7797
+Encoding: 7797 7797 1637
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 816 816 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 703 816 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E76
-Encoding: 7798 7798 7798
+Encoding: 7798 7798 1638
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E77
-Encoding: 7799 7799 7799
+Encoding: 7799 7799 1639
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 813 813 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 700 813 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E78
-Encoding: 7800 7800 7800
+Encoding: 7800 7800 1640
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 262 2
-Refer: 1114115 -1 N 1 0 0 1 50 515 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 262 2
+Refer: 3728 -1 N 1 0 0 1 50 515 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E79
-Encoding: 7801 7801 7801
+Encoding: 7801 7801 1641
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 769 769 N 1 0 0 1 0 404 2
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 656 769 N 1 0 0 1 0 404 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7C
-Encoding: 7804 7804 7804
+Encoding: 7804 7804 1642
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 348 2
-Refer: 86 86 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 0 348 2
+Refer: 55 86 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E7D
-Encoding: 7805 7805 7805
+Encoding: 7805 7805 1643
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 -40 2
-Refer: 118 118 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 0 -40 2
+Refer: 87 118 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E7E
-Encoding: 7806 7806 7806
+Encoding: 7806 7806 1644
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 86 86 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E7F
-Encoding: 7807 7807 7807
+Encoding: 7807 7807 1645
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 118 118 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wgrave
-Encoding: 7808 7808 7808
+Encoding: 7808 7808 1646
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wgrave
-Encoding: 7809 7809 7809
+Encoding: 7809 7809 1647
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -64 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -64 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wacute
-Encoding: 7810 7810 7810
+Encoding: 7810 7810 1648
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 0 380 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3728 -1 N 1 0 0 1 0 380 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wacute
-Encoding: 7811 7811 7811
+Encoding: 7811 7811 1649
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 64 7 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 64 7 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: Wdieresis
-Encoding: 7812 7812 7812
+Encoding: 7812 7812 1650
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 292 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 292 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: wdieresis
-Encoding: 7813 7813 7813
+Encoding: 7813 7813 1651
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 -81 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 104 168 N 1 0 0 1 0 -81 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E86
-Encoding: 7814 7814 7814
+Encoding: 7814 7814 1652
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E87
-Encoding: 7815 7815 7815
+Encoding: 7815 7815 1653
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E88
-Encoding: 7816 7816 7816
+Encoding: 7816 7816 1654
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E89
-Encoding: 7817 7817 7817
+Encoding: 7817 7817 1655
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8A
-Encoding: 7818 7818 7818
+Encoding: 7818 7818 1656
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8B
-Encoding: 7819 7819 7819
+Encoding: 7819 7819 1657
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8C
-Encoding: 7820 7820 7820
+Encoding: 7820 7820 1658
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114114 -1 N 1 0 0 1 18 348 2
-Refer: 88 88 N 1 0 0 1 0 0 3
+Refer: 3727 -1 N 1 0 0 1 18 348 2
+Refer: 57 88 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8D
-Encoding: 7821 7821 7821
+Encoding: 7821 7821 1659
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0.5 -81 2
-Refer: 120 120 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 0.5 -81 2
+Refer: 89 120 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E8E
-Encoding: 7822 7822 7822
+Encoding: 7822 7822 1660
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E8F
-Encoding: 7823 7823 7823
+Encoding: 7823 7823 1661
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 775 775 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 662 775 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E90
-Encoding: 7824 7824 7824
+Encoding: 7824 7824 1662
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 46 380 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 46 380 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E91
-Encoding: 7825 7825 7825
+Encoding: 7825 7825 1663
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 17 7 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 17 7 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E92
-Encoding: 7826 7826 7826
+Encoding: 7826 7826 1664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E93
-Encoding: 7827 7827 7827
+Encoding: 7827 7827 1665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E94
-Encoding: 7828 7828 7828
+Encoding: 7828 7828 1666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 50 0 2
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 50 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E95
-Encoding: 7829 7829 7829
+Encoding: 7829 7829 1667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E96
-Encoding: 7830 7830 7830
+Encoding: 7830 7830 1668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 817 817 N 1 0 0 1 0 0 2
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 704 817 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E97
-Encoding: 7831 7831 7831
+Encoding: 7831 7831 1669
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 -94 210 2
-Refer: 116 116 N 1 0 0 1 0 0 3
+Refer: 104 168 N 1 0 0 1 -94 210 2
+Refer: 85 116 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E98
-Encoding: 7832 7832 7832
+Encoding: 7832 7832 1670
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 0 20 2
-Refer: 119 119 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 0 20 2
+Refer: 88 119 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E99
-Encoding: 7833 7833 7833
+Encoding: 7833 7833 1671
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 730 730 N 1 0 0 1 12 20 2
-Refer: 121 121 N 1 0 0 1 0 0 3
+Refer: 638 730 N 1 0 0 1 12 20 2
+Refer: 90 121 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1E9B
-Encoding: 7835 7835 7835
+Encoding: 7835 7835 1672
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114123 -1 N 1 0 0 1 0 0 2
-Refer: 383 383 N 1 0 0 1 0 0 2
+Refer: 3736 -1 N 1 0 0 1 0 0 2
+Refer: 319 383 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1E9F
-Encoding: 7839 7839 7839
+Encoding: 7839 7839 1673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 948 948 N 1 0 0 1 0 0 2
+Refer: 777 948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA0
-Encoding: 7840 7840 7840
+Encoding: 7840 7840 1674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 34 65 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EA1
-Encoding: 7841 7841 7841
+Encoding: 7841 7841 1675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EAC
-Encoding: 7852 7852 7852
+Encoding: 7852 7852 1676
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 0 380 2
-Refer: 7840 7840 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 0 380 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EAD
-Encoding: 7853 7853 7853
+Encoding: 7853 7853 1677
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -24.5 7 2
-Refer: 7841 7841 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -24.5 7 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB0
-Encoding: 7856 7856 7856
+Encoding: 7856 7856 1678
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 -128 2
-Refer: 65 65 N 1 0 0 1 0 0 2
-Refer: 1114117 -1 N 1 0 0 1 0 515 2
+Refer: 3735 -1 N 1 0 0 1 0 -128 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 515 2
 EndChar
+
 StartChar: uni1EB1
-Encoding: 7857 7857 7857
+Encoding: 7857 7857 1679
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 768 768 N 1 0 0 1 0 316 2
-Refer: 259 259 N 1 0 0 1 0 0 3
+Refer: 655 768 N 1 0 0 1 0 316 2
+Refer: 195 259 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB6
-Encoding: 7862 7862 7862
+Encoding: 7862 7862 1680
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 7840 7840 N 1 0 0 1 0 0 3
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 1674 7840 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB7
-Encoding: 7863 7863 7863
+Encoding: 7863 7863 1681
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 728 728 N 1 0 0 1 -24.5 -52 2
-Refer: 7841 7841 N 1 0 0 1 0 0 3
+Refer: 636 728 N 1 0 0 1 -24.5 -52 2
+Refer: 1675 7841 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EB8
-Encoding: 7864 7864 7864
+Encoding: 7864 7864 1682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 18 0 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 18 0 2
+Refer: 38 69 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EB9
-Encoding: 7865 7865 7865
+Encoding: 7865 7865 1683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 14 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 14 0 2
+Refer: 70 101 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBC
-Encoding: 7868 7868 7868
+Encoding: 7868 7868 1684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 42 373 2
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 42 373 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EBD
-Encoding: 7869 7869 7869
+Encoding: 7869 7869 1685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EC6
-Encoding: 7878 7878 7878
+Encoding: 7878 7878 1686
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 23.5 380 2
-Refer: 7864 7864 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 23.5 380 2
+Refer: 1682 7864 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EC7
-Encoding: 7879 7879 7879
+Encoding: 7879 7879 1687
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 34.5 7 2
-Refer: 7865 7865 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 34.5 7 2
+Refer: 1683 7865 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1ECA
-Encoding: 7882 7882 7882
+Encoding: 7882 7882 1688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 42 73 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECB
-Encoding: 7883 7883 7883
+Encoding: 7883 7883 1689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 74 105 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECC
-Encoding: 7884 7884 7884
+Encoding: 7884 7884 1690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 48 79 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ECD
-Encoding: 7885 7885 7885
+Encoding: 7885 7885 1691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 80 111 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1ED8
-Encoding: 7896 7896 7896
+Encoding: 7896 7896 1692
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114118 -1 N 1 0 0 1 -0.5 380 2
-Refer: 7884 7884 N 1 0 0 1 0 0 3
+Refer: 3731 -1 N 1 0 0 1 -0.5 380 2
+Refer: 1690 7884 S 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1ED9
-Encoding: 7897 7897 7897
+Encoding: 7897 7897 1693
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 710 710 N 1 0 0 1 -0.5 7 2
-Refer: 7885 7885 N 1 0 0 1 0 0 3
+Refer: 622 710 N 1 0 0 1 -0.5 7 2
+Refer: 1691 7885 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDA
-Encoding: 7898 7898 7898
+Encoding: 7898 7898 1694
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDB
-Encoding: 7899 7899 7899
+Encoding: 7899 7899 1695
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDC
-Encoding: 7900 7900 7900
+Encoding: 7900 7900 1696
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3730 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 S 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EDD
-Encoding: 7901 7901 7901
+Encoding: 7901 7901 1697
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -105 0 2
+Refer: 353 417 S 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE0
-Encoding: 7904 7904 7904
+Encoding: 7904 7904 1698
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 -111 373 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 -111 373 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE1
-Encoding: 7905 7905 7905
+Encoding: 7905 7905 1699
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE2
-Encoding: 7906 7906 7906
+Encoding: 7906 7906 1700
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -111 0 2
-Refer: 416 416 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -111 0 2
+Refer: 352 416 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE3
-Encoding: 7907 7907 7907
+Encoding: 7907 7907 1701
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -105 0 2
-Refer: 417 417 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -105 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE4
-Encoding: 7908 7908 7908
+Encoding: 7908 7908 1702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 54 85 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE5
-Encoding: 7909 7909 7909
+Encoding: 7909 7909 1703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 86 117 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EE8
-Encoding: 7912 7912 7912
+Encoding: 7912 7912 1704
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114115 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3728 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EE9
-Encoding: 7913 7913 7913
+Encoding: 7913 7913 1705
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 116 180 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEA
-Encoding: 7914 7914 7914
+Encoding: 7914 7914 1706
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3730 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 S 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEB
-Encoding: 7915 7915 7915
+Encoding: 7915 7915 1707
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 65 96 N 1 0 0 1 -156 0 2
+Refer: 368 432 S 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEE
-Encoding: 7918 7918 7918
+Encoding: 7918 7918 1708
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 -138 373 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 3729 -1 N 1 0 0 1 -138 373 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EEF
-Encoding: 7919 7919 7919
+Encoding: 7919 7919 1709
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 640 732 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EF0
-Encoding: 7920 7920 7920
+Encoding: 7920 7920 1710
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -138 0 2
-Refer: 431 431 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -138 0 2
+Refer: 367 431 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni1EF1
-Encoding: 7921 7921 7921
+Encoding: 7921 7921 1711
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 -156 0 2
-Refer: 432 432 N 1 0 0 1 0 0 3
+Refer: 690 803 N 1 0 0 1 -156 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: Ygrave
-Encoding: 7922 7922 7922
+Encoding: 7922 7922 1712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114117 -1 N 1 0 0 1 0 380 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3730 -1 N 1 0 0 1 0 380 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: ygrave
-Encoding: 7923 7923 7923
+Encoding: 7923 7923 1713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 -52 7 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 -52 7 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF4
-Encoding: 7924 7924 7924
+Encoding: 7924 7924 1714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 0 0 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF5
-Encoding: 7925 7925 7925
+Encoding: 7925 7925 1715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 803 803 N 1 0 0 1 250 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 690 803 N 1 0 0 1 250 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF8
-Encoding: 7928 7928 7928
+Encoding: 7928 7928 1716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114116 -1 N 1 0 0 1 0 373 2
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 3729 -1 N 1 0 0 1 0 373 2
+Refer: 58 89 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1EF9
-Encoding: 7929 7929 7929
+Encoding: 7929 7929 1717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
+Refer: 90 121 S 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F00
-Encoding: 7936 7936 7936
+Encoding: 7936 7936 1718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F01
-Encoding: 7937 7937 7937
+Encoding: 7937 7937 1719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F02
-Encoding: 7938 7938 7938
+Encoding: 7938 7938 1720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F03
-Encoding: 7939 7939 7939
+Encoding: 7939 7939 1721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F04
-Encoding: 7940 7940 7940
+Encoding: 7940 7940 1722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F05
-Encoding: 7941 7941 7941
+Encoding: 7941 7941 1723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F06
-Encoding: 7942 7942 7942
+Encoding: 7942 7942 1724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F07
-Encoding: 7943 7943 7943
+Encoding: 7943 7943 1725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F08
-Encoding: 7944 7944 7944
+Encoding: 7944 7944 1726
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -350 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -350 0 2
 EndChar
+
 StartChar: uni1F09
-Encoding: 7945 7945 7945
+Encoding: 7945 7945 1727
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1F0A
-Encoding: 7946 7946 7946
+Encoding: 7946 7946 1728
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -650 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F0B
-Encoding: 7947 7947 7947
+Encoding: 7947 7947 1729
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -650 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F0C
-Encoding: 7948 7948 7948
+Encoding: 7948 7948 1730
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -525 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: uni1F0D
-Encoding: 7949 7949 7949
+Encoding: 7949 7949 1731
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -525 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -525 0 2
 EndChar
+
 StartChar: uni1F0E
-Encoding: 7950 7950 7950
+Encoding: 7950 7950 1732
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -350 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -350 0 2
 EndChar
+
 StartChar: uni1F0F
-Encoding: 7951 7951 7951
+Encoding: 7951 7951 1733
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1F10
-Encoding: 7952 7952 7952
+Encoding: 7952 7952 1734
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F11
-Encoding: 7953 7953 7953
+Encoding: 7953 7953 1735
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F12
-Encoding: 7954 7954 7954
+Encoding: 7954 7954 1736
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F13
-Encoding: 7955 7955 7955
+Encoding: 7955 7955 1737
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F14
-Encoding: 7956 7956 7956
+Encoding: 7956 7956 1738
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F15
-Encoding: 7957 7957 7957
+Encoding: 7957 7957 1739
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F18
-Encoding: 7960 7960 7960
+Encoding: 7960 7960 1740
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F19
-Encoding: 7961 7961 7961
+Encoding: 7961 7961 1741
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F1A
-Encoding: 7962 7962 7962
+Encoding: 7962 7962 1742
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F1B
-Encoding: 7963 7963 7963
+Encoding: 7963 7963 1743
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F1C
-Encoding: 7964 7964 7964
+Encoding: 7964 7964 1744
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F1D
-Encoding: 7965 7965 7965
+Encoding: 7965 7965 1745
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F20
-Encoding: 7968 7968 7968
+Encoding: 7968 7968 1746
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F21
-Encoding: 7969 7969 7969
+Encoding: 7969 7969 1747
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F22
-Encoding: 7970 7970 7970
+Encoding: 7970 7970 1748
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F23
-Encoding: 7971 7971 7971
+Encoding: 7971 7971 1749
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F24
-Encoding: 7972 7972 7972
+Encoding: 7972 7972 1750
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F25
-Encoding: 7973 7973 7973
+Encoding: 7973 7973 1751
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F26
-Encoding: 7974 7974 7974
+Encoding: 7974 7974 1752
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F27
-Encoding: 7975 7975 7975
+Encoding: 7975 7975 1753
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F28
-Encoding: 7976 7976 7976
+Encoding: 7976 7976 1754
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -675 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -675 0 2
 EndChar
+
 StartChar: uni1F29
-Encoding: 7977 7977 7977
+Encoding: 7977 7977 1755
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -675 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -675 0 2
 EndChar
+
 StartChar: uni1F2A
-Encoding: 7978 7978 7978
+Encoding: 7978 7978 1756
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -950 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F2B
-Encoding: 7979 7979 7979
+Encoding: 7979 7979 1757
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F2C
-Encoding: 7980 7980 7980
+Encoding: 7980 7980 1758
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -900 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -900 0 2
 EndChar
+
 StartChar: uni1F2D
-Encoding: 7981 7981 7981
+Encoding: 7981 7981 1759
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -900 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -900 0 2
 EndChar
+
 StartChar: uni1F2E
-Encoding: 7982 7982 7982
+Encoding: 7982 7982 1760
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1F2F
-Encoding: 7983 7983 7983
+Encoding: 7983 7983 1761
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1F30
-Encoding: 7984 7984 7984
+Encoding: 7984 7984 1762
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F31
-Encoding: 7985 7985 7985
+Encoding: 7985 7985 1763
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F32
-Encoding: 7986 7986 7986
+Encoding: 7986 7986 1764
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F33
-Encoding: 7987 7987 7987
+Encoding: 7987 7987 1765
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F34
-Encoding: 7988 7988 7988
+Encoding: 7988 7988 1766
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F35
-Encoding: 7989 7989 7989
+Encoding: 7989 7989 1767
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F36
-Encoding: 7990 7990 7990
+Encoding: 7990 7990 1768
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F37
-Encoding: 7991 7991 7991
+Encoding: 7991 7991 1769
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F38
-Encoding: 7992 7992 7992
+Encoding: 7992 7992 1770
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F39
-Encoding: 7993 7993 7993
+Encoding: 7993 7993 1771
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F3A
-Encoding: 7994 7994 7994
+Encoding: 7994 7994 1772
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -850 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -850 0 2
 EndChar
+
 StartChar: uni1F3B
-Encoding: 7995 7995 7995
+Encoding: 7995 7995 1773
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -850 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -850 0 2
 EndChar
+
 StartChar: uni1F3C
-Encoding: 7996 7996 7996
+Encoding: 7996 7996 1774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -800 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F3D
-Encoding: 7997 7997 7997
+Encoding: 7997 7997 1775
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -800 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -800 0 2
 EndChar
+
 StartChar: uni1F3E
-Encoding: 7998 7998 7998
+Encoding: 7998 7998 1776
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F3F
-Encoding: 7999 7999 7999
+Encoding: 7999 7999 1777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F40
-Encoding: 8000 8000 8000
+Encoding: 8000 8000 1778
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F41
-Encoding: 8001 8001 8001
+Encoding: 8001 8001 1779
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F42
-Encoding: 8002 8002 8002
+Encoding: 8002 8002 1780
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F43
-Encoding: 8003 8003 8003
+Encoding: 8003 8003 1781
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F44
-Encoding: 8004 8004 8004
+Encoding: 8004 8004 1782
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F45
-Encoding: 8005 8005 8005
+Encoding: 8005 8005 1783
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F48
-Encoding: 8008 8008 8008
+Encoding: 8008 8008 1784
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F49
-Encoding: 8009 8009 8009
+Encoding: 8009 8009 1785
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F4A
-Encoding: 8010 8010 8010
+Encoding: 8010 8010 1786
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F4B
-Encoding: 8011 8011 8011
+Encoding: 8011 8011 1787
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F4C
-Encoding: 8012 8012 8012
+Encoding: 8012 8012 1788
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -650 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F4D
-Encoding: 8013 8013 8013
+Encoding: 8013 8013 1789
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -650 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F50
-Encoding: 8016 8016 8016
+Encoding: 8016 8016 1790
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F51
-Encoding: 8017 8017 8017
+Encoding: 8017 8017 1791
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F52
-Encoding: 8018 8018 8018
+Encoding: 8018 8018 1792
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F53
-Encoding: 8019 8019 8019
+Encoding: 8019 8019 1793
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F54
-Encoding: 8020 8020 8020
+Encoding: 8020 8020 1794
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F55
-Encoding: 8021 8021 8021
+Encoding: 8021 8021 1795
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F56
-Encoding: 8022 8022 8022
+Encoding: 8022 8022 1796
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F57
-Encoding: 8023 8023 8023
+Encoding: 8023 8023 1797
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F59
-Encoding: 8025 8025 8025
+Encoding: 8025 8025 1798
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -775 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -775 0 2
 EndChar
+
 StartChar: uni1F5B
-Encoding: 8027 8027 8027
+Encoding: 8027 8027 1799
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -950 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -950 0 2
 EndChar
+
 StartChar: uni1F5D
-Encoding: 8029 8029 8029
+Encoding: 8029 8029 1800
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -975 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -975 0 2
 EndChar
+
 StartChar: uni1F5F
-Encoding: 8031 8031 8031
+Encoding: 8031 8031 1801
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -775 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -775 0 2
 EndChar
+
 StartChar: uni1F60
-Encoding: 8032 8032 8032
+Encoding: 8032 8032 1802
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F61
-Encoding: 8033 8033 8033
+Encoding: 8033 8033 1803
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F62
-Encoding: 8034 8034 8034
+Encoding: 8034 8034 1804
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F63
-Encoding: 8035 8035 8035
+Encoding: 8035 8035 1805
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F64
-Encoding: 8036 8036 8036
+Encoding: 8036 8036 1806
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F65
-Encoding: 8037 8037 8037
+Encoding: 8037 8037 1807
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F66
-Encoding: 8038 8038 8038
+Encoding: 8038 8038 1808
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F67
-Encoding: 8039 8039 8039
+Encoding: 8039 8039 1809
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F68
-Encoding: 8040 8040 8040
+Encoding: 8040 8040 1810
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 -550 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F69
-Encoding: 8041 8041 8041
+Encoding: 8041 8041 1811
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -650 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1F6A
-Encoding: 8042 8042 8042
+Encoding: 8042 8042 1812
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8141 8141 N 1 0 0 1 -875 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1907 8141 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F6B
-Encoding: 8043 8043 8043
+Encoding: 8043 8043 1813
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8157 8157 N 1 0 0 1 -875 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1920 8157 N 1 0 0 1 -875 0 2
 EndChar
+
 StartChar: uni1F6C
-Encoding: 8044 8044 8044
+Encoding: 8044 8044 1814
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8142 8142 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1908 8142 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F6D
-Encoding: 8045 8045 8045
+Encoding: 8045 8045 1815
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8158 8158 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1921 8158 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F6E
-Encoding: 8046 8046 8046
+Encoding: 8046 8046 1816
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8143 8143 N 1 0 0 1 -550 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1909 8143 N 1 0 0 1 -550 0 2
 EndChar
+
 StartChar: uni1F6F
-Encoding: 8047 8047 8047
+Encoding: 8047 8047 1817
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8159 8159 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1922 8159 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1F70
-Encoding: 8048 8048 8048
+Encoding: 8048 8048 1818
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F71
-Encoding: 8049 8049 8049
+Encoding: 8049 8049 1819
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F72
-Encoding: 8050 8050 8050
+Encoding: 8050 8050 1820
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 949 949 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 778 949 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F73
-Encoding: 8051 8051 8051
+Encoding: 8051 8051 1821
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 941 941 N 1 0 0 1 0 0 2
+Refer: 770 941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F74
-Encoding: 8052 8052 8052
+Encoding: 8052 8052 1822
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F75
-Encoding: 8053 8053 8053
+Encoding: 8053 8053 1823
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F76
-Encoding: 8054 8054 8054
+Encoding: 8054 8054 1824
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F77
-Encoding: 8055 8055 8055
+Encoding: 8055 8055 1825
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 943 943 N 1 0 0 1 0 0 2
+Refer: 772 943 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F78
-Encoding: 8056 8056 8056
+Encoding: 8056 8056 1826
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 959 959 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 788 959 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F79
-Encoding: 8057 8057 8057
+Encoding: 8057 8057 1827
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 972 972 N 1 0 0 1 0 0 2
+Refer: 801 972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7A
-Encoding: 8058 8058 8058
+Encoding: 8058 8058 1828
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7B
-Encoding: 8059 8059 8059
+Encoding: 8059 8059 1829
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 973 973 N 1 0 0 1 0 0 2
+Refer: 802 973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7C
-Encoding: 8060 8060 8060
+Encoding: 8060 8060 1830
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F7D
-Encoding: 8061 8061 8061
+Encoding: 8061 8061 1831
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F80
-Encoding: 8064 8064 8064
+Encoding: 8064 8064 1832
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7936 7936 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1718 7936 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F81
-Encoding: 8065 8065 8065
+Encoding: 8065 8065 1833
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7937 7937 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1719 7937 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F82
-Encoding: 8066 8066 8066
+Encoding: 8066 8066 1834
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7938 7938 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1720 7938 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F83
-Encoding: 8067 8067 8067
+Encoding: 8067 8067 1835
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7939 7939 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1721 7939 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F84
-Encoding: 8068 8068 8068
+Encoding: 8068 8068 1836
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7940 7940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1722 7940 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F85
-Encoding: 8069 8069 8069
+Encoding: 8069 8069 1837
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -100 0 2
-Refer: 7941 7941 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
+Refer: 1723 7941 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F86
-Encoding: 8070 8070 8070
+Encoding: 8070 8070 1838
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7942 7942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1724 7942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F87
-Encoding: 8071 8071 8071
+Encoding: 8071 8071 1839
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7943 7943 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1725 7943 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1F88
-Encoding: 8072 8072 8072
+Encoding: 8072 8072 1840
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7944 7944 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1726 7944 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F89
-Encoding: 8073 8073 8073
+Encoding: 8073 8073 1841
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7945 7945 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1727 7945 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8A
-Encoding: 8074 8074 8074
+Encoding: 8074 8074 1842
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7946 7946 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1728 7946 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8B
-Encoding: 8075 8075 8075
+Encoding: 8075 8075 1843
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7947 7947 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1729 7947 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8C
-Encoding: 8076 8076 8076
+Encoding: 8076 8076 1844
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7948 7948 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1730 7948 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8D
-Encoding: 8077 8077 8077
+Encoding: 8077 8077 1845
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7949 7949 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1731 7949 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8E
-Encoding: 8078 8078 8078
+Encoding: 8078 8078 1846
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7950 7950 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1732 7950 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F8F
-Encoding: 8079 8079 8079
+Encoding: 8079 8079 1847
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7951 7951 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1733 7951 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F90
-Encoding: 8080 8080 8080
+Encoding: 8080 8080 1848
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7968 7968 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1746 7968 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F91
-Encoding: 8081 8081 8081
+Encoding: 8081 8081 1849
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7969 7969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1747 7969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F92
-Encoding: 8082 8082 8082
+Encoding: 8082 8082 1850
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7970 7970 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1748 7970 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F93
-Encoding: 8083 8083 8083
+Encoding: 8083 8083 1851
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7971 7971 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1749 7971 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F94
-Encoding: 8084 8084 8084
+Encoding: 8084 8084 1852
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7972 7972 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1750 7972 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F95
-Encoding: 8085 8085 8085
+Encoding: 8085 8085 1853
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 -312 0 2
-Refer: 7973 7973 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
+Refer: 1751 7973 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F96
-Encoding: 8086 8086 8086
+Encoding: 8086 8086 1854
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7974 7974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1752 7974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F97
-Encoding: 8087 8087 8087
+Encoding: 8087 8087 1855
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7975 7975 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1753 7975 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1F98
-Encoding: 8088 8088 8088
+Encoding: 8088 8088 1856
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7976 7976 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1754 7976 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F99
-Encoding: 8089 8089 8089
+Encoding: 8089 8089 1857
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7977 7977 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1755 7977 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9A
-Encoding: 8090 8090 8090
+Encoding: 8090 8090 1858
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7978 7978 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1756 7978 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9B
-Encoding: 8091 8091 8091
+Encoding: 8091 8091 1859
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7979 7979 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1757 7979 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9C
-Encoding: 8092 8092 8092
+Encoding: 8092 8092 1860
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7980 7980 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1758 7980 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9D
-Encoding: 8093 8093 8093
+Encoding: 8093 8093 1861
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 7981 7981 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1759 7981 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9E
-Encoding: 8094 8094 8094
+Encoding: 8094 8094 1862
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7982 7982 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1760 7982 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1F9F
-Encoding: 8095 8095 8095
+Encoding: 8095 8095 1863
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7983 7983 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1761 7983 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA0
-Encoding: 8096 8096 8096
+Encoding: 8096 8096 1864
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8032 8032 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1802 8032 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA1
-Encoding: 8097 8097 8097
+Encoding: 8097 8097 1865
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8033 8033 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1803 8033 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA2
-Encoding: 8098 8098 8098
+Encoding: 8098 8098 1866
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8034 8034 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1804 8034 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA3
-Encoding: 8099 8099 8099
+Encoding: 8099 8099 1867
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8035 8035 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1805 8035 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA4
-Encoding: 8100 8100 8100
+Encoding: 8100 8100 1868
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8036 8036 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1806 8036 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA5
-Encoding: 8101 8101 8101
+Encoding: 8101 8101 1869
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
-Refer: 8037 8037 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
+Refer: 1807 8037 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA6
-Encoding: 8102 8102 8102
+Encoding: 8102 8102 1870
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8038 8038 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1808 8038 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA7
-Encoding: 8103 8103 8103
+Encoding: 8103 8103 1871
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8039 8039 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1809 8039 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA8
-Encoding: 8104 8104 8104
+Encoding: 8104 8104 1872
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8040 8040 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1810 8040 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FA9
-Encoding: 8105 8105 8105
+Encoding: 8105 8105 1873
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8041 8041 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1811 8041 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAA
-Encoding: 8106 8106 8106
+Encoding: 8106 8106 1874
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8042 8042 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1812 8042 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAB
-Encoding: 8107 8107 8107
+Encoding: 8107 8107 1875
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8043 8043 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1813 8043 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAC
-Encoding: 8108 8108 8108
+Encoding: 8108 8108 1876
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8044 8044 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1814 8044 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAD
-Encoding: 8109 8109 8109
+Encoding: 8109 8109 1877
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8126 8126 N 1 0 0 1 0 0 2
-Refer: 8045 8045 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
+Refer: 1815 8045 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAE
-Encoding: 8110 8110 8110
+Encoding: 8110 8110 1878
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8046 8046 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1816 8046 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FAF
-Encoding: 8111 8111 8111
+Encoding: 8111 8111 1879
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8047 8047 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 1817 8047 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB0
-Encoding: 8112 8112 8112
+Encoding: 8112 8112 1880
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB1
-Encoding: 8113 8113 8113
+Encoding: 8113 8113 1881
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB2
-Encoding: 8114 8114 8114
+Encoding: 8114 8114 1882
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8048 8048 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1818 8048 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB3
-Encoding: 8115 8115 8115
+Encoding: 8115 8115 1883
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB4
-Encoding: 8116 8116 8116
+Encoding: 8116 8116 1884
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 940 940 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 769 940 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB6
-Encoding: 8118 8118 8118
+Encoding: 8118 8118 1885
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB7
-Encoding: 8119 8119 8119
+Encoding: 8119 8119 1886
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8118 8118 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -100 0 2
+Refer: 1885 8118 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -100 0 2
 EndChar
+
 StartChar: uni1FB8
-Encoding: 8120 8120 8120
+Encoding: 8120 8120 1887
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FB9
-Encoding: 8121 8121 8121
+Encoding: 8121 8121 1888
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 913 913 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBA
-Encoding: 8122 8122 8122
+Encoding: 8122 8122 1889
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -400 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -400 0 2
 EndChar
+
 StartChar: uni1FBB
-Encoding: 8123 8123 8123
+Encoding: 8123 8123 1890
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 902 902 N 1 0 0 1 0 0 2
+Refer: 734 902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBC
-Encoding: 8124 8124 8124
+Encoding: 8124 8124 1891
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 913 913 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 743 913 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBD
-Encoding: 8125 8125 8125
+Encoding: 8125 8125 1892
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBE
-Encoding: 8126 8126 8126
+Encoding: 8126 8126 1893
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FBF
-Encoding: 8127 8127 8127
+Encoding: 8127 8127 1894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -55792,491 +57716,547 @@ SplineSet
  737 1475 l 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni1FC0
-Encoding: 8128 8128 8128
+Encoding: 8128 8128 1895
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 732 732 N 1 0 0 1 0 0 2
+Refer: 640 732 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC1
-Encoding: 8129 8129 8129
+Encoding: 8129 8129 1896
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 340 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 340 2
 EndChar
+
 StartChar: uni1FC2
-Encoding: 8130 8130 8130
+Encoding: 8130 8130 1897
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8052 8052 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1822 8052 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC3
-Encoding: 8131 8131 8131
+Encoding: 8131 8131 1898
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC4
-Encoding: 8132 8132 8132
+Encoding: 8132 8132 1899
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 942 942 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 771 942 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC6
-Encoding: 8134 8134 8134
+Encoding: 8134 8134 1900
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 951 951 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 780 951 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FC7
-Encoding: 8135 8135 8135
+Encoding: 8135 8135 1901
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8134 8134 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 -312 0 2
+Refer: 1900 8134 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 -312 0 2
 EndChar
+
 StartChar: uni1FC8
-Encoding: 8136 8136 8136
+Encoding: 8136 8136 1902
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 917 917 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -650 0 2
+Refer: 747 917 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -650 0 2
 EndChar
+
 StartChar: uni1FC9
-Encoding: 8137 8137 8137
+Encoding: 8137 8137 1903
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 904 904 N 1 0 0 1 0 0 2
+Refer: 736 904 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCA
-Encoding: 8138 8138 8138
+Encoding: 8138 8138 1904
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1FCB
-Encoding: 8139 8139 8139
+Encoding: 8139 8139 1905
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 905 905 N 1 0 0 1 0 0 2
+Refer: 737 905 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCC
-Encoding: 8140 8140 8140
+Encoding: 8140 8140 1906
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 919 919 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 749 919 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FCD
-Encoding: 8141 8141 8141
+Encoding: 8141 8141 1907
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -250 0 2
-Refer: 8175 8175 N 1 0 0 1 250 0 2
+Refer: 1894 8127 N 1 0 0 1 -250 0 2
+Refer: 1938 8175 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni1FCE
-Encoding: 8142 8142 8142
+Encoding: 8142 8142 1908
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 -200 0 2
-Refer: 8189 8189 N 1 0 0 1 100 0 2
+Refer: 1894 8127 N 1 0 0 1 -200 0 2
+Refer: 1949 8189 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1FCF
-Encoding: 8143 8143 8143
+Encoding: 8143 8143 1909
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8127 8127 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 410 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
 EndChar
+
 StartChar: uni1FD0
-Encoding: 8144 8144 8144
+Encoding: 8144 8144 1910
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD1
-Encoding: 8145 8145 8145
+Encoding: 8145 8145 1911
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD2
-Encoding: 8146 8146 8146
+Encoding: 8146 8146 1912
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD3
-Encoding: 8147 8147 8147
+Encoding: 8147 8147 1913
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 912 912 N 1 0 0 1 0 0 2
+Refer: 742 912 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD6
-Encoding: 8150 8150 8150
+Encoding: 8150 8150 1914
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD7
-Encoding: 8151 8151 8151
+Encoding: 8151 8151 1915
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD8
-Encoding: 8152 8152 8152
+Encoding: 8152 8152 1916
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FD9
-Encoding: 8153 8153 8153
+Encoding: 8153 8153 1917
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 921 921 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDA
-Encoding: 8154 8154 8154
+Encoding: 8154 8154 1918
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 921 921 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -600 0 2
+Refer: 751 921 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -600 0 2
 EndChar
+
 StartChar: uni1FDB
-Encoding: 8155 8155 8155
+Encoding: 8155 8155 1919
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 906 906 N 1 0 0 1 0 0 2
+Refer: 738 906 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FDD
-Encoding: 8157 8157 8157
+Encoding: 8157 8157 1920
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -250 0 2
-Refer: 8175 8175 N 1 0 0 1 250 0 2
+Refer: 1950 8190 N 1 0 0 1 -250 0 2
+Refer: 1938 8175 N 1 0 0 1 250 0 2
 EndChar
+
 StartChar: uni1FDE
-Encoding: 8158 8158 8158
+Encoding: 8158 8158 1921
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 -220 0 2
-Refer: 8189 8189 N 1 0 0 1 100 0 2
+Refer: 1950 8190 N 1 0 0 1 -220 0 2
+Refer: 1949 8189 N 1 0 0 1 100 0 2
 EndChar
+
 StartChar: uni1FDF
-Encoding: 8159 8159 8159
+Encoding: 8159 8159 1922
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8190 8190 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 410 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 410 2
 EndChar
+
 StartChar: uni1FE0
-Encoding: 8160 8160 8160
+Encoding: 8160 8160 1923
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 774 774 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 661 774 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE1
-Encoding: 8161 8161 8161
+Encoding: 8161 8161 1924
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 772 772 N 1 0 0 1 0 0 2
-Refer: 965 965 N 1 0 0 1 0 0 2
+Refer: 659 772 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE2
-Encoding: 8162 8162 8162
+Encoding: 8162 8162 1925
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8173 8173 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1936 8173 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE3
-Encoding: 8163 8163 8163
+Encoding: 8163 8163 1926
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 944 944 N 1 0 0 1 0 0 2
+Refer: 773 944 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE4
-Encoding: 8164 8164 8164
+Encoding: 8164 8164 1927
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8127 8127 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
+Refer: 1894 8127 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE5
-Encoding: 8165 8165 8165
+Encoding: 8165 8165 1928
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE6
-Encoding: 8166 8166 8166
+Encoding: 8166 8166 1929
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE7
-Encoding: 8167 8167 8167
+Encoding: 8167 8167 1930
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 965 965 N 1 0 0 1 0 0 2
-Refer: 8129 8129 N 1 0 0 1 0 0 2
+Refer: 794 965 N 1 0 0 1 0 0 2
+Refer: 1896 8129 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE8
-Encoding: 8168 8168 8168
+Encoding: 8168 8168 1931
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114122 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3735 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FE9
-Encoding: 8169 8169 8169
+Encoding: 8169 8169 1932
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114127 -1 N 1 0 0 1 0 0 2
-Refer: 933 933 N 1 0 0 1 0 0 2
+Refer: 3740 -1 N 1 0 0 1 0 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEA
-Encoding: 8170 8170 8170
+Encoding: 8170 8170 1933
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 933 933 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -700 0 2
+Refer: 762 933 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -700 0 2
 EndChar
+
 StartChar: uni1FEB
-Encoding: 8171 8171 8171
+Encoding: 8171 8171 1934
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 910 910 N 1 0 0 1 0 0 2
+Refer: 740 910 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEC
-Encoding: 8172 8172 8172
+Encoding: 8172 8172 1935
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 929 929 N 1 0 0 1 0 0 2
-Refer: 8190 8190 N 1 0 0 1 -625 0 2
+Refer: 759 929 N 1 0 0 1 0 0 2
+Refer: 1950 8190 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FED
-Encoding: 8173 8173 8173
+Encoding: 8173 8173 1936
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 168 168 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 0 370 2
+Refer: 104 168 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 0 370 2
 EndChar
+
 StartChar: uni1FEE
-Encoding: 8174 8174 8174
+Encoding: 8174 8174 1937
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 901 901 N 1 0 0 1 0 0 2
+Refer: 733 901 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FEF
-Encoding: 8175 8175 8175
+Encoding: 8175 8175 1938
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 96 96 N 1 0 0 1 0 0 2
+Refer: 65 96 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF2
-Encoding: 8178 8178 8178
+Encoding: 8178 8178 1939
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8060 8060 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1830 8060 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF3
-Encoding: 8179 8179 8179
+Encoding: 8179 8179 1940
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF4
-Encoding: 8180 8180 8180
+Encoding: 8180 8180 1941
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 974 974 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 803 974 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF6
-Encoding: 8182 8182 8182
+Encoding: 8182 8182 1942
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
-Refer: 8128 8128 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
+Refer: 1895 8128 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF7
-Encoding: 8183 8183 8183
+Encoding: 8183 8183 1943
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8182 8182 N 1 0 0 1 0 0 2
-Refer: 890 890 N 1 0 0 1 0 0 2
+Refer: 1942 8182 N 1 0 0 1 0 0 2
+Refer: 726 890 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FF8
-Encoding: 8184 8184 8184
+Encoding: 8184 8184 1944
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 927 927 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
+Refer: 757 927 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FF9
-Encoding: 8185 8185 8185
+Encoding: 8185 8185 1945
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 908 908 N 1 0 0 1 0 0 2
+Refer: 739 908 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFA
-Encoding: 8186 8186 8186
+Encoding: 8186 8186 1946
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8175 8175 N 1 0 0 1 -625 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1938 8175 N 1 0 0 1 -625 0 2
 EndChar
+
 StartChar: uni1FFB
-Encoding: 8187 8187 8187
+Encoding: 8187 8187 1947
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 911 911 N 1 0 0 1 0 0 2
+Refer: 741 911 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFC
-Encoding: 8188 8188 8188
+Encoding: 8188 8188 1948
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
-Refer: 8126 8126 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
+Refer: 1893 8126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFD
-Encoding: 8189 8189 8189
+Encoding: 8189 8189 1949
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 180 180 N 1 0 0 1 0 0 2
+Refer: 116 180 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni1FFE
-Encoding: 8190 8190 8190
+Encoding: 8190 8190 1950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56292,74 +58272,86 @@ SplineSet
  495.5 1218 495.5 1218 495.5 1475 c 2,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2000
-Encoding: 8192 8192 8192
+Encoding: 8192 8192 1951
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2001
-Encoding: 8193 8193 8193
+Encoding: 8193 8193 1952
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2002
-Encoding: 8194 8194 8194
+Encoding: 8194 8194 1953
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2003
-Encoding: 8195 8195 8195
+Encoding: 8195 8195 1954
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2004
-Encoding: 8196 8196 8196
+Encoding: 8196 8196 1955
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2005
-Encoding: 8197 8197 8197
+Encoding: 8197 8197 1956
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2006
-Encoding: 8198 8198 8198
+Encoding: 8198 8198 1957
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2007
-Encoding: 8199 8199 8199
+Encoding: 8199 8199 1958
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2008
-Encoding: 8200 8200 8200
+Encoding: 8200 8200 1959
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2009
-Encoding: 8201 8201 8201
+Encoding: 8201 8201 1960
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni200A
-Encoding: 8202 8202 8202
+Encoding: 8202 8202 1961
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2010
-Encoding: 8208 8208 8208
+Encoding: 8208 8208 1962
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56391,16 +58383,18 @@ SplineSet
  356 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2011
-Encoding: 8209 8209 8209
+Encoding: 8209 8209 1963
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8208 8208 N 1 0 0 1 0 0 2
+Refer: 1962 8208 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: figuredash
-Encoding: 8210 8210 8210
+Encoding: 8210 8210 1964
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56431,8 +58425,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: endash
-Encoding: 8211 8211 8211
+Encoding: 8211 8211 1965
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56463,8 +58458,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: emdash
-Encoding: 8212 8212 8212
+Encoding: 8212 8212 1966
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56494,8 +58490,9 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2015
-Encoding: 8213 8213 8213
+Encoding: 8213 8213 1967
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56525,26 +58522,29 @@ SplineSet
  0 633 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2016
-Encoding: 8214 8214 8214
+Encoding: 8214 8214 1968
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 245 0 2
-Refer: 124 124 N 1 0 0 1 -245 0 2
+Refer: 93 124 N 1 0 0 1 245 0 2
+Refer: 93 124 N 1 0 0 1 -245 0 2
 EndChar
+
 StartChar: underscoredbl
-Encoding: 8215 8215 8215
+Encoding: 8215 8215 1969
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 0 2
-Refer: 95 95 N 1 0 0 1 0 240 2
+Refer: 64 95 N 1 0 0 1 0 0 2
+Refer: 64 95 N 1 0 0 1 0 240 2
 EndChar
+
 StartChar: quoteleft
-Encoding: 8216 8216 8216
+Encoding: 8216 8216 1970
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56585,8 +58585,9 @@ SplineSet
  715 967 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quoteright
-Encoding: 8217 8217 8217
+Encoding: 8217 8217 1971
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56627,8 +58628,9 @@ SplineSet
  561 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotesinglbase
-Encoding: 8218 8218 8218
+Encoding: 8218 8218 1972
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56670,8 +58672,9 @@ SplineSet
  502 303 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotereversed
-Encoding: 8219 8219 8219
+Encoding: 8219 8219 1973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56686,8 +58689,9 @@ SplineSet
  715 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblleft
-Encoding: 8220 8220 8220
+Encoding: 8220 8220 1974
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56748,8 +58752,9 @@ SplineSet
  465 967 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblright
-Encoding: 8221 8221 8221
+Encoding: 8221 8221 1975
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56812,8 +58817,9 @@ SplineSet
  309 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: quotedblbase
-Encoding: 8222 8222 8222
+Encoding: 8222 8222 1976
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56878,8 +58884,9 @@ SplineSet
  309 303 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni201F
-Encoding: 8223 8223 8223
+Encoding: 8223 8223 1977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -56901,8 +58908,9 @@ SplineSet
  922 1556 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: dagger
-Encoding: 8224 8224 8224
+Encoding: 8224 8224 1978
 Width: 1233
 Flags: W
 TtInstrs:
@@ -56964,8 +58972,9 @@ SplineSet
  528 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: daggerdbl
-Encoding: 8225 8225 8225
+Encoding: 8225 8225 1979
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57056,8 +59065,9 @@ SplineSet
  1071 223 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: bullet
-Encoding: 8226 8226 8226
+Encoding: 8226 8226 1980
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57094,8 +59104,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2023
-Encoding: 8227 8227 8227
+Encoding: 8227 8227 1981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57107,20 +59118,23 @@ SplineSet
  319 385 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: onedotenleader
-Encoding: 8228 8228 8228
+Encoding: 8228 8228 1982
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: twodotenleader
-Encoding: 8229 8229 8229
+Encoding: 8229 8229 1983
 Width: 1233
 LayerCount: 2
 Colour: ffff00
 EndChar
+
 StartChar: ellipsis
-Encoding: 8230 8230 8230
+Encoding: 8230 8230 1984
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57180,14 +59194,16 @@ SplineSet
  489 305 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni202F
-Encoding: 8239 8239 8239
+Encoding: 8239 8239 1985
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: perthousand
-Encoding: 8240 8240 8240
+Encoding: 8240 8240 1986
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57325,22 +59341,22 @@ SplineSet
  166 358 166 358 166 289 c 0,4,5
 45 289 m 0,16,17
  45 410 45 410 127.5 492.5 c 128,-1,18
- 210 575 210 575 330 575 c 0,19,20
+ 210 575 210 575 330 575 c 256,19,20
  450 575 450 575 533 492 c 128,-1,21
  616 409 616 409 616 289 c 0,22,23
  616 168 616 168 532.5 84 c 128,-1,24
  449 0 449 0 330 0 c 0,25,26
  209 0 209 0 127 83 c 128,-1,27
  45 166 45 166 45 289 c 0,16,17
-121 1145 m 0,28,29
+121 1145 m 256,28,29
  121 1076 121 1076 169.5 1027.5 c 128,-1,30
- 218 979 218 979 287 979 c 0,31,32
+ 218 979 218 979 287 979 c 256,31,32
  356 979 356 979 404.5 1027.5 c 128,-1,33
  453 1076 453 1076 453 1145 c 0,34,35
  453 1212 453 1212 403.5 1261.5 c 128,-1,36
  354 1311 354 1311 287 1311 c 0,37,38
  218 1311 218 1311 169.5 1262.5 c 128,-1,39
- 121 1214 121 1214 121 1145 c 0,28,29
+ 121 1214 121 1214 121 1145 c 256,28,29
 0 1145 m 0,40,41
  0 1265 0 1265 83 1348.5 c 128,-1,42
  166 1432 166 1432 287 1432 c 0,43,44
@@ -57370,8 +59386,9 @@ SplineSet
  659 167 659 167 659 289 c 0,64,65
 EndSplineSet
 EndChar
+
 StartChar: uni2031
-Encoding: 8241 8241 8241
+Encoding: 8241 8241 1987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57414,7 +59431,7 @@ SplineSet
  1093.68 575 1093.68 575 1163.34 492 c 128,-1,46
  1233 409 1233 409 1233 289 c 0,47,48
  1233 168 1233 168 1163.34 84 c 128,-1,49
- 1093.68 4.57764e-05 1093.68 4.57764e-05 993.574 0 c 0,50,51
+ 1093.68 4.57764e-005 1093.68 4.57764e-005 993.574 0 c 0,50,51
  892.632 0 892.632 0 823.391 83.5 c 0,52,53
  813.057 95.9621 813.057 95.9621 804.265 109.282 c 1,54,55
  795.589 96.2476 795.589 96.2476 785.433 84 c 0,56,57
@@ -57454,8 +59471,9 @@ SplineSet
  855.091 358 855.091 358 855.091 289 c 0,93,94
 EndSplineSet
 EndChar
+
 StartChar: minute
-Encoding: 8242 8242 8242
+Encoding: 8242 8242 1988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57468,27 +59486,30 @@ SplineSet
  428 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: second
-Encoding: 8243 8243 8243
+Encoding: 8243 8243 1989
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 150 0 2
-Refer: 8242 8242 N 1 0 0 1 -150 0 2
+Refer: 1988 8242 N 1 0 0 1 150 0 2
+Refer: 1988 8242 N 1 0 0 1 -150 0 2
 EndChar
+
 StartChar: uni2034
-Encoding: 8244 8244 8244
+Encoding: 8244 8244 1990
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8242 8242 N 1 0 0 1 300 0 2
-Refer: 8242 8242 N 1 0 0 1 -300 0 2
-Refer: 8242 8242 N 1 0 0 1 0 0 2
+Refer: 1988 8242 N 1 0 0 1 300 0 2
+Refer: 1988 8242 N 1 0 0 1 -300 0 2
+Refer: 1988 8242 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2035
-Encoding: 8245 8245 8245
+Encoding: 8245 8245 1991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57501,27 +59522,30 @@ SplineSet
  804 1120 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2036
-Encoding: 8246 8246 8246
+Encoding: 8246 8246 1992
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 150 0 2
-Refer: 8245 8245 N 1 0 0 1 -150 0 2
+Refer: 1991 8245 N 1 0 0 1 150 0 2
+Refer: 1991 8245 N 1 0 0 1 -150 0 2
 EndChar
+
 StartChar: uni2037
-Encoding: 8247 8247 8247
+Encoding: 8247 8247 1993
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8245 8245 N 1 0 0 1 0 0 2
-Refer: 8245 8245 N 1 0 0 1 300 0 2
-Refer: 8245 8245 N 1 0 0 1 -300 0 2
+Refer: 1991 8245 N 1 0 0 1 0 0 2
+Refer: 1991 8245 N 1 0 0 1 300 0 2
+Refer: 1991 8245 N 1 0 0 1 -300 0 2
 EndChar
+
 StartChar: guilsinglleft
-Encoding: 8249 8249 8249
+Encoding: 8249 8249 1994
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57565,8 +59589,9 @@ SplineSet
  815 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: guilsinglright
-Encoding: 8250 8250 8250
+Encoding: 8250 8250 1995
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57610,18 +59635,20 @@ SplineSet
  420 1059 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: exclamdbl
-Encoding: 8252 8252 8252
+Encoding: 8252 8252 1996
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni203D
-Encoding: 8253 8253 8253
+Encoding: 8253 8253 1997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57657,16 +59684,18 @@ SplineSet
  735 1332 735 1332 684 1346 c 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni203E
-Encoding: 8254 8254 8254
+Encoding: 8254 8254 1998
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 95 95 N 1 0 0 1 0 1950 2
+Refer: 64 95 N 1 0 0 1 0 1950 2
 EndChar
+
 StartChar: uni203F
-Encoding: 8255 8255 8255
+Encoding: 8255 8255 1999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57685,8 +59714,9 @@ SplineSet
  442 -331 442 -331 615 -331 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2045
-Encoding: 8261 8261 8261
+Encoding: 8261 8261 2000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57707,8 +59737,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2046
-Encoding: 8262 8262 8262
+Encoding: 8262 8262 2001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57729,38 +59760,42 @@ SplineSet
  770 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2047
-Encoding: 8263 8263 8263
+Encoding: 8263 8263 2002
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -324.5 0 2
-Refer: 1114126 -1 N 1 0 0 1 283.5 0 2
-LCarets2: 1 0 
+Refer: 3739 -1 N 1 0 0 1 -324.5 0 2
+Refer: 3739 -1 N 1 0 0 1 283.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2048
-Encoding: 8264 8264 8264
+Encoding: 8264 8264 2003
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114126 -1 N 1 0 0 1 -324.5 0 2
-Refer: 33 33 N 1 0 0 1 308 0 2
-LCarets2: 1 0 
+Refer: 3739 -1 N 1 0 0 1 -324.5 0 2
+Refer: 2 33 N 1 0 0 1 308 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2049
-Encoding: 8265 8265 8265
+Encoding: 8265 8265 2004
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 33 33 N 1 0 0 1 -308 0 2
-Refer: 1114126 -1 N 1 0 0 1 283.5 0 2
-LCarets2: 1 0 
+Refer: 2 33 N 1 0 0 1 -308 0 2
+Refer: 3739 -1 N 1 0 0 1 283.5 0 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni204B
-Encoding: 8267 8267 8267
+Encoding: 8267 8267 2005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57781,14 +59816,16 @@ SplineSet
  651 1493 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni205F
-Encoding: 8287 8287 8287
+Encoding: 8287 8287 2006
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uni2070
-Encoding: 8304 8304 8304
+Encoding: 8304 8304 2007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57823,8 +59860,9 @@ SplineSet
  468.004 1520 468.004 1520 616 1520 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2071
-Encoding: 8305 8305 8305
+Encoding: 8305 8305 2008
 Width: 1233
 Flags: W
 AnchorPoint: "below" 604.58 668 basechar 0
@@ -57849,8 +59887,9 @@ SplineSet
  558 1539 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2074
-Encoding: 8308 8308 8308
+Encoding: 8308 8308 2009
 Width: 1233
 Flags: W
 TtInstrs:
@@ -57925,8 +59964,9 @@ SplineSet
  655 1378 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2075
-Encoding: 8309 8309 8309
+Encoding: 8309 8309 2010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57957,8 +59997,9 @@ SplineSet
  358 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2076
-Encoding: 8310 8310 8310
+Encoding: 8310 8310 2011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -57993,8 +60034,9 @@ SplineSet
  720.996 1133 720.996 1133 638 1133 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2077
-Encoding: 8311 8311 8311
+Encoding: 8311 8311 2012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58010,8 +60052,9 @@ SplineSet
  317 1503 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2078
-Encoding: 8312 8312 8312
+Encoding: 8312 8312 2013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58054,8 +60097,9 @@ SplineSet
  462 1359 462 1359 462 1291 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2079
-Encoding: 8313 8313 8313
+Encoding: 8313 8313 2014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58090,8 +60134,9 @@ SplineSet
  413.999 670 413.999 670 371 686 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni207A
-Encoding: 8314 8314 8314
+Encoding: 8314 8314 2015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58112,8 +60157,9 @@ SplineSet
  670 1324 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207B
-Encoding: 8315 8315 8315
+Encoding: 8315 8315 2016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58126,8 +60172,9 @@ SplineSet
  284 1075 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207C
-Encoding: 8316 8316 8316
+Encoding: 8316 8316 2017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58145,8 +60192,9 @@ SplineSet
  284 1189 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207D
-Encoding: 8317 8317 8317
+Encoding: 8317 8317 2018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58165,8 +60213,9 @@ SplineSet
  762 1538 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni207E
-Encoding: 8318 8318 8318
+Encoding: 8318 8318 2019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58185,8 +60234,9 @@ SplineSet
  556 1410 556 1410 472 1538 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni207F
-Encoding: 8319 8319 8319
+Encoding: 8319 8319 2020
 Width: 1233
 Flags: W
 TtInstrs:
@@ -58245,232 +60295,261 @@ SplineSet
  911.97 1176.48 911.97 1176.48 911.97 1046.56 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2080
-Encoding: 8320 8320 8320
+Encoding: 8320 8320 2021
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 0 -668 3
+Refer: 2007 8304 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2081
-Encoding: 8321 8321 8321
+Encoding: 8321 8321 2022
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 185 185 N 1 0 0 1 0 -668 3
+Refer: 121 185 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2082
-Encoding: 8322 8322 8322
+Encoding: 8322 8322 2023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 178 178 N 1 0 0 1 0 -668 3
+Refer: 114 178 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2083
-Encoding: 8323 8323 8323
+Encoding: 8323 8323 2024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 0 -668 3
+Refer: 115 179 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2084
-Encoding: 8324 8324 8324
+Encoding: 8324 8324 2025
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 0 -668 3
+Refer: 2009 8308 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2085
-Encoding: 8325 8325 8325
+Encoding: 8325 8325 2026
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 0 -668 3
+Refer: 2010 8309 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2086
-Encoding: 8326 8326 8326
+Encoding: 8326 8326 2027
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 0 -668 3
+Refer: 2011 8310 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2087
-Encoding: 8327 8327 8327
+Encoding: 8327 8327 2028
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8311 8311 N 1 0 0 1 0 -668 3
+Refer: 2012 8311 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2088
-Encoding: 8328 8328 8328
+Encoding: 8328 8328 2029
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 0 -668 3
+Refer: 2013 8312 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2089
-Encoding: 8329 8329 8329
+Encoding: 8329 8329 2030
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8313 8313 N 1 0 0 1 0 -668 3
+Refer: 2014 8313 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208A
-Encoding: 8330 8330 8330
+Encoding: 8330 8330 2031
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8314 8314 N 1 0 0 1 0 -668 3
+Refer: 2015 8314 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208B
-Encoding: 8331 8331 8331
+Encoding: 8331 8331 2032
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8315 8315 N 1 0 0 1 0 -668 3
+Refer: 2016 8315 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208C
-Encoding: 8332 8332 8332
+Encoding: 8332 8332 2033
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8316 8316 N 1 0 0 1 0 -668 3
+Refer: 2017 8316 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208D
-Encoding: 8333 8333 8333
+Encoding: 8333 8333 2034
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8317 8317 N 1 0 0 1 0 -668 3
+Refer: 2018 8317 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni208E
-Encoding: 8334 8334 8334
+Encoding: 8334 8334 2035
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8318 8318 N 1 0 0 1 0 -668 3
+Refer: 2019 8318 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2090
-Encoding: 8336 8336 8336
+Encoding: 8336 8336 2036
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7491 7491 N 1 0 0 1 0 -668 3
+Refer: 1467 7491 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2091
-Encoding: 8337 8337 8337
+Encoding: 8337 8337 2037
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7497 7497 N 1 0 0 1 0 -668 3
+Refer: 1473 7497 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2092
-Encoding: 8338 8338 8338
+Encoding: 8338 8338 2038
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7506 7506 N 1 0 0 1 0 -668 3
+Refer: 1482 7506 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2093
-Encoding: 8339 8339 8339
+Encoding: 8339 8339 2039
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 739 739 N 1 0 0 1 0 -668 3
+Refer: 646 739 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2094
-Encoding: 8340 8340 8340
+Encoding: 8340 8340 2040
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7498 7498 N 1 0 0 1 0 -668 3
+Refer: 1474 7498 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2095
-Encoding: 8341 8341 8341
+Encoding: 8341 8341 2041
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 688 688 N 1 0 0 1 0 -668 3
+Refer: 605 688 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2096
-Encoding: 8342 8342 8342
+Encoding: 8342 8342 2042
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7503 7503 N 1 0 0 1 0 -668 3
+Refer: 1479 7503 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2097
-Encoding: 8343 8343 8343
+Encoding: 8343 8343 2043
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 737 737 N 1 0 0 1 0 -668 3
+Refer: 644 737 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2098
-Encoding: 8344 8344 8344
+Encoding: 8344 8344 2044
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7504 7504 N 1 0 0 1 0 -668 3
+Refer: 1480 7504 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2099
-Encoding: 8345 8345 8345
+Encoding: 8345 8345 2045
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8319 8319 N 1 0 0 1 0 -668 3
+Refer: 2020 8319 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209A
-Encoding: 8346 8346 8346
+Encoding: 8346 8346 2046
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7510 7510 N 1 0 0 1 0 -668 3
+Refer: 1486 7510 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209B
-Encoding: 8347 8347 8347
+Encoding: 8347 8347 2047
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 738 738 N 1 0 0 1 0 -668 3
+Refer: 645 738 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni209C
-Encoding: 8348 8348 8348
+Encoding: 8348 8348 2048
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 7511 7511 N 1 0 0 1 0 -668 3
+Refer: 1487 7511 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni20A0
-Encoding: 8352 8352 8352
+Encoding: 8352 8352 2049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58509,8 +60588,9 @@ SplineSet
  687 428 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: colonmonetary
-Encoding: 8353 8353 8353
+Encoding: 8353 8353 2050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58558,8 +60638,9 @@ SplineSet
  887 1330 l 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni20A2
-Encoding: 8354 8354 8354
+Encoding: 8354 8354 2051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58599,8 +60680,9 @@ SplineSet
  755 138 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: franc
-Encoding: 8355 8355 8355
+Encoding: 8355 8355 2052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58627,8 +60709,9 @@ SplineSet
  233 382 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: lira
-Encoding: 8356 8356 8356
+Encoding: 8356 8356 2053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58669,8 +60752,9 @@ SplineSet
  575 492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A5
-Encoding: 8357 8357 8357
+Encoding: 8357 8357 2054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58711,8 +60795,9 @@ SplineSet
  778 1122 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20A6
-Encoding: 8358 8358 8358
+Encoding: 8358 8358 2055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58767,8 +60852,9 @@ SplineSet
  795.935 550 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: peseta
-Encoding: 8359 8359 8359
+Encoding: 8359 8359 2056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58839,8 +60925,9 @@ SplineSet
  488 1019 l 1,9,10
 EndSplineSet
 EndChar
+
 StartChar: uni20A8
-Encoding: 8360 8360 8360
+Encoding: 8360 8360 2057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58901,8 +60988,9 @@ SplineSet
  781 -3 781 -3 752 7 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20A9
-Encoding: 8361 8361 8361
+Encoding: 8361 8361 2058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -58965,8 +61053,9 @@ SplineSet
  616 1156 l 1,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AA
-Encoding: 8362 8362 8362
+Encoding: 8362 8362 2059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59000,17 +61089,19 @@ SplineSet
  1190 -29 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: dong
-Encoding: 8363 8363 8363
+Encoding: 8363 8363 2060
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 273 273 N 1 0 0 1 0 0 3
-Refer: 717 717 N 1 0 0 1 122 0 2
+Refer: 209 273 N 1 0 0 1 0 0 3
+Refer: 627 717 N 1 0 0 1 122 0 2
 EndChar
+
 StartChar: Euro
-Encoding: 8364 8364 8364
+Encoding: 8364 8364 2061
 Width: 1233
 Flags: W
 TtInstrs:
@@ -59171,8 +61262,9 @@ SplineSet
  211 948 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20AD
-Encoding: 8365 8365 8365
+Encoding: 8365 8365 2062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59199,8 +61291,9 @@ SplineSet
  180 852 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AE
-Encoding: 8366 8366 8366
+Encoding: 8366 8366 2063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59233,8 +61326,9 @@ SplineSet
  516 909 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20AF
-Encoding: 8367 8367 8367
+Encoding: 8367 8367 2064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59322,8 +61416,9 @@ SplineSet
  185 142 185 142 201 204 c 1,113,114
 EndSplineSet
 EndChar
+
 StartChar: uni20B0
-Encoding: 8368 8368 8368
+Encoding: 8368 8368 2065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59361,8 +61456,9 @@ SplineSet
  680 998 680 998 834 881 c 1,42,43
 EndSplineSet
 EndChar
+
 StartChar: uni20B1
-Encoding: 8369 8369 8369
+Encoding: 8369 8369 2066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59409,8 +61505,9 @@ SplineSet
  926.968 997 l 1,35,36
 EndSplineSet
 EndChar
+
 StartChar: uni20B2
-Encoding: 8370 8370 8370
+Encoding: 8370 8370 2067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59450,8 +61547,9 @@ SplineSet
  448 182 448 182 581 150 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B3
-Encoding: 8371 8371 8371
+Encoding: 8371 8371 2068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59493,8 +61591,9 @@ SplineSet
  521 973 l 1,39,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B4
-Encoding: 8372 8372 8372
+Encoding: 8372 8372 2069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59542,8 +61641,9 @@ SplineSet
  830.93 943 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B5
-Encoding: 8373 8373 8373
+Encoding: 8373 8373 2070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59581,8 +61681,9 @@ SplineSet
  550.043 164.957 550.043 164.957 641.761 142.417 c 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B8
-Encoding: 8376 8376 8376
+Encoding: 8376 8376 2071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59604,8 +61705,9 @@ SplineSet
  47 1203 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20B9
-Encoding: 8377 8377 8377
+Encoding: 8377 8377 2072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59642,8 +61744,9 @@ SplineSet
  1137 1493 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni20BA
-Encoding: 8378 8378 8378
+Encoding: 8378 8378 2073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59677,8 +61780,9 @@ SplineSet
  1180 748 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni20BD
-Encoding: 8381 8381 8381
+Encoding: 8381 8381 2074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59716,8 +61820,9 @@ SplineSet
  506 1327 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2102
-Encoding: 8450 8450 8450
+Encoding: 8450 8450 2075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59749,8 +61854,9 @@ SplineSet
  408 1282 l 0,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2105
-Encoding: 8453 8453 8453
+Encoding: 8453 8453 2076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59800,8 +61906,9 @@ SplineSet
  854 880 854 880 975 880 c 128,-1,43
 EndSplineSet
 EndChar
+
 StartChar: uni210D
-Encoding: 8461 8461 8461
+Encoding: 8461 8461 2077
 Width: 1233
 Flags: W
 AnchorPoint: "below" 609 0 basechar 0
@@ -59834,8 +61941,9 @@ SplineSet
  58 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210E
-Encoding: 8462 8462 8462
+Encoding: 8462 8462 2078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59864,8 +61972,9 @@ SplineSet
  1085 746 1085 746 1075 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni210F
-Encoding: 8463 8463 8463
+Encoding: 8463 8463 2079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59899,8 +62008,9 @@ SplineSet
  455 952 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2115
-Encoding: 8469 8469 8469
+Encoding: 8469 8469 2080
 Width: 1233
 Flags: W
 AnchorPoint: "above" 612 1506 basechar 0
@@ -59926,8 +62036,9 @@ SplineSet
  74 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2116
-Encoding: 8470 8470 8470
+Encoding: 8470 8470 2081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -59969,8 +62080,9 @@ SplineSet
  133 246 133 246 133 305 c 2,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2117
-Encoding: 8471 8471 8471
+Encoding: 8471 8471 2082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60030,8 +62142,9 @@ SplineSet
  411 1113 l 1,35,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2119
-Encoding: 8473 8473 8473
+Encoding: 8473 8473 2083
 Width: 1233
 Flags: W
 AnchorPoint: "below" 565 0 basechar 0
@@ -60069,8 +62182,9 @@ SplineSet
  943 1348 943 1348 883 1370 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211A
-Encoding: 8474 8474 8474
+Encoding: 8474 8474 2084
 Width: 1233
 Flags: W
 AnchorPoint: "below" 807 0 basechar 0
@@ -60113,8 +62227,9 @@ SplineSet
  947 1269 947 1269 917 1298 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni211D
-Encoding: 8477 8477 8477
+Encoding: 8477 8477 2085
 Width: 1233
 Flags: W
 AnchorPoint: "below" 613 0 basechar 0
@@ -60167,8 +62282,9 @@ SplineSet
  122 1393 l 1,47,-1
 EndSplineSet
 EndChar
+
 StartChar: trademark
-Encoding: 8482 8482 8482
+Encoding: 8482 8482 2086
 Width: 1233
 Flags: W
 TtInstrs:
@@ -60305,8 +62421,9 @@ SplineSet
  692 1493 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2124
-Encoding: 8484 8484 8484
+Encoding: 8484 8484 2087
 Width: 1233
 Flags: W
 AnchorPoint: "below" 608 0 basechar 0
@@ -60332,32 +62449,36 @@ SplineSet
  67 1493 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2126
-Encoding: 8486 8486 8486
+Encoding: 8486 8486 2088
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 937 937 N 1 0 0 1 0 0 2
+Refer: 766 937 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212A
-Encoding: 8490 8490 8490
+Encoding: 8490 8490 2089
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni212B
-Encoding: 8491 8491 8491
+Encoding: 8491 8491 2090
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 197 197 N 1 0 0 1 0 0 2
+Refer: 133 197 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: estimated
-Encoding: 8494 8494 8494
+Encoding: 8494 8494 2091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60395,8 +62516,9 @@ SplineSet
  233 704 l 2,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2148
-Encoding: 8520 8520 8520
+Encoding: 8520 8520 2092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60425,169 +62547,186 @@ SplineSet
  693 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2150
-Encoding: 8528 8528 8528
+Encoding: 8528 8528 2093
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8311 8311 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 2012 8311 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: uni2151
-Encoding: 8529 8529 8529
+Encoding: 8529 8529 2094
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-Refer: 8313 8313 N 1 0 0 1 201 -928 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+Refer: 2014 8313 N 1 0 0 1 201 -928 2
 EndChar
+
 StartChar: onethird
-Encoding: 8531 8531 8531
+Encoding: 8531 8531 2095
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: twothirds
-Encoding: 8532 8532 8532
+Encoding: 8532 8532 2096
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2155
-Encoding: 8533 8533 8533
+Encoding: 8533 8533 2097
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2156
-Encoding: 8534 8534 8534
+Encoding: 8534 8534 2098
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 178 178 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 114 178 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2157
-Encoding: 8535 8535 8535
+Encoding: 8535 8535 2099
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2158
-Encoding: 8536 8536 8536
+Encoding: 8536 8536 2100
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8309 8309 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8308 8308 N 1 0 0 1 -258 156 2
+Refer: 2010 8309 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2009 8308 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni2159
-Encoding: 8537 8537 8537
+Encoding: 8537 8537 2101
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: uni215A
-Encoding: 8538 8538 8538
+Encoding: 8538 8538 2102
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8310 8310 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
+Refer: 2011 8310 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: oneeighth
-Encoding: 8539 8539 8539
+Encoding: 8539 8539 2103
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: threeeighths
-Encoding: 8540 8540 8540
+Encoding: 8540 8540 2104
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: fiveeighths
-Encoding: 8541 8541 8541
+Encoding: 8541 8541 2105
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8309 8309 N 1 0 0 1 -258 156 2
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2010 8309 N 1 0 0 1 -258 156 2
 EndChar
+
 StartChar: seveneighths
-Encoding: 8542 8542 8542
+Encoding: 8542 8542 2106
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8312 8312 N 1 0 0 1 201 -938 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 8311 8311 N 1 0 0 1 -258 156 2
-LCarets2: 2 0 0 
+Refer: 2013 8312 N 1 0 0 1 201 -938 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 2012 8311 N 1 0 0 1 -258 156 2
+LCarets2: 2 0 0
 EndChar
+
 StartChar: uni215F
-Encoding: 8543 8543 8543
+Encoding: 8543 8543 2107
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 185 185 N 1 0 0 1 -258 156 2
-LCarets2: 1 0 
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 121 185 N 1 0 0 1 -258 156 2
+LCarets2: 1 0
 EndChar
+
 StartChar: uni2189
-Encoding: 8585 8585 8585
+Encoding: 8585 8585 2108
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8304 8304 N 1 0 0 1 -258 156 2
-Refer: 1114120 -1 N 1 0 0 1 0 0 2
-Refer: 179 179 N 1 0 0 1 201 -938 2
+Refer: 2007 8304 N 1 0 0 1 -258 156 2
+Refer: 3733 -1 N 1 0 0 1 0 0 2
+Refer: 115 179 N 1 0 0 1 201 -938 2
 EndChar
+
 StartChar: arrowleft
-Encoding: 8592 8592 8592
+Encoding: 8592 8592 2109
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60606,8 +62745,9 @@ SplineSet
  66 520 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowup
-Encoding: 8593 8593 8593
+Encoding: 8593 8593 2110
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60626,8 +62766,9 @@ SplineSet
  657.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowright
-Encoding: 8594 8594 8594
+Encoding: 8594 8594 2111
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60646,8 +62787,9 @@ SplineSet
  1167 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdown
-Encoding: 8595 8595 8595
+Encoding: 8595 8595 2112
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60666,8 +62808,9 @@ SplineSet
  575.5 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowboth
-Encoding: 8596 8596 8596
+Encoding: 8596 8596 2113
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60692,8 +62835,9 @@ SplineSet
  946 479 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdn
-Encoding: 8597 8597 8597
+Encoding: 8597 8597 2114
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60718,8 +62862,9 @@ SplineSet
  698.5 221 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2196
-Encoding: 8598 8598 8598
+Encoding: 8598 8598 2115
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60738,8 +62883,9 @@ SplineSet
  184 807 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2197
-Encoding: 8599 8599 8599
+Encoding: 8599 8599 2116
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60758,8 +62904,9 @@ SplineSet
  1049 807 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2198
-Encoding: 8600 8600 8600
+Encoding: 8600 8600 2117
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60778,8 +62925,9 @@ SplineSet
  991 0 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2199
-Encoding: 8601 8601 8601
+Encoding: 8601 8601 2118
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60798,8 +62946,9 @@ SplineSet
  184 58 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219A
-Encoding: 8602 8602 8602
+Encoding: 8602 8602 2119
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60826,8 +62975,9 @@ SplineSet
  961 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219B
-Encoding: 8603 8603 8603
+Encoding: 8603 8603 2120
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60854,8 +63004,9 @@ SplineSet
  272 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219C
-Encoding: 8604 8604 8604
+Encoding: 8604 8604 2121
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60896,8 +63047,9 @@ SplineSet
  292.277 738 l 17,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219D
-Encoding: 8605 8605 8605
+Encoding: 8605 8605 2122
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60938,8 +63090,9 @@ SplineSet
  933.723 726 933.723 726 940.723 738 c 9,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni219E
-Encoding: 8606 8606 8606
+Encoding: 8606 8606 2123
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60966,8 +63119,9 @@ SplineSet
  617 643 l 16,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni219F
-Encoding: 8607 8607 8607
+Encoding: 8607 8607 2124
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -60994,8 +63148,9 @@ SplineSet
  534.5 550 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A0
-Encoding: 8608 8608 8608
+Encoding: 8608 8608 2125
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61022,8 +63177,9 @@ SplineSet
  616 643 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A1
-Encoding: 8609 8609 8609
+Encoding: 8609 8609 2126
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61050,8 +63206,9 @@ SplineSet
  698.5 551 l 8,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A2
-Encoding: 8610 8610 8610
+Encoding: 8610 8610 2127
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61075,8 +63232,9 @@ SplineSet
  925 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A3
-Encoding: 8611 8611 8611
+Encoding: 8611 8611 2128
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61100,8 +63258,9 @@ SplineSet
  308 561 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21A4
-Encoding: 8612 8612 8612
+Encoding: 8612 8612 2129
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61124,8 +63283,9 @@ SplineSet
  1003 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A5
-Encoding: 8613 8613 8613
+Encoding: 8613 8613 2130
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61148,8 +63308,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A6
-Encoding: 8614 8614 8614
+Encoding: 8614 8614 2131
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61172,8 +63333,9 @@ SplineSet
  230 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A7
-Encoding: 8615 8615 8615
+Encoding: 8615 8615 2132
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61196,8 +63358,9 @@ SplineSet
  698.5 937 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: arrowupdnbse
-Encoding: 8616 8616 8616
+Encoding: 8616 8616 2133
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61226,8 +63389,9 @@ SplineSet
  534.5 164 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21A9
-Encoding: 8617 8617 8617
+Encoding: 8617 8617 2134
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61262,8 +63426,9 @@ SplineSet
  868 643 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AA
-Encoding: 8618 8618 8618
+Encoding: 8618 8618 2135
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61298,8 +63463,9 @@ SplineSet
  334.689 643.263 334.689 643.263 365 643 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AB
-Encoding: 8619 8619 8619
+Encoding: 8619 8619 2136
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61349,8 +63515,9 @@ SplineSet
  901.207 894.534 901.207 894.534 876 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AC
-Encoding: 8620 8620 8620
+Encoding: 8620 8620 2137
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61400,8 +63567,9 @@ SplineSet
  373.894 895.312 373.894 895.312 357 895 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21AD
-Encoding: 8621 8621 8621
+Encoding: 8621 8621 2138
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61468,8 +63636,9 @@ SplineSet
  287 643.002 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AE
-Encoding: 8622 8622 8622
+Encoding: 8622 8622 2139
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61502,8 +63671,9 @@ SplineSet
  946 479 l 1,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21AF
-Encoding: 8623 8623 8623
+Encoding: 8623 8623 2140
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61526,8 +63696,9 @@ SplineSet
  860.688 210.873 l 9,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B0
-Encoding: 8624 8624 8624
+Encoding: 8624 8624 2141
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61548,8 +63719,9 @@ SplineSet
  404.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B1
-Encoding: 8625 8625 8625
+Encoding: 8625 8625 2142
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61570,8 +63742,9 @@ SplineSet
  828.5 967 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B2
-Encoding: 8626 8626 8626
+Encoding: 8626 8626 2143
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61592,8 +63765,9 @@ SplineSet
  404.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B3
-Encoding: 8627 8627 8627
+Encoding: 8627 8627 2144
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61614,8 +63788,9 @@ SplineSet
  828.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B4
-Encoding: 8628 8628 8628
+Encoding: 8628 8628 2145
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61636,8 +63811,9 @@ SplineSet
  633 221 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: carriagereturn
-Encoding: 8629 8629 8629
+Encoding: 8629 8629 2146
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61658,8 +63834,9 @@ SplineSet
  284.5 414 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B6
-Encoding: 8630 8630 8630
+Encoding: 8630 8630 2147
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61694,8 +63871,9 @@ SplineSet
  331.244 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B7
-Encoding: 8631 8631 8631
+Encoding: 8631 8631 2148
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61730,8 +63908,9 @@ SplineSet
  901.756 565 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B8
-Encoding: 8632 8632 8632
+Encoding: 8632 8632 2149
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61755,8 +63934,9 @@ SplineSet
  50.5 970 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21B9
-Encoding: 8633 8633 8633
+Encoding: 8633 8633 2150
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61794,8 +63974,9 @@ SplineSet
  1003 373.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21BA
-Encoding: 8634 8634 8634
+Encoding: 8634 8634 2151
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61838,8 +64019,9 @@ SplineSet
  917.375 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BB
-Encoding: 8635 8635 8635
+Encoding: 8635 8635 2152
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61882,8 +64064,9 @@ SplineSet
  315.625 889.691 l 25,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BC
-Encoding: 8636 8636 8636
+Encoding: 8636 8636 2153
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61899,8 +64082,9 @@ SplineSet
  66 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BD
-Encoding: 8637 8637 8637
+Encoding: 8637 8637 2154
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61916,8 +64100,9 @@ SplineSet
  66 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BE
-Encoding: 8638 8638 8638
+Encoding: 8638 8638 2155
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61933,8 +64118,9 @@ SplineSet
  534.5 1101 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21BF
-Encoding: 8639 8639 8639
+Encoding: 8639 8639 2156
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61950,8 +64136,9 @@ SplineSet
  698.5 1101 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C0
-Encoding: 8640 8640 8640
+Encoding: 8640 8640 2157
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61967,8 +64154,9 @@ SplineSet
  1167 479 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C1
-Encoding: 8641 8641 8641
+Encoding: 8641 8641 2158
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -61984,8 +64172,9 @@ SplineSet
  1167 643 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C2
-Encoding: 8642 8642 8642
+Encoding: 8642 8642 2159
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62001,8 +64190,9 @@ SplineSet
  534.5 0 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C3
-Encoding: 8643 8643 8643
+Encoding: 8643 8643 2160
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62018,8 +64208,9 @@ SplineSet
  741 0 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C4
-Encoding: 8644 8644 8644
+Encoding: 8644 8644 2161
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62049,8 +64240,9 @@ SplineSet
  66 291 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C5
-Encoding: 8645 8645 8645
+Encoding: 8645 8645 2162
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62080,8 +64272,9 @@ SplineSet
  333.5 1101 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C6
-Encoding: 8646 8646 8646
+Encoding: 8646 8646 2163
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62111,8 +64304,9 @@ SplineSet
  66 857 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21C7
-Encoding: 8647 8647 8647
+Encoding: 8647 8647 2164
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62139,8 +64333,9 @@ SplineSet
  267 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C8
-Encoding: 8648 8648 8648
+Encoding: 8648 8648 2165
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62167,8 +64362,9 @@ SplineSet
  616.5 900 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21C9
-Encoding: 8649 8649 8649
+Encoding: 8649 8649 2166
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62195,8 +64391,9 @@ SplineSet
  966 574 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CA
-Encoding: 8650 8650 8650
+Encoding: 8650 8650 2167
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62223,8 +64420,9 @@ SplineSet
  616.5 201 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CB
-Encoding: 8651 8651 8651
+Encoding: 8651 8651 2168
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62248,8 +64446,9 @@ SplineSet
  66 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CC
-Encoding: 8652 8652 8652
+Encoding: 8652 8652 2169
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62273,8 +64472,9 @@ SplineSet
  1167 643 l 25,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CD
-Encoding: 8653 8653 8653
+Encoding: 8653 8653 2170
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62311,8 +64511,9 @@ SplineSet
  737 643 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21CE
-Encoding: 8654 8654 8654
+Encoding: 8654 8654 2171
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62357,8 +64558,9 @@ SplineSet
  692 643.001 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21CF
-Encoding: 8655 8655 8655
+Encoding: 8655 8655 2172
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62395,8 +64597,9 @@ SplineSet
  496 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblleft
-Encoding: 8656 8656 8656
+Encoding: 8656 8656 2173
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62420,8 +64623,9 @@ SplineSet
  287 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblup
-Encoding: 8657 8657 8657
+Encoding: 8657 8657 2174
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62445,8 +64649,9 @@ SplineSet
  534.499 880 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblright
-Encoding: 8658 8658 8658
+Encoding: 8658 8658 2175
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62470,8 +64675,9 @@ SplineSet
  946 643.001 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdbldown
-Encoding: 8659 8659 8659
+Encoding: 8659 8659 2176
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62495,8 +64701,9 @@ SplineSet
  698.501 221 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: arrowdblboth
-Encoding: 8660 8660 8660
+Encoding: 8660 8660 2177
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62528,8 +64735,9 @@ SplineSet
  864 725 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D5
-Encoding: 8661 8661 8661
+Encoding: 8661 8661 2178
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62561,8 +64769,9 @@ SplineSet
  780.5 798 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21D6
-Encoding: 8662 8662 8662
+Encoding: 8662 8662 2179
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62586,8 +64795,9 @@ SplineSet
  398 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D7
-Encoding: 8663 8663 8663
+Encoding: 8663 8663 2180
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62611,8 +64821,9 @@ SplineSet
  835 738 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D8
-Encoding: 8664 8664 8664
+Encoding: 8664 8664 2181
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62636,8 +64847,9 @@ SplineSet
  951 243 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21D9
-Encoding: 8665 8665 8665
+Encoding: 8665 8665 2182
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62661,8 +64873,9 @@ SplineSet
  398 127 l 1,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DA
-Encoding: 8666 8666 8666
+Encoding: 8666 8666 2183
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62687,8 +64900,9 @@ SplineSet
  447 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DB
-Encoding: 8667 8667 8667
+Encoding: 8667 8667 2184
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62713,8 +64927,9 @@ SplineSet
  786 319 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DC
-Encoding: 8668 8668 8668
+Encoding: 8668 8668 2185
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62746,8 +64961,9 @@ SplineSet
  287 643 l 17,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DD
-Encoding: 8669 8669 8669
+Encoding: 8669 8669 2186
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62779,8 +64995,9 @@ SplineSet
  946 643 l 9,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21DE
-Encoding: 8670 8670 8670
+Encoding: 8670 8670 2187
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62815,8 +65032,9 @@ SplineSet
  698.5 188.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21DF
-Encoding: 8671 8671 8671
+Encoding: 8671 8671 2188
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62851,8 +65069,9 @@ SplineSet
  534.5 912.5 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E0
-Encoding: 8672 8672 8672
+Encoding: 8672 8672 2189
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62881,8 +65100,9 @@ SplineSet
  980.001 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E1
-Encoding: 8673 8673 8673
+Encoding: 8673 8673 2190
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62911,8 +65131,9 @@ SplineSet
  698.499 186.999 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E2
-Encoding: 8674 8674 8674
+Encoding: 8674 8674 2191
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62941,8 +65162,9 @@ SplineSet
  252.999 479.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E3
-Encoding: 8675 8675 8675
+Encoding: 8675 8675 2192
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62971,8 +65193,9 @@ SplineSet
  534.501 914.001 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E4
-Encoding: 8676 8676 8676
+Encoding: 8676 8676 2193
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -62995,8 +65218,9 @@ SplineSet
  230.001 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E5
-Encoding: 8677 8677 8677
+Encoding: 8677 8677 2194
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63019,8 +65243,9 @@ SplineSet
  1003 602.003 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21E6
-Encoding: 8678 8678 8678
+Encoding: 8678 8678 2195
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63044,8 +65269,9 @@ SplineSet
  398 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E7
-Encoding: 8679 8679 8679
+Encoding: 8679 8679 2196
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63069,8 +65295,9 @@ SplineSet
  989.5 769 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E8
-Encoding: 8680 8680 8680
+Encoding: 8680 8680 2197
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63094,8 +65321,9 @@ SplineSet
  835.5 188 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21E9
-Encoding: 8681 8681 8681
+Encoding: 8681 8681 2198
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63119,8 +65347,9 @@ SplineSet
  243.5 373 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21EA
-Encoding: 8682 8682 8682
+Encoding: 8682 8682 2199
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63154,8 +65383,9 @@ SplineSet
  444.5 410 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EB
-Encoding: 8683 8683 8683
+Encoding: 8683 8683 2200
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63187,8 +65417,9 @@ SplineSet
  444.495 280 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EC
-Encoding: 8684 8684 8684
+Encoding: 8684 8684 2201
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63225,8 +65456,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21ED
-Encoding: 8685 8685 8685
+Encoding: 8685 8685 2202
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63262,8 +65494,9 @@ SplineSet
  444.495 280 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EE
-Encoding: 8686 8686 8686
+Encoding: 8686 8686 2203
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63298,8 +65531,9 @@ SplineSet
  443.5 769 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21EF
-Encoding: 8687 8687 8687
+Encoding: 8687 8687 2204
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63342,8 +65576,9 @@ SplineSet
  444.5 569 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F0
-Encoding: 8688 8688 8688
+Encoding: 8688 8688 2205
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63375,8 +65610,9 @@ SplineSet
  346.5 388.995 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F1
-Encoding: 8689 8689 8689
+Encoding: 8689 8689 2206
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63402,8 +65638,9 @@ SplineSet
  1162.74 1094 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F2
-Encoding: 8690 8690 8690
+Encoding: 8690 8690 2207
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63429,8 +65666,9 @@ SplineSet
  1163.5 1093 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F3
-Encoding: 8691 8691 8691
+Encoding: 8691 8691 2208
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63460,8 +65698,9 @@ SplineSet
  444.5 769 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F4
-Encoding: 8692 8692 8692
+Encoding: 8692 8692 2209
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63504,8 +65743,9 @@ SplineSet
  576.115 460.271 576.115 460.271 587 479 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F5
-Encoding: 8693 8693 8693
+Encoding: 8693 8693 2210
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63535,8 +65775,9 @@ SplineSet
  899.5 1101 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F6
-Encoding: 8694 8694 8694
+Encoding: 8694 8694 2211
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63571,8 +65812,9 @@ SplineSet
  786.001 319 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F7
-Encoding: 8695 8695 8695
+Encoding: 8695 8695 2212
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63599,8 +65841,9 @@ SplineSet
  798.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21F8
-Encoding: 8696 8696 8696
+Encoding: 8696 8696 2213
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63627,8 +65870,9 @@ SplineSet
  434.5 479 l 0,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21F9
-Encoding: 8697 8697 8697
+Encoding: 8697 8697 2214
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63661,8 +65905,9 @@ SplineSet
  534.5 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FA
-Encoding: 8698 8698 8698
+Encoding: 8698 8698 2215
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63697,8 +65942,9 @@ SplineSet
  978.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FB
-Encoding: 8699 8699 8699
+Encoding: 8699 8699 2216
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63733,8 +65979,9 @@ SplineSet
  254.5 479 l 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni21FC
-Encoding: 8700 8700 8700
+Encoding: 8700 8700 2217
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63775,8 +66022,9 @@ SplineSet
  287 479 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FD
-Encoding: 8701 8701 8701
+Encoding: 8701 8701 2218
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63796,8 +66044,9 @@ SplineSet
  398 643 l 9,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FE
-Encoding: 8702 8702 8702
+Encoding: 8702 8702 2219
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63817,8 +66066,9 @@ SplineSet
  835 643 l 17,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni21FF
-Encoding: 8703 8703 8703
+Encoding: 8703 8703 2220
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63845,8 +66095,9 @@ SplineSet
  398 479 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: universal
-Encoding: 8704 8704 8704
+Encoding: 8704 8704 2221
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63867,8 +66118,9 @@ SplineSet
  494 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2201
-Encoding: 8705 8705 8705
+Encoding: 8705 8705 2222
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63895,8 +66147,9 @@ SplineSet
  117 367 117 367 117 745 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: partialdiff
-Encoding: 8706 8706 8706
+Encoding: 8706 8706 2223
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63931,8 +66184,9 @@ SplineSet
  353 412 353 412 353 310 c 0,33,34
 EndSplineSet
 EndChar
+
 StartChar: existential
-Encoding: 8707 8707 8707
+Encoding: 8707 8707 2224
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63953,8 +66207,9 @@ SplineSet
  178 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2204
-Encoding: 8708 8708 8708
+Encoding: 8708 8708 2225
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -63993,8 +66248,9 @@ SplineSet
  609 662 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: emptyset
-Encoding: 8709 8709 8709
+Encoding: 8709 8709 2226
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64045,8 +66301,9 @@ SplineSet
  967.676 833.623 967.676 833.623 942.785 868.669 c 1,49,-1
 EndSplineSet
 EndChar
+
 StartChar: Delta
-Encoding: 8710 8710 8710
+Encoding: 8710 8710 2227
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64144,8 +66401,9 @@ SplineSet
  616 1219 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: gradient
-Encoding: 8711 8711 8711
+Encoding: 8711 8711 2228
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64162,8 +66420,9 @@ SplineSet
  616 204 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: element
-Encoding: 8712 8712 8712
+Encoding: 8712 8712 2229
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64193,8 +66452,9 @@ SplineSet
  304.5 647 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: notelement
-Encoding: 8713 8713 8713
+Encoding: 8713 8713 2230
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64240,8 +66500,9 @@ SplineSet
  554 647 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220A
-Encoding: 8714 8714 8714
+Encoding: 8714 8714 2231
 Width: 1233
 Flags: W
 CounterMasks: 1 00
@@ -64338,8 +66599,9 @@ SplineSet
  1102 726 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: suchthat
-Encoding: 8715 8715 8715
+Encoding: 8715 8715 2232
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64369,8 +66631,9 @@ SplineSet
  928.5 817 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220C
-Encoding: 8716 8716 8716
+Encoding: 8716 8716 2233
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64416,8 +66679,9 @@ SplineSet
  679 817 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni220D
-Encoding: 8717 8717 8717
+Encoding: 8717 8717 2234
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64445,8 +66709,9 @@ SplineSet
  131 556 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni220E
-Encoding: 8718 8718 8718
+Encoding: 8718 8718 2235
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64459,8 +66724,9 @@ SplineSet
  250 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: product
-Encoding: 8719 8719 8719
+Encoding: 8719 8719 2236
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64508,8 +66774,9 @@ SplineSet
  152 -436 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2210
-Encoding: 8720 8720 8720
+Encoding: 8720 8720 2237
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64526,8 +66793,9 @@ SplineSet
  1081 1518 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: summation
-Encoding: 8721 8721 8721
+Encoding: 8721 8721 2238
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64597,8 +66865,9 @@ SplineSet
  332 -299 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: minus
-Encoding: 8722 8722 8722
+Encoding: 8722 8722 2239
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64630,8 +66899,9 @@ SplineSet
  88 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2213
-Encoding: 8723 8723 8723
+Encoding: 8723 8723 2240
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64657,40 +66927,45 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2215
-Encoding: 8725 8725 8725
+Encoding: 8725 8725 2241
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 47 47 N 1 0 0 1 0 0 2
+Refer: 16 47 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: asteriskmath
-Encoding: 8727 8727 8727
+Encoding: 8727 8727 2242
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42 42 N 1 0 0 1 0 -411 2
+Refer: 11 42 N 1 0 0 1 0 -411 2
 EndChar
+
 StartChar: uni2218
-Encoding: 8728 8728 8728
+Encoding: 8728 8728 2243
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 176 176 N 1 0 0 1 0 -558 2
+Refer: 112 176 N 1 0 0 1 0 -558 2
 EndChar
+
 StartChar: uni2219
-Encoding: 8729 8729 8729
+Encoding: 8729 8729 2244
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8226 8226 N 1 0 0 1 0 -55 2
+Refer: 1980 8226 N 1 0 0 1 0 -55 2
 EndChar
+
 StartChar: radical
-Encoding: 8730 8730 8730
+Encoding: 8730 8730 2245
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64759,26 +67034,29 @@ SplineSet
  100 733 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni221B
-Encoding: 8731 8731 8731
+Encoding: 8731 8731 2246
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 179 179 N 1 0 0 1 -155 390 2
-Refer: 8730 8730 N 1 0 0 1 0 0 3
+Refer: 115 179 N 1 0 0 1 -155 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uni221C
-Encoding: 8732 8732 8732
+Encoding: 8732 8732 2247
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8308 8308 N 1 0 0 1 -155 390 2
-Refer: 8730 8730 N 1 0 0 1 0 0 3
+Refer: 2009 8308 N 1 0 0 1 -155 390 2
+Refer: 2245 8730 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: proportional
-Encoding: 8733 8733 8733
+Encoding: 8733 8733 2248
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64814,8 +67092,9 @@ SplineSet
  1046.5 250 l 17,33,34
 EndSplineSet
 EndChar
+
 StartChar: infinity
-Encoding: 8734 8734 8734
+Encoding: 8734 8734 2249
 Width: 1233
 Flags: W
 TtInstrs:
@@ -64915,8 +67194,9 @@ SplineSet
  560 893 560 893 616 764 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: orthogonal
-Encoding: 8735 8735 8735
+Encoding: 8735 8735 2250
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64931,8 +67211,9 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: angle
-Encoding: 8736 8736 8736
+Encoding: 8736 8736 2251
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64947,16 +67228,18 @@ SplineSet
  1107.5 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2223
-Encoding: 8739 8739 8739
+Encoding: 8739 8739 2252
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 124 124 N 1 0 0 1 0 0 3
+Refer: 93 124 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: logicaland
-Encoding: 8743 8743 8743
+Encoding: 8743 8743 2253
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64972,8 +67255,9 @@ SplineSet
  164.25 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: logicalor
-Encoding: 8744 8744 8744
+Encoding: 8744 8744 2254
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -64989,8 +67273,9 @@ SplineSet
  164.25 1186 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: intersection
-Encoding: 8745 8745 8745
+Encoding: 8745 8745 2255
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65021,8 +67306,9 @@ SplineSet
  164.25 580 l 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: union
-Encoding: 8746 8746 8746
+Encoding: 8746 8746 2256
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65053,8 +67339,9 @@ SplineSet
  164.25 376 164.25 376 164.25 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integral
-Encoding: 8747 8747 8747
+Encoding: 8747 8747 2257
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65105,8 +67392,9 @@ SplineSet
  524.5 -213.72 524.5 -213.72 524.5 -68 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni222C
-Encoding: 8748 8748 8748
+Encoding: 8748 8748 2258
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65143,10 +67431,11 @@ SplineSet
  206.738 -247.167 206.738 -247.167 255 -232 c 0,22,23
  308.5 -215.188 308.5 -215.188 308.5 -68 c 2,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uni222D
-Encoding: 8749 8749 8749
+Encoding: 8749 8749 2259
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65198,59 +67487,65 @@ SplineSet
  123.223 -205 123.223 -205 173 -205 c 0,11,12
  200.5 -204.972 200.5 -204.972 200.5 -127 c 2,13,-1
 EndSplineSet
-LCarets2: 2 0 0 
+LCarets2: 2 0 0
 EndChar
+
 StartChar: therefore
-Encoding: 8756 8756 8756
+Encoding: 8756 8756 2260
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
 EndChar
+
 StartChar: uni2235
-Encoding: 8757 8757 8757
+Encoding: 8757 8757 2261
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2236
-Encoding: 8758 8758 8758
+Encoding: 8758 8758 2262
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 3 -425 2
-Refer: 8901 8901 N 1 0 0 1 -1 292 2
+Refer: 2375 8901 N 1 0 0 1 3 -425 2
+Refer: 2375 8901 N 1 0 0 1 -1 292 2
 EndChar
+
 StartChar: uni2237
-Encoding: 8759 8759 8759
+Encoding: 8759 8759 2263
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 -302 -425 2
-Refer: 8901 8901 N 1 0 0 1 -301 292 2
-Refer: 8901 8901 N 1 0 0 1 308 -425 2
-Refer: 8901 8901 N 1 0 0 1 304 292 2
+Refer: 2375 8901 N 1 0 0 1 -302 -425 2
+Refer: 2375 8901 N 1 0 0 1 -301 292 2
+Refer: 2375 8901 N 1 0 0 1 308 -425 2
+Refer: 2375 8901 N 1 0 0 1 304 292 2
 EndChar
+
 StartChar: uni2238
-Encoding: 8760 8760 8760
+Encoding: 8760 8760 2264
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1.5 292 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1.5 292 2
 EndChar
+
 StartChar: uni2239
-Encoding: 8761 8761 8761
+Encoding: 8761 8761 2265
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65273,30 +67568,33 @@ SplineSet
  74 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni223A
-Encoding: 8762 8762 8762
+Encoding: 8762 8762 2266
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8722 8722 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 404 292 2
-Refer: 8901 8901 N 1 0 0 1 408 -425 2
-Refer: 8901 8901 N 1 0 0 1 -401 292 2
-Refer: 8901 8901 N 1 0 0 1 -402 -425 2
+Refer: 2239 8722 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 404 292 2
+Refer: 2375 8901 N 1 0 0 1 408 -425 2
+Refer: 2375 8901 N 1 0 0 1 -401 292 2
+Refer: 2375 8901 N 1 0 0 1 -402 -425 2
 EndChar
+
 StartChar: uni223B
-Encoding: 8763 8763 8763
+Encoding: 8763 8763 2267
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 292 2
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 292 2
+Refer: 2375 8901 N 1 0 0 1 1 -425 2
 EndChar
+
 StartChar: similar
-Encoding: 8764 8764 8764
+Encoding: 8764 8764 2268
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65323,8 +67621,9 @@ SplineSet
  1071.01 723 1071.01 723 1145 786 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni223D
-Encoding: 8765 8765 8765
+Encoding: 8765 8765 2269
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65351,8 +67650,9 @@ SplineSet
  88 786 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2241
-Encoding: 8769 8769 8769
+Encoding: 8769 8769 2270
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65383,8 +67683,9 @@ SplineSet
  536 592.401 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2242
-Encoding: 8770 8770 8770
+Encoding: 8770 8770 2271
 Width: 1233
 LayerCount: 2
 Fore
@@ -65415,8 +67716,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2243
-Encoding: 8771 8771 8771
+Encoding: 8771 8771 2272
 Width: 1233
 LayerCount: 2
 Fore
@@ -65447,8 +67749,9 @@ SplineSet
  1071.01 900 1071.01 900 1145 963 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2244
-Encoding: 8772 8772 8772
+Encoding: 8772 8772 2273
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65486,8 +67789,9 @@ SplineSet
  967.079 1137.1 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: congruent
-Encoding: 8773 8773 8773
+Encoding: 8773 8773 2274
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65524,8 +67828,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2246
-Encoding: 8774 8774 8774
+Encoding: 8774 8774 2275
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65573,8 +67878,9 @@ SplineSet
  1071.01 1104 1071.01 1104 1145 1167 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2247
-Encoding: 8775 8775 8775
+Encoding: 8775 8775 2276
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65623,8 +67929,9 @@ SplineSet
  360 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: approxequal
-Encoding: 8776 8776 8776
+Encoding: 8776 8776 2277
 Width: 1233
 Flags: W
 TtInstrs:
@@ -65747,8 +68054,9 @@ SplineSet
  1070 532 1070 532 1145 596 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2249
-Encoding: 8777 8777 8777
+Encoding: 8777 8777 2278
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65796,8 +68104,9 @@ SplineSet
  477 419.074 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224A
-Encoding: 8778 8778 8778
+Encoding: 8778 8778 2279
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65848,8 +68157,9 @@ SplineSet
  88 364 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224B
-Encoding: 8779 8779 8779
+Encoding: 8779 8779 2280
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65914,8 +68224,9 @@ SplineSet
  1070 740 1070 740 1145 804 c 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224C
-Encoding: 8780 8780 8780
+Encoding: 8780 8780 2281
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65952,8 +68263,9 @@ SplineSet
  88 1167 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni224D
-Encoding: 8781 8781 8781
+Encoding: 8781 8781 2282
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -65975,8 +68287,9 @@ SplineSet
  416 555 416 555 616 555 c 129,-1,4
 EndSplineSet
 EndChar
+
 StartChar: uni224E
-Encoding: 8782 8782 8782
+Encoding: 8782 8782 2283
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66022,8 +68335,9 @@ SplineSet
  666 1062 666 1062 617 1059 c 24,2,-1
 EndSplineSet
 EndChar
+
 StartChar: uni224F
-Encoding: 8783 8783 8783
+Encoding: 8783 8783 2284
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66055,48 +68369,53 @@ SplineSet
  88 522 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2250
-Encoding: 8784 8784 8784
+Encoding: 8784 8784 2285
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1.5 441 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1.5 441 2
 EndChar
+
 StartChar: uni2251
-Encoding: 8785 8785 8785
+Encoding: 8785 8785 2286
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 441 2
-Refer: 8901 8901 N 1 0 0 1 2 441 2
-Refer: 8901 8901 N 1 0 0 1 1 -582 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 441 2
+Refer: 2375 8901 N 1 0 0 1 2 441 2
+Refer: 2375 8901 N 1 0 0 1 1 -582 2
 EndChar
+
 StartChar: uni2252
-Encoding: 8786 8786 8786
+Encoding: 8786 8786 2287
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 404 -579 2
-Refer: 61 61 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 -401 441 2
+Refer: 2375 8901 N 1 0 0 1 404 -579 2
+Refer: 30 61 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 -401 441 2
 EndChar
+
 StartChar: uni2253
-Encoding: 8787 8787 8787
+Encoding: 8787 8787 2288
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8901 8901 N 1 0 0 1 404.5 441 2
-Refer: 61 61 N 1 0 0 1 -0.5 0 2
-Refer: 8901 8901 N 1 0 0 1 -401.5 -579 2
+Refer: 2375 8901 N 1 0 0 1 404.5 441 2
+Refer: 30 61 N 1 0 0 1 -0.5 0 2
+Refer: 2375 8901 N 1 0 0 1 -401.5 -579 2
 EndChar
+
 StartChar: uni2254
-Encoding: 8788 8788 8788
+Encoding: 8788 8788 2289
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66124,8 +68443,9 @@ SplineSet
  1159 930 l 17,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2255
-Encoding: 8789 8789 8789
+Encoding: 8789 8789 2290
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66153,8 +68473,9 @@ SplineSet
  74 930 l 9,5,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2256
-Encoding: 8790 8790 8790
+Encoding: 8790 8790 2291
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66184,8 +68505,9 @@ SplineSet
  860 585 860 585 833 522 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2257
-Encoding: 8791 8791 8791
+Encoding: 8791 8791 2292
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66223,8 +68545,9 @@ SplineSet
  495.949 1556.95 495.949 1556.95 617 1556.95 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2258
-Encoding: 8792 8792 8792
+Encoding: 8792 8792 2293
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66249,8 +68572,9 @@ SplineSet
  392.396 1355 392.396 1355 617.85 1355 c 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni2259
-Encoding: 8793 8793 8793
+Encoding: 8793 8793 2294
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66276,8 +68600,9 @@ SplineSet
  302 1002 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225A
-Encoding: 8794 8794 8794
+Encoding: 8794 8794 2295
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66303,8 +68628,9 @@ SplineSet
  302 1604 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225B
-Encoding: 8795 8795 8795
+Encoding: 8795 8795 2296
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66333,8 +68659,9 @@ SplineSet
  264.2 1445.2 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225C
-Encoding: 8796 8796 8796
+Encoding: 8796 8796 2297
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66361,8 +68688,9 @@ SplineSet
  566.1 1711.15 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni225D
-Encoding: 8797 8797 8797
+Encoding: 8797 8797 2298
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66444,8 +68772,9 @@ SplineSet
  137.64 1278.51 137.64 1278.51 137.64 1205.43 c 0,73,74
 EndSplineSet
 EndChar
+
 StartChar: uni225E
-Encoding: 8798 8798 8798
+Encoding: 8798 8798 2299
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66491,8 +68820,9 @@ SplineSet
  626.424 1495.24 626.424 1495.24 646.267 1437.43 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni225F
-Encoding: 8799 8799 8799
+Encoding: 8799 8799 2300
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66540,8 +68870,9 @@ SplineSet
  637.75 1194.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notequal
-Encoding: 8800 8800 8800
+Encoding: 8800 8800 2301
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66632,8 +68963,9 @@ SplineSet
  88 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: equivalence
-Encoding: 8801 8801 8801
+Encoding: 8801 8801 2302
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66656,8 +68988,9 @@ SplineSet
  88 1090 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2262
-Encoding: 8802 8802 8802
+Encoding: 8802 8802 2303
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66694,8 +69027,9 @@ SplineSet
  327 192 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2263
-Encoding: 8803 8803 8803
+Encoding: 8803 8803 2304
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66723,8 +69057,9 @@ SplineSet
  88 1262 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: lessequal
-Encoding: 8804 8804 8804
+Encoding: 8804 8804 2305
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66787,8 +69122,9 @@ SplineSet
  1145 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: greaterequal
-Encoding: 8805 8805 8805
+Encoding: 8805 8805 2306
 Width: 1233
 Flags: W
 TtInstrs:
@@ -66851,8 +69187,9 @@ SplineSet
  88 170 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2266
-Encoding: 8806 8806 8806
+Encoding: 8806 8806 2307
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66878,8 +69215,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2267
-Encoding: 8807 8807 8807
+Encoding: 8807 8807 2308
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66905,8 +69243,9 @@ SplineSet
  1143 266 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2268
-Encoding: 8808 8808 8808
+Encoding: 8808 8808 2309
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66943,8 +69282,9 @@ SplineSet
  1143 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2269
-Encoding: 8809 8809 8809
+Encoding: 8809 8809 2310
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -66981,8 +69321,9 @@ SplineSet
  86 534 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni226D
-Encoding: 8813 8813 8813
+Encoding: 8813 8813 2311
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67011,8 +69352,9 @@ SplineSet
  564 731 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226E
-Encoding: 8814 8814 8814
+Encoding: 8814 8814 2312
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67041,8 +69383,9 @@ SplineSet
  590 751.908 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni226F
-Encoding: 8815 8815 8815
+Encoding: 8815 8815 2313
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67071,8 +69414,9 @@ SplineSet
  643 531 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2270
-Encoding: 8816 8816 8816
+Encoding: 8816 8816 2314
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67109,8 +69453,9 @@ SplineSet
  356 0 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2271
-Encoding: 8817 8817 8817
+Encoding: 8817 8817 2315
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67147,8 +69492,9 @@ SplineSet
  643 599.856 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2272
-Encoding: 8818 8818 8818
+Encoding: 8818 8818 2316
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67183,8 +69529,9 @@ SplineSet
  1143 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2273
-Encoding: 8819 8819 8819
+Encoding: 8819 8819 2317
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67219,8 +69566,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2274
-Encoding: 8820 8820 8820
+Encoding: 8820 8820 2318
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67267,8 +69615,9 @@ SplineSet
  601 746.693 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2275
-Encoding: 8821 8821 8821
+Encoding: 8821 8821 2319
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67315,8 +69664,9 @@ SplineSet
  736 883.452 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2276
-Encoding: 8822 8822 8822
+Encoding: 8822 8822 2320
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67340,8 +69690,9 @@ SplineSet
  1143 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2277
-Encoding: 8823 8823 8823
+Encoding: 8823 8823 2321
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67365,8 +69716,9 @@ SplineSet
  86 586 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2278
-Encoding: 8824 8824 8824
+Encoding: 8824 8824 2322
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67411,8 +69763,9 @@ SplineSet
  587 146.067 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2279
-Encoding: 8825 8825 8825
+Encoding: 8825 8825 2323
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67457,8 +69810,9 @@ SplineSet
  801.872 844.55 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227A
-Encoding: 8826 8826 8826
+Encoding: 8826 8826 2324
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67474,8 +69828,9 @@ SplineSet
  1143 1088 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227B
-Encoding: 8827 8827 8827
+Encoding: 8827 8827 2325
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67491,8 +69846,9 @@ SplineSet
  415 728 415 728 88 1088 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227C
-Encoding: 8828 8828 8828
+Encoding: 8828 8828 2326
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67517,8 +69873,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227D
-Encoding: 8829 8829 8829
+Encoding: 8829 8829 2327
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67543,8 +69900,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227E
-Encoding: 8830 8830 8830
+Encoding: 8830 8830 2328
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67581,8 +69939,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni227F
-Encoding: 8831 8831 8831
+Encoding: 8831 8831 2329
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67619,8 +69978,9 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2280
-Encoding: 8832 8832 8832
+Encoding: 8832 8832 2330
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67649,8 +70009,9 @@ SplineSet
  480.263 621.903 480.263 621.903 560.301 593 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2281
-Encoding: 8833 8833 8833
+Encoding: 8833 8833 2331
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67679,8 +70040,9 @@ SplineSet
  748.737 660.097 748.737 660.097 668.699 689 c 1,22,-1
 EndSplineSet
 EndChar
+
 StartChar: propersubset
-Encoding: 8834 8834 8834
+Encoding: 8834 8834 2332
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67703,8 +70065,9 @@ SplineSet
  1145 163 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: propersuperset
-Encoding: 8835 8835 8835
+Encoding: 8835 8835 2333
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67727,8 +70090,9 @@ SplineSet
  88 163 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: notsubset
-Encoding: 8836 8836 8836
+Encoding: 8836 8836 2334
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67763,8 +70127,9 @@ SplineSet
  379 198.472 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2285
-Encoding: 8837 8837 8837
+Encoding: 8837 8837 2335
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67799,8 +70164,9 @@ SplineSet
  854 1083.53 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: reflexsubset
-Encoding: 8838 8838 8838
+Encoding: 8838 8838 2336
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67828,8 +70194,9 @@ SplineSet
  1145 324 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: reflexsuperset
-Encoding: 8839 8839 8839
+Encoding: 8839 8839 2337
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67857,8 +70224,9 @@ SplineSet
  88 324 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2288
-Encoding: 8840 8840 8840
+Encoding: 8840 8840 2338
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67900,8 +70268,9 @@ SplineSet
  692 1130 l 17,30,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2289
-Encoding: 8841 8841 8841
+Encoding: 8841 8841 2339
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67945,8 +70314,9 @@ SplineSet
  648 474 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni228A
-Encoding: 8842 8842 8842
+Encoding: 8842 8842 2340
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67954,10 +70324,10 @@ Fore
 SplineSet
 1145 170 m 1,0,-1
  1145 0 l 1,1,-1
- 657.182 -7.04992e-15 l 1,2,-1
+ 657.182 -7.04992e-015 l 1,2,-1
  490 -208 l 1,3,-1
  358 -102 l 1,4,-1
- 439.812 -1.33227e-15 l 1,5,-1
+ 439.812 -1.33227e-015 l 1,5,-1
  88 0 l 1,6,-1
  88 170 l 1,7,-1
  576.167 170 l 1,8,-1
@@ -67982,8 +70352,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228B
-Encoding: 8843 8843 8843
+Encoding: 8843 8843 2341
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -67991,10 +70362,10 @@ Fore
 SplineSet
 1145 170 m 1,0,-1
  1145 0 l 1,1,-1
- 657.182 -7.04992e-15 l 1,2,-1
+ 657.182 -7.04992e-015 l 1,2,-1
  490 -208 l 1,3,-1
  358 -102 l 1,4,-1
- 439.812 -1.33227e-15 l 1,5,-1
+ 439.812 -1.33227e-015 l 1,5,-1
  88 0 l 1,6,-1
  88 170 l 1,7,-1
  576.167 170 l 1,8,-1
@@ -68019,8 +70390,9 @@ SplineSet
  1145 170 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228D
-Encoding: 8845 8845 8845
+Encoding: 8845 8845 2342
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68048,8 +70420,9 @@ SplineSet
  131 199 131 199 131 495 c 2,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228E
-Encoding: 8846 8846 8846
+Encoding: 8846 8846 2343
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68085,8 +70458,9 @@ SplineSet
  667 779 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni228F
-Encoding: 8847 8847 8847
+Encoding: 8847 8847 2344
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68154,8 +70528,9 @@ SplineSet
  88 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2290
-Encoding: 8848 8848 8848
+Encoding: 8848 8848 2345
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68223,8 +70598,9 @@ SplineSet
  1145 1163 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2291
-Encoding: 8849 8849 8849
+Encoding: 8849 8849 2346
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68320,8 +70696,9 @@ SplineSet
  88 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2292
-Encoding: 8850 8850 8850
+Encoding: 8850 8850 2347
 Width: 1233
 Flags: W
 TtInstrs:
@@ -68419,8 +70796,9 @@ SplineSet
  1145 1268 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2293
-Encoding: 8851 8851 8851
+Encoding: 8851 8851 2348
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68437,8 +70815,9 @@ SplineSet
  1138 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2294
-Encoding: 8852 8852 8852
+Encoding: 8852 8852 2349
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68455,8 +70834,9 @@ SplineSet
  94 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: circleplus
-Encoding: 8853 8853 8853
+Encoding: 8853 8853 2350
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68511,8 +70891,9 @@ SplineSet
  546 989 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2296
-Encoding: 8854 8854 8854
+Encoding: 8854 8854 2351
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68559,8 +70940,9 @@ SplineSet
  962 712 l 1,52,-1
 EndSplineSet
 EndChar
+
 StartChar: circlemultiply
-Encoding: 8855 8855 8855
+Encoding: 8855 8855 2352
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68615,8 +70997,9 @@ SplineSet
  322.344 837.954 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2298
-Encoding: 8856 8856 8856
+Encoding: 8856 8856 2353
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68663,8 +71046,9 @@ SplineSet
  812.368 936.242 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2299
-Encoding: 8857 8857 8857
+Encoding: 8857 8857 2354
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68711,8 +71095,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,33
 EndSplineSet
 EndChar
+
 StartChar: uni229A
-Encoding: 8858 8858 8858
+Encoding: 8858 8858 2355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68774,8 +71159,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,27
 EndSplineSet
 EndChar
+
 StartChar: uni229B
-Encoding: 8859 8859 8859
+Encoding: 8859 8859 2356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68834,8 +71220,9 @@ SplineSet
  318.758 905.499 318.758 905.499 303.521 886.352 c 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229C
-Encoding: 8860 8860 8860
+Encoding: 8860 8860 2357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68887,8 +71274,9 @@ SplineSet
  697.819 1040.6 697.819 1040.6 616.5 1040.6 c 128,-1,35
 EndSplineSet
 EndChar
+
 StartChar: uni229D
-Encoding: 8861 8861 8861
+Encoding: 8861 8861 2358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68935,8 +71323,9 @@ SplineSet
  818 572 l 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229E
-Encoding: 8862 8862 8862
+Encoding: 8862 8862 2359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68967,8 +71356,9 @@ SplineSet
  546 1025 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni229F
-Encoding: 8863 8863 8863
+Encoding: 8863 8863 2360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -68991,8 +71381,9 @@ SplineSet
  962 712 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A0
-Encoding: 8864 8864 8864
+Encoding: 8864 8864 2361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69023,8 +71414,9 @@ SplineSet
  252.072 907.604 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A1
-Encoding: 8865 8865 8865
+Encoding: 8865 8865 2362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69047,8 +71439,9 @@ SplineSet
  80 1180 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A2
-Encoding: 8866 8866 8866
+Encoding: 8866 8866 2363
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69065,8 +71458,9 @@ SplineSet
  256 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A3
-Encoding: 8867 8867 8867
+Encoding: 8867 8867 2364
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69083,8 +71477,9 @@ SplineSet
  977 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22A4
-Encoding: 8868 8868 8868
+Encoding: 8868 8868 2365
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69101,8 +71496,9 @@ SplineSet
  533 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: perpendicular
-Encoding: 8869 8869 8869
+Encoding: 8869 8869 2366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69119,8 +71515,9 @@ SplineSet
  701 1284 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B2
-Encoding: 8882 8882 8882
+Encoding: 8882 8882 2367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69137,8 +71534,9 @@ SplineSet
  1145 141 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B3
-Encoding: 8883 8883 8883
+Encoding: 8883 8883 2368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69155,8 +71553,9 @@ SplineSet
  256 387 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B4
-Encoding: 8884 8884 8884
+Encoding: 8884 8884 2369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69178,8 +71577,9 @@ SplineSet
  1145 256 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B5
-Encoding: 8885 8885 8885
+Encoding: 8885 8885 2370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69201,8 +71601,9 @@ SplineSet
  256 487 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22B8
-Encoding: 8888 8888 8888
+Encoding: 8888 8888 2371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69231,8 +71632,9 @@ SplineSet
  1057 700 1057 700 1017.5 740 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni22C2
-Encoding: 8898 8898 8898
+Encoding: 8898 8898 2372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69255,8 +71657,9 @@ SplineSet
  1102 1319 1102 1319 1102 1023 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C3
-Encoding: 8899 8899 8899
+Encoding: 8899 8899 2373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69279,8 +71682,9 @@ SplineSet
  131 -237 131 -237 131 59 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C4
-Encoding: 8900 8900 8900
+Encoding: 8900 8900 2374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69298,8 +71702,9 @@ SplineSet
  105 642 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: dotmath
-Encoding: 8901 8901 8901
+Encoding: 8901 8901 2375
 Width: 1233
 Flags: W
 TtInstrs:
@@ -69333,8 +71738,9 @@ SplineSet
  489 864 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22C6
-Encoding: 8902 8902 8902
+Encoding: 8902 8902 2376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69353,8 +71759,9 @@ SplineSet
  264.907 823.703 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22CD
-Encoding: 8909 8909 8909
+Encoding: 8909 8909 2377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69386,8 +71793,9 @@ SplineSet
  88 963 l 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni22CE
-Encoding: 8910 8910 8910
+Encoding: 8910 8910 2378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69403,8 +71811,9 @@ SplineSet
  532 0 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22CF
-Encoding: 8911 8911 8911
+Encoding: 8911 8911 2379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69420,8 +71829,9 @@ SplineSet
  698 1284 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22D0
-Encoding: 8912 8912 8912
+Encoding: 8912 8912 2380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69459,8 +71869,9 @@ SplineSet
  1143 -6 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22D1
-Encoding: 8913 8913 8913
+Encoding: 8913 8913 2381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69498,8 +71909,9 @@ SplineSet
  90 1290 l 25,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DA
-Encoding: 8922 8922 8922
+Encoding: 8922 8922 2382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69528,8 +71940,9 @@ SplineSet
  1145 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DB
-Encoding: 8923 8923 8923
+Encoding: 8923 8923 2383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69558,8 +71971,9 @@ SplineSet
  88 640 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DC
-Encoding: 8924 8924 8924
+Encoding: 8924 8924 2384
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69580,8 +71994,9 @@ SplineSet
  1143 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DD
-Encoding: 8925 8925 8925
+Encoding: 8925 8925 2385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69602,8 +72017,9 @@ SplineSet
  88 917 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DE
-Encoding: 8926 8926 8926
+Encoding: 8926 8926 2386
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69628,8 +72044,9 @@ SplineSet
  852 291 852 291 1143 -13 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22DF
-Encoding: 8927 8927 8927
+Encoding: 8927 8927 2387
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69654,8 +72071,9 @@ SplineSet
  86 -13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E0
-Encoding: 8928 8928 8928
+Encoding: 8928 8928 2388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69695,8 +72113,9 @@ SplineSet
  536.138 814.711 536.138 814.711 618.897 785.045 c 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E1
-Encoding: 8929 8929 8929
+Encoding: 8929 8929 2389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69735,8 +72154,9 @@ SplineSet
  766.207 837.893 766.207 837.893 751.566 841.087 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E2
-Encoding: 8930 8930 8930
+Encoding: 8930 8930 2390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69766,8 +72186,9 @@ SplineSet
  383.753 289 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E3
-Encoding: 8931 8931 8931
+Encoding: 8931 8931 2391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69797,8 +72218,9 @@ SplineSet
  849.247 993 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E4
-Encoding: 8932 8932 8932
+Encoding: 8932 8932 2392
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69828,8 +72250,9 @@ SplineSet
  88 1268 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E5
-Encoding: 8933 8933 8933
+Encoding: 8933 8933 2393
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69859,8 +72282,9 @@ SplineSet
  1145 184 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E6
-Encoding: 8934 8934 8934
+Encoding: 8934 8934 2394
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69898,8 +72322,9 @@ SplineSet
  534 51.4014 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni22E7
-Encoding: 8935 8935 8935
+Encoding: 8935 8935 2395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69938,8 +72363,9 @@ SplineSet
  86 438 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E8
-Encoding: 8936 8936 8936
+Encoding: 8936 8936 2396
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -69980,8 +72406,9 @@ SplineSet
  1143 1218 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22E9
-Encoding: 8937 8937 8937
+Encoding: 8937 8937 2397
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70022,23 +72449,26 @@ SplineSet
  377 914 377 914 86 1218 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni22EF
-Encoding: 8943 8943 8943
+Encoding: 8943 8943 2398
 Width: 1233
 LayerCount: 2
 Fore
-Refer: 8230 8230 N 1 0 0 1 0 490 2
+Refer: 1984 8230 N 1 0 0 1 0 490 2
 EndChar
+
 StartChar: uni2300
-Encoding: 8960 8960 8960
+Encoding: 8960 8960 2399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8709 8709 N 1 0 0 1 0 0 2
+Refer: 2226 8709 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2301
-Encoding: 8961 8961 8961
+Encoding: 8961 8961 2400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70055,8 +72485,9 @@ SplineSet
  674 634 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: house
-Encoding: 8962 8962 8962
+Encoding: 8962 8962 2401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70076,8 +72507,9 @@ SplineSet
  268.5 122 l 17,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2303
-Encoding: 8963 8963 8963
+Encoding: 8963 8963 2402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70092,8 +72524,9 @@ SplineSet
  616 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2304
-Encoding: 8964 8964 8964
+Encoding: 8964 8964 2403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70108,8 +72541,9 @@ SplineSet
  616 -269.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2305
-Encoding: 8965 8965 8965
+Encoding: 8965 8965 2404
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70129,8 +72563,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2306
-Encoding: 8966 8966 8966
+Encoding: 8966 8966 2405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70155,8 +72590,9 @@ SplineSet
  616 697 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2308
-Encoding: 8968 8968 8968
+Encoding: 8968 8968 2406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70171,8 +72607,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2309
-Encoding: 8969 8969 8969
+Encoding: 8969 8969 2407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70187,8 +72624,9 @@ SplineSet
  770 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230A
-Encoding: 8970 8970 8970
+Encoding: 8970 8970 2408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70203,8 +72641,9 @@ SplineSet
  463 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230B
-Encoding: 8971 8971 8971
+Encoding: 8971 8971 2409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70219,8 +72658,9 @@ SplineSet
  770 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230C
-Encoding: 8972 8972 8972
+Encoding: 8972 8972 2410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70238,8 +72678,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230D
-Encoding: 8973 8973 8973
+Encoding: 8973 8973 2411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70257,8 +72698,9 @@ SplineSet
  549 630 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230E
-Encoding: 8974 8974 8974
+Encoding: 8974 8974 2412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70276,8 +72718,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni230F
-Encoding: 8975 8975 8975
+Encoding: 8975 8975 2413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70295,8 +72738,9 @@ SplineSet
  549 1406 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: revlogicalnot
-Encoding: 8976 8976 8976
+Encoding: 8976 8976 2414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70311,8 +72755,9 @@ SplineSet
  1145 862 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2311
-Encoding: 8977 8977 8977
+Encoding: 8977 8977 2415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70330,16 +72775,18 @@ SplineSet
  616 435.5 616 435.5 97 258.5 c 1,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2312
-Encoding: 8978 8978 8978
+Encoding: 8978 8978 2416
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9696 9696 N 1 0 0 1 0 -100 2
+Refer: 2760 9696 N 1 0 0 1 0 -100 2
 EndChar
+
 StartChar: uni2313
-Encoding: 8979 8979 8979
+Encoding: 8979 8979 2417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70359,8 +72806,9 @@ SplineSet
  180.288 743.534 180.288 743.534 139.268 546 c 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2314
-Encoding: 8980 8980 8980
+Encoding: 8980 8980 2418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70380,8 +72828,9 @@ SplineSet
  740 925 740 925 616 925 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2315
-Encoding: 8981 8981 8981
+Encoding: 8981 8981 2419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70411,8 +72860,9 @@ SplineSet
  518.878 1103.87 518.878 1103.87 674.11 1103.87 c 0,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2318
-Encoding: 8984 8984 8984
+Encoding: 8984 8984 2420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70498,8 +72948,9 @@ SplineSet
  824 570 l 1,85,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2319
-Encoding: 8985 8985 8985
+Encoding: 8985 8985 2421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70514,8 +72965,9 @@ SplineSet
  1145 371 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni231C
-Encoding: 8988 8988 8988
+Encoding: 8988 8988 2422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70530,8 +72982,9 @@ SplineSet
  949 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231D
-Encoding: 8989 8989 8989
+Encoding: 8989 8989 2423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70546,8 +72999,9 @@ SplineSet
  284 1292 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231E
-Encoding: 8990 8990 8990
+Encoding: 8990 8990 2424
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70562,8 +73016,9 @@ SplineSet
  949 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni231F
-Encoding: 8991 8991 8991
+Encoding: 8991 8991 2425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70578,8 +73033,9 @@ SplineSet
  284 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: integraltp
-Encoding: 8992 8992 8992
+Encoding: 8992 8992 2426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70604,8 +73060,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: integralbt
-Encoding: 8993 8993 8993
+Encoding: 8993 8993 2427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70630,8 +73087,9 @@ SplineSet
  711 1929 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2325
-Encoding: 8997 8997 8997
+Encoding: 8997 8997 2428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70653,8 +73111,9 @@ SplineSet
  713 1225 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2326
-Encoding: 8998 8998 8998
+Encoding: 8998 8998 2429
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70689,8 +73148,9 @@ SplineSet
  578.025 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2327
-Encoding: 8999 8999 8999
+Encoding: 8999 8999 2430
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -70723,8 +73183,9 @@ SplineSet
  747.024 410 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2328
-Encoding: 9000 9000 9000
+Encoding: 9000 9000 2431
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71122,8 +73583,9 @@ SplineSet
  402 535 l 2,509,510
 EndSplineSet
 EndChar
+
 StartChar: uni232B
-Encoding: 9003 9003 9003
+Encoding: 9003 9003 2432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71158,8 +73620,9 @@ SplineSet
  654.976 410 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2335
-Encoding: 9013 9013 9013
+Encoding: 9013 9013 2433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71174,8 +73637,9 @@ SplineSet
  616 -45 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2336
-Encoding: 9014 9014 9014
+Encoding: 9014 9014 2434
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71196,8 +73660,9 @@ SplineSet
  532 1114 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2337
-Encoding: 9015 9015 9015
+Encoding: 9015 9015 2435
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71215,8 +73680,9 @@ SplineSet
  256 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2338
-Encoding: 9016 9016 9016
+Encoding: 9016 9016 2436
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71244,8 +73710,9 @@ SplineSet
  120 930 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2339
-Encoding: 9017 9017 9017
+Encoding: 9017 9017 2437
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71278,8 +73745,9 @@ SplineSet
  120 727 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233A
-Encoding: 9018 9018 9018
+Encoding: 9018 9018 2438
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71309,17 +73777,19 @@ SplineSet
  120 846.093 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233B
-Encoding: 9019 9019 9019
+Encoding: 9019 9019 2439
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni233C
-Encoding: 9020 9020 9020
+Encoding: 9020 9020 2440
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71357,8 +73827,9 @@ SplineSet
  120 1096.51 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni233D
-Encoding: 9021 9021 9021
+Encoding: 9021 9021 2441
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71393,17 +73864,19 @@ SplineSet
  775.861 1202.85 775.861 1202.85 692 1217.96 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni233E
-Encoding: 9022 9022 9022
+Encoding: 9022 9022 2442
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni233F
-Encoding: 9023 9023 9023
+Encoding: 9023 9023 2443
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71424,8 +73897,9 @@ SplineSet
  889 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2340
-Encoding: 9024 9024 9024
+Encoding: 9024 9024 2444
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71446,8 +73920,9 @@ SplineSet
  460 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2341
-Encoding: 9025 9025 9025
+Encoding: 9025 9025 2445
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71468,8 +73943,9 @@ SplineSet
  1113 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2342
-Encoding: 9026 9026 9026
+Encoding: 9026 9026 2446
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71490,8 +73966,9 @@ SplineSet
  120 1517.82 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2343
-Encoding: 9027 9027 9027
+Encoding: 9027 9027 2447
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71518,8 +73995,9 @@ SplineSet
  1113 435.934 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2344
-Encoding: 9028 9028 9028
+Encoding: 9028 9028 2448
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71546,8 +74024,9 @@ SplineSet
  120 1230.35 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2345
-Encoding: 9029 9029 9029
+Encoding: 9029 9029 2449
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71574,8 +74053,9 @@ SplineSet
  66 682 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2346
-Encoding: 9030 9030 9030
+Encoding: 9030 9030 2450
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71602,8 +74082,9 @@ SplineSet
  1167 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2347
-Encoding: 9031 9031 9031
+Encoding: 9031 9031 2451
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71632,8 +74113,9 @@ SplineSet
  120 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2348
-Encoding: 9032 9032 9032
+Encoding: 9032 9032 2452
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71662,8 +74144,9 @@ SplineSet
  1113 766 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2349
-Encoding: 9033 9033 9033
+Encoding: 9033 9033 2453
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71698,8 +74181,9 @@ SplineSet
  553.559 1224.8 553.559 1224.8 491.148 1206.37 c 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234A
-Encoding: 9034 9034 9034
+Encoding: 9034 9034 2454
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71721,8 +74205,9 @@ SplineSet
  701 1284 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234B
-Encoding: 9035 9035 9035
+Encoding: 9035 9035 2455
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71734,10 +74219,10 @@ SplineSet
  692 1493 l 1,3,-1
  739 1493 l 1,4,-1
  1196 0 l 1,5,-1
- 692 -3.28626e-14 l 1,6,-1
+ 692 -3.28626e-014 l 1,6,-1
  692 -350 l 1,7,-1
  540 -350 l 1,8,-1
- 540 -2.42861e-15 l 1,9,-1
+ 540 -2.42861e-015 l 1,9,-1
  37 0 l 1,10,-1
  494 1493 l 1,11,-1
  540 1493 l 1,0,-1
@@ -71751,8 +74236,9 @@ SplineSet
  692 170 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234C
-Encoding: 9036 9036 9036
+Encoding: 9036 9036 2456
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71778,8 +74264,9 @@ SplineSet
  120 909.059 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234D
-Encoding: 9037 9037 9037
+Encoding: 9037 9037 2457
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71796,8 +74283,8 @@ SplineSet
  6 -204 l 1,3,-1
 120 -90 m 1,7,-1
  1113 -90 l 1,8,-1
- 1113 4.89192e-16 l 1,9,10
- 120 -2.85327e-14 l 1,11,-1
+ 1113 4.89192e-016 l 1,9,10
+ 120 -2.85327e-014 l 1,11,-1
  120 -90 l 1,7,-1
 120 90.9297 m 1,12,-1
  506.25 1493 l 1,13,-1
@@ -71808,8 +74295,9 @@ SplineSet
  120 90.9297 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni234E
-Encoding: 9038 9038 9038
+Encoding: 9038 9038 2458
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71844,8 +74332,9 @@ SplineSet
  700 616 l 1,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni234F
-Encoding: 9039 9039 9039
+Encoding: 9039 9039 2459
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71872,8 +74361,9 @@ SplineSet
  658 1550 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2350
-Encoding: 9040 9040 9040
+Encoding: 9040 9040 2460
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71902,8 +74392,9 @@ SplineSet
  534.5 -90 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2351
-Encoding: 9041 9041 9041
+Encoding: 9041 9041 2461
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71925,8 +74416,9 @@ SplineSet
  532 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2352
-Encoding: 9042 9042 9042
+Encoding: 9042 9042 2462
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71955,8 +74447,9 @@ SplineSet
  692 1323 l 1,15,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2353
-Encoding: 9043 9043 9043
+Encoding: 9043 9043 2463
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -71982,8 +74475,9 @@ SplineSet
  120 583.942 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2354
-Encoding: 9044 9044 9044
+Encoding: 9044 9044 2464
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72012,8 +74506,9 @@ SplineSet
  120 1493 l 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2355
-Encoding: 9045 9045 9045
+Encoding: 9045 9045 2465
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72048,8 +74543,9 @@ SplineSet
  532 850 l 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2356
-Encoding: 9046 9046 9046
+Encoding: 9046 9046 2466
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72076,8 +74572,9 @@ SplineSet
  576 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2357
-Encoding: 9047 9047 9047
+Encoding: 9047 9047 2467
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72106,53 +74603,59 @@ SplineSet
  534.5 1583 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2358
-Encoding: 9048 9048 9048
+Encoding: 9048 9048 2468
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 39 39 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2359
-Encoding: 9049 9049 9049
+Encoding: 9049 9049 2469
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 916 916 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 746 916 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235A
-Encoding: 9050 9050 9050
+Encoding: 9050 9050 2470
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 9671 9671 N 1 0 0 1 0 200 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 2735 9671 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235B
-Encoding: 9051 9051 9051
+Encoding: 9051 9051 2471
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235C
-Encoding: 9052 9052 9052
+Encoding: 9052 9052 2472
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni235D
-Encoding: 9053 9053 9053
+Encoding: 9053 9053 2473
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72195,35 +74698,39 @@ SplineSet
  761 792 761 792 718 834.5 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni235E
-Encoding: 9054 9054 9054
+Encoding: 9054 9054 2474
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 39 39 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 8 39 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni235F
-Encoding: 9055 9055 9055
+Encoding: 9055 9055 2475
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9711 9711 N 1 0 0 1 0 200 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 2775 9711 N 1 0 0 1 0 200 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2360
-Encoding: 9056 9056 9056
+Encoding: 9056 9056 2476
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 27 58 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2361
-Encoding: 9057 9057 9057
+Encoding: 9057 9057 2477
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72250,8 +74757,9 @@ SplineSet
  533 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2362
-Encoding: 9058 9058 9058
+Encoding: 9058 9058 2478
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72278,35 +74786,39 @@ SplineSet
  616 211 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2363
-Encoding: 9059 9059 9059
+Encoding: 9059 9059 2479
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -250 2
-Refer: 8902 8902 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -250 2
+Refer: 2376 8902 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2364
-Encoding: 9060 9060 9060
+Encoding: 9060 9060 2480
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 1114131 -1 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 3744 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2365
-Encoding: 9061 9061 9061
+Encoding: 9061 9061 2481
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 150 2
-Refer: 9675 9675 N 1 0 0 1 0 200 2
+Refer: 3745 -1 N 1 0 0 1 0 150 2
+Refer: 2739 9675 N 1 0 0 1 0 200 2
 EndChar
+
 StartChar: uni2366
-Encoding: 9062 9062 9062
+Encoding: 9062 9062 2482
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72343,8 +74855,9 @@ SplineSet
  164 376 164 376 164 606 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2367
-Encoding: 9063 9063 9063
+Encoding: 9063 9063 2483
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72376,26 +74889,29 @@ SplineSet
  420 314 420 314 540 314 c 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2368
-Encoding: 9064 9064 9064
+Encoding: 9064 9064 2484
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 126 126 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 95 126 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2369
-Encoding: 9065 9065 9065
+Encoding: 9065 9065 2485
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114132 -1 N 1 0 0 1 0 -200 2
-Refer: 62 62 N 1 0 0 1 0 0 2
+Refer: 3745 -1 N 1 0 0 1 0 -200 2
+Refer: 31 62 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni236A
-Encoding: 9066 9066 9066
+Encoding: 9066 9066 2486
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72415,8 +74931,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236B
-Encoding: 9067 9067 9067
+Encoding: 9067 9067 2487
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72455,8 +74972,9 @@ SplineSet
  474.095 714.191 474.095 714.191 464.707 715.983 c 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236C
-Encoding: 9068 9068 9068
+Encoding: 9068 9068 2488
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72501,8 +75019,9 @@ SplineSet
  358.197 724 358.197 724 336.101 721.542 c 1,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni236D
-Encoding: 9069 9069 9069
+Encoding: 9069 9069 2489
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72533,8 +75052,9 @@ SplineSet
  1071 828 1071 828 1145 890 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236E
-Encoding: 9070 9070 9070
+Encoding: 9070 9070 2490
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72562,8 +75082,9 @@ SplineSet
  502 303 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni236F
-Encoding: 9071 9071 9071
+Encoding: 9071 9071 2491
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72602,17 +75123,19 @@ SplineSet
  193.7 930 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2370
-Encoding: 9072 9072 9072
+Encoding: 9072 9072 2492
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 63 63 N 1 0 0 1 0 0 2
-Refer: 9109 9109 N 1 0 0 1 0 0 2
+Refer: 32 63 N 1 0 0 1 0 0 2
+Refer: 2512 9109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2371
-Encoding: 9073 9073 9073
+Encoding: 9073 9073 2493
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72644,8 +75167,9 @@ SplineSet
  574 575 574 575 520 592 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2372
-Encoding: 9074 9074 9074
+Encoding: 9074 9074 2494
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72677,76 +75201,85 @@ SplineSet
  669 705 669 705 683 699 c 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2373
-Encoding: 9075 9075 9075
+Encoding: 9075 9075 2495
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2374
-Encoding: 9076 9076 9076
+Encoding: 9076 9076 2496
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 961 961 N 1 0 0 1 0 0 2
+Refer: 790 961 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2375
-Encoding: 9077 9077 9077
+Encoding: 9077 9077 2497
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2376
-Encoding: 9078 9078 9078
+Encoding: 9078 9078 2498
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2377
-Encoding: 9079 9079 9079
+Encoding: 9079 9079 2499
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114128 -1 N 1 0 0 1 0 0 2
-Refer: 1013 1013 N 1 0 0 1 0 0 2
+Refer: 3741 -1 N 1 0 0 1 0 0 2
+Refer: 827 1013 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2378
-Encoding: 9080 9080 9080
+Encoding: 9080 9080 2500
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114130 -1 N 1 0 0 1 0 0 2
-Refer: 953 953 N 1 0 0 1 0 0 2
+Refer: 3743 -1 N 1 0 0 1 0 0 2
+Refer: 782 953 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2379
-Encoding: 9081 9081 9081
+Encoding: 9081 9081 2501
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114129 -1 N 1 0 0 1 0 0 2
-Refer: 969 969 N 1 0 0 1 0 0 2
+Refer: 3742 -1 N 1 0 0 1 0 0 2
+Refer: 798 969 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237A
-Encoding: 9082 9082 9082
+Encoding: 9082 9082 2502
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 945 945 N 1 0 0 1 0 0 2
+Refer: 774 945 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni237D
-Encoding: 9085 9085 9085
+Encoding: 9085 9085 2503
 Width: 1233
 Flags: W
 TtInstrs:
@@ -72802,8 +75335,9 @@ SplineSet
  225 -466 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2380
-Encoding: 9088 9088 9088
+Encoding: 9088 9088 2504
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72851,8 +75385,9 @@ SplineSet
  874 880 874 880 874 798 c 2,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2381
-Encoding: 9089 9089 9089
+Encoding: 9089 9089 2505
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72913,8 +75448,9 @@ SplineSet
  588 880 588 880 588 798 c 2,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2382
-Encoding: 9090 9090 9090
+Encoding: 9090 9090 2506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -72998,8 +75534,9 @@ SplineSet
  1174 880 1174 880 1174 798 c 2,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2383
-Encoding: 9091 9091 9091
+Encoding: 9091 9091 2507
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73070,8 +75607,9 @@ SplineSet
  306 624 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2388
-Encoding: 9096 9096 9096
+Encoding: 9096 9096 2508
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73151,8 +75689,9 @@ SplineSet
  902 695.508 902 695.508 885.367 741.284 c 1,91,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2389
-Encoding: 9097 9097 9097
+Encoding: 9097 9097 2509
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73204,8 +75743,9 @@ SplineSet
  498.478 216.579 498.478 216.579 554.11 208.772 c 1,40,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238A
-Encoding: 9098 9098 9098
+Encoding: 9098 9098 2510
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73258,8 +75798,9 @@ SplineSet
  1013.7 817.67 1013.7 817.67 1009.82 825.874 c 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni238B
-Encoding: 9099 9099 9099
+Encoding: 9099 9099 2511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73306,8 +75847,9 @@ SplineSet
  70 528.7 70 528.7 70 640 c 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2395
-Encoding: 9109 9109 9109
+Encoding: 9109 9109 2512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73325,8 +75867,9 @@ SplineSet
  6 -204 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni239B
-Encoding: 9115 9115 9115
+Encoding: 9115 9115 2513
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73343,8 +75886,9 @@ SplineSet
  475 -528 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239C
-Encoding: 9116 9116 9116
+Encoding: 9116 9116 2514
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73357,8 +75901,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni239D
-Encoding: 9117 9117 9117
+Encoding: 9117 9117 2515
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73375,8 +75920,9 @@ SplineSet
  475 1929 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239E
-Encoding: 9118 9118 9118
+Encoding: 9118 9118 2516
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73393,8 +75939,9 @@ SplineSet
  758 -528 l 17,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni239F
-Encoding: 9119 9119 9119
+Encoding: 9119 9119 2517
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73407,8 +75954,9 @@ SplineSet
  953 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A0
-Encoding: 9120 9120 9120
+Encoding: 9120 9120 2518
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73425,8 +75973,9 @@ SplineSet
  758 1929 l 9,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A1
-Encoding: 9121 9121 9121
+Encoding: 9121 9121 2519
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73441,8 +75990,9 @@ SplineSet
  475 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A2
-Encoding: 9122 9122 9122
+Encoding: 9122 9122 2520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73455,8 +76005,9 @@ SplineSet
  280 1929 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A3
-Encoding: 9123 9123 9123
+Encoding: 9123 9123 2521
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73471,8 +76022,9 @@ SplineSet
  475 1929 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A4
-Encoding: 9124 9124 9124
+Encoding: 9124 9124 2522
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73487,8 +76039,9 @@ SplineSet
  757 -516 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A5
-Encoding: 9125 9125 9125
+Encoding: 9125 9125 2523
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73501,8 +76054,9 @@ SplineSet
  757 1914 l 25,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni23A6
-Encoding: 9126 9126 9126
+Encoding: 9126 9126 2524
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73517,8 +76071,9 @@ SplineSet
  757 1914 l 25,3,4
 EndSplineSet
 EndChar
+
 StartChar: uni23A7
-Encoding: 9127 9127 9127
+Encoding: 9127 9127 2525
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73537,8 +76092,9 @@ SplineSet
  710 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23A8
-Encoding: 9128 9128 9128
+Encoding: 9128 9128 2526
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73564,8 +76120,9 @@ SplineSet
  569 738 569 738 509 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23A9
-Encoding: 9129 9129 9129
+Encoding: 9129 9129 2527
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73584,8 +76141,9 @@ SplineSet
  710 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AA
-Encoding: 9130 9130 9130
+Encoding: 9130 9130 2528
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73598,8 +76156,9 @@ SplineSet
  710 -524 l 25,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23AB
-Encoding: 9131 9131 9131
+Encoding: 9131 9131 2529
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73618,8 +76177,9 @@ SplineSet
  523 -534 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AC
-Encoding: 9132 9132 9132
+Encoding: 9132 9132 2530
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73645,8 +76205,9 @@ SplineSet
  665.971 673.084 665.971 673.084 724 705 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni23AD
-Encoding: 9133 9133 9133
+Encoding: 9133 9133 2531
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73665,8 +76226,9 @@ SplineSet
  523 1926 l 25,26,27
 EndSplineSet
 EndChar
+
 StartChar: uni23AE
-Encoding: 9134 9134 9134
+Encoding: 9134 9134 2532
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73679,8 +76241,9 @@ SplineSet
  513 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CE
-Encoding: 9166 9166 9166
+Encoding: 9166 9166 2533
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73708,8 +76271,9 @@ SplineSet
  893 663 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni23CF
-Encoding: 9167 9167 9167
+Encoding: 9167 9167 2534
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73726,8 +76290,9 @@ SplineSet
  1227 0 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2423
-Encoding: 9251 9251 9251
+Encoding: 9251 9251 2535
 Width: 1233
 Flags: W
 TtInstrs:
@@ -73774,8 +76339,9 @@ SplineSet
  150 -466 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF100000
-Encoding: 9472 9472 9472
+Encoding: 9472 9472 2536
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73788,8 +76354,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2501
-Encoding: 9473 9473 9473
+Encoding: 9473 9473 2537
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73802,8 +76369,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF110000
-Encoding: 9474 9474 9474
+Encoding: 9474 9474 2538
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73816,8 +76384,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2503
-Encoding: 9475 9475 9475
+Encoding: 9475 9475 2539
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73830,8 +76399,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2504
-Encoding: 9476 9476 9476
+Encoding: 9476 9476 2540
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73854,8 +76424,9 @@ SplineSet
  60 618 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2505
-Encoding: 9477 9477 9477
+Encoding: 9477 9477 2541
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73878,8 +76449,9 @@ SplineSet
  60 532 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2506
-Encoding: 9478 9478 9478
+Encoding: 9478 9478 2542
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73902,8 +76474,9 @@ SplineSet
  536 1193 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2507
-Encoding: 9479 9479 9479
+Encoding: 9479 9479 2543
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73926,8 +76499,9 @@ SplineSet
  456 1193 l 17,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2508
-Encoding: 9480 9480 9480
+Encoding: 9480 9480 2544
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73955,8 +76529,9 @@ SplineSet
  984 618 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2509
-Encoding: 9481 9481 9481
+Encoding: 9481 9481 2545
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -73984,8 +76559,9 @@ SplineSet
  984 532 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250A
-Encoding: 9482 9482 9482
+Encoding: 9482 9482 2546
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74013,8 +76589,9 @@ SplineSet
  536 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250B
-Encoding: 9483 9483 9483
+Encoding: 9483 9483 2547
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74042,8 +76619,9 @@ SplineSet
  456 196 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF010000
-Encoding: 9484 9484 9484
+Encoding: 9484 9484 2548
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74058,8 +76636,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250D
-Encoding: 9485 9485 9485
+Encoding: 9485 9485 2549
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74074,8 +76653,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250E
-Encoding: 9486 9486 9486
+Encoding: 9486 9486 2550
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74090,8 +76670,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni250F
-Encoding: 9487 9487 9487
+Encoding: 9487 9487 2551
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74106,8 +76687,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF030000
-Encoding: 9488 9488 9488
+Encoding: 9488 9488 2552
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74122,8 +76704,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2511
-Encoding: 9489 9489 9489
+Encoding: 9489 9489 2553
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74138,8 +76721,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2512
-Encoding: 9490 9490 9490
+Encoding: 9490 9490 2554
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74154,8 +76738,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2513
-Encoding: 9491 9491 9491
+Encoding: 9491 9491 2555
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74170,8 +76755,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF020000
-Encoding: 9492 9492 9492
+Encoding: 9492 9492 2556
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74186,8 +76772,9 @@ SplineSet
  536 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2515
-Encoding: 9493 9493 9493
+Encoding: 9493 9493 2557
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74202,8 +76789,9 @@ SplineSet
  536 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2516
-Encoding: 9494 9494 9494
+Encoding: 9494 9494 2558
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74218,8 +76806,9 @@ SplineSet
  456 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2517
-Encoding: 9495 9495 9495
+Encoding: 9495 9495 2559
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74234,8 +76823,9 @@ SplineSet
  456 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF040000
-Encoding: 9496 9496 9496
+Encoding: 9496 9496 2560
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74250,8 +76840,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2519
-Encoding: 9497 9497 9497
+Encoding: 9497 9497 2561
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74266,8 +76857,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251A
-Encoding: 9498 9498 9498
+Encoding: 9498 9498 2562
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74282,8 +76874,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251B
-Encoding: 9499 9499 9499
+Encoding: 9499 9499 2563
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74298,8 +76891,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF080000
-Encoding: 9500 9500 9500
+Encoding: 9500 9500 2564
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74316,8 +76910,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251D
-Encoding: 9501 9501 9501
+Encoding: 9501 9501 2565
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74334,8 +76929,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251E
-Encoding: 9502 9502 9502
+Encoding: 9502 9502 2566
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74354,8 +76950,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni251F
-Encoding: 9503 9503 9503
+Encoding: 9503 9503 2567
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74374,8 +76971,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2520
-Encoding: 9504 9504 9504
+Encoding: 9504 9504 2568
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74392,8 +76990,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2521
-Encoding: 9505 9505 9505
+Encoding: 9505 9505 2569
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74412,8 +77011,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2522
-Encoding: 9506 9506 9506
+Encoding: 9506 9506 2570
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74432,8 +77032,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2523
-Encoding: 9507 9507 9507
+Encoding: 9507 9507 2571
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74450,8 +77051,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF090000
-Encoding: 9508 9508 9508
+Encoding: 9508 9508 2572
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74468,8 +77070,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2525
-Encoding: 9509 9509 9509
+Encoding: 9509 9509 2573
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74486,8 +77089,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2526
-Encoding: 9510 9510 9510
+Encoding: 9510 9510 2574
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74506,8 +77110,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2527
-Encoding: 9511 9511 9511
+Encoding: 9511 9511 2575
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74526,8 +77131,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2528
-Encoding: 9512 9512 9512
+Encoding: 9512 9512 2576
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74544,8 +77150,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2529
-Encoding: 9513 9513 9513
+Encoding: 9513 9513 2577
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74564,8 +77171,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252A
-Encoding: 9514 9514 9514
+Encoding: 9514 9514 2578
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74584,8 +77192,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252B
-Encoding: 9515 9515 9515
+Encoding: 9515 9515 2579
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74602,8 +77211,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF060000
-Encoding: 9516 9516 9516
+Encoding: 9516 9516 2580
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74620,8 +77230,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252D
-Encoding: 9517 9517 9517
+Encoding: 9517 9517 2581
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74640,8 +77251,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252E
-Encoding: 9518 9518 9518
+Encoding: 9518 9518 2582
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74660,8 +77272,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni252F
-Encoding: 9519 9519 9519
+Encoding: 9519 9519 2583
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74678,8 +77291,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2530
-Encoding: 9520 9520 9520
+Encoding: 9520 9520 2584
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74696,8 +77310,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2531
-Encoding: 9521 9521 9521
+Encoding: 9521 9521 2585
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74716,8 +77331,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2532
-Encoding: 9522 9522 9522
+Encoding: 9522 9522 2586
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74736,8 +77352,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2533
-Encoding: 9523 9523 9523
+Encoding: 9523 9523 2587
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74754,8 +77371,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF070000
-Encoding: 9524 9524 9524
+Encoding: 9524 9524 2588
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74772,8 +77390,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2535
-Encoding: 9525 9525 9525
+Encoding: 9525 9525 2589
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74792,8 +77411,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2536
-Encoding: 9526 9526 9526
+Encoding: 9526 9526 2590
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74812,8 +77432,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2537
-Encoding: 9527 9527 9527
+Encoding: 9527 9527 2591
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74830,8 +77451,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2538
-Encoding: 9528 9528 9528
+Encoding: 9528 9528 2592
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74848,8 +77470,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2539
-Encoding: 9529 9529 9529
+Encoding: 9529 9529 2593
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74868,8 +77491,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253A
-Encoding: 9530 9530 9530
+Encoding: 9530 9530 2594
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74888,8 +77512,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253B
-Encoding: 9531 9531 9531
+Encoding: 9531 9531 2595
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74906,8 +77531,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF050000
-Encoding: 9532 9532 9532
+Encoding: 9532 9532 2596
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74928,8 +77554,9 @@ SplineSet
  696 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253D
-Encoding: 9533 9533 9533
+Encoding: 9533 9533 2597
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74950,8 +77577,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253E
-Encoding: 9534 9534 9534
+Encoding: 9534 9534 2598
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74972,8 +77600,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni253F
-Encoding: 9535 9535 9535
+Encoding: 9535 9535 2599
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -74994,8 +77623,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2540
-Encoding: 9536 9536 9536
+Encoding: 9536 9536 2600
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75016,8 +77646,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2541
-Encoding: 9537 9537 9537
+Encoding: 9537 9537 2601
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75038,8 +77669,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2542
-Encoding: 9538 9538 9538
+Encoding: 9538 9538 2602
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75060,8 +77692,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2543
-Encoding: 9539 9539 9539
+Encoding: 9539 9539 2603
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75084,8 +77717,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2544
-Encoding: 9540 9540 9540
+Encoding: 9540 9540 2604
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75108,8 +77742,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2545
-Encoding: 9541 9541 9541
+Encoding: 9541 9541 2605
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75132,8 +77767,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2546
-Encoding: 9542 9542 9542
+Encoding: 9542 9542 2606
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75156,8 +77792,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2547
-Encoding: 9543 9543 9543
+Encoding: 9543 9543 2607
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75178,8 +77815,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2548
-Encoding: 9544 9544 9544
+Encoding: 9544 9544 2608
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75200,8 +77838,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2549
-Encoding: 9545 9545 9545
+Encoding: 9545 9545 2609
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75222,8 +77861,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254A
-Encoding: 9546 9546 9546
+Encoding: 9546 9546 2610
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75244,8 +77884,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254B
-Encoding: 9547 9547 9547
+Encoding: 9547 9547 2611
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75266,8 +77907,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254C
-Encoding: 9548 9548 9548
+Encoding: 9548 9548 2612
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75285,8 +77927,9 @@ SplineSet
  677 618 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254D
-Encoding: 9549 9549 9549
+Encoding: 9549 9549 2613
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75304,8 +77947,9 @@ SplineSet
  60 532 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254E
-Encoding: 9550 9550 9550
+Encoding: 9550 9550 2614
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75323,8 +77967,9 @@ SplineSet
  536 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni254F
-Encoding: 9551 9551 9551
+Encoding: 9551 9551 2615
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75342,8 +77987,9 @@ SplineSet
  456 -320 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF430000
-Encoding: 9552 9552 9552
+Encoding: 9552 9552 2616
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75361,8 +78007,9 @@ SplineSet
  -20 446 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF240000
-Encoding: 9553 9553 9553
+Encoding: 9553 9553 2617
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75380,8 +78027,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF510000
-Encoding: 9554 9554 9554
+Encoding: 9554 9554 2618
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75400,8 +78048,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF520000
-Encoding: 9555 9555 9555
+Encoding: 9555 9555 2619
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75420,8 +78069,9 @@ SplineSet
  376 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF390000
-Encoding: 9556 9556 9556
+Encoding: 9556 9556 2620
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75443,8 +78093,9 @@ SplineSet
  696 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF220000
-Encoding: 9557 9557 9557
+Encoding: 9557 9557 2621
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75463,8 +78114,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF210000
-Encoding: 9558 9558 9558
+Encoding: 9558 9558 2622
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75483,8 +78135,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF250000
-Encoding: 9559 9559 9559
+Encoding: 9559 9559 2623
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75506,8 +78159,9 @@ SplineSet
  376 -512 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF500000
-Encoding: 9560 9560 9560
+Encoding: 9560 9560 2624
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75526,8 +78180,9 @@ SplineSet
  536 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF490000
-Encoding: 9561 9561 9561
+Encoding: 9561 9561 2625
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75546,8 +78201,9 @@ SplineSet
  376 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF380000
-Encoding: 9562 9562 9562
+Encoding: 9562 9562 2626
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75569,8 +78225,9 @@ SplineSet
  376 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF280000
-Encoding: 9563 9563 9563
+Encoding: 9563 9563 2627
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75589,8 +78246,9 @@ SplineSet
  -20 446 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF270000
-Encoding: 9564 9564 9564
+Encoding: 9564 9564 2628
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75609,8 +78267,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF260000
-Encoding: 9565 9565 9565
+Encoding: 9565 9565 2629
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75632,8 +78291,9 @@ SplineSet
  -20 446 l 1,6,-1
 EndSplineSet
 EndChar
+
 StartChar: SF360000
-Encoding: 9566 9566 9566
+Encoding: 9566 9566 2630
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75654,8 +78314,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF370000
-Encoding: 9567 9567 9567
+Encoding: 9567 9567 2631
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75677,8 +78338,9 @@ SplineSet
  696 -512 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF420000
-Encoding: 9568 9568 9568
+Encoding: 9568 9568 2632
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75705,8 +78367,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF190000
-Encoding: 9569 9569 9569
+Encoding: 9569 9569 2633
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75727,8 +78390,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF200000
-Encoding: 9570 9570 9570
+Encoding: 9570 9570 2634
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75750,8 +78414,9 @@ SplineSet
  696 -512 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF230000
-Encoding: 9571 9571 9571
+Encoding: 9571 9571 2635
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75778,8 +78443,9 @@ SplineSet
  696 -512 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: SF470000
-Encoding: 9572 9572 9572
+Encoding: 9572 9572 2636
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75801,8 +78467,9 @@ SplineSet
  -20 790 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: SF480000
-Encoding: 9573 9573 9573
+Encoding: 9573 9573 2637
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75823,8 +78490,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF410000
-Encoding: 9574 9574 9574
+Encoding: 9574 9574 2638
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75851,8 +78519,9 @@ SplineSet
  696 -512 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF450000
-Encoding: 9575 9575 9575
+Encoding: 9575 9575 2639
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75874,8 +78543,9 @@ SplineSet
  -20 790 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: SF460000
-Encoding: 9576 9576 9576
+Encoding: 9576 9576 2640
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75896,8 +78566,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF400000
-Encoding: 9577 9577 9577
+Encoding: 9577 9577 2641
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75924,8 +78595,9 @@ SplineSet
  696 790 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: SF540000
-Encoding: 9578 9578 9578
+Encoding: 9578 9578 2642
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75954,8 +78626,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF530000
-Encoding: 9579 9579 9579
+Encoding: 9579 9579 2643
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -75984,8 +78657,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: SF440000
-Encoding: 9580 9580 9580
+Encoding: 9580 9580 2644
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76021,8 +78695,9 @@ SplineSet
  696 790 l 1,18,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256D
-Encoding: 9581 9581 9581
+Encoding: 9581 9581 2645
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76041,8 +78716,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256E
-Encoding: 9582 9582 9582
+Encoding: 9582 9582 2646
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76061,8 +78737,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni256F
-Encoding: 9583 9583 9583
+Encoding: 9583 9583 2647
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76081,8 +78758,9 @@ SplineSet
  -20 618 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2570
-Encoding: 9584 9584 9584
+Encoding: 9584 9584 2648
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76101,8 +78779,9 @@ SplineSet
  1253 618 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2571
-Encoding: 9585 9585 9585
+Encoding: 9585 9585 2649
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76115,8 +78794,9 @@ SplineSet
  -89 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2572
-Encoding: 9586 9586 9586
+Encoding: 9586 9586 2650
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76129,8 +78809,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2573
-Encoding: 9587 9587 9587
+Encoding: 9587 9587 2651
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76151,8 +78832,9 @@ SplineSet
  1322 -492 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2574
-Encoding: 9588 9588 9588
+Encoding: 9588 9588 2652
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76165,8 +78847,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2575
-Encoding: 9589 9589 9589
+Encoding: 9589 9589 2653
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76179,8 +78862,9 @@ SplineSet
  536 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2576
-Encoding: 9590 9590 9590
+Encoding: 9590 9590 2654
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76193,8 +78877,9 @@ SplineSet
  616 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2577
-Encoding: 9591 9591 9591
+Encoding: 9591 9591 2655
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76207,8 +78892,9 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2578
-Encoding: 9592 9592 9592
+Encoding: 9592 9592 2656
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76221,8 +78907,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2579
-Encoding: 9593 9593 9593
+Encoding: 9593 9593 2657
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76235,8 +78922,9 @@ SplineSet
  456 704 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257A
-Encoding: 9594 9594 9594
+Encoding: 9594 9594 2658
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76249,8 +78937,9 @@ SplineSet
  616 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257B
-Encoding: 9595 9595 9595
+Encoding: 9595 9595 2659
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76263,8 +78952,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257C
-Encoding: 9596 9596 9596
+Encoding: 9596 9596 2660
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76281,8 +78971,9 @@ SplineSet
  -20 618 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257D
-Encoding: 9597 9597 9597
+Encoding: 9597 9597 2661
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76299,8 +78990,9 @@ SplineSet
  456 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257E
-Encoding: 9598 9598 9598
+Encoding: 9598 9598 2662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76317,8 +79009,9 @@ SplineSet
  -20 532 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni257F
-Encoding: 9599 9599 9599
+Encoding: 9599 9599 2663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76335,16 +79028,18 @@ SplineSet
  536 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: upblock
-Encoding: 9600 9600 9600
+Encoding: 9600 9600 2664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9604 9604 N 1 0 0 1 0 1216 2
+Refer: 2668 9604 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2581
-Encoding: 9601 9601 9601
+Encoding: 9601 9601 2665
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76357,8 +79052,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2582
-Encoding: 9602 9602 9602
+Encoding: 9602 9602 2666
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76371,8 +79067,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2583
-Encoding: 9603 9603 9603
+Encoding: 9603 9603 2667
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76385,8 +79082,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: dnblock
-Encoding: 9604 9604 9604
+Encoding: 9604 9604 2668
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76399,8 +79097,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2585
-Encoding: 9605 9605 9605
+Encoding: 9605 9605 2669
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76413,8 +79112,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2586
-Encoding: 9606 9606 9606
+Encoding: 9606 9606 2670
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76427,8 +79127,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2587
-Encoding: 9607 9607 9607
+Encoding: 9607 9607 2671
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76441,8 +79142,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: block
-Encoding: 9608 9608 9608
+Encoding: 9608 9608 2672
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76455,8 +79157,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2589
-Encoding: 9609 9609 9609
+Encoding: 9609 9609 2673
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76469,8 +79172,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258A
-Encoding: 9610 9610 9610
+Encoding: 9610 9610 2674
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76483,8 +79187,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258B
-Encoding: 9611 9611 9611
+Encoding: 9611 9611 2675
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76497,8 +79202,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: lfblock
-Encoding: 9612 9612 9612
+Encoding: 9612 9612 2676
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76511,8 +79217,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258D
-Encoding: 9613 9613 9613
+Encoding: 9613 9613 2677
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76525,8 +79232,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258E
-Encoding: 9614 9614 9614
+Encoding: 9614 9614 2678
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76539,8 +79247,9 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni258F
-Encoding: 9615 9615 9615
+Encoding: 9615 9615 2679
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76553,16 +79262,18 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: rtblock
-Encoding: 9616 9616 9616
+Encoding: 9616 9616 2680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9612 9612 N 1 0 0 1 637 0 2
+Refer: 2676 9612 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: ltshade
-Encoding: 9617 9617 9617
+Encoding: 9617 9617 2681
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76650,8 +79361,9 @@ SplineSet
  0 1059 l 25,60,-1
 EndSplineSet
 EndChar
+
 StartChar: shade
-Encoding: 9618 9618 9618
+Encoding: 9618 9618 2682
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76809,8 +79521,9 @@ SplineSet
  0 1661 l 1,116,-1
 EndSplineSet
 EndChar
+
 StartChar: dkshade
-Encoding: 9619 9619 9619
+Encoding: 9619 9619 2683
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76894,24 +79607,27 @@ SplineSet
  770 1901 l 1,36,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2594
-Encoding: 9620 9620 9620
+Encoding: 9620 9620 2684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9601 9601 N 1 0 0 1 0 2114 2
+Refer: 2665 9601 N 1 0 0 1 0 2114 2
 EndChar
+
 StartChar: uni2595
-Encoding: 9621 9621 9621
+Encoding: 9621 9621 2685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9615 9615 N 1 0 0 1 1114 0 2
+Refer: 2679 9615 N 1 0 0 1 1114 0 2
 EndChar
+
 StartChar: uni2596
-Encoding: 9622 9622 9622
+Encoding: 9622 9622 2686
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76924,24 +79640,27 @@ SplineSet
  -20 -512 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2597
-Encoding: 9623 9623 9623
+Encoding: 9623 9623 2687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 0 2
+Refer: 2686 9622 N 1 0 0 1 637 0 2
 EndChar
+
 StartChar: uni2598
-Encoding: 9624 9624 9624
+Encoding: 9624 9624 2688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 0 1216 2
+Refer: 2686 9622 N 1 0 0 1 0 1216 2
 EndChar
+
 StartChar: uni2599
-Encoding: 9625 9625 9625
+Encoding: 9625 9625 2689
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76956,17 +79675,19 @@ SplineSet
  -20 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259A
-Encoding: 9626 9626 9626
+Encoding: 9626 9626 2690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9623 9623 N 1 0 0 1 0 0 2
-Refer: 9624 9624 N 1 0 0 1 0 0 2
+Refer: 2687 9623 N 1 0 0 1 0 0 2
+Refer: 2688 9624 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259B
-Encoding: 9627 9627 9627
+Encoding: 9627 9627 2691
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76981,8 +79702,9 @@ SplineSet
  -20 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259C
-Encoding: 9628 9628 9628
+Encoding: 9628 9628 2692
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -76997,25 +79719,28 @@ SplineSet
  1254 1920 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni259D
-Encoding: 9629 9629 9629
+Encoding: 9629 9629 2693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9622 9622 N 1 0 0 1 637 1216 2
+Refer: 2686 9622 N 1 0 0 1 637 1216 2
 EndChar
+
 StartChar: uni259E
-Encoding: 9630 9630 9630
+Encoding: 9630 9630 2694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9629 9629 N 1 0 0 1 0 0 2
-Refer: 9622 9622 N 1 0 0 1 0 0 2
+Refer: 2693 9629 N 1 0 0 1 0 0 2
+Refer: 2686 9622 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni259F
-Encoding: 9631 9631 9631
+Encoding: 9631 9631 2695
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77030,8 +79755,9 @@ SplineSet
  1254 -512 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: filledbox
-Encoding: 9632 9632 9632
+Encoding: 9632 9632 2696
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77044,8 +79770,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H22073
-Encoding: 9633 9633 9633
+Encoding: 9633 9633 2697
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77063,8 +79790,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A2
-Encoding: 9634 9634 9634
+Encoding: 9634 9634 2698
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77090,17 +79818,19 @@ SplineSet
  6 -78.5 6 -78.5 6 263.5 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25A3
-Encoding: 9635 9635 9635
+Encoding: 9635 9635 2699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 9642 9642 N 1 0 0 1 0 0 2
-Refer: 9633 9633 N 1 0 0 1 0 0 2
+Refer: 2706 9642 N 1 0 0 1 0 0 2
+Refer: 2697 9633 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni25A4
-Encoding: 9636 9636 9636
+Encoding: 9636 9636 2700
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77138,8 +79868,9 @@ SplineSet
  120 922 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A5
-Encoding: 9637 9637 9637
+Encoding: 9637 9637 2701
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77177,8 +79908,9 @@ SplineSet
  120 36 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A6
-Encoding: 9638 9638 9638
+Encoding: 9638 9638 2702
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77316,8 +80048,9 @@ SplineSet
  6 -78.5 l 1,100,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A7
-Encoding: 9639 9639 9639
+Encoding: 9639 9639 2703
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77365,8 +80098,9 @@ SplineSet
  120 182 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A8
-Encoding: 9640 9640 9640
+Encoding: 9640 9640 2704
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77414,8 +80148,9 @@ SplineSet
  967 36 l 1,29,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25A9
-Encoding: 9641 9641 9641
+Encoding: 9641 9641 2705
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77565,8 +80300,9 @@ SplineSet
  6 -78.5 l 1,112,-1
 EndSplineSet
 EndChar
+
 StartChar: H18543
-Encoding: 9642 9642 9642
+Encoding: 9642 9642 2706
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77579,8 +80315,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: H18551
-Encoding: 9643 9643 9643
+Encoding: 9643 9643 2707
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77598,8 +80335,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: filledrect
-Encoding: 9644 9644 9644
+Encoding: 9644 9644 2708
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77612,8 +80350,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AD
-Encoding: 9645 9645 9645
+Encoding: 9645 9645 2709
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77631,8 +80370,9 @@ SplineSet
  1227 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AE
-Encoding: 9646 9646 9646
+Encoding: 9646 9646 2710
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77645,8 +80385,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25AF
-Encoding: 9647 9647 9647
+Encoding: 9647 9647 2711
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77664,8 +80405,9 @@ SplineSet
  324.5 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B0
-Encoding: 9648 9648 9648
+Encoding: 9648 9648 2712
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77678,8 +80420,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B1
-Encoding: 9649 9649 9649
+Encoding: 9649 9649 2713
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77697,8 +80440,9 @@ SplineSet
  919 240 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagup
-Encoding: 9650 9650 9650
+Encoding: 9650 9650 2714
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77710,8 +80454,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B3
-Encoding: 9651 9651 9651
+Encoding: 9651 9651 2715
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77727,8 +80472,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B4
-Encoding: 9652 9652 9652
+Encoding: 9652 9652 2716
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77740,8 +80486,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B5
-Encoding: 9653 9653 9653
+Encoding: 9653 9653 2717
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77757,8 +80504,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B6
-Encoding: 9654 9654 9654
+Encoding: 9654 9654 2718
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77770,8 +80518,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B7
-Encoding: 9655 9655 9655
+Encoding: 9655 9655 2719
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77787,8 +80536,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B8
-Encoding: 9656 9656 9656
+Encoding: 9656 9656 2720
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77800,8 +80550,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25B9
-Encoding: 9657 9657 9657
+Encoding: 9657 9657 2721
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77817,8 +80568,9 @@ SplineSet
  219 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagrt
-Encoding: 9658 9658 9658
+Encoding: 9658 9658 2722
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77830,8 +80582,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BB
-Encoding: 9659 9659 9659
+Encoding: 9659 9659 2723
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77847,8 +80600,9 @@ SplineSet
  6 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triagdn
-Encoding: 9660 9660 9660
+Encoding: 9660 9660 2724
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77860,8 +80614,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BD
-Encoding: 9661 9661 9661
+Encoding: 9661 9661 2725
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77877,8 +80632,9 @@ SplineSet
  616 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BE
-Encoding: 9662 9662 9662
+Encoding: 9662 9662 2726
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77890,8 +80646,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25BF
-Encoding: 9663 9663 9663
+Encoding: 9663 9663 2727
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77907,8 +80664,9 @@ SplineSet
  616 135 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C0
-Encoding: 9664 9664 9664
+Encoding: 9664 9664 2728
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77920,8 +80678,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C1
-Encoding: 9665 9665 9665
+Encoding: 9665 9665 2729
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77937,8 +80696,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C2
-Encoding: 9666 9666 9666
+Encoding: 9666 9666 2730
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77950,8 +80710,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C3
-Encoding: 9667 9667 9667
+Encoding: 9667 9667 2731
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77967,8 +80728,9 @@ SplineSet
  219 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: triaglf
-Encoding: 9668 9668 9668
+Encoding: 9668 9668 2732
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77980,8 +80742,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C5
-Encoding: 9669 9669 9669
+Encoding: 9669 9669 2733
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -77997,8 +80760,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C6
-Encoding: 9670 9670 9670
+Encoding: 9670 9670 2734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78011,8 +80775,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C7
-Encoding: 9671 9671 9671
+Encoding: 9671 9671 2735
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78030,8 +80795,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C8
-Encoding: 9672 9672 9672
+Encoding: 9672 9672 2736
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78054,8 +80820,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25C9
-Encoding: 9673 9673 9673
+Encoding: 9673 9673 2737
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78090,8 +80857,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: lozenge
-Encoding: 9674 9674 9674
+Encoding: 9674 9674 2738
 Width: 1233
 Flags: W
 TtInstrs:
@@ -78145,8 +80913,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: circle
-Encoding: 9675 9675 9675
+Encoding: 9675 9675 2739
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78172,8 +80941,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25CC
-Encoding: 9676 9676 9676
+Encoding: 9676 9676 2740
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78237,8 +81007,9 @@ SplineSet
  141 652 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25CD
-Encoding: 9677 9677 9677
+Encoding: 9677 9677 2741
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78284,8 +81055,9 @@ SplineSet
  1105 714 1105 714 1002 838 c 1,51,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25CE
-Encoding: 9678 9678 9678
+Encoding: 9678 9678 2742
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78329,8 +81101,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: H18533
-Encoding: 9679 9679 9679
+Encoding: 9679 9679 2743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78347,8 +81120,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D0
-Encoding: 9680 9680 9680
+Encoding: 9680 9680 2744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78371,8 +81145,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D1
-Encoding: 9681 9681 9681
+Encoding: 9681 9681 2745
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78395,8 +81170,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D2
-Encoding: 9682 9682 9682
+Encoding: 9682 9682 2746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78419,8 +81195,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D3
-Encoding: 9683 9683 9683
+Encoding: 9683 9683 2747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78443,8 +81220,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D4
-Encoding: 9684 9684 9684
+Encoding: 9684 9684 2748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78470,8 +81248,9 @@ SplineSet
  6 180 6 180 6 532 c 152,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D5
-Encoding: 9685 9685 9685
+Encoding: 9685 9685 2749
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78493,8 +81272,9 @@ SplineSet
  6 180 6 180 6 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25D6
-Encoding: 9686 9686 9686
+Encoding: 9686 9686 2750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78508,8 +81288,9 @@ SplineSet
  921.5 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25D7
-Encoding: 9687 9687 9687
+Encoding: 9687 9687 2751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78523,8 +81304,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: invbullet
-Encoding: 9688 9688 9688
+Encoding: 9688 9688 2752
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78546,8 +81328,9 @@ SplineSet
  -20 -20 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: invcircle
-Encoding: 9689 9689 9689
+Encoding: 9689 9689 2753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78578,8 +81361,9 @@ SplineSet
  -20 -512 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DA
-Encoding: 9690 9690 9690
+Encoding: 9690 9690 2754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78603,8 +81387,9 @@ SplineSet
  1104.9 813.293 1104.9 813.293 1104.9 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DB
-Encoding: 9691 9691 9691
+Encoding: 9691 9691 2755
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78628,8 +81413,9 @@ SplineSet
  128.1 250.631 128.1 250.631 128.1 532 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25DC
-Encoding: 9692 9692 9692
+Encoding: 9692 9692 2756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78644,8 +81430,9 @@ SplineSet
  311.45 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25DD
-Encoding: 9693 9693 9693
+Encoding: 9693 9693 2757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78660,8 +81447,9 @@ SplineSet
  311.5 1148 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DE
-Encoding: 9694 9694 9694
+Encoding: 9694 9694 2758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78676,8 +81464,9 @@ SplineSet
  462.5 -84 462.5 -84 311.5 -84 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25DF
-Encoding: 9695 9695 9695
+Encoding: 9695 9695 2759
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78692,8 +81481,9 @@ SplineSet
  921.45 -84 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E0
-Encoding: 9696 9696 9696
+Encoding: 9696 9696 2760
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78712,8 +81502,9 @@ SplineSet
  6 532 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E1
-Encoding: 9697 9697 9697
+Encoding: 9697 9697 2761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78732,8 +81523,9 @@ SplineSet
  6 180 6 180 6 532 c 9,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E2
-Encoding: 9698 9698 9698
+Encoding: 9698 9698 2762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78745,8 +81537,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E3
-Encoding: 9699 9699 9699
+Encoding: 9699 9699 2763
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78758,8 +81551,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E4
-Encoding: 9700 9700 9700
+Encoding: 9700 9700 2764
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78771,8 +81565,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E5
-Encoding: 9701 9701 9701
+Encoding: 9701 9701 2765
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78784,8 +81579,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: openbullet
-Encoding: 9702 9702 9702
+Encoding: 9702 9702 2766
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78811,8 +81607,9 @@ SplineSet
  319 636 319 636 319 762 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25E7
-Encoding: 9703 9703 9703
+Encoding: 9703 9703 2767
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78830,8 +81627,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E8
-Encoding: 9704 9704 9704
+Encoding: 9704 9704 2768
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78849,8 +81647,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25E9
-Encoding: 9705 9705 9705
+Encoding: 9705 9705 2769
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78867,8 +81666,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EA
-Encoding: 9706 9706 9706
+Encoding: 9706 9706 2770
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78885,8 +81685,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EB
-Encoding: 9707 9707 9707
+Encoding: 9707 9707 2771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78909,8 +81710,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EC
-Encoding: 9708 9708 9708
+Encoding: 9708 9708 2772
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78935,8 +81737,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25ED
-Encoding: 9709 9709 9709
+Encoding: 9709 9709 2773
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78952,8 +81755,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EE
-Encoding: 9710 9710 9710
+Encoding: 9710 9710 2774
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78969,8 +81773,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25EF
-Encoding: 9711 9711 9711
+Encoding: 9711 9711 2775
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -78996,8 +81801,9 @@ SplineSet
  -20 165 -20 165 -20 532 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni25F0
-Encoding: 9712 9712 9712
+Encoding: 9712 9712 2776
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79022,8 +81828,9 @@ SplineSet
  120 35.5 l 1,11,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F1
-Encoding: 9713 9713 9713
+Encoding: 9713 9713 2777
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79048,8 +81855,9 @@ SplineSet
  120 588.5 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F2
-Encoding: 9714 9714 9714
+Encoding: 9714 9714 2778
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79074,8 +81882,9 @@ SplineSet
  120 35.5 l 1,17,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F3
-Encoding: 9715 9715 9715
+Encoding: 9715 9715 2779
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79100,8 +81909,9 @@ SplineSet
  120 35.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni25F4
-Encoding: 9716 9716 9716
+Encoding: 9716 9716 2780
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79132,8 +81942,9 @@ SplineSet
  130.784 474.5 l 1,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni25F5
-Encoding: 9717 9717 9717
+Encoding: 9717 9717 2781
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79164,8 +81975,9 @@ SplineSet
  130.784 474.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F6
-Encoding: 9718 9718 9718
+Encoding: 9718 9718 2782
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79196,8 +82008,9 @@ SplineSet
  673 43.0479 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F7
-Encoding: 9719 9719 9719
+Encoding: 9719 9719 2783
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79228,8 +82041,9 @@ SplineSet
  1102.3 588.5 l 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uni25F8
-Encoding: 9720 9720 9720
+Encoding: 9720 9720 2784
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79245,8 +82059,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25F9
-Encoding: 9721 9721 9721
+Encoding: 9721 9721 2785
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79262,8 +82077,9 @@ SplineSet
  6 1142.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FA
-Encoding: 9722 9722 9722
+Encoding: 9722 9722 2786
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79279,8 +82095,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FB
-Encoding: 9723 9723 9723
+Encoding: 9723 9723 2787
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79298,8 +82115,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FC
-Encoding: 9724 9724 9724
+Encoding: 9724 9724 2788
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79312,8 +82130,9 @@ SplineSet
  97 13 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FD
-Encoding: 9725 9725 9725
+Encoding: 9725 9725 2789
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79331,8 +82150,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FE
-Encoding: 9726 9726 9726
+Encoding: 9726 9726 2790
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79345,8 +82165,9 @@ SplineSet
  175 91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni25FF
-Encoding: 9727 9727 9727
+Encoding: 9727 9727 2791
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79362,8 +82183,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2600
-Encoding: 9728 9728 9728
+Encoding: 9728 9728 2792
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79445,8 +82267,9 @@ SplineSet
  590 446 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2601
-Encoding: 9729 9729 9729
+Encoding: 9729 9729 2793
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79478,8 +82301,9 @@ SplineSet
  685.098 465 685.098 465 767.539 465 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2602
-Encoding: 9730 9730 9730
+Encoding: 9730 9730 2794
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79535,8 +82359,9 @@ SplineSet
  608.679 1068.13 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2603
-Encoding: 9731 9731 9731
+Encoding: 9731 9731 2795
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79791,8 +82616,9 @@ SplineSet
  106.419 947 106.419 947 110 944 c 2,822,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2604
-Encoding: 9732 9732 9732
+Encoding: 9732 9732 2796
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79966,8 +82792,9 @@ SplineSet
  1158.24 928.015 1158.24 928.015 1166.45 928.015 c 0,238,239
 EndSplineSet
 EndChar
+
 StartChar: uni2605
-Encoding: 9733 9733 9733
+Encoding: 9733 9733 2797
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -79986,8 +82813,9 @@ SplineSet
  58.4141 670 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2606
-Encoding: 9734 9734 9734
+Encoding: 9734 9734 2798
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80017,8 +82845,9 @@ SplineSet
  450.852 439.516 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2607
-Encoding: 9735 9735 9735
+Encoding: 9735 9735 2799
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80040,8 +82869,9 @@ SplineSet
  935 1494 935 1494 974 1494 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2608
-Encoding: 9736 9736 9736
+Encoding: 9736 9736 2800
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80069,8 +82899,9 @@ SplineSet
  59.1592 1497 59.1592 1497 121.972 1497 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2609
-Encoding: 9737 9737 9737
+Encoding: 9737 9737 2801
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80111,8 +82942,9 @@ SplineSet
  759.672 617.719 759.672 617.719 759.672 580.203 c 0,28,29
 EndSplineSet
 EndChar
+
 StartChar: uni260A
-Encoding: 9738 9738 9738
+Encoding: 9738 9738 2802
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80167,8 +82999,9 @@ SplineSet
  1199.91 630 1199.91 630 1111.86 507.5 c 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260B
-Encoding: 9739 9739 9739
+Encoding: 9739 9739 2803
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80223,8 +83056,9 @@ SplineSet
  1196.93 720.938 1196.93 720.938 1196.93 556.875 c 0,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260C
-Encoding: 9740 9740 9740
+Encoding: 9740 9740 2804
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80254,8 +83088,9 @@ SplineSet
  909 926 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni260D
-Encoding: 9741 9741 9741
+Encoding: 9741 9741 2805
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80302,8 +83137,9 @@ SplineSet
  571.188 625 l 1,24,25
 EndSplineSet
 EndChar
+
 StartChar: uni260E
-Encoding: 9742 9742 9742
+Encoding: 9742 9742 2806
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80449,8 +83285,9 @@ SplineSet
  684.987 660.66 684.987 660.66 691.811 676.24 c 0,174,175
 EndSplineSet
 EndChar
+
 StartChar: uni260F
-Encoding: 9743 9743 9743
+Encoding: 9743 9743 2807
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80629,8 +83466,9 @@ SplineSet
  942.763 1038.94 l 1,207,208
 EndSplineSet
 EndChar
+
 StartChar: uni2610
-Encoding: 9744 9744 9744
+Encoding: 9744 9744 2808
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80652,8 +83490,9 @@ SplineSet
  187.157 955 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2611
-Encoding: 9745 9745 9745
+Encoding: 9745 9745 2809
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80690,8 +83529,9 @@ SplineSet
  867.865 841.719 867.865 841.719 959.974 859.297 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2612
-Encoding: 9746 9746 9746
+Encoding: 9746 9746 2810
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80729,8 +83569,9 @@ SplineSet
  347.768 825 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2613
-Encoding: 9747 9747 9747
+Encoding: 9747 9747 2811
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80757,8 +83598,9 @@ SplineSet
  294.031 1347.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2614
-Encoding: 9748 9748 9748
+Encoding: 9748 9748 2812
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80863,8 +83705,9 @@ SplineSet
  593.062 925.823 l 1,63,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2615
-Encoding: 9749 9749 9749
+Encoding: 9749 9749 2813
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80966,8 +83809,9 @@ SplineSet
  737.088 1005 737.088 1005 735.682 940.312 c 0,120,121
 EndSplineSet
 EndChar
+
 StartChar: uni2616
-Encoding: 9750 9750 9750
+Encoding: 9750 9750 2814
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -80990,8 +83834,9 @@ SplineSet
  197.625 1044 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2617
-Encoding: 9751 9751 9751
+Encoding: 9751 9751 2815
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81009,8 +83854,9 @@ SplineSet
  619.926 1490 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2618
-Encoding: 9752 9752 9752
+Encoding: 9752 9752 2816
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81059,8 +83905,9 @@ SplineSet
  593.65 637.562 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2619
-Encoding: 9753 9753 9753
+Encoding: 9753 9753 2817
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81106,8 +83953,9 @@ SplineSet
  1050.67 821.25 1050.67 821.25 901.382 852.125 c 1,58,59
 EndSplineSet
 EndChar
+
 StartChar: uni261A
-Encoding: 9754 9754 9754
+Encoding: 9754 9754 2818
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81153,8 +84001,9 @@ SplineSet
  1127.99 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261B
-Encoding: 9755 9755 9755
+Encoding: 9755 9755 2819
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81200,8 +84049,9 @@ SplineSet
  105.004 270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni261C
-Encoding: 9756 9756 9756
+Encoding: 9756 9756 2820
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81259,8 +84109,9 @@ SplineSet
  559.22 282.062 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261D
-Encoding: 9757 9757 9757
+Encoding: 9757 9757 2821
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81319,8 +84170,9 @@ SplineSet
  141 812 l 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261E
-Encoding: 9758 9758 9758
+Encoding: 9758 9758 2822
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81378,8 +84230,9 @@ SplineSet
  749.345 282.875 749.345 282.875 673.783 282.062 c 2,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni261F
-Encoding: 9759 9759 9759
+Encoding: 9759 9759 2823
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81437,8 +84290,9 @@ SplineSet
  140 1399 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2620
-Encoding: 9760 9760 9760
+Encoding: 9760 9760 2824
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81698,8 +84552,9 @@ SplineSet
  726.951 305.125 l 1,306,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2621
-Encoding: 9761 9761 9761
+Encoding: 9761 9761 2825
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81733,8 +84588,9 @@ SplineSet
  755.843 1491 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2622
-Encoding: 9762 9762 9762
+Encoding: 9762 9762 2826
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81800,8 +84656,9 @@ SplineSet
  577.5 740.562 577.5 740.562 614.062 740.562 c 0,71,72
 EndSplineSet
 EndChar
+
 StartChar: uni2623
-Encoding: 9763 9763 9763
+Encoding: 9763 9763 2827
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -81879,8 +84736,9 @@ SplineSet
  76.8975 426.156 76.8975 426.156 37.7959 289.656 c 1,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2624
-Encoding: 9764 9764 9764
+Encoding: 9764 9764 2828
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82066,8 +84924,9 @@ SplineSet
  714.02 1077.92 714.02 1077.92 652.38 1012.6 c 1,210,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2625
-Encoding: 9765 9765 9765
+Encoding: 9765 9765 2829
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82100,8 +84959,9 @@ SplineSet
  553.497 966 l 1,8,9
 EndSplineSet
 EndChar
+
 StartChar: uni2626
-Encoding: 9766 9766 9766
+Encoding: 9766 9766 2830
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82157,8 +85017,9 @@ SplineSet
  573.5 579 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2627
-Encoding: 9767 9767 9767
+Encoding: 9767 9767 2831
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82198,8 +85059,9 @@ SplineSet
  485.709 567.6 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2628
-Encoding: 9768 9768 9768
+Encoding: 9768 9768 2832
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82240,8 +85102,9 @@ SplineSet
  524.061 1485 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2629
-Encoding: 9769 9769 9769
+Encoding: 9769 9769 2833
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82294,8 +85157,9 @@ SplineSet
  452.25 1123.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262A
-Encoding: 9770 9770 9770
+Encoding: 9770 9770 2834
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82337,8 +85201,9 @@ SplineSet
  980.764 913.609 l 1,28,-1
 EndSplineSet
 EndChar
+
 StartChar: uni262B
-Encoding: 9771 9771 9771
+Encoding: 9771 9771 2835
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82424,8 +85289,9 @@ SplineSet
  868.784 1079.81 l 1,99,100
 EndSplineSet
 EndChar
+
 StartChar: uni262C
-Encoding: 9772 9772 9772
+Encoding: 9772 9772 2836
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82497,8 +85363,9 @@ SplineSet
  863.52 1046.96 863.52 1046.96 702.52 1113.2 c 1,96,97
 EndSplineSet
 EndChar
+
 StartChar: uni262D
-Encoding: 9773 9773 9773
+Encoding: 9773 9773 2837
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82540,8 +85407,9 @@ SplineSet
  507.019 1313.12 507.019 1313.12 682.509 1313.12 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni262E
-Encoding: 9774 9774 9774
+Encoding: 9774 9774 2838
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82578,8 +85446,9 @@ SplineSet
  998.438 312.013 l 1,27,28
 EndSplineSet
 EndChar
+
 StartChar: uni262F
-Encoding: 9775 9775 9775
+Encoding: 9775 9775 2839
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82628,8 +85497,9 @@ SplineSet
  1218.64 856.245 1218.64 856.245 1218.64 605.891 c 0,43,44
 EndSplineSet
 EndChar
+
 StartChar: uni2638
-Encoding: 9784 9784 9784
+Encoding: 9784 9784 2840
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82719,8 +85589,9 @@ SplineSet
  563 548 l 1,106,107
 EndSplineSet
 EndChar
+
 StartChar: uni2639
-Encoding: 9785 9785 9785
+Encoding: 9785 9785 2841
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82763,8 +85634,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: smileface
-Encoding: 9786 9786 9786
+Encoding: 9786 9786 2842
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82807,8 +85679,9 @@ SplineSet
  517 839 517 839 428 835 c 0,42,43
 EndSplineSet
 EndChar
+
 StartChar: invsmileface
-Encoding: 9787 9787 9787
+Encoding: 9787 9787 2843
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82842,8 +85715,9 @@ SplineSet
  496 860 496 860 501 970 c 0,30,31
 EndSplineSet
 EndChar
+
 StartChar: sun
-Encoding: 9788 9788 9788
+Encoding: 9788 9788 2844
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82934,8 +85808,9 @@ SplineSet
  592 924 592 924 556 910 c 0,74,75
 EndSplineSet
 EndChar
+
 StartChar: uni263D
-Encoding: 9789 9789 9789
+Encoding: 9789 9789 2845
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -82972,8 +85847,9 @@ SplineSet
  342.844 1416.19 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263E
-Encoding: 9790 9790 9790
+Encoding: 9790 9790 2846
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83010,8 +85886,9 @@ SplineSet
  894.5 69 l 1,24,-1
 EndSplineSet
 EndChar
+
 StartChar: uni263F
-Encoding: 9791 9791 9791
+Encoding: 9791 9791 2847
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83064,8 +85941,9 @@ SplineSet
  744 1012 744 1012 635 1018 c 2,50,-1
 EndSplineSet
 EndChar
+
 StartChar: female
-Encoding: 9792 9792 9792
+Encoding: 9792 9792 2848
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83102,8 +85980,9 @@ SplineSet
  397 443 397 443 284 548 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2641
-Encoding: 9793 9793 9793
+Encoding: 9793 9793 2849
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83140,8 +86019,9 @@ SplineSet
  397 798 397 798 550 811 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: male
-Encoding: 9794 9794 9794
+Encoding: 9794 9794 2850
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83177,8 +86057,9 @@ SplineSet
  910 411 910 411 781 282 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2643
-Encoding: 9795 9795 9795
+Encoding: 9795 9795 2851
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83210,8 +86091,9 @@ SplineSet
  488 543 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2644
-Encoding: 9796 9796 9796
+Encoding: 9796 9796 2852
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83246,8 +86128,9 @@ SplineSet
  274 1141 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2645
-Encoding: 9797 9797 9797
+Encoding: 9797 9797 2853
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83300,8 +86183,9 @@ SplineSet
  679 553 l 1,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2646
-Encoding: 9798 9798 9798
+Encoding: 9798 9798 2854
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83363,8 +86247,9 @@ SplineSet
  679 287 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2647
-Encoding: 9799 9799 9799
+Encoding: 9799 9799 2855
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83396,8 +86281,9 @@ SplineSet
  352 1322 l 1,19,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2648
-Encoding: 9800 9800 9800
+Encoding: 9800 9800 2856
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83427,8 +86313,9 @@ SplineSet
  570.919 1.8125 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2649
-Encoding: 9801 9801 9801
+Encoding: 9801 9801 2857
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83470,8 +86357,9 @@ SplineSet
  516.966 824.688 516.966 824.688 615.731 820.586 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264A
-Encoding: 9802 9802 9802
+Encoding: 9802 9802 2858
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83499,8 +86387,9 @@ SplineSet
  425.56 202.312 l 1,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni264B
-Encoding: 9803 9803 9803
+Encoding: 9803 9803 2859
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83554,8 +86443,9 @@ SplineSet
  399.116 1293.75 399.116 1293.75 499.193 1294.69 c 0,44,45
 EndSplineSet
 EndChar
+
 StartChar: uni264C
-Encoding: 9804 9804 9804
+Encoding: 9804 9804 2860
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83604,8 +86494,9 @@ SplineSet
  400.728 931.328 400.728 931.328 400.728 994.609 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni264D
-Encoding: 9805 9805 9805
+Encoding: 9805 9805 2861
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83659,8 +86550,9 @@ SplineSet
  921.845 596.469 921.845 596.469 899.305 478.562 c 2,55,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264E
-Encoding: 9806 9806 9806
+Encoding: 9806 9806 2862
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83697,8 +86589,9 @@ SplineSet
  481.424 530.5 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni264F
-Encoding: 9807 9807 9807
+Encoding: 9807 9807 2863
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83747,8 +86640,9 @@ SplineSet
  857.441 226.344 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2650
-Encoding: 9808 9808 9808
+Encoding: 9808 9808 2864
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83777,8 +86671,9 @@ SplineSet
  981.282 1098.94 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2651
-Encoding: 9809 9809 9809
+Encoding: 9809 9809 2865
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83819,8 +86714,9 @@ SplineSet
  858.493 608.398 858.493 608.398 796.969 421.367 c 1,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni2652
-Encoding: 9810 9810 9810
+Encoding: 9810 9810 2866
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83868,8 +86764,9 @@ SplineSet
  89.3398 726.484 l 1,34,35
 EndSplineSet
 EndChar
+
 StartChar: uni2653
-Encoding: 9811 9811 9811
+Encoding: 9811 9811 2867
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83899,8 +86796,9 @@ SplineSet
  721.938 587.625 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2654
-Encoding: 9812 9812 9812
+Encoding: 9812 9812 2868
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -83987,8 +86885,9 @@ SplineSet
  545.296 903.977 545.296 903.977 545.296 885.602 c 0,86,87
 EndSplineSet
 EndChar
+
 StartChar: uni2655
-Encoding: 9813 9813 9813
+Encoding: 9813 9813 2869
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84146,8 +87045,9 @@ SplineSet
  840.062 398.125 l 1,170,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2656
-Encoding: 9814 9814 9814
+Encoding: 9814 9814 2870
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84211,8 +87111,9 @@ SplineSet
  896.94 402.5 l 1,46,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2657
-Encoding: 9815 9815 9815
+Encoding: 9815 9815 2871
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84292,8 +87193,9 @@ SplineSet
  525.446 1115.9 525.446 1115.9 525.446 1092.11 c 0,83,84
 EndSplineSet
 EndChar
+
 StartChar: uni2658
-Encoding: 9816 9816 9816
+Encoding: 9816 9816 2872
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84360,8 +87262,9 @@ SplineSet
  419.874 1010.81 l 1,52,53
 EndSplineSet
 EndChar
+
 StartChar: uni2659
-Encoding: 9817 9817 9817
+Encoding: 9817 9817 2873
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84437,8 +87340,9 @@ SplineSet
  998.625 105 l 1,85,86
 EndSplineSet
 EndChar
+
 StartChar: uni265A
-Encoding: 9818 9818 9818
+Encoding: 9818 9818 2874
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84554,8 +87458,9 @@ SplineSet
  702.521 662.305 l 2,123,124
 EndSplineSet
 EndChar
+
 StartChar: uni265B
-Encoding: 9819 9819 9819
+Encoding: 9819 9819 2875
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84627,8 +87532,9 @@ SplineSet
  911.438 51.75 l 1,77,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265C
-Encoding: 9820 9820 9820
+Encoding: 9820 9820 2876
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84682,8 +87588,9 @@ SplineSet
  1040.22 50.5 l 1,38,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265D
-Encoding: 9821 9821 9821
+Encoding: 9821 9821 2877
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84736,8 +87643,9 @@ SplineSet
  664.439 606.5 l 1,53,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265E
-Encoding: 9822 9822 9822
+Encoding: 9822 9822 2878
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84789,8 +87697,9 @@ SplineSet
  1026.88 792 1026.88 792 620 1030 c 1,56,-1
 EndSplineSet
 EndChar
+
 StartChar: uni265F
-Encoding: 9823 9823 9823
+Encoding: 9823 9823 2879
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84828,8 +87737,9 @@ SplineSet
  126.971 5.9375 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: spade
-Encoding: 9824 9824 9824
+Encoding: 9824 9824 2880
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84862,8 +87772,9 @@ SplineSet
  619 1359 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2661
-Encoding: 9825 9825 9825
+Encoding: 9825 9825 2881
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84903,8 +87814,9 @@ SplineSet
  56 1112 56 1112 56 1053 c 2,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2662
-Encoding: 9826 9826 9826
+Encoding: 9826 9826 2882
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84925,8 +87837,9 @@ SplineSet
  614 1293 l 1,9,-1
 EndSplineSet
 EndChar
+
 StartChar: club
-Encoding: 9827 9827 9827
+Encoding: 9827 9827 2883
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -84970,8 +87883,9 @@ SplineSet
  586 1359 586 1359 618 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2664
-Encoding: 9828 9828 9828
+Encoding: 9828 9828 2884
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85024,8 +87938,9 @@ SplineSet
  592 176 l 1,61,-1
 EndSplineSet
 EndChar
+
 StartChar: heart
-Encoding: 9829 9829 9829
+Encoding: 9829 9829 2885
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85048,8 +87963,9 @@ SplineSet
  244 1359 244 1359 315 1359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: diamond
-Encoding: 9830 9830 9830
+Encoding: 9830 9830 2886
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85064,8 +87980,9 @@ SplineSet
  617 1359 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2667
-Encoding: 9831 9831 9831
+Encoding: 9831 9831 2887
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85140,8 +88057,9 @@ SplineSet
  617 277 l 1,97,98
 EndSplineSet
 EndChar
+
 StartChar: uni2668
-Encoding: 9832 9832 9832
+Encoding: 9832 9832 2888
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85205,8 +88123,9 @@ SplineSet
  895.998 570.281 l 2,45,46
 EndSplineSet
 EndChar
+
 StartChar: uni2669
-Encoding: 9833 9833 9833
+Encoding: 9833 9833 2889
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85229,8 +88148,9 @@ SplineSet
  789 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnote
-Encoding: 9834 9834 9834
+Encoding: 9834 9834 2890
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85259,8 +88179,9 @@ SplineSet
  566 1450 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: musicalnotedbl
-Encoding: 9835 9835 9835
+Encoding: 9835 9835 2891
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85292,8 +88213,9 @@ SplineSet
  473 1445 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266C
-Encoding: 9836 9836 9836
+Encoding: 9836 9836 2892
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85324,8 +88246,9 @@ SplineSet
  438 1189 l 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266D
-Encoding: 9837 9837 9837
+Encoding: 9837 9837 2893
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85349,8 +88272,9 @@ SplineSet
  519 658 519 658 376 441 c 1,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266E
-Encoding: 9838 9838 9838
+Encoding: 9838 9838 2894
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85380,8 +88304,9 @@ SplineSet
  483 870 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: uni266F
-Encoding: 9839 9839 9839
+Encoding: 9839 9839 2895
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85433,8 +88358,9 @@ SplineSet
  482 867 l 1,41,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2670
-Encoding: 9840 9840 9840
+Encoding: 9840 9840 2896
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85491,8 +88417,9 @@ SplineSet
  553.5 685 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2671
-Encoding: 9841 9841 9841
+Encoding: 9841 9841 2897
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85562,8 +88489,9 @@ SplineSet
  593.75 894.375 l 1,60,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2672
-Encoding: 9842 9842 9842
+Encoding: 9842 9842 2898
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85719,8 +88647,9 @@ SplineSet
  319.811 333.77 l 1,167,168
 EndSplineSet
 EndChar
+
 StartChar: uni2673
-Encoding: 9843 9843 9843
+Encoding: 9843 9843 2899
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85786,8 +88715,9 @@ SplineSet
  549.741 1076.68 549.741 1076.68 592.787 1079.6 c 0,51,52
 EndSplineSet
 EndChar
+
 StartChar: uni2674
-Encoding: 9844 9844 9844
+Encoding: 9844 9844 2900
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85863,8 +88793,9 @@ SplineSet
  551.45 1048.24 551.45 1048.24 593.396 1051.09 c 0,69,70
 EndSplineSet
 EndChar
+
 StartChar: uni2675
-Encoding: 9845 9845 9845
+Encoding: 9845 9845 2901
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -85948,8 +88879,9 @@ SplineSet
  550.62 1062.8 550.62 1062.8 593.1 1065.68 c 0,81,82
 EndSplineSet
 EndChar
+
 StartChar: uni2676
-Encoding: 9846 9846 9846
+Encoding: 9846 9846 2902
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86019,8 +88951,9 @@ SplineSet
  546.805 1120.55 546.805 1120.55 591.745 1123.59 c 0,54,55
 EndSplineSet
 EndChar
+
 StartChar: uni2677
-Encoding: 9847 9847 9847
+Encoding: 9847 9847 2903
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86097,8 +89030,9 @@ SplineSet
  549.938 1072.09 549.938 1072.09 592.857 1075 c 0,70,71
 EndSplineSet
 EndChar
+
 StartChar: uni2678
-Encoding: 9848 9848 9848
+Encoding: 9848 9848 2904
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86179,8 +89113,9 @@ SplineSet
  551.449 1039.09 551.449 1039.09 593.395 1041.94 c 0,77,78
 EndSplineSet
 EndChar
+
 StartChar: uni2679
-Encoding: 9849 9849 9849
+Encoding: 9849 9849 2905
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86242,8 +89177,9 @@ SplineSet
  547.875 1108.25 547.875 1108.25 592.125 1111.25 c 0,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni267A
-Encoding: 9850 9850 9850
+Encoding: 9850 9850 2906
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86297,8 +89233,9 @@ SplineSet
  547.875 1095.75 547.875 1095.75 592.125 1098.75 c 0,40,41
 EndSplineSet
 EndChar
+
 StartChar: uni267B
-Encoding: 9851 9851 9851
+Encoding: 9851 9851 2907
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86373,8 +89310,9 @@ SplineSet
  583.125 351.25 l 1,73,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267C
-Encoding: 9852 9852 9852
+Encoding: 9852 9852 2908
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86461,8 +89399,9 @@ SplineSet
  338.853 421.074 l 1,93,94
 EndSplineSet
 EndChar
+
 StartChar: uni267D
-Encoding: 9853 9853 9853
+Encoding: 9853 9853 2909
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86554,8 +89493,9 @@ SplineSet
  301.125 334 301.125 334 354.375 402.25 c 1,97,-1
 EndSplineSet
 EndChar
+
 StartChar: uni267E
-Encoding: 9854 9854 9854
+Encoding: 9854 9854 2910
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86609,8 +89549,9 @@ SplineSet
  79.1064 729.297 79.1064 729.297 79.1064 576.191 c 0,56,57
 EndSplineSet
 EndChar
+
 StartChar: uni267F
-Encoding: 9855 9855 9855
+Encoding: 9855 9855 2911
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86652,8 +89593,9 @@ SplineSet
  757.812 92.875 757.812 92.875 702.688 63.125 c 0,25,26
 EndSplineSet
 EndChar
+
 StartChar: uni2680
-Encoding: 9856 9856 9856
+Encoding: 9856 9856 2912
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86684,8 +89626,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2681
-Encoding: 9857 9857 9857
+Encoding: 9857 9857 2913
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86729,8 +89672,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2682
-Encoding: 9858 9858 9858
+Encoding: 9858 9858 2914
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86787,8 +89731,9 @@ SplineSet
  184.5 128.75 l 1,76,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2683
-Encoding: 9859 9859 9859
+Encoding: 9859 9859 2915
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86858,8 +89803,9 @@ SplineSet
  184.5 125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2684
-Encoding: 9860 9860 9860
+Encoding: 9860 9860 2916
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -86942,8 +89888,9 @@ SplineSet
  184.5 128.75 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2685
-Encoding: 9861 9861 9861
+Encoding: 9861 9861 2917
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87039,8 +89986,9 @@ SplineSet
  184.5 120 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2686
-Encoding: 9862 9862 9862
+Encoding: 9862 9862 2918
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87087,8 +90035,9 @@ SplineSet
  809.214 544.863 809.214 544.863 809.214 570 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni2687
-Encoding: 9863 9863 9863
+Encoding: 9863 9863 2919
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87148,8 +90097,9 @@ SplineSet
  298.101 670.977 298.101 670.977 322.476 670.977 c 0,48,49
 EndSplineSet
 EndChar
+
 StartChar: uni2688
-Encoding: 9864 9864 9864
+Encoding: 9864 9864 2920
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87183,8 +90133,9 @@ SplineSet
  880.816 474.023 880.816 474.023 905.953 474.023 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2689
-Encoding: 9865 9865 9865
+Encoding: 9865 9865 2921
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87231,8 +90182,9 @@ SplineSet
  226.5 585.137 226.5 585.137 226.5 560 c 0,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni268A
-Encoding: 9866 9866 9866
+Encoding: 9866 9866 2922
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87245,8 +90197,9 @@ SplineSet
  82.3447 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni268B
-Encoding: 9867 9867 9867
+Encoding: 9867 9867 2923
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87264,8 +90217,9 @@ SplineSet
  716.476 150 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2690
-Encoding: 9872 9872 9872
+Encoding: 9872 9872 2924
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87296,8 +90250,9 @@ SplineSet
  212.689 1167.25 l 1,10,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2691
-Encoding: 9873 9873 9873
+Encoding: 9873 9873 2925
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87320,8 +90275,9 @@ SplineSet
  181.625 1263.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2692
-Encoding: 9874 9874 9874
+Encoding: 9874 9874 2926
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87361,8 +90317,9 @@ SplineSet
  548.606 451.891 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2693
-Encoding: 9875 9875 9875
+Encoding: 9875 9875 2927
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87434,8 +90391,9 @@ SplineSet
  793.222 11.375 793.222 11.375 692.472 4.0625 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2694
-Encoding: 9876 9876 9876
+Encoding: 9876 9876 2928
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87513,8 +90471,9 @@ SplineSet
  651 511.5 l 1,58,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2695
-Encoding: 9877 9877 9877
+Encoding: 9877 9877 2929
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87583,8 +90542,9 @@ SplineSet
  663.5 1032 l 1,68,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2696
-Encoding: 9878 9878 9878
+Encoding: 9878 9878 2930
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87636,8 +90596,9 @@ SplineSet
  980.625 900 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2697
-Encoding: 9879 9879 9879
+Encoding: 9879 9879 2931
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87672,8 +90633,9 @@ SplineSet
  1139.62 457.75 l 1,23,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2698
-Encoding: 9880 9880 9880
+Encoding: 9880 9880 2932
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87722,8 +90684,9 @@ SplineSet
  723.25 744 723.25 744 671.625 736.125 c 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2699
-Encoding: 9881 9881 9881
+Encoding: 9881 9881 2933
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87794,8 +90757,9 @@ SplineSet
  749 673 749 673 749 618 c 128,-1,70
 EndSplineSet
 EndChar
+
 StartChar: uni269A
-Encoding: 9882 9882 9882
+Encoding: 9882 9882 2934
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -87909,8 +90873,9 @@ SplineSet
  544.312 1119.88 544.312 1119.88 589.812 1128.62 c 1,82,-1
 EndSplineSet
 EndChar
+
 StartChar: uni269B
-Encoding: 9883 9883 9883
+Encoding: 9883 9883 2935
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88049,8 +91014,9 @@ SplineSet
  683.936 353.938 683.936 353.938 614.874 388.062 c 1,204,205
 EndSplineSet
 EndChar
+
 StartChar: uni269C
-Encoding: 9884 9884 9884
+Encoding: 9884 9884 2936
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88150,8 +91116,9 @@ SplineSet
  542.562 833.375 542.562 833.375 616.938 833.375 c 0,131,132
 EndSplineSet
 EndChar
+
 StartChar: uni26A0
-Encoding: 9888 9888 9888
+Encoding: 9888 9888 2937
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88191,8 +91158,9 @@ SplineSet
  607.968 235.414 607.968 235.414 622.187 235.414 c 0,22,23
 EndSplineSet
 EndChar
+
 StartChar: uni26A1
-Encoding: 9889 9889 9889
+Encoding: 9889 9889 2938
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88216,8 +91184,9 @@ SplineSet
  1066.25 1313.75 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B0
-Encoding: 9904 9904 9904
+Encoding: 9904 9904 2939
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88232,8 +91201,9 @@ SplineSet
  430 1496 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni26B1
-Encoding: 9905 9905 9905
+Encoding: 9905 9905 2940
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88256,8 +91226,9 @@ SplineSet
  714.812 1033.5 714.812 1033.5 810.688 1014 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2701
-Encoding: 9985 9985 9985
+Encoding: 9985 9985 2941
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88351,8 +91322,9 @@ SplineSet
  371.175 939.535 371.175 939.535 353.531 948.359 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2702
-Encoding: 9986 9986 9986
+Encoding: 9986 9986 2942
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88447,8 +91419,9 @@ SplineSet
  206.625 975 206.625 975 189.375 975 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2703
-Encoding: 9987 9987 9987
+Encoding: 9987 9987 2943
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88542,8 +91515,9 @@ SplineSet
  340.812 374.5 340.812 374.5 359.375 380.688 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2704
-Encoding: 9988 9988 9988
+Encoding: 9988 9988 2944
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88741,8 +91715,9 @@ SplineSet
  601.031 686 601.031 686 601.031 678.438 c 152,-1,335
 EndSplineSet
 EndChar
+
 StartChar: uni2706
-Encoding: 9990 9990 9990
+Encoding: 9990 9990 2945
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88828,8 +91803,9 @@ SplineSet
  793.273 994.133 793.273 994.133 788.891 1013.12 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2707
-Encoding: 9991 9991 9991
+Encoding: 9991 9991 2946
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88917,8 +91893,9 @@ SplineSet
  499.5 1225 499.5 1225 616.5 1225 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2708
-Encoding: 9992 9992 9992
+Encoding: 9992 9992 2947
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -88966,8 +91943,9 @@ SplineSet
  82.125 572.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2709
-Encoding: 9993 9993 9993
+Encoding: 9993 9993 2948
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89012,8 +91990,9 @@ SplineSet
  63.4922 115.469 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270C
-Encoding: 9996 9996 9996
+Encoding: 9996 9996 2949
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89156,8 +92135,9 @@ SplineSet
  386.49 675.2 l 1,5,6
 EndSplineSet
 EndChar
+
 StartChar: uni270D
-Encoding: 9997 9997 9997
+Encoding: 9997 9997 2950
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89256,8 +92236,9 @@ SplineSet
  186.961 280.123 186.961 280.123 159.826 296.548 c 1,25,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270E
-Encoding: 9998 9998 9998
+Encoding: 9998 9998 2951
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89330,8 +92311,9 @@ SplineSet
  279.719 812.875 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni270F
-Encoding: 9999 9999 9999
+Encoding: 9999 9999 2952
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89402,8 +92384,9 @@ SplineSet
  272.762 352.531 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2710
-Encoding: 10000 10000 10000
+Encoding: 10000 10000 2953
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89476,8 +92459,9 @@ SplineSet
  279.719 564.125 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2711
-Encoding: 10001 10001 10001
+Encoding: 10001 10001 2954
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89531,8 +92515,9 @@ SplineSet
  176.227 632.793 176.227 632.793 176.227 580.234 c 152,-1,0
 EndSplineSet
 EndChar
+
 StartChar: uni2712
-Encoding: 10002 10002 10002
+Encoding: 10002 10002 2955
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89565,8 +92550,9 @@ SplineSet
  738.727 489.023 738.727 489.023 744.469 502.969 c 9,23,24
 EndSplineSet
 EndChar
+
 StartChar: uni2713
-Encoding: 10003 10003 10003
+Encoding: 10003 10003 2956
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89590,8 +92576,9 @@ SplineSet
  251.273 591.5 251.273 591.5 280.5 591.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2714
-Encoding: 10004 10004 10004
+Encoding: 10004 10004 2957
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89615,8 +92602,9 @@ SplineSet
  220.845 654.375 220.845 654.375 263 653.5 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2715
-Encoding: 10005 10005 10005
+Encoding: 10005 10005 2958
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89637,8 +92625,9 @@ SplineSet
  731.062 599.625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2716
-Encoding: 10006 10006 10006
+Encoding: 10006 10006 2959
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89659,8 +92648,9 @@ SplineSet
  821.312 709.043 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2717
-Encoding: 10007 10007 10007
+Encoding: 10007 10007 2960
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89703,8 +92693,9 @@ SplineSet
  957.344 1213.62 957.344 1213.62 968.719 1213.62 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2718
-Encoding: 10008 10008 10008
+Encoding: 10008 10008 2961
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89754,8 +92745,9 @@ SplineSet
  1012 1322.25 1012 1322.25 1024.25 1322.25 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2719
-Encoding: 10009 10009 10009
+Encoding: 10009 10009 2962
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89802,8 +92794,9 @@ SplineSet
  690.438 631.274 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271A
-Encoding: 10010 10010 10010
+Encoding: 10010 10010 2963
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89824,8 +92817,9 @@ SplineSet
  758.688 655 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271B
-Encoding: 10011 10011 10011
+Encoding: 10011 10011 2964
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89851,8 +92845,9 @@ SplineSet
  527 477 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni271C
-Encoding: 10012 10012 10012
+Encoding: 10012 10012 2965
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89878,8 +92873,9 @@ SplineSet
  768.844 720.762 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271D
-Encoding: 10013 10013 10013
+Encoding: 10013 10013 2966
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89900,8 +92896,9 @@ SplineSet
  715 960 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271E
-Encoding: 10014 10014 10014
+Encoding: 10014 10014 2967
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89939,8 +92936,9 @@ SplineSet
  669 957.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni271F
-Encoding: 10015 10015 10015
+Encoding: 10015 10015 2968
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -89987,8 +92985,9 @@ SplineSet
  704 860 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2720
-Encoding: 10016 10016 10016
+Encoding: 10016 10016 2969
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90049,8 +93048,9 @@ SplineSet
  559.371 515.742 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2721
-Encoding: 10017 10017 10017
+Encoding: 10017 10017 2970
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90102,8 +93102,9 @@ SplineSet
  299.625 713.062 l 1,33,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2722
-Encoding: 10018 10018 10018
+Encoding: 10018 10018 2971
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90152,8 +93153,9 @@ SplineSet
  578.731 603.182 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2723
-Encoding: 10019 10019 10019
+Encoding: 10019 10019 2972
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90242,8 +93244,9 @@ SplineSet
  562.418 492.695 562.418 492.695 549.469 504.883 c 24,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni2724
-Encoding: 10020 10020 10020
+Encoding: 10020 10020 2973
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90332,8 +93335,9 @@ SplineSet
  530.426 610 530.426 610 578.414 610 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2725
-Encoding: 10021 10021 10021
+Encoding: 10021 10021 2974
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90502,8 +93506,9 @@ SplineSet
  592.766 1159.3 592.766 1159.3 616.5 1159.3 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2726
-Encoding: 10022 10022 10022
+Encoding: 10022 10022 2975
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90528,8 +93533,9 @@ SplineSet
  158.27 552.941 158.27 552.941 43.1543 552.941 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2727
-Encoding: 10023 10023 10023
+Encoding: 10023 10023 2976
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90571,8 +93577,9 @@ SplineSet
  153.75 557.25 153.75 557.25 37.5 557.25 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2729
-Encoding: 10025 10025 10025
+Encoding: 10025 10025 2977
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90602,8 +93609,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272A
-Encoding: 10026 10026 10026
+Encoding: 10026 10026 2978
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90639,8 +93647,9 @@ SplineSet
  505.594 1076.06 505.594 1076.06 616.5 1076.06 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni272B
-Encoding: 10027 10027 10027
+Encoding: 10027 10027 2979
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90676,8 +93685,9 @@ SplineSet
  616.5 1070 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272C
-Encoding: 10028 10028 10028
+Encoding: 10028 10028 2980
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90724,8 +93734,9 @@ SplineSet
  616.5 1083.74 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272D
-Encoding: 10029 10029 10029
+Encoding: 10029 10029 2981
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90766,8 +93777,9 @@ SplineSet
  616.5 1080 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272E
-Encoding: 10030 10030 10030
+Encoding: 10030 10030 2982
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90808,8 +93820,9 @@ SplineSet
  616.5 820 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni272F
-Encoding: 10031 10031 10031
+Encoding: 10031 10031 2983
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90848,8 +93861,9 @@ SplineSet
  616.5 1086.43 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2730
-Encoding: 10032 10032 10032
+Encoding: 10032 10032 2984
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90883,8 +93897,9 @@ SplineSet
  559.547 909.375 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2731
-Encoding: 10033 10033 10033
+Encoding: 10033 10033 2985
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90911,8 +93926,9 @@ SplineSet
  492.75 790.773 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2732
-Encoding: 10034 10034 10034
+Encoding: 10034 10034 2986
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90946,8 +93962,9 @@ SplineSet
  436.5 559.75 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2733
-Encoding: 10035 10035 10035
+Encoding: 10035 10035 2987
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -90980,8 +93997,9 @@ SplineSet
  709.43 527.91 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2734
-Encoding: 10036 10036 10036
+Encoding: 10036 10036 2988
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91006,8 +94024,9 @@ SplineSet
  616.5 1146 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2735
-Encoding: 10037 10037 10037
+Encoding: 10037 10037 2989
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91064,8 +94083,9 @@ SplineSet
  616.5 1157.77 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2736
-Encoding: 10038 10038 10038
+Encoding: 10038 10038 2990
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91086,8 +94106,9 @@ SplineSet
  616.5 1279.38 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2737
-Encoding: 10039 10039 10039
+Encoding: 10039 10039 2991
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91112,8 +94133,9 @@ SplineSet
  616.499 1138.44 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2738
-Encoding: 10040 10040 10040
+Encoding: 10040 10040 2992
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91138,8 +94160,9 @@ SplineSet
  616.5 1157.91 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2739
-Encoding: 10041 10041 10041
+Encoding: 10041 10041 2993
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91172,8 +94195,9 @@ SplineSet
  616.5 1127.25 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni273A
-Encoding: 10042 10042 10042
+Encoding: 10042 10042 2994
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91230,8 +94254,9 @@ SplineSet
  570.797 800 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273B
-Encoding: 10043 10043 10043
+Encoding: 10043 10043 2995
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91328,8 +94353,9 @@ SplineSet
  568.922 757.695 568.922 757.695 574.664 760.156 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273C
-Encoding: 10044 10044 10044
+Encoding: 10044 10044 2996
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91443,8 +94469,9 @@ SplineSet
  569.375 747.562 569.375 747.562 575.062 750 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273D
-Encoding: 10045 10045 10045
+Encoding: 10045 10045 2997
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91513,8 +94540,9 @@ SplineSet
  530.469 613.646 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni273E
-Encoding: 10046 10046 10046
+Encoding: 10046 10046 2998
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91634,8 +94662,9 @@ SplineSet
  843.25 485.769 843.25 485.769 785.949 500 c 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni273F
-Encoding: 10047 10047 10047
+Encoding: 10047 10047 2999
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91717,8 +94746,9 @@ SplineSet
  818.244 808.656 818.244 808.656 812.812 798.569 c 1,4,5
 EndSplineSet
 EndChar
+
 StartChar: uni2740
-Encoding: 10048 10048 10048
+Encoding: 10048 10048 3000
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -91862,8 +94892,9 @@ SplineSet
  893.682 527.473 893.682 527.473 891.299 510 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2741
-Encoding: 10049 10049 10049
+Encoding: 10049 10049 3001
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92169,8 +95200,9 @@ SplineSet
  644.141 807.139 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2742
-Encoding: 10050 10050 10050
+Encoding: 10050 10050 3002
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92246,8 +95278,9 @@ SplineSet
  616.5 1123.25 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2743
-Encoding: 10051 10051 10051
+Encoding: 10051 10051 3003
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92376,8 +95409,9 @@ SplineSet
  836.482 541.685 836.482 541.685 780.891 557.25 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2744
-Encoding: 10052 10052 10052
+Encoding: 10052 10052 3004
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92452,8 +95486,9 @@ SplineSet
  512.906 685.062 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2745
-Encoding: 10053 10053 10053
+Encoding: 10053 10053 3005
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92522,8 +95557,9 @@ SplineSet
  665.06 515 l 1,50,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2746
-Encoding: 10054 10054 10054
+Encoding: 10054 10054 3006
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92598,8 +95634,9 @@ SplineSet
  568.562 1215.31 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2747
-Encoding: 10055 10055 10055
+Encoding: 10055 10055 3007
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92692,8 +95729,9 @@ SplineSet
  1143.29 960.151 1143.29 960.151 1160.88 924.938 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2748
-Encoding: 10056 10056 10056
+Encoding: 10056 10056 3008
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92782,8 +95820,9 @@ SplineSet
  824.982 511.552 824.982 511.552 779.66 554.607 c 1,104,105
 EndSplineSet
 EndChar
+
 StartChar: uni2749
-Encoding: 10057 10057 10057
+Encoding: 10057 10057 3009
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92872,8 +95911,9 @@ SplineSet
  976.344 692.312 976.344 692.312 1019.22 692.312 c 152,-1,105
 EndSplineSet
 EndChar
+
 StartChar: uni274A
-Encoding: 10058 10058 10058
+Encoding: 10058 10058 3010
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -92970,8 +96010,9 @@ SplineSet
  647.891 -21.4375 647.891 -21.4375 616.5 -21.4375 c 128,-1,30
 EndSplineSet
 EndChar
+
 StartChar: uni274B
-Encoding: 10059 10059 10059
+Encoding: 10059 10059 3011
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93044,8 +96085,9 @@ SplineSet
  583.785 1050.28 583.785 1050.28 616.5 1050.28 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni274D
-Encoding: 10061 10061 10061
+Encoding: 10061 10061 3012
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93079,8 +96121,9 @@ SplineSet
  633.562 -10.1484 633.562 -10.1484 615.789 -8.72656 c 0,14,15
 EndSplineSet
 EndChar
+
 StartChar: uni274F
-Encoding: 10063 10063 10063
+Encoding: 10063 10063 3013
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93102,8 +96145,9 @@ SplineSet
  138 6.3125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2750
-Encoding: 10064 10064 10064
+Encoding: 10064 10064 3014
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93125,8 +96169,9 @@ SplineSet
  1101.72 69.8516 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2751
-Encoding: 10065 10065 10065
+Encoding: 10065 10065 3015
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93146,8 +96191,9 @@ SplineSet
  56.8125 -0.703125 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2752
-Encoding: 10066 10066 10066
+Encoding: 10066 10066 3016
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93167,8 +96213,9 @@ SplineSet
  1113.15 0.989258 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2756
-Encoding: 10070 10070 10070
+Encoding: 10070 10070 3017
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93196,8 +96243,9 @@ SplineSet
  358.484 254.031 l 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2758
-Encoding: 10072 10072 10072
+Encoding: 10072 10072 3018
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93210,8 +96258,9 @@ SplineSet
  693.85 1435.92 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2759
-Encoding: 10073 10073 10073
+Encoding: 10073 10073 3019
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93224,8 +96273,9 @@ SplineSet
  771.2 1433 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275A
-Encoding: 10074 10074 10074
+Encoding: 10074 10074 3020
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93238,8 +96288,9 @@ SplineSet
  895.3 1386.98 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275B
-Encoding: 10075 10075 10075
+Encoding: 10075 10075 3021
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93255,8 +96306,9 @@ SplineSet
  755.895 975.215 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275C
-Encoding: 10076 10076 10076
+Encoding: 10076 10076 3022
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93272,26 +96324,29 @@ SplineSet
  467.812 1478.5 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni275D
-Encoding: 10077 10077 10077
+Encoding: 10077 10077 3023
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10075 10075 N 1 0 0 1 221 0 2
-Refer: 10075 10075 N 1 0 0 1 -221 0 2
+Refer: 3021 10075 N 1 0 0 1 221 0 2
+Refer: 3021 10075 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni275E
-Encoding: 10078 10078 10078
+Encoding: 10078 10078 3024
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10076 10076 N 1 0 0 1 221 0 2
-Refer: 10076 10076 N 1 0 0 1 -221 0 2
+Refer: 3022 10076 N 1 0 0 1 221 0 2
+Refer: 3022 10076 N 1 0 0 1 -221 0 2
 EndChar
+
 StartChar: uni2761
-Encoding: 10081 10081 10081
+Encoding: 10081 10081 3025
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93351,8 +96406,9 @@ SplineSet
  738.781 619.188 l 9,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2762
-Encoding: 10082 10082 10082
+Encoding: 10082 10082 3026
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93390,8 +96446,9 @@ SplineSet
  566.125 449.875 566.125 449.875 616.5 449.875 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2763
-Encoding: 10083 10083 10083
+Encoding: 10083 10083 3027
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93437,8 +96494,9 @@ SplineSet
  566.125 459.375 566.125 459.375 616.5 459.375 c 128,-1,1
 EndSplineSet
 EndChar
+
 StartChar: uni2764
-Encoding: 10084 10084 10084
+Encoding: 10084 10084 3028
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93467,8 +96525,9 @@ SplineSet
  720.855 299.188 720.855 299.188 616.5 105 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2765
-Encoding: 10085 10085 10085
+Encoding: 10085 10085 3029
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93497,8 +96556,9 @@ SplineSet
  910.5 769.25 910.5 769.25 1118.75 650.25 c 1,29,30
 EndSplineSet
 EndChar
+
 StartChar: uni2766
-Encoding: 10086 10086 10086
+Encoding: 10086 10086 3030
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93562,8 +96622,9 @@ SplineSet
  824.094 798.625 824.094 798.625 758.281 810 c 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2767
-Encoding: 10087 10087 10087
+Encoding: 10087 10087 3031
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93614,8 +96675,9 @@ SplineSet
  839.531 307.688 839.531 307.688 724.156 307.688 c 0,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2768
-Encoding: 10088 10088 10088
+Encoding: 10088 10088 3032
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93642,8 +96704,9 @@ SplineSet
  992.688 -100.812 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni2769
-Encoding: 10089 10089 10089
+Encoding: 10089 10089 3033
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93670,8 +96733,9 @@ SplineSet
  391.438 -100.625 391.438 -100.625 240.312 -100.625 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276A
-Encoding: 10090 10090 10090
+Encoding: 10090 10090 3034
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93690,8 +96754,9 @@ SplineSet
  874.469 1361.38 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276B
-Encoding: 10091 10091 10091
+Encoding: 10091 10091 3035
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93710,8 +96775,9 @@ SplineSet
  471.993 1134.7 471.993 1134.7 366.469 1315.82 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni276C
-Encoding: 10092 10092 10092
+Encoding: 10092 10092 3036
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93726,8 +96792,9 @@ SplineSet
  909.23 -130.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276D
-Encoding: 10093 10093 10093
+Encoding: 10093 10093 3037
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93742,8 +96809,9 @@ SplineSet
  324.135 -130.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276E
-Encoding: 10094 10094 10094
+Encoding: 10094 10094 3038
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93758,8 +96826,9 @@ SplineSet
  1022.38 -169.04 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni276F
-Encoding: 10095 10095 10095
+Encoding: 10095 10095 3039
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93774,8 +96843,9 @@ SplineSet
  210.62 -169.04 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2770
-Encoding: 10096 10096 10096
+Encoding: 10096 10096 3040
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93790,8 +96860,9 @@ SplineSet
  1027.32 -190.36 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2771
-Encoding: 10097 10097 10097
+Encoding: 10097 10097 3041
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93806,8 +96877,9 @@ SplineSet
  206.09 -189.68 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2772
-Encoding: 10098 10098 10098
+Encoding: 10098 10098 3042
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93824,8 +96896,9 @@ SplineSet
  580.42 -0.0996094 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2773
-Encoding: 10099 10099 10099
+Encoding: 10099 10099 3043
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93842,8 +96915,9 @@ SplineSet
  652.58 1121.92 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2774
-Encoding: 10100 10100 10100
+Encoding: 10100 10100 3044
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93881,8 +96955,9 @@ SplineSet
  951.73 -198.35 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2775
-Encoding: 10101 10101 10101
+Encoding: 10101 10101 3045
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93920,8 +96995,9 @@ SplineSet
  249.51 -204.12 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2794
-Encoding: 10132 10132 10132
+Encoding: 10132 10132 3046
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93939,8 +97015,9 @@ SplineSet
  1149.35 650 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2798
-Encoding: 10136 10136 10136
+Encoding: 10136 10136 3047
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93956,8 +97033,9 @@ SplineSet
  783.625 393.875 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2799
-Encoding: 10137 10137 10137
+Encoding: 10137 10137 3048
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93973,8 +97051,9 @@ SplineSet
  815.206 680.234 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279A
-Encoding: 10138 10138 10138
+Encoding: 10138 10138 3049
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -93990,8 +97069,9 @@ SplineSet
  870.25 860.75 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279B
-Encoding: 10139 10139 10139
+Encoding: 10139 10139 3050
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94007,8 +97087,9 @@ SplineSet
  45.5918 750.703 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279C
-Encoding: 10140 10140 10140
+Encoding: 10140 10140 3051
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94051,8 +97132,9 @@ SplineSet
  1159.5 710 1159.5 710 1159.5 691.25 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni279D
-Encoding: 10141 10141 10141
+Encoding: 10141 10141 3052
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94068,8 +97150,9 @@ SplineSet
  837.957 721.562 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279E
-Encoding: 10142 10142 10142
+Encoding: 10142 10142 3053
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94085,8 +97168,9 @@ SplineSet
  853.775 626.211 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni279F
-Encoding: 10143 10143 10143
+Encoding: 10143 10143 3054
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94117,8 +97201,9 @@ SplineSet
  850.125 551.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A0
-Encoding: 10144 10144 10144
+Encoding: 10144 10144 3055
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94149,8 +97234,9 @@ SplineSet
  126.31 510.328 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A1
-Encoding: 10145 10145 10145
+Encoding: 10145 10145 3056
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94166,8 +97252,9 @@ SplineSet
  837.957 557.812 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A2
-Encoding: 10146 10146 10146
+Encoding: 10146 10146 3057
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94184,8 +97271,9 @@ SplineSet
  433.5 710 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A3
-Encoding: 10147 10147 10147
+Encoding: 10147 10147 3058
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94202,8 +97290,9 @@ SplineSet
  443.03 740 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A4
-Encoding: 10148 10148 10148
+Encoding: 10148 10148 3059
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94216,8 +97305,9 @@ SplineSet
  371.938 750 l 25,6,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A5
-Encoding: 10149 10149 10149
+Encoding: 10149 10149 3060
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94241,8 +97331,9 @@ SplineSet
  54.375 689 54.375 689 54.375 725 c 10,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A6
-Encoding: 10150 10150 10150
+Encoding: 10150 10150 3061
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94266,8 +97357,9 @@ SplineSet
  54.375 755 l 18,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni27A7
-Encoding: 10151 10151 10151
+Encoding: 10151 10151 3062
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94283,8 +97375,9 @@ SplineSet
  613.125 530 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A8
-Encoding: 10152 10152 10152
+Encoding: 10152 10152 3063
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94300,8 +97393,9 @@ SplineSet
  737.625 905 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27A9
-Encoding: 10153 10153 10153
+Encoding: 10153 10153 3064
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94327,8 +97421,9 @@ SplineSet
  663.777 589.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AA
-Encoding: 10154 10154 10154
+Encoding: 10154 10154 3065
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94354,8 +97449,9 @@ SplineSet
  770.418 529.141 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AB
-Encoding: 10155 10155 10155
+Encoding: 10155 10155 3066
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94384,8 +97480,9 @@ SplineSet
  748.38 552.203 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AC
-Encoding: 10156 10156 10156
+Encoding: 10156 10156 3067
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94414,8 +97511,9 @@ SplineSet
  738.237 619.59 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AD
-Encoding: 10157 10157 10157
+Encoding: 10157 10157 3068
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94443,8 +97541,9 @@ SplineSet
  643.875 547.5 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AE
-Encoding: 10158 10158 10158
+Encoding: 10158 10158 3069
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94472,8 +97571,9 @@ SplineSet
  646.159 730 l 25,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27AF
-Encoding: 10159 10159 10159
+Encoding: 10159 10159 3070
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94504,8 +97604,9 @@ SplineSet
  232.125 775 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B1
-Encoding: 10161 10161 10161
+Encoding: 10161 10161 3071
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94536,8 +97637,9 @@ SplineSet
  226.118 625 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B2
-Encoding: 10162 10162 10162
+Encoding: 10162 10162 3072
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94566,8 +97668,9 @@ SplineSet
  145.247 935 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27B3
-Encoding: 10163 10163 10163
+Encoding: 10163 10163 3073
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94629,8 +97732,9 @@ SplineSet
  263.877 590 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B4
-Encoding: 10164 10164 10164
+Encoding: 10164 10164 3074
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94658,8 +97762,9 @@ SplineSet
  393.472 955.375 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B5
-Encoding: 10165 10165 10165
+Encoding: 10165 10165 3075
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94685,8 +97790,9 @@ SplineSet
  225.84 698.438 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B6
-Encoding: 10166 10166 10166
+Encoding: 10166 10166 3076
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94714,8 +97820,9 @@ SplineSet
  347.156 406.875 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B7
-Encoding: 10167 10167 10167
+Encoding: 10167 10167 3077
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94752,8 +97859,9 @@ SplineSet
  1118.32 309.875 1118.32 309.875 1154.19 185.625 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B8
-Encoding: 10168 10168 10168
+Encoding: 10168 10168 3078
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94788,8 +97896,9 @@ SplineSet
  1050.23 692.328 1050.23 692.328 1190.34 615 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27B9
-Encoding: 10169 10169 10169
+Encoding: 10169 10169 3079
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94826,8 +97935,9 @@ SplineSet
  999.593 1140.88 999.593 1140.88 1115.78 1175 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27BA
-Encoding: 10170 10170 10170
+Encoding: 10170 10170 3080
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94874,8 +97984,9 @@ SplineSet
  906.375 725.75 906.375 725.75 770.625 785.75 c 24,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27BB
-Encoding: 10171 10171 10171
+Encoding: 10171 10171 3081
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94909,8 +98020,9 @@ SplineSet
  889.5 623.312 889.5 623.312 919.562 655 c 1,10,11
 EndSplineSet
 EndChar
+
 StartChar: uni27BC
-Encoding: 10172 10172 10172
+Encoding: 10172 10172 3082
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -94983,8 +98095,9 @@ SplineSet
  1195 697.312 1195 697.312 1195 690 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BD
-Encoding: 10173 10173 10173
+Encoding: 10173 10173 3083
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95057,8 +98170,9 @@ SplineSet
  1195 690.312 1195 690.312 1195 683 c 152,-1,21
 EndSplineSet
 EndChar
+
 StartChar: uni27BE
-Encoding: 10174 10174 10174
+Encoding: 10174 10174 3084
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95097,16 +98211,18 @@ SplineSet
  653.89 945.203 l 17,32,33
 EndSplineSet
 EndChar
+
 StartChar: uni27C2
-Encoding: 10178 10178 10178
+Encoding: 10178 10178 3085
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8869 8869 N 1 0 0 1 0 0 2
+Refer: 2366 8869 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni27C5
-Encoding: 10181 10181 10181
+Encoding: 10181 10181 3086
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95131,8 +98247,9 @@ SplineSet
  922 -334 l 17,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27C6
-Encoding: 10182 10182 10182
+Encoding: 10182 10182 3087
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95157,8 +98274,9 @@ SplineSet
  320 -334 320 -334 311 -334 c 9,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni27DC
-Encoding: 10204 10204 10204
+Encoding: 10204 10204 3088
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95187,8 +98305,9 @@ SplineSet
  176 589 176 589 215.5 549 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: uni27E0
-Encoding: 10208 10208 10208
+Encoding: 10208 10208 3089
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95209,8 +98328,9 @@ SplineSet
  616 -233 l 1,7,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E6
-Encoding: 10214 10214 10214
+Encoding: 10214 10214 3090
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95232,8 +98352,9 @@ SplineSet
  297 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E7
-Encoding: 10215 10215 10215
+Encoding: 10215 10215 3091
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95255,8 +98376,9 @@ SplineSet
  936 1556 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E8
-Encoding: 10216 10216 10216
+Encoding: 10216 10216 3092
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95271,8 +98393,9 @@ SplineSet
  390.609 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27E9
-Encoding: 10217 10217 10217
+Encoding: 10217 10217 3093
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95287,26 +98410,29 @@ SplineSet
  842.391 642 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27EA
-Encoding: 10218 10218 10218
+Encoding: 10218 10218 3094
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10216 10216 N 1 0 0 1 190 0 2
-Refer: 10216 10216 N 1 0 0 1 -200 0 2
+Refer: 3092 10216 N 1 0 0 1 190 0 2
+Refer: 3092 10216 N 1 0 0 1 -200 0 2
 EndChar
+
 StartChar: uni27EB
-Encoding: 10219 10219 10219
+Encoding: 10219 10219 3095
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 10217 10217 N 1 0 0 1 200 0 2
-Refer: 10217 10217 N 1 0 0 1 -200 0 2
+Refer: 3093 10217 N 1 0 0 1 200 0 2
+Refer: 3093 10217 N 1 0 0 1 -200 0 2
 EndChar
+
 StartChar: uni27F5
-Encoding: 10229 10229 10229
+Encoding: 10229 10229 3096
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95325,8 +98451,9 @@ SplineSet
  -100 602 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F6
-Encoding: 10230 10230 10230
+Encoding: 10230 10230 3097
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95345,8 +98472,9 @@ SplineSet
  1333 520 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni27F7
-Encoding: 10231 10231 10231
+Encoding: 10231 10231 3098
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -95371,1544 +98499,1801 @@ SplineSet
  1333 520 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2800
-Encoding: 10240 10240 10240
+Encoding: 10240 10240 3099
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2801
-Encoding: 10241 10241 10241
+Encoding: 10241 10241 3100
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2802
-Encoding: 10242 10242 10242
+Encoding: 10242 10242 3101
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2803
-Encoding: 10243 10243 10243
+Encoding: 10243 10243 3102
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2804
-Encoding: 10244 10244 10244
+Encoding: 10244 10244 3103
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2805
-Encoding: 10245 10245 10245
+Encoding: 10245 10245 3104
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2806
-Encoding: 10246 10246 10246
+Encoding: 10246 10246 3105
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2807
-Encoding: 10247 10247 10247
+Encoding: 10247 10247 3106
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2808
-Encoding: 10248 10248 10248
+Encoding: 10248 10248 3107
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2809
-Encoding: 10249 10249 10249
+Encoding: 10249 10249 3108
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280A
-Encoding: 10250 10250 10250
+Encoding: 10250 10250 3109
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280B
-Encoding: 10251 10251 10251
+Encoding: 10251 10251 3110
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280C
-Encoding: 10252 10252 10252
+Encoding: 10252 10252 3111
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280D
-Encoding: 10253 10253 10253
+Encoding: 10253 10253 3112
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280E
-Encoding: 10254 10254 10254
+Encoding: 10254 10254 3113
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni280F
-Encoding: 10255 10255 10255
+Encoding: 10255 10255 3114
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2810
-Encoding: 10256 10256 10256
+Encoding: 10256 10256 3115
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2811
-Encoding: 10257 10257 10257
+Encoding: 10257 10257 3116
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2812
-Encoding: 10258 10258 10258
+Encoding: 10258 10258 3117
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2813
-Encoding: 10259 10259 10259
+Encoding: 10259 10259 3118
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2814
-Encoding: 10260 10260 10260
+Encoding: 10260 10260 3119
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2815
-Encoding: 10261 10261 10261
+Encoding: 10261 10261 3120
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2816
-Encoding: 10262 10262 10262
+Encoding: 10262 10262 3121
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2817
-Encoding: 10263 10263 10263
+Encoding: 10263 10263 3122
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2818
-Encoding: 10264 10264 10264
+Encoding: 10264 10264 3123
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2819
-Encoding: 10265 10265 10265
+Encoding: 10265 10265 3124
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281A
-Encoding: 10266 10266 10266
+Encoding: 10266 10266 3125
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281B
-Encoding: 10267 10267 10267
+Encoding: 10267 10267 3126
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281C
-Encoding: 10268 10268 10268
+Encoding: 10268 10268 3127
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281D
-Encoding: 10269 10269 10269
+Encoding: 10269 10269 3128
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281E
-Encoding: 10270 10270 10270
+Encoding: 10270 10270 3129
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni281F
-Encoding: 10271 10271 10271
+Encoding: 10271 10271 3130
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2820
-Encoding: 10272 10272 10272
+Encoding: 10272 10272 3131
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2821
-Encoding: 10273 10273 10273
+Encoding: 10273 10273 3132
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2822
-Encoding: 10274 10274 10274
+Encoding: 10274 10274 3133
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2823
-Encoding: 10275 10275 10275
+Encoding: 10275 10275 3134
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2824
-Encoding: 10276 10276 10276
+Encoding: 10276 10276 3135
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2825
-Encoding: 10277 10277 10277
+Encoding: 10277 10277 3136
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2826
-Encoding: 10278 10278 10278
+Encoding: 10278 10278 3137
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2827
-Encoding: 10279 10279 10279
+Encoding: 10279 10279 3138
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2828
-Encoding: 10280 10280 10280
+Encoding: 10280 10280 3139
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2829
-Encoding: 10281 10281 10281
+Encoding: 10281 10281 3140
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282A
-Encoding: 10282 10282 10282
+Encoding: 10282 10282 3141
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282B
-Encoding: 10283 10283 10283
+Encoding: 10283 10283 3142
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282C
-Encoding: 10284 10284 10284
+Encoding: 10284 10284 3143
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282D
-Encoding: 10285 10285 10285
+Encoding: 10285 10285 3144
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282E
-Encoding: 10286 10286 10286
+Encoding: 10286 10286 3145
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni282F
-Encoding: 10287 10287 10287
+Encoding: 10287 10287 3146
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2830
-Encoding: 10288 10288 10288
+Encoding: 10288 10288 3147
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2831
-Encoding: 10289 10289 10289
+Encoding: 10289 10289 3148
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2832
-Encoding: 10290 10290 10290
+Encoding: 10290 10290 3149
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2833
-Encoding: 10291 10291 10291
+Encoding: 10291 10291 3150
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2834
-Encoding: 10292 10292 10292
+Encoding: 10292 10292 3151
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2835
-Encoding: 10293 10293 10293
+Encoding: 10293 10293 3152
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2836
-Encoding: 10294 10294 10294
+Encoding: 10294 10294 3153
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2837
-Encoding: 10295 10295 10295
+Encoding: 10295 10295 3154
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2838
-Encoding: 10296 10296 10296
+Encoding: 10296 10296 3155
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2839
-Encoding: 10297 10297 10297
+Encoding: 10297 10297 3156
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283A
-Encoding: 10298 10298 10298
+Encoding: 10298 10298 3157
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283B
-Encoding: 10299 10299 10299
+Encoding: 10299 10299 3158
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283C
-Encoding: 10300 10300 10300
+Encoding: 10300 10300 3159
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283D
-Encoding: 10301 10301 10301
+Encoding: 10301 10301 3160
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283E
-Encoding: 10302 10302 10302
+Encoding: 10302 10302 3161
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni283F
-Encoding: 10303 10303 10303
+Encoding: 10303 10303 3162
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2840
-Encoding: 10304 10304 10304
+Encoding: 10304 10304 3163
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2841
-Encoding: 10305 10305 10305
+Encoding: 10305 10305 3164
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2842
-Encoding: 10306 10306 10306
+Encoding: 10306 10306 3165
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2843
-Encoding: 10307 10307 10307
+Encoding: 10307 10307 3166
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2844
-Encoding: 10308 10308 10308
+Encoding: 10308 10308 3167
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2845
-Encoding: 10309 10309 10309
+Encoding: 10309 10309 3168
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2846
-Encoding: 10310 10310 10310
+Encoding: 10310 10310 3169
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2847
-Encoding: 10311 10311 10311
+Encoding: 10311 10311 3170
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2848
-Encoding: 10312 10312 10312
+Encoding: 10312 10312 3171
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2849
-Encoding: 10313 10313 10313
+Encoding: 10313 10313 3172
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284A
-Encoding: 10314 10314 10314
+Encoding: 10314 10314 3173
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284B
-Encoding: 10315 10315 10315
+Encoding: 10315 10315 3174
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284C
-Encoding: 10316 10316 10316
+Encoding: 10316 10316 3175
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284D
-Encoding: 10317 10317 10317
+Encoding: 10317 10317 3176
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284E
-Encoding: 10318 10318 10318
+Encoding: 10318 10318 3177
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni284F
-Encoding: 10319 10319 10319
+Encoding: 10319 10319 3178
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2850
-Encoding: 10320 10320 10320
+Encoding: 10320 10320 3179
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2851
-Encoding: 10321 10321 10321
+Encoding: 10321 10321 3180
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2852
-Encoding: 10322 10322 10322
+Encoding: 10322 10322 3181
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2853
-Encoding: 10323 10323 10323
+Encoding: 10323 10323 3182
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2854
-Encoding: 10324 10324 10324
+Encoding: 10324 10324 3183
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2855
-Encoding: 10325 10325 10325
+Encoding: 10325 10325 3184
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2856
-Encoding: 10326 10326 10326
+Encoding: 10326 10326 3185
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2857
-Encoding: 10327 10327 10327
+Encoding: 10327 10327 3186
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2858
-Encoding: 10328 10328 10328
+Encoding: 10328 10328 3187
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2859
-Encoding: 10329 10329 10329
+Encoding: 10329 10329 3188
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285A
-Encoding: 10330 10330 10330
+Encoding: 10330 10330 3189
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285B
-Encoding: 10331 10331 10331
+Encoding: 10331 10331 3190
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285C
-Encoding: 10332 10332 10332
+Encoding: 10332 10332 3191
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285D
-Encoding: 10333 10333 10333
+Encoding: 10333 10333 3192
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285E
-Encoding: 10334 10334 10334
+Encoding: 10334 10334 3193
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni285F
-Encoding: 10335 10335 10335
+Encoding: 10335 10335 3194
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2860
-Encoding: 10336 10336 10336
+Encoding: 10336 10336 3195
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2861
-Encoding: 10337 10337 10337
+Encoding: 10337 10337 3196
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2862
-Encoding: 10338 10338 10338
+Encoding: 10338 10338 3197
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2863
-Encoding: 10339 10339 10339
+Encoding: 10339 10339 3198
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2864
-Encoding: 10340 10340 10340
+Encoding: 10340 10340 3199
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2865
-Encoding: 10341 10341 10341
+Encoding: 10341 10341 3200
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2866
-Encoding: 10342 10342 10342
+Encoding: 10342 10342 3201
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2867
-Encoding: 10343 10343 10343
+Encoding: 10343 10343 3202
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2868
-Encoding: 10344 10344 10344
+Encoding: 10344 10344 3203
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2869
-Encoding: 10345 10345 10345
+Encoding: 10345 10345 3204
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286A
-Encoding: 10346 10346 10346
+Encoding: 10346 10346 3205
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286B
-Encoding: 10347 10347 10347
+Encoding: 10347 10347 3206
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286C
-Encoding: 10348 10348 10348
+Encoding: 10348 10348 3207
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286D
-Encoding: 10349 10349 10349
+Encoding: 10349 10349 3208
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286E
-Encoding: 10350 10350 10350
+Encoding: 10350 10350 3209
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni286F
-Encoding: 10351 10351 10351
+Encoding: 10351 10351 3210
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2870
-Encoding: 10352 10352 10352
+Encoding: 10352 10352 3211
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2871
-Encoding: 10353 10353 10353
+Encoding: 10353 10353 3212
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2872
-Encoding: 10354 10354 10354
+Encoding: 10354 10354 3213
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2873
-Encoding: 10355 10355 10355
+Encoding: 10355 10355 3214
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2874
-Encoding: 10356 10356 10356
+Encoding: 10356 10356 3215
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2875
-Encoding: 10357 10357 10357
+Encoding: 10357 10357 3216
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2876
-Encoding: 10358 10358 10358
+Encoding: 10358 10358 3217
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2877
-Encoding: 10359 10359 10359
+Encoding: 10359 10359 3218
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2878
-Encoding: 10360 10360 10360
+Encoding: 10360 10360 3219
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2879
-Encoding: 10361 10361 10361
+Encoding: 10361 10361 3220
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287A
-Encoding: 10362 10362 10362
+Encoding: 10362 10362 3221
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287B
-Encoding: 10363 10363 10363
+Encoding: 10363 10363 3222
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287C
-Encoding: 10364 10364 10364
+Encoding: 10364 10364 3223
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287D
-Encoding: 10365 10365 10365
+Encoding: 10365 10365 3224
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287E
-Encoding: 10366 10366 10366
+Encoding: 10366 10366 3225
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni287F
-Encoding: 10367 10367 10367
+Encoding: 10367 10367 3226
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2880
-Encoding: 10368 10368 10368
+Encoding: 10368 10368 3227
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2881
-Encoding: 10369 10369 10369
+Encoding: 10369 10369 3228
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2882
-Encoding: 10370 10370 10370
+Encoding: 10370 10370 3229
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2883
-Encoding: 10371 10371 10371
+Encoding: 10371 10371 3230
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2884
-Encoding: 10372 10372 10372
+Encoding: 10372 10372 3231
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2885
-Encoding: 10373 10373 10373
+Encoding: 10373 10373 3232
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2886
-Encoding: 10374 10374 10374
+Encoding: 10374 10374 3233
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2887
-Encoding: 10375 10375 10375
+Encoding: 10375 10375 3234
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2888
-Encoding: 10376 10376 10376
+Encoding: 10376 10376 3235
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2889
-Encoding: 10377 10377 10377
+Encoding: 10377 10377 3236
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288A
-Encoding: 10378 10378 10378
+Encoding: 10378 10378 3237
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288B
-Encoding: 10379 10379 10379
+Encoding: 10379 10379 3238
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288C
-Encoding: 10380 10380 10380
+Encoding: 10380 10380 3239
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288D
-Encoding: 10381 10381 10381
+Encoding: 10381 10381 3240
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288E
-Encoding: 10382 10382 10382
+Encoding: 10382 10382 3241
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni288F
-Encoding: 10383 10383 10383
+Encoding: 10383 10383 3242
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2890
-Encoding: 10384 10384 10384
+Encoding: 10384 10384 3243
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2891
-Encoding: 10385 10385 10385
+Encoding: 10385 10385 3244
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2892
-Encoding: 10386 10386 10386
+Encoding: 10386 10386 3245
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2893
-Encoding: 10387 10387 10387
+Encoding: 10387 10387 3246
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2894
-Encoding: 10388 10388 10388
+Encoding: 10388 10388 3247
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2895
-Encoding: 10389 10389 10389
+Encoding: 10389 10389 3248
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2896
-Encoding: 10390 10390 10390
+Encoding: 10390 10390 3249
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2897
-Encoding: 10391 10391 10391
+Encoding: 10391 10391 3250
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2898
-Encoding: 10392 10392 10392
+Encoding: 10392 10392 3251
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2899
-Encoding: 10393 10393 10393
+Encoding: 10393 10393 3252
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289A
-Encoding: 10394 10394 10394
+Encoding: 10394 10394 3253
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289B
-Encoding: 10395 10395 10395
+Encoding: 10395 10395 3254
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289C
-Encoding: 10396 10396 10396
+Encoding: 10396 10396 3255
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289D
-Encoding: 10397 10397 10397
+Encoding: 10397 10397 3256
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289E
-Encoding: 10398 10398 10398
+Encoding: 10398 10398 3257
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni289F
-Encoding: 10399 10399 10399
+Encoding: 10399 10399 3258
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A0
-Encoding: 10400 10400 10400
+Encoding: 10400 10400 3259
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A1
-Encoding: 10401 10401 10401
+Encoding: 10401 10401 3260
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A2
-Encoding: 10402 10402 10402
+Encoding: 10402 10402 3261
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A3
-Encoding: 10403 10403 10403
+Encoding: 10403 10403 3262
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A4
-Encoding: 10404 10404 10404
+Encoding: 10404 10404 3263
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A5
-Encoding: 10405 10405 10405
+Encoding: 10405 10405 3264
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A6
-Encoding: 10406 10406 10406
+Encoding: 10406 10406 3265
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A7
-Encoding: 10407 10407 10407
+Encoding: 10407 10407 3266
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A8
-Encoding: 10408 10408 10408
+Encoding: 10408 10408 3267
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28A9
-Encoding: 10409 10409 10409
+Encoding: 10409 10409 3268
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AA
-Encoding: 10410 10410 10410
+Encoding: 10410 10410 3269
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AB
-Encoding: 10411 10411 10411
+Encoding: 10411 10411 3270
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AC
-Encoding: 10412 10412 10412
+Encoding: 10412 10412 3271
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AD
-Encoding: 10413 10413 10413
+Encoding: 10413 10413 3272
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AE
-Encoding: 10414 10414 10414
+Encoding: 10414 10414 3273
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28AF
-Encoding: 10415 10415 10415
+Encoding: 10415 10415 3274
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B0
-Encoding: 10416 10416 10416
+Encoding: 10416 10416 3275
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B1
-Encoding: 10417 10417 10417
+Encoding: 10417 10417 3276
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B2
-Encoding: 10418 10418 10418
+Encoding: 10418 10418 3277
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B3
-Encoding: 10419 10419 10419
+Encoding: 10419 10419 3278
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B4
-Encoding: 10420 10420 10420
+Encoding: 10420 10420 3279
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B5
-Encoding: 10421 10421 10421
+Encoding: 10421 10421 3280
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B6
-Encoding: 10422 10422 10422
+Encoding: 10422 10422 3281
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B7
-Encoding: 10423 10423 10423
+Encoding: 10423 10423 3282
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B8
-Encoding: 10424 10424 10424
+Encoding: 10424 10424 3283
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28B9
-Encoding: 10425 10425 10425
+Encoding: 10425 10425 3284
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BA
-Encoding: 10426 10426 10426
+Encoding: 10426 10426 3285
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BB
-Encoding: 10427 10427 10427
+Encoding: 10427 10427 3286
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BC
-Encoding: 10428 10428 10428
+Encoding: 10428 10428 3287
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BD
-Encoding: 10429 10429 10429
+Encoding: 10429 10429 3288
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BE
-Encoding: 10430 10430 10430
+Encoding: 10430 10430 3289
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28BF
-Encoding: 10431 10431 10431
+Encoding: 10431 10431 3290
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C0
-Encoding: 10432 10432 10432
+Encoding: 10432 10432 3291
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C1
-Encoding: 10433 10433 10433
+Encoding: 10433 10433 3292
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C2
-Encoding: 10434 10434 10434
+Encoding: 10434 10434 3293
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C3
-Encoding: 10435 10435 10435
+Encoding: 10435 10435 3294
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C4
-Encoding: 10436 10436 10436
+Encoding: 10436 10436 3295
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C5
-Encoding: 10437 10437 10437
+Encoding: 10437 10437 3296
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C6
-Encoding: 10438 10438 10438
+Encoding: 10438 10438 3297
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C7
-Encoding: 10439 10439 10439
+Encoding: 10439 10439 3298
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C8
-Encoding: 10440 10440 10440
+Encoding: 10440 10440 3299
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28C9
-Encoding: 10441 10441 10441
+Encoding: 10441 10441 3300
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CA
-Encoding: 10442 10442 10442
+Encoding: 10442 10442 3301
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CB
-Encoding: 10443 10443 10443
+Encoding: 10443 10443 3302
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CC
-Encoding: 10444 10444 10444
+Encoding: 10444 10444 3303
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CD
-Encoding: 10445 10445 10445
+Encoding: 10445 10445 3304
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CE
-Encoding: 10446 10446 10446
+Encoding: 10446 10446 3305
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28CF
-Encoding: 10447 10447 10447
+Encoding: 10447 10447 3306
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D0
-Encoding: 10448 10448 10448
+Encoding: 10448 10448 3307
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D1
-Encoding: 10449 10449 10449
+Encoding: 10449 10449 3308
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D2
-Encoding: 10450 10450 10450
+Encoding: 10450 10450 3309
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D3
-Encoding: 10451 10451 10451
+Encoding: 10451 10451 3310
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D4
-Encoding: 10452 10452 10452
+Encoding: 10452 10452 3311
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D5
-Encoding: 10453 10453 10453
+Encoding: 10453 10453 3312
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D6
-Encoding: 10454 10454 10454
+Encoding: 10454 10454 3313
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D7
-Encoding: 10455 10455 10455
+Encoding: 10455 10455 3314
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D8
-Encoding: 10456 10456 10456
+Encoding: 10456 10456 3315
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28D9
-Encoding: 10457 10457 10457
+Encoding: 10457 10457 3316
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DA
-Encoding: 10458 10458 10458
+Encoding: 10458 10458 3317
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DB
-Encoding: 10459 10459 10459
+Encoding: 10459 10459 3318
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DC
-Encoding: 10460 10460 10460
+Encoding: 10460 10460 3319
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DD
-Encoding: 10461 10461 10461
+Encoding: 10461 10461 3320
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DE
-Encoding: 10462 10462 10462
+Encoding: 10462 10462 3321
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28DF
-Encoding: 10463 10463 10463
+Encoding: 10463 10463 3322
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E0
-Encoding: 10464 10464 10464
+Encoding: 10464 10464 3323
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E1
-Encoding: 10465 10465 10465
+Encoding: 10465 10465 3324
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E2
-Encoding: 10466 10466 10466
+Encoding: 10466 10466 3325
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E3
-Encoding: 10467 10467 10467
+Encoding: 10467 10467 3326
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E4
-Encoding: 10468 10468 10468
+Encoding: 10468 10468 3327
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E5
-Encoding: 10469 10469 10469
+Encoding: 10469 10469 3328
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E6
-Encoding: 10470 10470 10470
+Encoding: 10470 10470 3329
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E7
-Encoding: 10471 10471 10471
+Encoding: 10471 10471 3330
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E8
-Encoding: 10472 10472 10472
+Encoding: 10472 10472 3331
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28E9
-Encoding: 10473 10473 10473
+Encoding: 10473 10473 3332
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EA
-Encoding: 10474 10474 10474
+Encoding: 10474 10474 3333
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EB
-Encoding: 10475 10475 10475
+Encoding: 10475 10475 3334
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EC
-Encoding: 10476 10476 10476
+Encoding: 10476 10476 3335
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28ED
-Encoding: 10477 10477 10477
+Encoding: 10477 10477 3336
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EE
-Encoding: 10478 10478 10478
+Encoding: 10478 10478 3337
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28EF
-Encoding: 10479 10479 10479
+Encoding: 10479 10479 3338
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F0
-Encoding: 10480 10480 10480
+Encoding: 10480 10480 3339
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F1
-Encoding: 10481 10481 10481
+Encoding: 10481 10481 3340
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F2
-Encoding: 10482 10482 10482
+Encoding: 10482 10482 3341
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F3
-Encoding: 10483 10483 10483
+Encoding: 10483 10483 3342
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F4
-Encoding: 10484 10484 10484
+Encoding: 10484 10484 3343
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F5
-Encoding: 10485 10485 10485
+Encoding: 10485 10485 3344
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F6
-Encoding: 10486 10486 10486
+Encoding: 10486 10486 3345
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F7
-Encoding: 10487 10487 10487
+Encoding: 10487 10487 3346
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F8
-Encoding: 10488 10488 10488
+Encoding: 10488 10488 3347
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28F9
-Encoding: 10489 10489 10489
+Encoding: 10489 10489 3348
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FA
-Encoding: 10490 10490 10490
+Encoding: 10490 10490 3349
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FB
-Encoding: 10491 10491 10491
+Encoding: 10491 10491 3350
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FC
-Encoding: 10492 10492 10492
+Encoding: 10492 10492 3351
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FD
-Encoding: 10493 10493 10493
+Encoding: 10493 10493 3352
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FE
-Encoding: 10494 10494 10494
+Encoding: 10494 10494 3353
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni28FF
-Encoding: 10495 10495 10495
+Encoding: 10495 10495 3354
 Width: 2048
 LayerCount: 2
 Colour: ff00
 EndChar
+
 StartChar: uni2987
-Encoding: 10631 10631 10631
+Encoding: 10631 10631 3355
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96928,8 +100313,9 @@ SplineSet
  833 1373 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2988
-Encoding: 10632 10632 10632
+Encoding: 10632 10632 3356
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96949,8 +100335,9 @@ SplineSet
  400 -89 l 1,7,8
 EndSplineSet
 EndChar
+
 StartChar: uni2997
-Encoding: 10647 10647 10647
+Encoding: 10647 10647 3357
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96967,8 +100354,9 @@ SplineSet
  882 -322 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2998
-Encoding: 10648 10648 10648
+Encoding: 10648 10648 3358
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96985,8 +100373,9 @@ SplineSet
  351 1608 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29EB
-Encoding: 10731 10731 10731
+Encoding: 10731 10731 3359
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -96999,8 +100388,9 @@ SplineSet
  616 1653 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FA
-Encoding: 10746 10746 10746
+Encoding: 10746 10746 3360
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97029,8 +100419,9 @@ SplineSet
  732 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni29FB
-Encoding: 10747 10747 10747
+Encoding: 10747 10747 3361
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97067,8 +100458,9 @@ SplineSet
  202 727 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2A00
-Encoding: 10752 10752 10752
+Encoding: 10752 10752 3362
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97091,35 +100483,39 @@ SplineSet
  80 1547 80 1547 616 1547 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: uni2A2F
-Encoding: 10799 10799 10799
+Encoding: 10799 10799 3363
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 215 215 N 1 0 0 1 0 0 2
+Refer: 151 215 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni2A6A
-Encoding: 10858 10858 10858
+Encoding: 10858 10858 3364
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 2 292 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 2 292 2
 EndChar
+
 StartChar: uni2A6B
-Encoding: 10859 10859 10859
+Encoding: 10859 10859 3365
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 242 292 2
-Refer: 8901 8901 N 1 0 0 1 -239 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 242 292 2
+Refer: 2375 8901 N 1 0 0 1 -239 -425 2
 EndChar
+
 StartChar: uni2B05
-Encoding: 11013 11013 11013
+Encoding: 11013 11013 3366
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97135,8 +100531,9 @@ SplineSet
  395 842 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B06
-Encoding: 11014 11014 11014
+Encoding: 11014 11014 3367
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97152,8 +100549,9 @@ SplineSet
  759 921 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B07
-Encoding: 11015 11015 11015
+Encoding: 11015 11015 3368
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97169,8 +100567,9 @@ SplineSet
  474 479 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B08
-Encoding: 11016 11016 11016
+Encoding: 11016 11016 3369
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97186,8 +100585,9 @@ SplineSet
  874 756 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B09
-Encoding: 11017 11017 11017
+Encoding: 11017 11017 3370
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97203,8 +100603,9 @@ SplineSet
  560 957 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0A
-Encoding: 11018 11018 11018
+Encoding: 11018 11018 3371
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97220,8 +100621,9 @@ SplineSet
  773 342 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0B
-Encoding: 11019 11019 11019
+Encoding: 11019 11019 3372
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97237,8 +100639,9 @@ SplineSet
  259 543 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0C
-Encoding: 11020 11020 11020
+Encoding: 11020 11020 3373
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97257,8 +100660,9 @@ SplineSet
  395 842 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B0D
-Encoding: 11021 11021 11021
+Encoding: 11021 11021 3374
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97277,8 +100681,9 @@ SplineSet
  474 479 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2B12
-Encoding: 11026 11026 11026
+Encoding: 11026 11026 3375
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97296,8 +100701,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B13
-Encoding: 11027 11027 11027
+Encoding: 11027 11027 3376
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97315,8 +100721,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B14
-Encoding: 11028 11028 11028
+Encoding: 11028 11028 3377
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97333,8 +100740,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B15
-Encoding: 11029 11029 11029
+Encoding: 11029 11029 3378
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97351,8 +100759,9 @@ SplineSet
  6 -78.5 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B16
-Encoding: 11030 11030 11030
+Encoding: 11030 11030 3379
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97369,8 +100778,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B17
-Encoding: 11031 11031 11031
+Encoding: 11031 11031 3380
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97387,8 +100797,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B18
-Encoding: 11032 11032 11032
+Encoding: 11032 11032 3381
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97405,8 +100816,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B19
-Encoding: 11033 11033 11033
+Encoding: 11033 11033 3382
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97423,8 +100835,9 @@ SplineSet
  6 532 l 25,0,0
 EndSplineSet
 EndChar
+
 StartChar: uni2B1A
-Encoding: 11034 11034 11034
+Encoding: 11034 11034 3383
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97500,8 +100913,9 @@ SplineSet
  206 1142.5 l 1,66,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C64
-Encoding: 11364 11364 11364
+Encoding: 11364 11364 3384
 Width: 1233
 Flags: W
 AnchorPoint: "above" 566 1493 basechar 0
@@ -97543,8 +100957,9 @@ SplineSet
  346 1327 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6D
-Encoding: 11373 11373 11373
+Encoding: 11373 11373 3385
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97575,8 +100990,9 @@ SplineSet
  317 1047.18 317 1047.18 317 745.5 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C6E
-Encoding: 11374 11374 11374
+Encoding: 11374 11374 3386
 Width: 1233
 Flags: W
 AnchorPoint: "below" 676 -426 basechar 0
@@ -97607,8 +101023,9 @@ SplineSet
  958 1319 l 17,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C6F
-Encoding: 11375 11375 11375
+Encoding: 11375 11375 3387
 Width: 1233
 Flags: W
 AnchorPoint: "above" 617 1493 basechar 0
@@ -97631,8 +101048,9 @@ SplineSet
  739 0 l 1,3,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C70
-Encoding: 11376 11376 11376
+Encoding: 11376 11376 3388
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97663,8 +101081,9 @@ SplineSet
  895 443.821 895 443.821 895 745.5 c 0,20,21
 EndSplineSet
 EndChar
+
 StartChar: uni2C75
-Encoding: 11381 11381 11381
+Encoding: 11381 11381 3389
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97681,8 +101100,9 @@ SplineSet
  137 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C76
-Encoding: 11382 11382 11382
+Encoding: 11382 11382 3390
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97699,8 +101119,9 @@ SplineSet
  379 515 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C77
-Encoding: 11383 11383 11383
+Encoding: 11383 11383 3391
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97732,8 +101153,9 @@ SplineSet
  525 1128 525 1128 773 1128 c 8,11,12
 EndSplineSet
 EndChar
+
 StartChar: uni2C79
-Encoding: 11385 11385 11385
+Encoding: 11385 11385 3392
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1556 basechar 0
@@ -97764,8 +101186,9 @@ SplineSet
  945 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7A
-Encoding: 11386 11386 11386
+Encoding: 11386 11386 3393
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 0 basechar 0
@@ -97803,16 +101226,18 @@ SplineSet
  901 498 901 498 901 559 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni2C7C
-Encoding: 11388 11388 11388
+Encoding: 11388 11388 3394
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 690 690 N 1 0 0 1 0 -668 3
+Refer: 607 690 N 1 0 0 1 0 -668 3
 EndChar
+
 StartChar: uni2C7D
-Encoding: 11389 11389 11389
+Encoding: 11389 11389 3395
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97828,8 +101253,9 @@ SplineSet
  616 763 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7E
-Encoding: 11390 11390 11390
+Encoding: 11390 11390 3396
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1493 basechar 0
@@ -97881,8 +101307,9 @@ SplineSet
  907 1481 907 1481 1012 1442 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2C7F
-Encoding: 11391 11391 11391
+Encoding: 11391 11391 3397
 Width: 1233
 Flags: W
 AnchorPoint: "above" 666 1493 basechar 0
@@ -97917,8 +101344,9 @@ SplineSet
  156 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18
-Encoding: 11800 11800 11800
+Encoding: 11800 11800 3398
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97955,17 +101383,19 @@ SplineSet
 EndSplineSet
 Substitution2: "'case' Case-Sensitive Forms" uni2E18.case
 EndChar
+
 StartChar: uni2E1F
-Encoding: 11807 11807 11807
+Encoding: 11807 11807 3399
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 8764 8764 N 1 0 0 1 0 0 2
-Refer: 8901 8901 N 1 0 0 1 1 -425 2
+Refer: 2268 8764 N 1 0 0 1 0 0 2
+Refer: 2375 8901 N 1 0 0 1 1 -425 2
 EndChar
+
 StartChar: uni2E22
-Encoding: 11810 11810 11810
+Encoding: 11810 11810 3400
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97980,8 +101410,9 @@ SplineSet
  463 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E23
-Encoding: 11811 11811 11811
+Encoding: 11811 11811 3401
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -97996,8 +101427,9 @@ SplineSet
  586 1413 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E24
-Encoding: 11812 11812 11812
+Encoding: 11812 11812 3402
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98012,8 +101444,9 @@ SplineSet
  647 -127 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E25
-Encoding: 11813 11813 11813
+Encoding: 11813 11813 3403
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98028,16 +101461,18 @@ SplineSet
  770 -270 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E2E
-Encoding: 11822 11822 11822
+Encoding: 11822 11822 3404
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1567 1567 N 1 0 0 1 0 0 2
+Refer: 1167 1567 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniA708
-Encoding: 42760 42760 42760
+Encoding: 42760 42760 3405
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98055,8 +101490,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA709
-Encoding: 42761 42761 42761
+Encoding: 42761 42761 3406
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98074,8 +101510,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70A
-Encoding: 42762 42762 42762
+Encoding: 42762 42762 3407
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98093,8 +101530,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70B
-Encoding: 42763 42763 42763
+Encoding: 42763 42763 3408
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98112,8 +101550,9 @@ SplineSet
  797 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70C
-Encoding: 42764 42764 42764
+Encoding: 42764 42764 3409
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98131,8 +101570,9 @@ SplineSet
  797 1368 l 1,1,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70D
-Encoding: 42765 42765 42765
+Encoding: 42765 42765 3410
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98150,8 +101590,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70E
-Encoding: 42766 42766 42766
+Encoding: 42766 42766 3411
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98169,8 +101610,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA70F
-Encoding: 42767 42767 42767
+Encoding: 42767 42767 3412
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98188,8 +101630,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA710
-Encoding: 42768 42768 42768
+Encoding: 42768 42768 3413
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98207,8 +101650,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA711
-Encoding: 42769 42769 42769
+Encoding: 42769 42769 3414
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98226,8 +101670,9 @@ SplineSet
  436 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA712
-Encoding: 42770 42770 42770
+Encoding: 42770 42770 3415
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98242,8 +101687,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA713
-Encoding: 42771 42771 42771
+Encoding: 42771 42771 3416
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98260,8 +101706,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA714
-Encoding: 42772 42772 42772
+Encoding: 42772 42772 3417
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98278,8 +101725,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA715
-Encoding: 42773 42773 42773
+Encoding: 42773 42773 3418
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98296,8 +101744,9 @@ SplineSet
  436 0 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA716
-Encoding: 42774 42774 42774
+Encoding: 42774 42774 3419
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98312,8 +101761,9 @@ SplineSet
  436 136 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71B
-Encoding: 42779 42779 42779
+Encoding: 42779 42779 3420
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98332,8 +101782,9 @@ SplineSet
  588 1508 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71C
-Encoding: 42780 42780 42780
+Encoding: 42780 42780 3421
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98352,8 +101803,9 @@ SplineSet
  646 664 l 9,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71D
-Encoding: 42781 42781 42781
+Encoding: 42781 42781 3422
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98373,8 +101825,9 @@ SplineSet
  552 1504 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71E
-Encoding: 42782 42782 42782
+Encoding: 42782 42782 3423
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98394,16 +101847,18 @@ SplineSet
  680 668 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA71F
-Encoding: 42783 42783 42783
+Encoding: 42783 42783 3424
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 42782 42782 N 1 0 0 1 0 -668 2
+Refer: 3423 42782 N 1 0 0 1 0 -668 2
 EndChar
+
 StartChar: uniA722
-Encoding: 42786 42786 42786
+Encoding: 42786 42786 3425
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98423,8 +101878,9 @@ SplineSet
  961 0 961 0 391 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA723
-Encoding: 42787 42787 42787
+Encoding: 42787 42787 3426
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98444,8 +101900,9 @@ SplineSet
  936 0 936 0 416 0 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA724
-Encoding: 42788 42788 42788
+Encoding: 42788 42788 3427
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98460,8 +101917,9 @@ SplineSet
  421 1301 421 1301 421 973 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA725
-Encoding: 42789 42789 42789
+Encoding: 42789 42789 3428
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98476,8 +101934,9 @@ SplineSet
  421 958 421 958 421 600 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA726
-Encoding: 42790 42790 42790
+Encoding: 42790 42790 3429
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -98507,8 +101966,9 @@ SplineSet
  1096 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA727
-Encoding: 42791 42791 42791
+Encoding: 42791 42791 3430
 Width: 1233
 Flags: W
 AnchorPoint: "below" 616 -426 basechar 0
@@ -98542,16 +102002,18 @@ SplineSet
  866 694 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA789
-Encoding: 42889 42889 42889
+Encoding: 42889 42889 3431
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 58 58 N 1 0 0 1 0 0 3
+Refer: 27 58 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78A
-Encoding: 42890 42890 42890
+Encoding: 42890 42890 3432
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98569,8 +102031,9 @@ SplineSet
  842 629 l 25,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78B
-Encoding: 42891 42891 42891
+Encoding: 42891 42891 3433
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98585,8 +102048,9 @@ SplineSet
  516 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78C
-Encoding: 42892 42892 42892
+Encoding: 42892 42892 3434
 Width: 1233
 Flags: W
 TtInstrs:
@@ -98619,16 +102083,18 @@ SplineSet
  702 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA78D
-Encoding: 42893 42893 42893
+Encoding: 42893 42893 3435
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1063 1063 N 1 0 0 1 0 0 3
+Refer: 877 1063 N 1 0 0 1 0 0 3
 EndChar
+
 StartChar: uniA78E
-Encoding: 42894 42894 42894
+Encoding: 42894 42894 3436
 Width: 1233
 Flags: W
 AnchorPoint: "below" 617 -426 basechar 0
@@ -98665,8 +102131,9 @@ SplineSet
  498 786 l 1,26,27
 EndSplineSet
 EndChar
+
 StartChar: uniA790
-Encoding: 42896 42896 42896
+Encoding: 42896 42896 3437
 Width: 1233
 Flags: W
 AnchorPoint: "above" 561 1493 basechar 0
@@ -98691,8 +102158,9 @@ SplineSet
  84 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA791
-Encoding: 42897 42897 42897
+Encoding: 42897 42897 3438
 Width: 1233
 Flags: W
 AnchorPoint: "below" 543 0 basechar 0
@@ -98723,8 +102191,9 @@ SplineSet
  978 922 978 922 978 694 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7AA
-Encoding: 42922 42922 42922
+Encoding: 42922 42922 3439
 Width: 1233
 Flags: W
 AnchorPoint: "below" 768 0 basechar 0
@@ -98755,8 +102224,9 @@ SplineSet
  338 1327 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F8
-Encoding: 43000 43000 43000
+Encoding: 43000 43000 3440
 Width: 1233
 Flags: W
 AnchorPoint: "above" 616 1504 basechar 0
@@ -98793,8 +102263,9 @@ SplineSet
  442 1287 l 1,20,-1
 EndSplineSet
 EndChar
+
 StartChar: uniA7F9
-Encoding: 43001 43001 43001
+Encoding: 43001 43001 3441
 Width: 1233
 Flags: W
 AnchorPoint: "below" 619 668 basechar 0
@@ -98844,8 +102315,9 @@ SplineSet
  1054 1038 l 1,49,50
 EndSplineSet
 EndChar
+
 StartChar: uniF6C5
-Encoding: 63173 63173 63173
+Encoding: 63173 63173 3442
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -98881,8 +102353,9 @@ SplineSet
  478.101 1146.41 478.101 1146.41 616 1147 c 0,12,13
 EndSplineSet
 EndChar
+
 StartChar: fi
-Encoding: 64257 64257 64257
+Encoding: 64257 64257 3443
 Width: 1233
 Flags: W
 TtInstrs:
@@ -98995,11 +102468,12 @@ SplineSet
  405 1556 405 1556 584 1556 c 2,25,-1
  776 1556 l 1,4,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 10" f i
 EndChar
+
 StartChar: fl
-Encoding: 64258 64258 64258
+Encoding: 64258 64258 3444
 Width: 1233
 Flags: W
 TtInstrs:
@@ -99095,593 +102569,647 @@ SplineSet
  405 1556 405 1556 584 1556 c 2,21,-1
  1079 1556 l 1,0,-1
 EndSplineSet
-LCarets2: 1 0 
+LCarets2: 1 0
 Ligature2: "'dlig' Discretionary Ligatures in Latin lookup 10" f l
 EndChar
+
 StartChar: uniFB52
-Encoding: 64338 64338 64338
+Encoding: 64338 64338 3445
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 617.5 -600 basechar 0
 AnchorPoint: "rtl-above" 617.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 542.5 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 542.5 -250 2
 EndChar
+
 StartChar: uniFB53
-Encoding: 64339 64339 64339
+Encoding: 64339 64339 3446
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 582.5 -600 basechar 0
 AnchorPoint: "rtl-above" 582.5 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 507.5 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 507.5 -250 2
 EndChar
+
 StartChar: uniFB54
-Encoding: 64340 64340 64340
+Encoding: 64340 64340 3447
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -550 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 524 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 524 -250 2
 EndChar
+
 StartChar: uniFB55
-Encoding: 64341 64341 64341
+Encoding: 64341 64341 3448
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -550 basechar 0
 AnchorPoint: "rtl-above" 599 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 524 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 524 -250 2
 EndChar
+
 StartChar: uniFB56
-Encoding: 64342 64342 64342
+Encoding: 64342 64342 3449
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 645 -600 basechar 0
 AnchorPoint: "rtl-above" 645 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 445 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 445 -250 2
 EndChar
+
 StartChar: uniFB57
-Encoding: 64343 64343 64343
+Encoding: 64343 64343 3450
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 576 -600 basechar 0
 AnchorPoint: "rtl-above" 576 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 376 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 376 -250 2
 EndChar
+
 StartChar: uniFB58
-Encoding: 64344 64344 64344
+Encoding: 64344 64344 3451
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -550 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 396 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 396 -250 2
 EndChar
+
 StartChar: uniFB59
-Encoding: 64345 64345 64345
+Encoding: 64345 64345 3452
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 593 -550 basechar 0
 AnchorPoint: "rtl-above" 596 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 396 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 396 -250 2
 EndChar
+
 StartChar: uniFB5A
-Encoding: 64346 64346 64346
+Encoding: 64346 64346 3453
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -600 basechar 0
 AnchorPoint: "rtl-above" 603 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 403 -250 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 403 -250 2
 EndChar
+
 StartChar: uniFB5B
-Encoding: 64347 64347 64347
+Encoding: 64347 64347 3454
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 570 -600 basechar 0
 AnchorPoint: "rtl-above" 570 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 370 -250 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 370 -250 2
 EndChar
+
 StartChar: uniFB5C
-Encoding: 64348 64348 64348
+Encoding: 64348 64348 3455
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 578 -550 basechar 0
 AnchorPoint: "rtl-above" 578 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 378 -250 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 378 -250 2
 EndChar
+
 StartChar: uniFB5D
-Encoding: 64349 64349 64349
+Encoding: 64349 64349 3456
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 608 -550 basechar 0
 AnchorPoint: "rtl-above" 608 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 408 -250 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 408 -250 2
 EndChar
+
 StartChar: uniFB5E
-Encoding: 64350 64350 64350
+Encoding: 64350 64350 3457
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 642 -150 basechar 0
 AnchorPoint: "rtl-above" 642 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 567 807 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 567 807 2
 EndChar
+
 StartChar: uniFB5F
-Encoding: 64351 64351 64351
+Encoding: 64351 64351 3458
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 588 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 513 813 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 513 813 2
 EndChar
+
 StartChar: uniFB60
-Encoding: 64352 64352 64352
+Encoding: 64352 64352 3459
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -101 basechar 0
 AnchorPoint: "rtl-above" 603 1299 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 528 994 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 528 994 2
 EndChar
+
 StartChar: uniFB61
-Encoding: 64353 64353 64353
+Encoding: 64353 64353 3460
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 602 -100 basechar 0
 AnchorPoint: "rtl-above" 602 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 527 983 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 527 983 2
 EndChar
+
 StartChar: uniFB62
-Encoding: 64354 64354 64354
+Encoding: 64354 64354 3461
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -150 basechar 0
 AnchorPoint: "rtl-above" 603 1181 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 403 900 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 403 900 2
 EndChar
+
 StartChar: uniFB63
-Encoding: 64355 64355 64355
+Encoding: 64355 64355 3462
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 585 -150 basechar 0
 AnchorPoint: "rtl-above" 585 1199 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 385 900 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 385 900 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB64
-Encoding: 64356 64356 64356
+Encoding: 64356 64356 3463
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 599 -100 basechar 0
 AnchorPoint: "rtl-above" 599 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 399 995 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 399 995 2
 EndChar
+
 StartChar: uniFB65
-Encoding: 64357 64357 64357
+Encoding: 64357 64357 3464
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -100 basechar 0
 AnchorPoint: "rtl-above" 596 1300 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 396 998 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 396 998 2
 EndChar
+
 StartChar: uniFB66
-Encoding: 64358 64358 64358
+Encoding: 64358 64358 3465
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -150 basechar 0
 AnchorPoint: "rtl-above" 588 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 76 -666 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 76 -666 2
 EndChar
+
 StartChar: uniFB67
-Encoding: 64359 64359 64359
+Encoding: 64359 64359 3466
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -150 basechar 0
 AnchorPoint: "rtl-above" 564 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 52 -681 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 52 -681 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB68
-Encoding: 64360 64360 64360
+Encoding: 64360 64360 3467
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 587 -100 basechar 0
 AnchorPoint: "rtl-above" 587 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 75 -508 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 75 -508 2
 EndChar
+
 StartChar: uniFB69
-Encoding: 64361 64361 64361
+Encoding: 64361 64361 3468
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 605 -100 basechar 0
 AnchorPoint: "rtl-above" 605 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1557 1557 N 1 0 0 1 93 -493 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 93 -493 2
 EndChar
+
 StartChar: uniFB6A
-Encoding: 64362 64362 64362
+Encoding: 64362 64362 3469
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 468 -180 basechar 0
 AnchorPoint: "rtl-above" 400 1388 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 628 994 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 628 994 2
 EndChar
+
 StartChar: uniFB6B
-Encoding: 64363 64363 64363
+Encoding: 64363 64363 3470
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 404 -192 basechar 0
 AnchorPoint: "rtl-above" 312 1268 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 644 886 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 644 886 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6C
-Encoding: 64364 64364 64364
+Encoding: 64364 64364 3471
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 500 1600 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 300 1150 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 300 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6D
-Encoding: 64365 64365 64365
+Encoding: 64365 64365 3472
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 598 -150 basechar 0
 AnchorPoint: "rtl-above" 606 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 406 896 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 406 896 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB6E
-Encoding: 64366 64366 64366
+Encoding: 64366 64366 3473
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -200 basechar 0
 AnchorPoint: "rtl-above" 288 1312 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 648 1256 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 648 1256 2
 EndChar
+
 StartChar: uniFB6F
-Encoding: 64367 64367 64367
+Encoding: 64367 64367 3474
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 392 -200 basechar 0
 AnchorPoint: "rtl-above" 264 1252 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 652 1140 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 652 1140 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB70
-Encoding: 64368 64368 64368
+Encoding: 64368 64368 3475
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -150 basechar 0
 AnchorPoint: "rtl-above" 500 1600 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 300 1400 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 300 1400 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB71
-Encoding: 64369 64369 64369
+Encoding: 64369 64369 3476
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 610 -150 basechar 0
 AnchorPoint: "rtl-above" 610 1450 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 410 1162 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 410 1162 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB72
-Encoding: 64370 64370 64370
+Encoding: 64370 64370 3477
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -600 basechar 0
 AnchorPoint: "rtl-above" 466 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 635 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 635 175 2
 EndChar
+
 StartChar: uniFB73
-Encoding: 64371 64371 64371
+Encoding: 64371 64371 3478
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 604 -600 basechar 0
 AnchorPoint: "rtl-above" 442 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114142 -1 N 1 0 0 1 559 125 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 559 125 2
 EndChar
+
 StartChar: uniFB74
-Encoding: 64372 64372 64372
+Encoding: 64372 64372 3479
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 428 -500 basechar 0
 AnchorPoint: "rtl-above" 428 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 353 -200 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 353 -200 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB75
-Encoding: 64373 64373 64373
+Encoding: 64373 64373 3480
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 525 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 525 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB76
-Encoding: 64374 64374 64374
+Encoding: 64374 64374 3481
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -600 basechar 0
 AnchorPoint: "rtl-above" 434 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 650 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 650 25 2
 EndChar
+
 StartChar: uniFB77
-Encoding: 64375 64375 64375
+Encoding: 64375 64375 3482
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -600 basechar 0
 AnchorPoint: "rtl-above" 422 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 550 -25 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 550 -25 2
 EndChar
+
 StartChar: uniFB78
-Encoding: 64376 64376 64376
+Encoding: 64376 64376 3483
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 388 -250 basechar 0
 AnchorPoint: "rtl-above" 388 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 188 -200 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 188 -200 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB79
-Encoding: 64377 64377 64377
+Encoding: 64377 64377 3484
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -250 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7A
-Encoding: 64378 64378 64378
+Encoding: 64378 64378 3485
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -600 basechar 0
 AnchorPoint: "rtl-above" 434 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 554 150 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 554 150 2
 EndChar
+
 StartChar: uniFB7B
-Encoding: 64379 64379 64379
+Encoding: 64379 64379 3486
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -601 basechar 0
 AnchorPoint: "rtl-above" 406 999 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114141 -1 N 1 0 0 1 453 66 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 453 66 2
 EndChar
+
 StartChar: uniFB7C
-Encoding: 64380 64380 64380
+Encoding: 64380 64380 3487
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 440 -540 basechar 0
 AnchorPoint: "rtl-above" 440 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 240 -240 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 240 -240 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7D
-Encoding: 64381 64381 64381
+Encoding: 64381 64381 3488
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB7E
-Encoding: 64382 64382 64382
+Encoding: 64382 64382 3489
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 616 -600 basechar 0
 AnchorPoint: "rtl-above" 454 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 562 175 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 562 175 2
 EndChar
+
 StartChar: uniFB7F
-Encoding: 64383 64383 64383
+Encoding: 64383 64383 3490
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -600 basechar 0
 AnchorPoint: "rtl-above" 450 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 65186 65186 N 1 0 0 1 0 0 2
-Refer: 1114143 -1 N 1 0 0 1 453 94 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 453 94 2
 EndChar
+
 StartChar: uniFB80
-Encoding: 64384 64384 64384
+Encoding: 64384 64384 3491
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 452 -540 basechar 0
 AnchorPoint: "rtl-above" 452 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 252 -240 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 252 -240 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB81
-Encoding: 64385 64385 64385
+Encoding: 64385 64385 3492
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -500 basechar 0
 AnchorPoint: "rtl-above" 600 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114143 -1 N 1 0 0 1 400 -200 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3756 -1 N 1 0 0 1 400 -200 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8A
-Encoding: 64394 64394 64394
+Encoding: 64394 64394 3493
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 623.5 1101.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 720.5 678.5 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 720.5 678.5 2
 EndChar
+
 StartChar: uniFB8B
-Encoding: 64395 64395 64395
+Encoding: 64395 64395 3494
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 700 1250 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 603.5 692 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 603.5 692 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8C
-Encoding: 64396 64396 64396
+Encoding: 64396 64396 3495
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 682 1215.5 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 341 -598.5 2
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 341 -598.5 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8D
-Encoding: 64397 64397 64397
+Encoding: 64397 64397 3496
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -500 basechar 0
 AnchorPoint: "rtl-above" 664 1265 basechar 0
 LayerCount: 2
 Fore
-Refer: 1557 1557 N 1 0 0 1 233 -621 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 1165 1557 N 1 0 0 1 233 -621 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8E
-Encoding: 64398 64398 64398
+Encoding: 64398 64398 3497
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 575 -150 basechar 0
 AnchorPoint: "rtl-above" 545 1364 basechar 0
 LayerCount: 2
 Fore
-Refer: 1705 1705 N 1 0 0 1 0 0 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB8F
-Encoding: 64399 64399 64399
+Encoding: 64399 64399 3498
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 454 -150 basechar 0
@@ -99723,80 +103251,88 @@ SplineSet
  1013 182 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFB90
-Encoding: 64400 64400 64400
+Encoding: 64400 64400 3499
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 511 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65243 65243 N 1 0 0 1 0 0 2
+Refer: 3623 65243 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB91
-Encoding: 64401 64401 64401
+Encoding: 64401 64401 3500
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 497.5 1550 basechar 0
 LayerCount: 2
 Fore
-Refer: 65244 65244 N 1 0 0 1 0 0 2
+Refer: 3624 65244 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB92
-Encoding: 64402 64402 64402
+Encoding: 64402 64402 3501
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596.5 -161 basechar 0
 AnchorPoint: "rtl-above" 396.5 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1705 1705 N 1 0 0 1 0 0 2
-Refer: 1114144 -1 N 1 0 0 1 684 14.5 2
+Refer: 1245 1705 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 684 14.5 2
 EndChar
+
 StartChar: uniFB93
-Encoding: 64403 64403 64403
+Encoding: 64403 64403 3502
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 494 -150 basechar 0
 AnchorPoint: "rtl-above" 243.5 1400 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114144 -1 N 1 0 0 1 596.5 18 2
-Refer: 64399 64399 N 1 0 0 1 0 0 2
+Refer: 3757 -1 N 1 0 0 1 596.5 18 2
+Refer: 3498 64399 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB94
-Encoding: 64404 64404 64404
+Encoding: 64404 64404 3503
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1700 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114145 -1 N 1 0 0 1 143 0 2
-Refer: 64400 64400 N 1 0 0 1 0 0 2
+Refer: 3758 -1 N 1 0 0 1 143 0 2
+Refer: 3499 64400 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB95
-Encoding: 64405 64405 64405
+Encoding: 64405 64405 3504
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -150 basechar 0
 AnchorPoint: "rtl-above" 250 1700 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114145 -1 N 1 0 0 1 156 0 2
-Refer: 64401 64401 N 1 0 0 1 0 0 2
+Refer: 3758 -1 N 1 0 0 1 156 0 2
+Refer: 3500 64401 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB9E
-Encoding: 64414 64414 64414
+Encoding: 64414 64414 3505
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFB9F
-Encoding: 64415 64415 64415
+Encoding: 64415 64415 3506
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99827,18 +103363,20 @@ SplineSet
  1053 -125 1053 -125 968 -265 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBAA
-Encoding: 64426 64426 64426
+Encoding: 64426 64426 3507
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -156 basechar 0
 AnchorPoint: "rtl-above" 596 1152 basechar 0
 LayerCount: 2
 Fore
-Refer: 1726 1726 N 1 0 0 1 0 0 2
+Refer: 1247 1726 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAB
-Encoding: 64427 64427 64427
+Encoding: 64427 64427 3508
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 596 1152 basechar 0
@@ -99888,18 +103426,20 @@ SplineSet
  922 464 922 464 877 508 c 1,55,56
 EndSplineSet
 EndChar
+
 StartChar: uniFBAC
-Encoding: 64428 64428 64428
+Encoding: 64428 64428 3509
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 440 1152 basechar 0
 AnchorPoint: "rtl-below" 440 -156 basechar 0
 LayerCount: 2
 Fore
-Refer: 65259 65259 N 1 0 0 1 0 0 2
+Refer: 3639 65259 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBAD
-Encoding: 64429 64429 64429
+Encoding: 64429 64429 3510
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 528 1152 basechar 0
@@ -99945,8 +103485,9 @@ SplineSet
  818 464 818 464 773 508 c 1,45,46
 EndSplineSet
 EndChar
+
 StartChar: uniFBE8
-Encoding: 64488 64488 64488
+Encoding: 64488 64488 3511
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99965,8 +103506,9 @@ SplineSet
  700 196 700 196 608 86 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBE9
-Encoding: 64489 64489 64489
+Encoding: 64489 64489 3512
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -99990,75 +103532,83 @@ SplineSet
  686 0 686 0 606 86 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFBFC
-Encoding: 64508 64508 64508
+Encoding: 64508 64508 3513
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 588 -400 basechar 0
 AnchorPoint: "rtl-above" 460 806 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFD
-Encoding: 64509 64509 64509
+Encoding: 64509 64509 3514
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 408 -400 basechar 0
 AnchorPoint: "rtl-above" 404 638 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFE
-Encoding: 64510 64510 64510
+Encoding: 64510 64510 3515
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 591 -350 basechar 0
 AnchorPoint: "rtl-above" 591 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 391 -300 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 391 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFBFF
-Encoding: 64511 64511 64511
+Encoding: 64511 64511 3516
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 603 -350 basechar 0
 AnchorPoint: "rtl-above" 603 1000 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 -300 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE70
-Encoding: 65136 65136 65136
+Encoding: 65136 65136 3517
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1611 1611 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE71
-Encoding: 65137 65137 65137
+Encoding: 65137 65137 3518
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1611 1611 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1205 1611 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE72
-Encoding: 65138 65138 65138
+Encoding: 65138 65138 3519
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1612 1612 N 1 0 0 1 0 0 2
+Refer: 1206 1612 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE73
-Encoding: 65139 65139 65139
+Encoding: 65139 65139 3520
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -100077,241 +103627,267 @@ SplineSet
  986 332 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFE74
-Encoding: 65140 65140 65140
+Encoding: 65140 65140 3521
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1613 1613 N 1 0 0 1 0 0 2
+Refer: 1207 1613 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE76
-Encoding: 65142 65142 65142
+Encoding: 65142 65142 3522
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1614 1614 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE77
-Encoding: 65143 65143 65143
+Encoding: 65143 65143 3523
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1614 1614 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1208 1614 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE78
-Encoding: 65144 65144 65144
+Encoding: 65144 65144 3524
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1615 1615 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE79
-Encoding: 65145 65145 65145
+Encoding: 65145 65145 3525
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1615 1615 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1209 1615 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7A
-Encoding: 65146 65146 65146
+Encoding: 65146 65146 3526
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1616 1616 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7B
-Encoding: 65147 65147 65147
+Encoding: 65147 65147 3527
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1616 1616 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1210 1616 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7C
-Encoding: 65148 65148 65148
+Encoding: 65148 65148 3528
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1617 1617 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7D
-Encoding: 65149 65149 65149
+Encoding: 65149 65149 3529
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1600 1600 N 1 0 0 1 0 0 2
-Refer: 1617 1617 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
+Refer: 1211 1617 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7E
-Encoding: 65150 65150 65150
+Encoding: 65150 65150 3530
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1618 1618 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE7F
-Encoding: 65151 65151 65151
+Encoding: 65151 65151 3531
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1618 1618 N 1 0 0 1 0 0 2
-Refer: 1600 1600 N 1 0 0 1 0 0 2
+Refer: 1212 1618 N 1 0 0 1 0 0 2
+Refer: 1194 1600 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE80
-Encoding: 65152 65152 65152
+Encoding: 65152 65152 3532
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 704 28 basechar 0
 AnchorPoint: "rtl-above" 688 1208 basechar 0
 LayerCount: 2
 Fore
-Refer: 1569 1569 N 1 0 0 1 0 0 2
+Refer: 1168 1569 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE81
-Encoding: 65153 65153 65153
+Encoding: 65153 65153 3533
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1619 1619 N 1 0 0 1 0 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
 EndChar
+
 StartChar: uniFE82
-Encoding: 65154 65154 65154
+Encoding: 65154 65154 3534
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 0 450 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 0 450 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE83
-Encoding: 65155 65155 65155
+Encoding: 65155 65155 3535
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 524 2264 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -10 450 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -10 450 2
 EndChar
+
 StartChar: uniFE84
-Encoding: 65156 65156 65156
+Encoding: 65156 65156 3536
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 600 2272 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 39 450 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 39 450 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE85
-Encoding: 65157 65157 65157
+Encoding: 65157 65157 3537
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 652 1360 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 96 -450 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 96 -450 2
 EndChar
+
 StartChar: uniFE86
-Encoding: 65158 65158 65158
+Encoding: 65158 65158 3538
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 600 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 50 -450 2
-Refer: 65262 65262 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 50 -450 2
+Refer: 3642 65262 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE87
-Encoding: 65159 65159 65159
+Encoding: 65159 65159 3539
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
-Refer: 1621 1621 N 1 0 0 1 -7 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -7 0 2
 EndChar
+
 StartChar: uniFE88
-Encoding: 65160 65160 65160
+Encoding: 65160 65160 3540
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 716 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 86 0 2
-Refer: 65166 65166 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 86 0 2
+Refer: 3546 65166 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE89
-Encoding: 65161 65161 65161
+Encoding: 65161 65161 3541
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 384 1240 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1620 1620 N 1 0 0 1 -167 -545 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -167 -545 2
 EndChar
+
 StartChar: uniFE8A
-Encoding: 65162 65162 65162
+Encoding: 65162 65162 3542
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 284 1012 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -284 -792 2
-Refer: 65264 65264 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -284 -792 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8B
-Encoding: 65163 65163 65163
+Encoding: 65163 65163 3543
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 536 -128 basechar 0
 AnchorPoint: "rtl-above" 556 1377 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -22 -400 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -22 -400 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8C
-Encoding: 65164 65164 65164
+Encoding: 65164 65164 3544
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -168 basechar 0
 AnchorPoint: "rtl-above" 580 1382 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 0 -400 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 0 -400 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8D
-Encoding: 65165 65165 65165
+Encoding: 65165 65165 3545
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -136 basechar 0
 AnchorPoint: "rtl-above" 604 1752 basechar 0
 LayerCount: 2
 Fore
-Refer: 1575 1575 N 1 0 0 1 0 0 2
+Refer: 1174 1575 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE8E
-Encoding: 65166 65166 65166
+Encoding: 65166 65166 3546
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 688 -168 basechar 0
@@ -100332,216 +103908,236 @@ SplineSet
  588 193 588 193 588 371 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFE8F
-Encoding: 65167 65167 65167
+Encoding: 65167 65167 3547
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -408 basechar 0
 AnchorPoint: "rtl-above" 616 828 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 539 -350 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 539 -350 2
 EndChar
+
 StartChar: uniFE90
-Encoding: 65168 65168 65168
+Encoding: 65168 65168 3548
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 540 -408 basechar 0
 AnchorPoint: "rtl-above" 528 744 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 465 -350 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 465 -350 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE91
-Encoding: 65169 65169 65169
+Encoding: 65169 65169 3549
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 580 -372 basechar 0
 AnchorPoint: "rtl-above" 524 968 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 504 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 504 -300 2
 EndChar
+
 StartChar: uniFE92
-Encoding: 65170 65170 65170
+Encoding: 65170 65170 3550
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -372 basechar 0
 AnchorPoint: "rtl-above" 604 924 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 532 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 532 -300 2
 EndChar
+
 StartChar: uniFE93
-Encoding: 65171 65171 65171
+Encoding: 65171 65171 3551
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 556 -180 basechar 0
 AnchorPoint: "rtl-above" 516 1224 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 362 900 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 362 900 2
 EndChar
+
 StartChar: uniFE94
-Encoding: 65172 65172 65172
+Encoding: 65172 65172 3552
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 604 1240 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 454 900 2
-Refer: 65258 65258 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 454 900 2
+Refer: 3638 65258 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE95
-Encoding: 65173 65173 65173
+Encoding: 65173 65173 3553
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 604 1012 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 447 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 447 650 2
 EndChar
+
 StartChar: uniFE96
-Encoding: 65174 65174 65174
+Encoding: 65174 65174 3554
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -144 basechar 0
 AnchorPoint: "rtl-above" 560 1044 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 412 650 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 412 650 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE97
-Encoding: 65175 65175 65175
+Encoding: 65175 65175 3555
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 572 -124 basechar 0
 AnchorPoint: "rtl-above" 556 1220 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 850 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE98
-Encoding: 65176 65176 65176
+Encoding: 65176 65176 3556
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -132 basechar 0
 AnchorPoint: "rtl-above" 560 1248 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 850 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 850 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE99
-Encoding: 65177 65177 65177
+Encoding: 65177 65177 3557
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 620 -124 basechar 0
 AnchorPoint: "rtl-above" 576 1264 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 442 650 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 442 650 2
 EndChar
+
 StartChar: uniFE9A
-Encoding: 65178 65178 65178
+Encoding: 65178 65178 3558
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -128 basechar 0
 AnchorPoint: "rtl-above" 556 1280 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 424 650 2
-Refer: 1114136 -1 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 424 650 2
+Refer: 3749 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9B
-Encoding: 65179 65179 65179
+Encoding: 65179 65179 3559
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 584 -132 basechar 0
 AnchorPoint: "rtl-above" 544 1380 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 412 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 412 850 2
 EndChar
+
 StartChar: uniFE9C
-Encoding: 65180 65180 65180
+Encoding: 65180 65180 3560
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 596 -140 basechar 0
 AnchorPoint: "rtl-above" 544 1376 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 411 812 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 411 812 2
 EndChar
+
 StartChar: uniFE9D
-Encoding: 65181 65181 65181
+Encoding: 65181 65181 3561
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 504 1152 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 671 25 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 671 25 2
 EndChar
+
 StartChar: uniFE9E
-Encoding: 65182 65182 65182
+Encoding: 65182 65182 3562
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 468 1148 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 624 -50 2
-Refer: 65186 65186 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 624 -50 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFE9F
-Encoding: 65183 65183 65183
+Encoding: 65183 65183 3563
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 520 -376 basechar 0
 AnchorPoint: "rtl-above" 372 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 -300 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA0
-Encoding: 65184 65184 65184
+Encoding: 65184 65184 3564
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 524 -404 basechar 0
 AnchorPoint: "rtl-above" 352 1072 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 -300 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 -300 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA1
-Encoding: 65185 65185 65185
+Encoding: 65185 65185 3565
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 476 1188 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA2
-Encoding: 65186 65186 65186
+Encoding: 65186 65186 3566
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
@@ -100579,8 +104175,9 @@ SplineSet
  1149 184 1149 184 1233 184 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA3
-Encoding: 65187 65187 65187
+Encoding: 65187 65187 3567
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 316 -124 basechar 0
@@ -100609,8 +104206,9 @@ SplineSet
  750 506 750 506 851 541 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA4
-Encoding: 65188 65188 65188
+Encoding: 65188 65188 3568
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 340 -144 basechar 0
@@ -100646,62 +104244,68 @@ SplineSet
  466 815 466 815 638 780 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEA5
-Encoding: 65189 65189 65189
+Encoding: 65189 65189 3569
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 476 1344 basechar 0
 LayerCount: 2
 Fore
-Refer: 1581 1581 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 476 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 476 1050 2
 EndChar
+
 StartChar: uniFEA6
-Encoding: 65190 65190 65190
+Encoding: 65190 65190 3570
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 512 -624 basechar 0
 AnchorPoint: "rtl-above" 472 1372 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 472 1050 2
-Refer: 65186 65186 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 472 1050 2
+Refer: 3566 65186 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA7
-Encoding: 65191 65191 65191
+Encoding: 65191 65191 3571
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 380 -128 basechar 0
 AnchorPoint: "rtl-above" 288 1248 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 950 2
-Refer: 65187 65187 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 950 2
+Refer: 3567 65187 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA8
-Encoding: 65192 65192 65192
+Encoding: 65192 65192 3572
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 324 -164 basechar 0
 AnchorPoint: "rtl-above" 280 1244 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 525 950 2
-Refer: 65188 65188 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 525 950 2
+Refer: 3568 65188 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEA9
-Encoding: 65193 65193 65193
+Encoding: 65193 65193 3573
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 524 1196 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAA
-Encoding: 65194 65194 65194
+Encoding: 65194 65194 3574
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
@@ -100731,40 +104335,44 @@ SplineSet
  1000 486 1000 486 1000 378 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAB
-Encoding: 65195 65195 65195
+Encoding: 65195 65195 3575
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 520 1364 basechar 0
 LayerCount: 2
 Fore
-Refer: 1583 1583 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 524 1050 2
+Refer: 1182 1583 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 524 1050 2
 EndChar
+
 StartChar: uniFEAC
-Encoding: 65196 65196 65196
+Encoding: 65196 65196 3576
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 568 -164 basechar 0
 AnchorPoint: "rtl-above" 532 1376 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 533 1050 2
-Refer: 65194 65194 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 533 1050 2
+Refer: 3574 65194 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAD
-Encoding: 65197 65197 65197
+Encoding: 65197 65197 3577
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 444 -576 basechar 0
 AnchorPoint: "rtl-above" 576 788 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEAE
-Encoding: 65198 65198 65198
+Encoding: 65198 65198 3578
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 396 -579 basechar 0
@@ -100790,40 +104398,44 @@ SplineSet
  803 414 803 414 750 550 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEAF
-Encoding: 65199 65199 65199
+Encoding: 65199 65199 3579
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 444 -576 basechar 0
 AnchorPoint: "rtl-above" 404 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 861 800 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 861 800 2
 EndChar
+
 StartChar: uniFEB0
-Encoding: 65200 65200 65200
+Encoding: 65200 65200 3580
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 412 -580 basechar 0
 AnchorPoint: "rtl-above" 312 1160 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 751 800 2
-Refer: 65198 65198 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 751 800 2
+Refer: 3578 65198 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB1
-Encoding: 65201 65201 65201
+Encoding: 65201 65201 3581
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 408 -500 basechar 0
 AnchorPoint: "rtl-above" 564 1039 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB2
-Encoding: 65202 65202 65202
+Encoding: 65202 65202 3582
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 344 -496 basechar 0
@@ -100875,8 +104487,9 @@ SplineSet
  895 -29 895 -29 820 -29 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB3
-Encoding: 65203 65203 65203
+Encoding: 65203 65203 3583
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -100917,8 +104530,9 @@ SplineSet
  415 181 415 181 486 181 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB4
-Encoding: 65204 65204 65204
+Encoding: 65204 65204 3584
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 272 -156 basechar 0
@@ -100964,62 +104578,68 @@ SplineSet
  721 594 l 17,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEB5
-Encoding: 65205 65205 65205
+Encoding: 65205 65205 3585
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 348 -484 basechar 0
 AnchorPoint: "rtl-above" 280 1348 basechar 0
 LayerCount: 2
 Fore
-Refer: 1587 1587 N 1 0 0 1 0 0 2
-Refer: 1114135 -1 N 1 0 0 1 310 800 2
+Refer: 1186 1587 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 310 800 2
 EndChar
+
 StartChar: uniFEB6
-Encoding: 65206 65206 65206
+Encoding: 65206 65206 3586
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 265 -488 basechar 0
 AnchorPoint: "rtl-above" 180 1336 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 236 800 2
-Refer: 65202 65202 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 236 800 2
+Refer: 3582 65202 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB7
-Encoding: 65207 65207 65207
+Encoding: 65207 65207 3587
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 304 1352 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 406 800 2
-Refer: 65203 65203 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 406 800 2
+Refer: 3583 65203 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB8
-Encoding: 65208 65208 65208
+Encoding: 65208 65208 3588
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 268 1340 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 338 800 2
-Refer: 65204 65204 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 338 800 2
+Refer: 3584 65204 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEB9
-Encoding: 65209 65209 65209
+Encoding: 65209 65209 3589
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 376 -492 basechar 0
 AnchorPoint: "rtl-above" 324 908 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBA
-Encoding: 65210 65210 65210
+Encoding: 65210 65210 3590
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 324 -495 basechar 0
@@ -101071,8 +104691,9 @@ SplineSet
  1141 495 1141 495 1141 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBB
-Encoding: 65211 65211 65211
+Encoding: 65211 65211 3591
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -101111,8 +104732,9 @@ SplineSet
  562 0 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBC
-Encoding: 65212 65212 65212
+Encoding: 65212 65212 3592
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
@@ -101158,62 +104780,68 @@ SplineSet
  486 0 l 2,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEBD
-Encoding: 65213 65213 65213
+Encoding: 65213 65213 3593
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 332 -496 basechar 0
 AnchorPoint: "rtl-above" 296 1100 basechar 0
 LayerCount: 2
 Fore
-Refer: 1589 1589 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 335 670 2
+Refer: 1188 1589 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 335 670 2
 EndChar
+
 StartChar: uniFEBE
-Encoding: 65214 65214 65214
+Encoding: 65214 65214 3594
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 288 -488 basechar 0
 AnchorPoint: "rtl-above" 208 1112 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 260 670 2
-Refer: 65210 65210 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 260 670 2
+Refer: 3590 65210 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEBF
-Encoding: 65215 65215 65215
+Encoding: 65215 65215 3595
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 300 -148 basechar 0
 AnchorPoint: "rtl-above" 292 1108 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 343 736 2
-Refer: 65211 65211 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 343 736 2
+Refer: 3591 65211 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC0
-Encoding: 65216 65216 65216
+Encoding: 65216 65216 3596
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 260 -148 basechar 0
 AnchorPoint: "rtl-above" 212 1140 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 308 722 2
-Refer: 65212 65212 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 308 722 2
+Refer: 3592 65212 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC1
-Encoding: 65217 65217 65217
+Encoding: 65217 65217 3597
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 240 1752 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC2
-Encoding: 65218 65218 65218
+Encoding: 65218 65218 3598
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 216 -148 basechar 0
@@ -101251,8 +104879,9 @@ SplineSet
  1152 495 1152 495 1152 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC3
-Encoding: 65219 65219 65219
+Encoding: 65219 65219 3599
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
@@ -101284,8 +104913,9 @@ SplineSet
  878 0 878 0 751 0 c 2,13,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEC4
-Encoding: 65220 65220 65220
+Encoding: 65220 65220 3600
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 208 -144 basechar 0
@@ -101323,62 +104953,68 @@ SplineSet
  1152 495 1152 495 1152 374 c 24,13,14
 EndSplineSet
 EndChar
+
 StartChar: uniFEC5
-Encoding: 65221 65221 65221
+Encoding: 65221 65221 3601
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 236 1780 basechar 0
 LayerCount: 2
 Fore
-Refer: 1591 1591 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
+Refer: 1190 1591 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
 EndChar
+
 StartChar: uniFEC6
-Encoding: 65222 65222 65222
+Encoding: 65222 65222 3602
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 208 -152 basechar 0
 AnchorPoint: "rtl-above" 208 1764 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65218 65218 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3598 65218 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC7
-Encoding: 65223 65223 65223
+Encoding: 65223 65223 3603
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 240 -148 basechar 0
 AnchorPoint: "rtl-above" 240 1768 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65219 65219 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3599 65219 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC8
-Encoding: 65224 65224 65224
+Encoding: 65224 65224 3604
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 220 -148 basechar 0
 AnchorPoint: "rtl-above" 200 1760 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 579 768 2
-Refer: 65220 65220 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 579 768 2
+Refer: 3600 65220 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEC9
-Encoding: 65225 65225 65225
+Encoding: 65225 65225 3605
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 388 1328 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECA
-Encoding: 65226 65226 65226
+Encoding: 65226 65226 3606
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
@@ -101421,8 +105057,9 @@ SplineSet
  573 597 573 597 547 597 c 128,-1,46
 EndSplineSet
 EndChar
+
 StartChar: uniFECB
-Encoding: 65227 65227 65227
+Encoding: 65227 65227 3607
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -109 basechar 0
@@ -101451,8 +105088,9 @@ SplineSet
  61 184 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFECC
-Encoding: 65228 65228 65228
+Encoding: 65228 65228 3608
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -115 basechar 0
@@ -101492,150 +105130,164 @@ SplineSet
  642 597 642 597 616 597 c 128,-1,38
 EndSplineSet
 EndChar
+
 StartChar: uniFECD
-Encoding: 65229 65229 65229
+Encoding: 65229 65229 3609
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 388 1584 basechar 0
 LayerCount: 2
 Fore
-Refer: 1593 1593 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 375 1200 2
+Refer: 1192 1593 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 1200 2
 EndChar
+
 StartChar: uniFECE
-Encoding: 65230 65230 65230
+Encoding: 65230 65230 3610
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 378 -553 basechar 0
 AnchorPoint: "rtl-above" 472 1392 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 470 950 2
-Refer: 65226 65226 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 470 950 2
+Refer: 3606 65226 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFECF
-Encoding: 65231 65231 65231
+Encoding: 65231 65231 3611
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 402 -97 basechar 0
 AnchorPoint: "rtl-above" 384 1612 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 375 1200 2
-Refer: 65227 65227 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 1200 2
+Refer: 3607 65227 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED0
-Encoding: 65232 65232 65232
+Encoding: 65232 65232 3612
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -97 basechar 0
 AnchorPoint: "rtl-above" 616 1340 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 539 950 2
-Refer: 65228 65228 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 539 950 2
+Refer: 3608 65228 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED1
-Encoding: 65233 65233 65233
+Encoding: 65233 65233 3613
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 606 -211 basechar 0
 AnchorPoint: "rtl-above" 760 1392 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114156 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 752 1066 2
+Refer: 3769 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 752 1066 2
 EndChar
+
 StartChar: uniFED2
-Encoding: 65234 65234 65234
+Encoding: 65234 65234 3614
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -241 basechar 0
 AnchorPoint: "rtl-above" 760 1272 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 758 950 2
-Refer: 1114140 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 758 950 2
+Refer: 3753 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED3
-Encoding: 65235 65235 65235
+Encoding: 65235 65235 3615
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 414 -139 basechar 0
 AnchorPoint: "rtl-above" 428 1464 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 425 1150 2
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 425 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED4
-Encoding: 65236 65236 65236
+Encoding: 65236 65236 3616
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -127 basechar 0
 AnchorPoint: "rtl-above" 620 1316 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 546 1000 2
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 546 1000 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED5
-Encoding: 65237 65237 65237
+Encoding: 65237 65237 3617
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -487 basechar 0
 AnchorPoint: "rtl-above" 612 1452 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114149 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 605 1150 2
+Refer: 3762 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 605 1150 2
 EndChar
+
 StartChar: uniFED6
-Encoding: 65238 65238 65238
+Encoding: 65238 65238 3618
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 480 -583 basechar 0
 AnchorPoint: "rtl-above" 608 1236 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 590 875 2
-Refer: 1114139 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 590 875 2
+Refer: 3752 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFED7
-Encoding: 65239 65239 65239
+Encoding: 65239 65239 3619
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 312 -115 basechar 0
 AnchorPoint: "rtl-above" 304 1436 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114137 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 300 1150 2
+Refer: 3750 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 300 1150 2
 EndChar
+
 StartChar: uniFED8
-Encoding: 65240 65240 65240
+Encoding: 65240 65240 3620
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -127 basechar 0
 AnchorPoint: "rtl-above" 616 1336 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114138 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 406 1000 2
+Refer: 3751 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 406 1000 2
 EndChar
+
 StartChar: uniFED9
-Encoding: 65241 65241 65241
+Encoding: 65241 65241 3621
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 570 -181 basechar 0
 AnchorPoint: "rtl-above" 572 1544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1603 1603 N 1 0 0 1 0 0 2
+Refer: 1197 1603 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDA
-Encoding: 65242 65242 65242
+Encoding: 65242 65242 3622
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 474 -175 basechar 0
@@ -101686,8 +105338,9 @@ SplineSet
  1059 1556 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDB
-Encoding: 65243 65243 65243
+Encoding: 65243 65243 3623
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 216 -127 basechar 0
@@ -101718,8 +105371,9 @@ SplineSet
  625 0 625 0 402 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDC
-Encoding: 65244 65244 65244
+Encoding: 65244 65244 3624
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 162 -163 basechar 0
@@ -101757,18 +105411,20 @@ SplineSet
  632 0 632 0 412 0 c 2,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDD
-Encoding: 65245 65245 65245
+Encoding: 65245 65245 3625
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -403 basechar 0
 AnchorPoint: "rtl-above" 592 1556 basechar 0
 LayerCount: 2
 Fore
-Refer: 1604 1604 N 1 0 0 1 0 0 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEDE
-Encoding: 65246 65246 65246
+Encoding: 65246 65246 3626
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 510 -415 basechar 0
@@ -101801,8 +105457,9 @@ SplineSet
  1042 1556 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEDF
-Encoding: 65247 65247 65247
+Encoding: 65247 65247 3627
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 612 -121 basechar 0
@@ -101823,8 +105480,9 @@ SplineSet
  1001 371 l 2,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE0
-Encoding: 65248 65248 65248
+Encoding: 65248 65248 3628
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 618 -139 basechar 0
@@ -101850,18 +105508,20 @@ SplineSet
  696 0 696 0 616 86 c 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEE1
-Encoding: 65249 65249 65249
+Encoding: 65249 65249 3629
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 786 -139 basechar 0
 AnchorPoint: "rtl-above" 652 984 basechar 0
 LayerCount: 2
 Fore
-Refer: 1605 1605 N 1 0 0 1 0 0 2
+Refer: 1199 1605 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE2
-Encoding: 65250 65250 65250
+Encoding: 65250 65250 3630
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 684 -349 basechar 0
@@ -101903,8 +105563,9 @@ SplineSet
  994 0 994 0 962 52 c 1,18,19
 EndSplineSet
 EndChar
+
 StartChar: uniFEE3
-Encoding: 65251 65251 65251
+Encoding: 65251 65251 3631
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 582 -235 basechar 0
@@ -101939,8 +105600,9 @@ SplineSet
  416 230 416 230 406 199 c 1,25,26
 EndSplineSet
 EndChar
+
 StartChar: uniFEE4
-Encoding: 65252 65252 65252
+Encoding: 65252 65252 3632
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 600 -217 basechar 0
@@ -101979,62 +105641,68 @@ SplineSet
  440 230 440 230 430 199 c 1,30,31
 EndSplineSet
 EndChar
+
 StartChar: uniFEE5
-Encoding: 65253 65253 65253
+Encoding: 65253 65253 3633
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 510 -427 basechar 0
 AnchorPoint: "rtl-above" 484 1160 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114158 -1 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 467 750 2
+Refer: 3771 -1 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 467 750 2
 EndChar
+
 StartChar: uniFEE6
-Encoding: 65254 65254 65254
+Encoding: 65254 65254 3634
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 391 850 basechar 0
 AnchorPoint: "rtl-below" 450 -571 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114133 -1 N 1 0 0 1 375 537 2
-Refer: 64415 64415 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 375 537 2
+Refer: 3506 64415 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEE7
-Encoding: 65255 65255 65255
+Encoding: 65255 65255 3635
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 544 1133.5 basechar 0
 AnchorPoint: "rtl-below" 576 -127 basechar 0
 LayerCount: 2
 Fore
-Refer: 64488 64488 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 528 850 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 528 850 2
 EndChar
+
 StartChar: uniFEE8
-Encoding: 65256 65256 65256
+Encoding: 65256 65256 3636
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 548.5 1142.5 basechar 0
 AnchorPoint: "rtl-below" 588 -133 basechar 0
 LayerCount: 2
 Fore
-Refer: 64489 64489 N 1 0 0 1 0 0 2
-Refer: 1114133 -1 N 1 0 0 1 533 850 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
+Refer: 3746 -1 N 1 0 0 1 533 850 2
 EndChar
+
 StartChar: uniFEE9
-Encoding: 65257 65257 65257
+Encoding: 65257 65257 3637
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 490 904 basechar 0
 AnchorPoint: "rtl-below" 594 -181 basechar 0
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEA
-Encoding: 65258 65258 65258
+Encoding: 65258 65258 3638
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 562 890.5 basechar 0
@@ -102067,8 +105735,9 @@ SplineSet
  555 653 555 653 706 668 c 1,11,12
 EndSplineSet
 EndChar
+
 StartChar: uniFEEB
-Encoding: 65259 65259 65259
+Encoding: 65259 65259 3639
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 431.5 1120 basechar 0
@@ -102114,8 +105783,9 @@ SplineSet
  768 438 768 438 701 508 c 1,46,47
 EndSplineSet
 EndChar
+
 StartChar: uniFEEC
-Encoding: 65260 65260 65260
+Encoding: 65260 65260 3640
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 494.5 796 basechar 0
@@ -102156,18 +105826,20 @@ SplineSet
  484 0 l 1,37,38
 EndSplineSet
 EndChar
+
 StartChar: uniFEED
-Encoding: 65261 65261 65261
+Encoding: 65261 65261 3641
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 643 845.5 basechar 0
 AnchorPoint: "rtl-below" 588 -535 basechar 0
 LayerCount: 2
 Fore
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEEE
-Encoding: 65262 65262 65262
+Encoding: 65262 65262 3642
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 571 809.5 basechar 0
@@ -102204,18 +105876,20 @@ SplineSet
  1003 279 1003 279 1007 184 c 1,12,-1
 EndSplineSet
 EndChar
+
 StartChar: uniFEEF
-Encoding: 65263 65263 65263
+Encoding: 65263 65263 3643
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 508 850 basechar 0
 AnchorPoint: "rtl-below" 558 -367 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF0
-Encoding: 65264 65264 65264
+Encoding: 65264 65264 3644
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 422.5 580 basechar 0
@@ -102255,52 +105929,57 @@ SplineSet
  770 22 770 22 769 51 c 24,0,1
 EndSplineSet
 EndChar
+
 StartChar: uniFEF1
-Encoding: 65265 65265 65265
+Encoding: 65265 65265 3645
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 517 872.5 basechar 0
 AnchorPoint: "rtl-below" 540 -595 basechar 0
 LayerCount: 2
 Fore
-Refer: 1609 1609 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 345 -500 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 345 -500 2
 EndChar
+
 StartChar: uniFEF2
-Encoding: 65266 65266 65266
+Encoding: 65266 65266 3646
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 368.5 607 basechar 0
 AnchorPoint: "rtl-below" 402 -580 basechar 0
 LayerCount: 2
 Fore
-Refer: 65264 65264 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 192 -500 2
+Refer: 3644 65264 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 192 -500 2
 EndChar
+
 StartChar: uniFEF3
-Encoding: 65267 65267 65267
+Encoding: 65267 65267 3647
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 553 841 basechar 0
 AnchorPoint: "rtl-below" 570 -373 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 386 -300 2
-Refer: 64488 64488 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 386 -300 2
+Refer: 3511 64488 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF4
-Encoding: 65268 65268 65268
+Encoding: 65268 65268 3648
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 544 850 basechar 0
 AnchorPoint: "rtl-below" 594 -379 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114134 -1 N 1 0 0 1 403 -300 2
-Refer: 64489 64489 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 403 -300 2
+Refer: 3512 64489 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uniFEF5
-Encoding: 65269 65269 65269
+Encoding: 65269 65269 3649
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 147 1845.5 baselig 1
@@ -102309,13 +105988,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 -362 300 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -362 300 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF6
-Encoding: 65270 65270 65270
+Encoding: 65270 65270 3650
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 91 1817.5 baselig 1
@@ -102324,13 +106004,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 816 -32 baselig 0
 LayerCount: 2
 Fore
-Refer: 1619 1619 N 1 0 0 1 -448 300 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1213 1619 N 1 0 0 1 -448 300 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE82
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF7
-Encoding: 65271 65271 65271
+Encoding: 65271 65271 3651
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 155 2038.5 baselig 1
@@ -102339,13 +106020,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -362 300 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -362 300 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF8
-Encoding: 65272 65272 65272
+Encoding: 65272 65272 3652
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 43 2042.5 baselig 1
@@ -102354,13 +106036,14 @@ AnchorPoint: "Ligature rtl-above" 852 1644 baselig 0
 AnchorPoint: "Ligature rtl-below" 828 -120 baselig 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -477 300 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -477 300 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE84
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEF9
-Encoding: 65273 65273 65273
+Encoding: 65273 65273 3653
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
@@ -102369,13 +106052,14 @@ AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 AnchorPoint: "Ligature rtl-below" 936 44 baselig 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 -312 0 2
-Refer: 65275 65275 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 0 2
+Refer: 3655 65275 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEDF uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFA
-Encoding: 65274 65274 65274
+Encoding: 65274 65274 3654
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 268 -548 baselig 1
@@ -102384,13 +106068,14 @@ AnchorPoint: "Ligature rtl-above" 223 1501.5 baselig 1
 AnchorPoint: "Ligature rtl-above" 924 1640 baselig 0
 LayerCount: 2
 Fore
-Refer: 1621 1621 N 1 0 0 1 -312 0 2
-Refer: 65276 65276 N 1 0 0 1 0 0 2
+Refer: 1215 1621 N 1 0 0 1 -312 0 2
+Refer: 3656 65276 N 1 0 0 1 0 0 2
 Ligature2: "'liga' Standard Ligatures in Arabic lookup 7" uniFEE0 uniFE88
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFB
-Encoding: 65275 65275 65275
+Encoding: 65275 65275 3655
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-below" 992 80 baselig 0
@@ -102418,10 +106103,11 @@ SplineSet
  1054 834 l 2,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 6" uniFEDF uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFC
-Encoding: 65276 65276 65276
+Encoding: 65276 65276 3656
 Width: 1233
 Flags: W
 AnchorPoint: "Ligature rtl-above" 159 1501.5 baselig 1
@@ -102455,40 +106141,46 @@ SplineSet
  830 284 830 284 831 316 c 9,0,1
 EndSplineSet
 Ligature2: "'rlig' Required Ligatures in Arabic lookup 6" uniFEE0 uniFE8E
-LCarets2: 1 0 
+LCarets2: 1 0
 EndChar
+
 StartChar: uniFEFF
-Encoding: 65279 65279 65279
+Encoding: 65279 65279 3657
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFF9
-Encoding: 65529 65529 65529
+Encoding: 65529 65529 3658
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFA
-Encoding: 65530 65530 65530
+Encoding: 65530 65530 3659
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFB
-Encoding: 65531 65531 65531
+Encoding: 65531 65531 3660
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFC
-Encoding: 65532 65532 65532
+Encoding: 65532 65532 3661
 Width: 1233
 Flags: W
 LayerCount: 2
 EndChar
+
 StartChar: uniFFFD
-Encoding: 65533 65533 65533
+Encoding: 65533 65533 3662
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102531,8 +106223,9 @@ SplineSet
  514 254 l 1,31,-1
 EndSplineSet
 EndChar
+
 StartChar: u1D55A
-Encoding: 120154 120154 120154
+Encoding: 120154 120154 3663
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -102561,504 +106254,567 @@ SplineSet
  542 1556 l 1,14,-1
 EndSplineSet
 EndChar
+
 StartChar: u1D670
-Encoding: 120432 120432 120432
+Encoding: 120432 120432 3664
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 65 65 N 1 0 0 1 0 0 2
+Refer: 34 65 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D671
-Encoding: 120433 120433 120433
+Encoding: 120433 120433 3665
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 66 66 N 1 0 0 1 0 0 2
+Refer: 35 66 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D672
-Encoding: 120434 120434 120434
+Encoding: 120434 120434 3666
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 67 67 N 1 0 0 1 0 0 2
+Refer: 36 67 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D673
-Encoding: 120435 120435 120435
+Encoding: 120435 120435 3667
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 68 68 N 1 0 0 1 0 0 2
+Refer: 37 68 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D674
-Encoding: 120436 120436 120436
+Encoding: 120436 120436 3668
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 69 69 N 1 0 0 1 0 0 2
+Refer: 38 69 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D675
-Encoding: 120437 120437 120437
+Encoding: 120437 120437 3669
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 70 70 N 1 0 0 1 0 0 2
+Refer: 39 70 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D676
-Encoding: 120438 120438 120438
+Encoding: 120438 120438 3670
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 71 71 N 1 0 0 1 0 0 2
+Refer: 40 71 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D677
-Encoding: 120439 120439 120439
+Encoding: 120439 120439 3671
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 72 72 N 1 0 0 1 0 0 2
+Refer: 41 72 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D678
-Encoding: 120440 120440 120440
+Encoding: 120440 120440 3672
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 73 73 N 1 0 0 1 0 0 2
+Refer: 42 73 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D679
-Encoding: 120441 120441 120441
+Encoding: 120441 120441 3673
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 74 74 N 1 0 0 1 0 0 2
+Refer: 43 74 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67A
-Encoding: 120442 120442 120442
+Encoding: 120442 120442 3674
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 75 75 N 1 0 0 1 0 0 2
+Refer: 44 75 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67B
-Encoding: 120443 120443 120443
+Encoding: 120443 120443 3675
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 76 76 N 1 0 0 1 0 0 2
+Refer: 45 76 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67C
-Encoding: 120444 120444 120444
+Encoding: 120444 120444 3676
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 77 77 N 1 0 0 1 0 0 2
+Refer: 46 77 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67D
-Encoding: 120445 120445 120445
+Encoding: 120445 120445 3677
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 78 78 N 1 0 0 1 0 0 2
+Refer: 47 78 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67E
-Encoding: 120446 120446 120446
+Encoding: 120446 120446 3678
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 79 79 N 1 0 0 1 0 0 2
+Refer: 48 79 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D67F
-Encoding: 120447 120447 120447
+Encoding: 120447 120447 3679
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 80 80 N 1 0 0 1 0 0 2
+Refer: 49 80 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D680
-Encoding: 120448 120448 120448
+Encoding: 120448 120448 3680
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 81 81 N 1 0 0 1 0 0 2
+Refer: 50 81 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D681
-Encoding: 120449 120449 120449
+Encoding: 120449 120449 3681
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 82 82 N 1 0 0 1 0 0 2
+Refer: 51 82 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D682
-Encoding: 120450 120450 120450
+Encoding: 120450 120450 3682
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 83 83 N 1 0 0 1 0 0 2
+Refer: 52 83 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D683
-Encoding: 120451 120451 120451
+Encoding: 120451 120451 3683
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 84 84 N 1 0 0 1 0 0 2
+Refer: 53 84 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D684
-Encoding: 120452 120452 120452
+Encoding: 120452 120452 3684
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 85 85 N 1 0 0 1 0 0 2
+Refer: 54 85 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D685
-Encoding: 120453 120453 120453
+Encoding: 120453 120453 3685
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 86 86 N 1 0 0 1 0 0 2
+Refer: 55 86 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D686
-Encoding: 120454 120454 120454
+Encoding: 120454 120454 3686
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 87 87 N 1 0 0 1 0 0 2
+Refer: 56 87 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D687
-Encoding: 120455 120455 120455
+Encoding: 120455 120455 3687
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 88 88 N 1 0 0 1 0 0 2
+Refer: 57 88 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D688
-Encoding: 120456 120456 120456
+Encoding: 120456 120456 3688
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 89 89 N 1 0 0 1 0 0 2
+Refer: 58 89 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D689
-Encoding: 120457 120457 120457
+Encoding: 120457 120457 3689
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 90 90 N 1 0 0 1 0 0 2
+Refer: 59 90 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68A
-Encoding: 120458 120458 120458
+Encoding: 120458 120458 3690
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 97 97 N 1 0 0 1 0 0 2
+Refer: 66 97 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68B
-Encoding: 120459 120459 120459
+Encoding: 120459 120459 3691
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 98 98 N 1 0 0 1 0 0 2
+Refer: 67 98 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68C
-Encoding: 120460 120460 120460
+Encoding: 120460 120460 3692
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 99 99 N 1 0 0 1 0 0 2
+Refer: 68 99 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68D
-Encoding: 120461 120461 120461
+Encoding: 120461 120461 3693
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 100 100 N 1 0 0 1 0 0 2
+Refer: 69 100 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68E
-Encoding: 120462 120462 120462
+Encoding: 120462 120462 3694
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 101 101 N 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D68F
-Encoding: 120463 120463 120463
+Encoding: 120463 120463 3695
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 102 102 N 1 0 0 1 0 0 2
+Refer: 71 102 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D690
-Encoding: 120464 120464 120464
+Encoding: 120464 120464 3696
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 103 103 N 1 0 0 1 0 0 2
+Refer: 72 103 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D691
-Encoding: 120465 120465 120465
+Encoding: 120465 120465 3697
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 104 104 N 1 0 0 1 0 0 2
+Refer: 73 104 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D692
-Encoding: 120466 120466 120466
+Encoding: 120466 120466 3698
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 105 105 N 1 0 0 1 0 0 2
+Refer: 74 105 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D693
-Encoding: 120467 120467 120467
+Encoding: 120467 120467 3699
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 106 106 N 1 0 0 1 0 0 2
+Refer: 75 106 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D694
-Encoding: 120468 120468 120468
+Encoding: 120468 120468 3700
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 107 107 N 1 0 0 1 0 0 2
+Refer: 76 107 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D695
-Encoding: 120469 120469 120469
+Encoding: 120469 120469 3701
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 108 108 N 1 0 0 1 0 0 2
+Refer: 77 108 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D696
-Encoding: 120470 120470 120470
+Encoding: 120470 120470 3702
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 109 109 N 1 0 0 1 0 0 2
+Refer: 78 109 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D697
-Encoding: 120471 120471 120471
+Encoding: 120471 120471 3703
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 110 110 N 1 0 0 1 0 0 2
+Refer: 79 110 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D698
-Encoding: 120472 120472 120472
+Encoding: 120472 120472 3704
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 111 111 N 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D699
-Encoding: 120473 120473 120473
+Encoding: 120473 120473 3705
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 112 112 N 1 0 0 1 0 0 2
+Refer: 81 112 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69A
-Encoding: 120474 120474 120474
+Encoding: 120474 120474 3706
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 113 113 N 1 0 0 1 0 0 2
+Refer: 82 113 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69B
-Encoding: 120475 120475 120475
+Encoding: 120475 120475 3707
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 114 114 N 1 0 0 1 0 0 2
+Refer: 83 114 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69C
-Encoding: 120476 120476 120476
+Encoding: 120476 120476 3708
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 115 115 N 1 0 0 1 0 0 2
+Refer: 84 115 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69D
-Encoding: 120477 120477 120477
+Encoding: 120477 120477 3709
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 116 116 N 1 0 0 1 0 0 2
+Refer: 85 116 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69E
-Encoding: 120478 120478 120478
+Encoding: 120478 120478 3710
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 117 117 N 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D69F
-Encoding: 120479 120479 120479
+Encoding: 120479 120479 3711
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 118 118 N 1 0 0 1 0 0 2
+Refer: 87 118 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A0
-Encoding: 120480 120480 120480
+Encoding: 120480 120480 3712
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 119 119 N 1 0 0 1 0 0 2
+Refer: 88 119 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A1
-Encoding: 120481 120481 120481
+Encoding: 120481 120481 3713
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 120 120 N 1 0 0 1 0 0 2
+Refer: 89 120 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A2
-Encoding: 120482 120482 120482
+Encoding: 120482 120482 3714
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 121 121 N 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D6A3
-Encoding: 120483 120483 120483
+Encoding: 120483 120483 3715
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 122 122 N 1 0 0 1 0 0 2
+Refer: 91 122 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F6
-Encoding: 120822 120822 120822
+Encoding: 120822 120822 3716
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 48 48 N 1 0 0 1 0 0 2
+Refer: 17 48 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F7
-Encoding: 120823 120823 120823
+Encoding: 120823 120823 3717
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 49 49 N 1 0 0 1 0 0 2
+Refer: 18 49 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F8
-Encoding: 120824 120824 120824
+Encoding: 120824 120824 3718
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 50 50 N 1 0 0 1 0 0 2
+Refer: 19 50 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7F9
-Encoding: 120825 120825 120825
+Encoding: 120825 120825 3719
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 51 51 N 1 0 0 1 0 0 2
+Refer: 20 51 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FA
-Encoding: 120826 120826 120826
+Encoding: 120826 120826 3720
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 52 52 N 1 0 0 1 0 0 2
+Refer: 21 52 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FB
-Encoding: 120827 120827 120827
+Encoding: 120827 120827 3721
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 53 53 N 1 0 0 1 0 0 2
+Refer: 22 53 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FC
-Encoding: 120828 120828 120828
+Encoding: 120828 120828 3722
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 54 54 N 1 0 0 1 0 0 2
+Refer: 23 54 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FD
-Encoding: 120829 120829 120829
+Encoding: 120829 120829 3723
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 55 55 N 1 0 0 1 0 0 2
+Refer: 24 55 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FE
-Encoding: 120830 120830 120830
+Encoding: 120830 120830 3724
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 56 56 N 1 0 0 1 0 0 2
+Refer: 25 56 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: u1D7FF
-Encoding: 120831 120831 120831
+Encoding: 120831 120831 3725
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 57 57 N 1 0 0 1 0 0 2
+Refer: 26 57 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: dlLtcaron
-Encoding: 1114113 -1 1114113
+Encoding: 1114113 -1 3726
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103090,8 +106846,9 @@ SplineSet
  544 1638 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Diaeresis
-Encoding: 1114114 -1 1114114
+Encoding: 1114114 -1 3727
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103180,8 +106937,9 @@ SplineSet
  711 1497 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: Acute
-Encoding: 1114115 -1 1114115
+Encoding: 1114115 -1 3728
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103291,8 +107049,9 @@ SplineSet
  672 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Tilde
-Encoding: 1114116 -1 1114116
+Encoding: 1114116 -1 3729
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103528,8 +107287,9 @@ SplineSet
  664 1310 664 1310 612 1337 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Grave
-Encoding: 1114117 -1 1114117
+Encoding: 1114117 -1 3730
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103631,8 +107391,9 @@ SplineSet
  561 1526 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Circumflex
-Encoding: 1114118 -1 1114118
+Encoding: 1114118 -1 3731
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103731,8 +107492,9 @@ SplineSet
  522 1528 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: Caron
-Encoding: 1114119 -1 1114119
+Encoding: 1114119 -1 3732
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103843,8 +107605,9 @@ SplineSet
  522 1262 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: fractionslash
-Encoding: 1114120 -1 1114120
+Encoding: 1114120 -1 3733
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103884,8 +107647,9 @@ SplineSet
  51 504 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0311.case
-Encoding: 1114121 -1 1114121
+Encoding: 1114121 -1 3734
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -103904,8 +107668,9 @@ SplineSet
  303 1659 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni0306.case
-Encoding: 1114122 -1 1114122
+Encoding: 1114122 -1 3735
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103951,13 +107716,14 @@ SplineSet
  796 1845 796 1845 811 1901 c 1,7,-1
  930 1901 l 1,8,9
  919 1782 919 1782 839.5 1720.5 c 128,-1,10
- 760 1659 760 1659 616 1659 c 0,11,12
+ 760 1659 760 1659 616 1659 c 256,11,12
  472 1659 472 1659 393 1720 c 128,-1,13
  314 1781 314 1781 303 1901 c 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0307.case
-Encoding: 1114123 -1 1114123
+Encoding: 1114123 -1 3736
 Width: 1233
 Flags: W
 TtInstrs:
@@ -103990,8 +107756,9 @@ SplineSet
  513 1872 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030B.case
-Encoding: 1114124 -1 1114124
+Encoding: 1114124 -1 3737
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104036,8 +107803,9 @@ SplineSet
  541 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: uni030F.case
-Encoding: 1114125 -1 1114125
+Encoding: 1114125 -1 3738
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104055,8 +107823,9 @@ SplineSet
  692 1899 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: thinquestion
-Encoding: 1114126 -1 1114126
+Encoding: 1114126 -1 3739
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104092,8 +107861,9 @@ SplineSet
  487 254 l 1,37,-1
 EndSplineSet
 EndChar
+
 StartChar: uni0304.case
-Encoding: 1114127 -1 1114127
+Encoding: 1114127 -1 3740
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104125,8 +107895,9 @@ SplineSet
  317 1840 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar
-Encoding: 1114128 -1 1114128
+Encoding: 1114128 -1 3741
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104139,8 +107910,9 @@ SplineSet
  1077 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.wide
-Encoding: 1114129 -1 1114129
+Encoding: 1114129 -1 3742
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104153,8 +107925,9 @@ SplineSet
  1227 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: underbar.small
-Encoding: 1114130 -1 1114130
+Encoding: 1114130 -1 3743
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104167,8 +107940,9 @@ SplineSet
  977 -204 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: jot
-Encoding: 1114131 -1 1114131
+Encoding: 1114131 -1 3744
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104195,8 +107969,9 @@ SplineSet
  675.36 876.6 675.36 876.6 615.96 876.6 c 128,-1,15
 EndSplineSet
 EndChar
+
 StartChar: diaeresis.symbols
-Encoding: 1114132 -1 1114132
+Encoding: 1114132 -1 3745
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104214,8 +107989,9 @@ SplineSet
  711 1552 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_dot
-Encoding: 1114133 -1 1114133
+Encoding: 1114133 -1 3746
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104228,8 +108004,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots
-Encoding: 1114134 -1 1114134
+Encoding: 1114134 -1 3747
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104247,8 +108024,9 @@ SplineSet
  0 150 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots
-Encoding: 1114135 -1 1114135
+Encoding: 1114135 -1 3748
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104271,8 +108049,9 @@ SplineSet
  0 150 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E.fina
-Encoding: 1114136 -1 1114136
+Encoding: 1114136 -1 3749
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104303,8 +108082,9 @@ SplineSet
  716 -20 716 -20 543 -20 c 0,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.init
-Encoding: 1114137 -1 1114137
+Encoding: 1114137 -1 3750
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104340,8 +108120,9 @@ SplineSet
  -20 184 l 1,16,-1
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.medi
-Encoding: 1114138 -1 1114138
+Encoding: 1114138 -1 3751
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104381,8 +108162,9 @@ SplineSet
  630 592 630 592 616 592 c 128,-1,34
 EndSplineSet
 EndChar
+
 StartChar: uni066F.fina
-Encoding: 1114139 -1 1114139
+Encoding: 1114139 -1 3752
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104427,8 +108209,9 @@ SplineSet
  937 205 937 205 951 203 c 1,47,48
 EndSplineSet
 EndChar
+
 StartChar: uni06A1.fina
-Encoding: 1114140 -1 1114140
+Encoding: 1114140 -1 3753
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104471,8 +108254,9 @@ SplineSet
  800 260 800 260 883 223 c 1,44,45
 EndSplineSet
 EndChar
+
 StartChar: arabic_3dots_a
-Encoding: 1114141 -1 1114141
+Encoding: 1114141 -1 3754
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104495,8 +108279,9 @@ SplineSet
  0 0 l 1,8,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_2dots_a
-Encoding: 1114142 -1 1114142
+Encoding: 1114142 -1 3755
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104514,8 +108299,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_4dots
-Encoding: 1114143 -1 1114143
+Encoding: 1114143 -1 3756
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104543,8 +108329,9 @@ SplineSet
  0 150 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar
-Encoding: 1114144 -1 1114144
+Encoding: 1114144 -1 3757
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104557,8 +108344,9 @@ SplineSet
  695 1670 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_gaf_bar_a
-Encoding: 1114145 -1 1114145
+Encoding: 1114145 -1 3758
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104571,8 +108359,9 @@ SplineSet
  924 1671 l 25,0,-1
 EndSplineSet
 EndChar
+
 StartChar: arabic_ring
-Encoding: 1114146 -1 1114146
+Encoding: 1114146 -1 3759
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104598,8 +108387,9 @@ SplineSet
  438 312 438 312 438 220 c 128,-1,13
 EndSplineSet
 EndChar
+
 StartChar: Eng.alt
-Encoding: 1114147 -1 1114147
+Encoding: 1114147 -1 3760
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104695,8 +108485,9 @@ SplineSet
  149 1493 l 1,0,-1
 EndSplineSet
 EndChar
+
 StartChar: uni066E
-Encoding: 1114148 -1 1114148
+Encoding: 1114148 -1 3761
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104719,8 +108510,9 @@ SplineSet
  1174 539 l 1,0,1
 EndSplineSet
 EndChar
+
 StartChar: uni066F
-Encoding: 1114149 -1 1114149
+Encoding: 1114149 -1 3762
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104759,71 +108551,78 @@ SplineSet
  312 -196 312 -196 452 -196 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni067C
-Encoding: 1114150 -1 1114150
+Encoding: 1114150 -1 3763
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 632 -560 basechar 0
 AnchorPoint: "rtl-above" 636 980 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114146 -1 N 1 0 0 1 408 -500 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
-Refer: 1114134 -1 N 1 0 0 1 440 650 2
+Refer: 3759 -1 N 1 0 0 1 408 -500 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
+Refer: 3747 -1 N 1 0 0 1 440 650 2
 EndChar
+
 StartChar: uni067D
-Encoding: 1114151 -1 1114151
+Encoding: 1114151 -1 3764
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 628 -168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114141 -1 N 1 0 0 1 425 800 2
-Refer: 1114148 -1 N 1 0 0 1 0 0 2
+Refer: 3754 -1 N 1 0 0 1 425 800 2
+Refer: 3761 -1 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0681
-Encoding: 1114152 -1 1114152
+Encoding: 1114152 -1 3765
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 580 -552 basechar 0
 LayerCount: 2
 Fore
-Refer: 1620 1620 N 1 0 0 1 -82 -200 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 1214 1620 N 1 0 0 1 -82 -200 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0682
-Encoding: 1114153 -1 1114153
+Encoding: 1114153 -1 3766
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 500 -560 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114142 -1 N 1 0 0 1 450 1300 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3755 -1 N 1 0 0 1 450 1300 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0685
-Encoding: 1114154 -1 1114154
+Encoding: 1114154 -1 3767
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 564 -544 basechar 0
 LayerCount: 2
 Fore
-Refer: 1114135 -1 N 1 0 0 1 340 1050 2
-Refer: 1581 1581 N 1 0 0 1 0 0 2
+Refer: 3748 -1 N 1 0 0 1 340 1050 2
+Refer: 1180 1581 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni0692
-Encoding: 1114155 -1 1114155
+Encoding: 1114155 -1 3768
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 623.5 1150.5 basechar 0
 AnchorPoint: "rtl-below" 581 -545 basechar 0
 LayerCount: 2
 Fore
-Refer: 1585 1585 N 1 0 0 1 0 0 2
-Refer: 1626 1626 N 1 0 0 1 318.5 -558 2
+Refer: 1184 1585 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 318.5 -558 2
 EndChar
+
 StartChar: uni06A1
-Encoding: 1114156 -1 1114156
+Encoding: 1114156 -1 3769
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104863,19 +108662,21 @@ SplineSet
  1164 149 1164 149 1064 70 c 0,16,17
 EndSplineSet
 EndChar
+
 StartChar: uni06B5
-Encoding: 1114157 -1 1114157
+Encoding: 1114157 -1 3770
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-above" 1002 2100 basechar 0
 AnchorPoint: "rtl-below" 520 -402 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 388 400 2
-Refer: 1604 1604 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 388 400 2
+Refer: 1198 1604 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06BA
-Encoding: 1114158 -1 1114158
+Encoding: 1114158 -1 3771
 Width: 1233
 Flags: W
 LayerCount: 2
@@ -104901,38 +108702,42 @@ SplineSet
 EndSplineSet
 Substitution2: "'fina' Terminal Forms in Arabic lookup 3" uniFB9F
 EndChar
+
 StartChar: uni06C6
-Encoding: 1114159 -1 1114159
+Encoding: 1114159 -1 3772
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 592 -548 basechar 0
 AnchorPoint: "rtl-above" 724 1220 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 112 -492 2
-Refer: 1608 1608 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 112 -492 2
+Refer: 1202 1608 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06CE
-Encoding: 1114160 -1 1114160
+Encoding: 1114160 -1 3773
 Width: 1233
 Flags: W
 AnchorPoint: "rtl-below" 525 -400 basechar 0
 AnchorPoint: "rtl-above" 391 1168 basechar 0
 LayerCount: 2
 Fore
-Refer: 1626 1626 N 1 0 0 1 -216 -544 2
-Refer: 1609 1609 N 1 0 0 1 0 0 2
+Refer: 1216 1626 N 1 0 0 1 -216 -544 2
+Refer: 1203 1609 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: uni06D5
-Encoding: 1114161 -1 1114161
+Encoding: 1114161 -1 3774
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 1607 1607 N 1 0 0 1 0 0 2
+Refer: 1201 1607 N 1 0 0 1 0 0 2
 EndChar
+
 StartChar: exclamdown.case
-Encoding: 1114162 -1 1114162
+Encoding: 1114162 -1 3775
 Width: 1233
 Flags: W
 TtInstrs:
@@ -104984,8 +108789,9 @@ SplineSet
  516 0 l 1,4,-1
 EndSplineSet
 EndChar
+
 StartChar: questiondown.case
-Encoding: 1114163 -1 1114163
+Encoding: 1114163 -1 3776
 Width: 1233
 Flags: W
 TtInstrs:
@@ -105155,13 +108961,474 @@ SplineSet
  745 1239 l 1,34,-1
 EndSplineSet
 EndChar
+
 StartChar: uni2E18.case
-Encoding: 1114164 -1 1114164
+Encoding: 1114164 -1 3777
 Width: 1233
 Flags: W
 LayerCount: 2
 Fore
-Refer: 11800 11800 N 1 0 0 1 0 373 3
+Refer: 3398 11800 N 1 0 0 1 0 373 3
+EndChar
+
+StartChar: uni1EA2
+Encoding: 7842 7842 3778
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 12 348 2
+Refer: 34 65 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EA3
+Encoding: 7843 7843 3779
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 66 97 N 1 0 0 1 0 0 2
+Refer: 664 777 S 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EBA
+Encoding: 7866 7866 3780
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 42 379 2
+Refer: 38 69 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EBB
+Encoding: 7867 7867 3781
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 70 101 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EC8
+Encoding: 7880 7880 3782
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 18 361 2
+Refer: 42 73 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EC9
+Encoding: 7881 7881 3783
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 241 305 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1ECE
+Encoding: 7886 7886 3784
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 18 361 2
+Refer: 48 79 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1ECF
+Encoding: 7887 7887 3785
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 80 111 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1ED4
+Encoding: 7892 7892 3786
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 N 1 0 0 1 326 529 2
+Refer: 148 212 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1ED5
+Encoding: 7893 7893 3787
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 N 1 0 0 1 357 221 2
+Refer: 180 244 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EDE
+Encoding: 7902 7902 3788
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -90 363 2
+Refer: 352 416 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EDF
+Encoding: 7903 7903 3789
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -114 0 2
+Refer: 353 417 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EE6
+Encoding: 7910 7910 3790
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 18 361 2
+Refer: 54 85 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EE7
+Encoding: 7911 7911 3791
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 86 117 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EEC
+Encoding: 7916 7916 3792
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -90 363 2
+Refer: 367 431 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EED
+Encoding: 7917 7917 3793
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 -114 0 2
+Refer: 368 432 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EF6
+Encoding: 7926 7926 3794
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 18 361 2
+Refer: 58 89 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EF7
+Encoding: 7927 7927 3795
+Width: 1233
+Flags: W
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 0 2
+Refer: 90 121 N 1 0 0 1 0 0 2
+EndChar
+
+StartChar: uni1EA7
+Encoding: 7847 7847 3796
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -364.5 361 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA4
+Encoding: 7844 7844 3797
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 372.5 632 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA5
+Encoding: 7845 7845 3798
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 351.5 351 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA6
+Encoding: 7846 7846 3799
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -365.5 637 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA8
+Encoding: 7848 7848 3800
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 259 651 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EA9
+Encoding: 7849 7849 3801
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 287 294 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAA
+Encoding: 7850 7850 3802
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 130 194 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAB
+Encoding: 7851 7851 3803
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 451 2
+Refer: 162 226 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAE
+Encoding: 7854 7854 3804
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 N 1 0 0 1 64.5 761 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EAF
+Encoding: 7855 7855 3805
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 N 1 0 0 1 64.5 468 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB2
+Encoding: 7858 7858 3806
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 27 765 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB3
+Encoding: 7859 7859 3807
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 0 443 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB4
+Encoding: 7860 7860 3808
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 194 258 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EB5
+Encoding: 7861 7861 3809
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 421 2
+Refer: 195 259 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBE
+Encoding: 7870 7870 3810
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 339.5 637 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EBF
+Encoding: 7871 7871 3811
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 358.5 352 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC0
+Encoding: 7872 7872 3812
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -375.5 637 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC1
+Encoding: 7873 7873 3813
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -330.5 344 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC2
+Encoding: 7874 7874 3814
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 354 576 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC3
+Encoding: 7875 7875 3815
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 664 777 S 1 0 0 1 310 320 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC4
+Encoding: 7876 7876 3816
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 18 729 2
+Refer: 138 202 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1EC5
+Encoding: 7877 7877 3817
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 14 451 2
+Refer: 170 234 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED0
+Encoding: 7888 7888 3818
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3728 -1 S 1 0 0 1 372.5 609 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED1
+Encoding: 7889 7889 3819
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 656 769 S 1 0 0 1 316.5 337 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED2
+Encoding: 7890 7890 3820
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3730 -1 S 1 0 0 1 -337.5 593 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED3
+Encoding: 7891 7891 3821
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 655 768 S 1 0 0 1 -330.5 359 2
+Refer: 180 244 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED6
+Encoding: 7894 7894 3822
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 3729 -1 N 1 0 0 1 0 729 2
+Refer: 148 212 N 1 0 0 1 0 0 3
+EndChar
+
+StartChar: uni1ED7
+Encoding: 7895 7895 3823
+Width: 1233
+VWidth: 0
+LayerCount: 2
+Fore
+Refer: 640 732 N 1 0 0 1 0 451 2
+Refer: 180 244 N 1 0 0 1 0 0 3
 EndChar
 EndChars
 EndSplineFont


### PR DESCRIPTION
This PR adds full Vietnamese support for DejaVu Sans Mono family. There was a PR about this before but I closed it because of faulty commits.